### PR TITLE
chore: add conversions back that used to exist

### DIFF
--- a/Cql/CoreTests/FhirTypeConverterTests.cs
+++ b/Cql/CoreTests/FhirTypeConverterTests.cs
@@ -1,5 +1,4 @@
 ﻿using Hl7.Cql.Conversion;
-using Hl7.Cql.Fhir;
 using Hl7.Cql.Iso8601;
 using Hl7.Cql.Primitives;
 using Hl7.Fhir.Model;
@@ -10,6 +9,7 @@ using static Hl7.Fhir.Model.Parameters;
 namespace CoreTests
 {
     [TestClass]
+    [TestCategory("UnitTest")]
     public class FhirTypeConverterTests
     {
         internal static readonly TypeConverter FhirTypeConverter = Hl7.Cql.Fhir.FhirTypeConverter.Create(Hl7.Fhir.Model.ModelInfo.ModelInspector);
@@ -435,6 +435,43 @@ namespace CoreTests
         }
 
         [TestMethod]
+        public void ConvertFhirDateTime_CqlDateTime()
+        {
+            var date = new FhirDateTime(2022, 1, 1, 1, 1, 1, TimeSpan.Zero);
+            var converted = FhirTypeConverter.Convert<CqlDateTime>(date);
+
+            Assert.IsNotNull(converted);
+            var isoDateTime = converted.Value;
+            Assert.IsNotNull(isoDateTime);
+
+            Assert.AreEqual(2022, isoDateTime.Year);
+            Assert.AreEqual(1, isoDateTime.Month);
+            Assert.AreEqual(1, isoDateTime.Day);
+            Assert.AreEqual(1, isoDateTime.Hour);
+            Assert.AreEqual(1, isoDateTime.Minute);
+            Assert.AreEqual(1, isoDateTime.Second);
+        }
+
+
+        [TestMethod]
+        public void ConvertFhirDate_CqlDateTime()
+        {
+            var date = new Date(2022, 1, 1);
+            var converted = FhirTypeConverter.Convert<CqlDateTime>(date);
+
+            Assert.IsNotNull(converted);
+            var isoDateTime = converted.Value;
+            Assert.IsNotNull(isoDateTime);
+
+            Assert.AreEqual(2022, isoDateTime.Year);
+            Assert.AreEqual(1, isoDateTime.Month);
+            Assert.AreEqual(1, isoDateTime.Day);
+            Assert.AreEqual(0, isoDateTime.Hour);
+            Assert.AreEqual(0, isoDateTime.Minute);
+            Assert.AreEqual(0, isoDateTime.Second);
+        }
+
+        [TestMethod]
         public void ConvertCqlTime_FhirTime()
         {
             var date = new CqlTime(1, 1, 1, 1, null, null);
@@ -461,6 +498,28 @@ namespace CoreTests
 
             Assert.AreEqual(1, converted.Value);
             Assert.AreEqual("oranges", converted.Unit);
+        }
+
+        [TestMethod]
+        public void ConvertQuantity_Int()
+        {
+            var quantity = new Quantity(1, "oranges");
+            var converted = FhirTypeConverter.Convert<int?>(quantity);
+
+            Assert.IsNotNull(converted);
+
+            Assert.AreEqual(1, converted.Value);
+        }
+
+        [TestMethod]
+        public void ConvertQuantity_Decimal()
+        {
+            var quantity = new Quantity(1, "oranges");
+            var converted = FhirTypeConverter.Convert<decimal?>(quantity);
+
+            Assert.IsNotNull(converted);
+
+            Assert.AreEqual(1, converted.Value);
         }
 
         [TestMethod]
@@ -510,6 +569,32 @@ namespace CoreTests
             Assert.AreEqual(1, converted.Low.Value);
             Assert.AreEqual(10, converted.High.Value);
         }
+
+
+        [TestMethod]
+        public void Convert_Range_CqlIntInterval()
+        {
+            var range = new Hl7.Fhir.Model.Range() { Low = new Quantity { Value = 1, Unit = "a"}, High = new Quantity { Value = 10, Unit = "a" } };
+            var converted = FhirTypeConverter.Convert<CqlInterval<int?>>(range);
+
+            Assert.IsNotNull(converted);
+
+            Assert.AreEqual(1, converted.low.Value);
+            Assert.AreEqual(10, converted.high.Value);
+        }
+
+        [TestMethod]
+        public void Convert_Range_CqlDecimalInterval()
+        {
+            var range = new Hl7.Fhir.Model.Range() { Low = new Quantity { Value = 1, Unit = "a" }, High = new Quantity { Value = 10, Unit = "a" } };
+            var converted = FhirTypeConverter.Convert<CqlInterval<decimal?>>(range);
+
+            Assert.IsNotNull(converted);
+
+            Assert.AreEqual(1, converted.low.Value);
+            Assert.AreEqual(10, converted.high.Value);
+        }
+
 
         [TestMethod]
         public void ConvertCqlRatio_Ratio()

--- a/Cql/Cql.Firely/FhirTypeConverter.cs
+++ b/Cql/Cql.Firely/FhirTypeConverter.cs
@@ -49,17 +49,27 @@ namespace Hl7.Cql.Fhir
             add((M.FhirBoolean p) => p.Value);
             add((M.FhirDecimal p) => p.Value);
             add((M.Date f) => f.TryToDate(out var date) ? new CqlDate(date!.Years!.Value, date.Months, date.Days) : null);
+            add((M.Date f) => f.TryToDate(out var date) ? new CqlDateTime(date!.Years!.Value, date.Months, date.Days, 0, 0, 0, 0, 0, 0) : null);
             add((M.Time f) => f.TryToTime(out var time) ? new CqlTime(time!.Hours!.Value, time.Minutes, time.Seconds, time.Millis, null, null) : null);
             add((M.FhirDateTime f) => f.TryToDateTime(out var dt) ?
                 new CqlDateTime(
                     dt!.Years!.Value, dt.Months,
                     dt.Days, dt.Hours, dt.Minutes, dt.Seconds, dt.Millis,
                     dt.HasOffset ? dt.Offset!.Value.Hours : null, dt.HasOffset ? dt.Offset!.Value.Minutes : null) : null);
+            add((M.FhirDateTime f) => f.TryToDateTime(out var dt) ? new CqlDate(dt!.Years!.Value, dt.Months, dt.Days) : null);
             add((M.Quantity f) => new CqlQuantity(f.Value, f.Unit));
+            add((M.Quantity f) => f.Value);
+            add((M.Quantity f) => (int?)f.Value);
             add((M.Period f) => new CqlInterval<CqlDateTime>(
                 converter.Convert<CqlDateTime>(f.StartElement), converter.Convert<CqlDateTime>(f.EndElement), lowClosed: true, highClosed: true));
+            add((M.Period f) => new CqlInterval<CqlDate>(
+                converter.Convert<CqlDate>(f.StartElement), converter.Convert<CqlDate>(f.EndElement), lowClosed: true, highClosed: true));
             add((M.Range f) => new CqlInterval<CqlQuantity>(
                     converter.Convert<CqlQuantity>(f.Low), converter.Convert<CqlQuantity>(f.High), lowClosed: true, highClosed: true));
+            add((M.Range f) => new CqlInterval<decimal?>(converter.Convert<decimal?>(f.Low), converter.Convert<decimal?>(f.High), 
+                lowClosed: true, highClosed: true));
+            add((M.Range f) => new CqlInterval<int?>(converter.Convert<int?>(f.Low), converter.Convert<int?>(f.High), 
+                lowClosed: true, highClosed: true));
             add((M.Id id) => id.Value);
             add((M.PositiveInt pi) => new M.Integer(pi.Value));
             add((M.UnsignedInt ui) => new M.Integer(ui.Value));

--- a/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
+++ b/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
@@ -199,7 +199,7 @@ namespace Hl7.Cql.Packaging
             var fhirTypeName = ModelInspector.GetFhirTypeNameForType(type);
             if (fhirTypeName is not null)
             {
-                return TypeEntryFor(fhirTypeName);
+                return TypeEntryFor($"{{http://hl7.org/fhir}}{fhirTypeName}");
             }
             var cqlPrimitiveAttribute = type.GetCustomAttribute<CqlPrimitiveTypeAttribute>(true);
             if (cqlPrimitiveAttribute is not null)
@@ -287,9 +287,6 @@ namespace Hl7.Cql.Packaging
         {
             if (!string.IsNullOrWhiteSpace(name))
             {
-                var runtimeType = TypeResolver.ResolveType(name);
-                if (string.IsNullOrWhiteSpace(name))
-                    return null;
                 if (name.StartsWith("{urn:hl7-org:elm-types:r1}"))
                 {
                     int prefixLength = "{urn:hl7-org:elm-types:r1}".Length;


### PR DESCRIPTION
There were a number of FHIR -> CQL conversions that we use at NCQA that were removed. This PR is to add those back and add some additional covering unit tests. 