### PR TITLE
chore: expose constants as public

### DIFF
--- a/Cql/Cql.Packaging/Constants.cs
+++ b/Cql/Cql.Packaging/Constants.cs
@@ -8,15 +8,42 @@
 
 namespace Hl7.Cql.Packaging
 {
-    internal static class Constants
+    /// <summary>
+    /// Constant values used when packaging measures
+    /// </summary>
+    public static class Constants
     {
+        /// <summary>
+        /// Measure group code system
+        /// </summary>
         public const string MeasureGroupCodeSystem = "https://ncqa.org/fhir/CodeSystem/measure-group";
+        /// <summary>
+        /// Extension ID added to parameters for the list element type value
+        /// </summary>
         public const string ParameterElementTypeExtensionUri = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.list-element-type";
+        /// <summary>
+        /// Extension ID added to parameters for the canonical URI value
+        /// </summary>
         public const string ParameterCanonicalUri = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.canonical-uri";
+        /// <summary>
+        /// Extension ID added to parameters for the access level value
+        /// </summary>
         public const string ParameterAccessLevel = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.access-level";
+        /// <summary>
+        /// Extension ID added to parameters for the CQL type value
+        /// </summary>
         public const string ParameterCqlType = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-type";
+        /// <summary>
+        /// Extension ID added to parameters for the CQL list element type value
+        /// </summary>
         public const string ParameterCqlElementType = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-element-type";
+        /// <summary>
+        /// Extension ID added to parameters for the CQL default value
+        /// </summary>
         public const string ParameterCqlDefaultValue = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-default-value";
+        /// <summary>
+        /// Extension ID added to parameters for the CQL default value type
+        /// </summary>
         public const string ParameterCqlDefaultValueType = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-default-type";
     }
 }

--- a/Cql/Cql.Packaging/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Packaging/PublicAPI.Unshipped.txt
@@ -1,5 +1,14 @@
 ﻿#nullable enable
+const Hl7.Cql.Packaging.Constants.MeasureGroupCodeSystem = "https://ncqa.org/fhir/CodeSystem/measure-group" -> string!
+const Hl7.Cql.Packaging.Constants.ParameterAccessLevel = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.access-level" -> string!
+const Hl7.Cql.Packaging.Constants.ParameterCanonicalUri = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.canonical-uri" -> string!
+const Hl7.Cql.Packaging.Constants.ParameterCqlDefaultValue = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-default-value" -> string!
+const Hl7.Cql.Packaging.Constants.ParameterCqlDefaultValueType = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-default-type" -> string!
+const Hl7.Cql.Packaging.Constants.ParameterCqlElementType = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-element-type" -> string!
+const Hl7.Cql.Packaging.Constants.ParameterCqlType = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-type" -> string!
+const Hl7.Cql.Packaging.Constants.ParameterElementTypeExtensionUri = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.list-element-type" -> string!
 Hl7.Cql.Packaging.AssemblyLoadContextExtensions
+Hl7.Cql.Packaging.Constants
 Hl7.Cql.Packaging.CqlTypeToFhirTypeMapper
 Hl7.Cql.Packaging.CqlTypeToFhirTypeMapper.CqlTypeToFhirTypeMapper(Hl7.Cql.Abstractions.TypeResolver! typeResolver) -> void
 Hl7.Cql.Packaging.CqlTypeToFhirTypeMapper.CqlTypeToFhirTypeMapper(Hl7.Cql.Abstractions.TypeResolver! typeResolver, Hl7.Fhir.Introspection.ModelInspector! modelInspector) -> void


### PR DESCRIPTION
At NCQA we need to be able to identify extension values that are useful for our measure processing. Specifically in this case, we need to be able to extract the CQL Default Value, CQL Default Value Type, and Type of the parameters using these constants.