### PR TITLE
Add a public non-generic Convert on TypeConverter.

### DIFF
--- a/Cql/Cql.Conversion/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Conversion/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
 Hl7.Cql.Conversion.TypeConverter
+Hl7.Cql.Conversion.TypeConverter.Convert(object! from, System.Type! t) -> object!
 Hl7.Cql.Conversion.TypeConverter.Convert<T>(object? from) -> T
 static Hl7.Cql.Conversion.TypeConverter.Create() -> Hl7.Cql.Conversion.TypeConverter!

--- a/Cql/Cql.Conversion/TypeConverter.cs
+++ b/Cql/Cql.Conversion/TypeConverter.cs
@@ -36,7 +36,17 @@ namespace Hl7.Cql.Conversion
         /// <typeparam name="T">The desired type.</typeparam>
         /// <param name="from">The object to convert.</param>
         /// <returns>The result of the conversion.</returns>
+        /// <exception cref="InvalidOperationException">If no conversion is defined.</exception>
         public T Convert<T>(object? from) => (T)ConvertHelper(from, typeof(T))!;
+
+        /// <summary>
+        /// Performs the conversion of an instance to type <paramref name="t"/> />.
+        /// </summary>
+        /// <param name="from">The object to convert.</param>
+        /// <param name="t">The type to convert the object to.</param>
+        /// <returns>The result of the conversion.</returns>
+        /// <exception cref="InvalidOperationException">If no conversion is defined.</exception>
+        public object Convert(object from, Type t) => ConvertHelper(from, t)!;
 
         /// <summary>
         /// Creates a TypeConverter with an empty set of conversions.


### PR DESCRIPTION
TypeConverter.Convert<T> cannot be used if all you have is an actual `Type`, so I have added a function to invoke the conversions with a runtime type.