### PR TITLE
Changing the java tooling to run at the folder level to speed it up

### DIFF
--- a/Demo/Cql/Build/Cql.Targets.xml
+++ b/Demo/Cql/Build/Cql.Targets.xml
@@ -9,11 +9,9 @@
 	</Target>
 	<Target Name="CQL to ELM"
 			DependsOnTargets="Download CQL to ELM CLI via Maven"
-			AfterTargets="Build"
-			Inputs="%(CQL.Identity)"
-			Outputs="@(CQL->'$(MSBuildProjectDirectory)\..\Elm\Json\%(Filename).json')">
+			AfterTargets="Build">
 		<Message Text="Converting CQL to ELM"/>
-		<Exec Command="java -classpath Build\target\dependency\* org.cqframework.cql.cql2elm.cli.CqlTranslator -input %22%(CQL.FullPath)%22 -f JSON -output $(MSBuildProjectDirectory)\..\Elm\Json -locators true -result-types true"/>
+		<Exec Command="java -classpath Build\target\dependency\* org.cqframework.cql.cql2elm.cli.CqlTranslator -input $(MSBuildProjectDirectory)\input -f JSON -output $(MSBuildProjectDirectory)\..\Elm\Json -locators true -result-types true"/>
 	</Target>
 	<Target Name="Delete ELM" AfterTargets="Clean">
 		<Message Text="Deleting ELM files...$(MSBuildProjectDirectory)\..\Elm\Json\*.json"></Message>


### PR DESCRIPTION
I stumbled on this when looking at maybe making the whole solution build. This minor adjustment to pass in the folder speeds up the java cql to elm and doesn't change the elm files or building process.