### PR TITLE
Add missing conversions

### DIFF
--- a/Cql/CoreTests/ExpressionBuilderTests.cs
+++ b/Cql/CoreTests/ExpressionBuilderTests.cs
@@ -9,6 +9,7 @@ using Hl7.Cql.Conversion;
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Cql.Abstractions;
+using System;
 
 namespace CoreTests
 {
@@ -44,6 +45,27 @@ namespace CoreTests
             var logger = CreateLogger();
             var eb = new ExpressionBuilder(binding, typeManager, elmPackage, logger);
             var expressions = eb.Build();
+        }
+
+        // https://github.com/FirelyTeam/firely-cql-sdk/issues/129
+        [TestMethod]
+        public void Medication_Request_Example_Test()
+        {
+            var binding = new CqlOperatorsBinding(TypeResolver, TypeConverter);
+            var typeManager = new TypeManager(TypeResolver);
+            var elm = new FileInfo(@"Input\ELM\Test\Medication_Request_Example.json");
+            var elmPackage = Hl7.Cql.Elm.Library.LoadFromJson(elm);
+            var logger = CreateLogger();
+            var eb = new ExpressionBuilder(binding, typeManager, elmPackage, logger);
+
+            var fdt = new FhirDateTime(2023, 12, 11, 9, 41, 30, TimeSpan.FromHours(-5));
+            var fdts = fdt.ToString();
+            var fs = new FhirDateTime(fdts);
+            Assert.AreEqual(fdt, fs);
+
+            
+            var expressions = eb.Build();
+            //new MedicationRequest()
         }
     }
 }

--- a/Cql/CoreTests/ExpressionBuilderTests.cs
+++ b/Cql/CoreTests/ExpressionBuilderTests.cs
@@ -1,15 +1,12 @@
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.Compiler;
+using Hl7.Cql.Conversion;
+using Hl7.Cql.Fhir;
+using Hl7.Fhir.Model;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Hl7.Cql.Compiler;
-using Hl7.Cql.Fhir;
-using Hl7.Cql.Elm;
-using System.IO;
-using Hl7.Cql.Model;
-using Hl7.Cql.Conversion;
-using Hl7.Fhir.Introspection;
-using Hl7.Fhir.Model;
-using Hl7.Cql.Abstractions;
 using System;
+using System.IO;
 
 namespace CoreTests
 {
@@ -63,9 +60,8 @@ namespace CoreTests
             var fs = new FhirDateTime(fdts);
             Assert.AreEqual(fdt, fs);
 
-            
             var expressions = eb.Build();
-            //new MedicationRequest()
+            Assert.IsNotNull(expressions);
         }
     }
 }

--- a/Cql/CoreTests/Input/ELM/Test/Medication_Request_Example.json
+++ b/Cql/CoreTests/Input/ELM/Test/Medication_Request_Example.json
@@ -1,0 +1,526 @@
+{
+   "library" : {
+      "annotation" : [ {
+         "translatorVersion" : "2.11.0",
+         "translatorOptions" : "EnableLocators,EnableResultTypes",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "MedicationRequestExample",
+         "version" : "0.1.001"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "locator" : "3:1-3:26",
+            "localIdentifier" : "FHIR",
+            "uri" : "http://hl7.org/fhir",
+            "version" : "4.0.1"
+         } ]
+      },
+      "includes" : {
+         "def" : [ {
+            "locator" : "5:1-5:56",
+            "localIdentifier" : "FHIRHelpers",
+            "path" : "FHIRHelpers",
+            "version" : "4.0.001"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "locator" : "7:1-45:5",
+            "resultTypeName" : "{http://hl7.org/fhir}MedicationRequest",
+            "name" : "MedicationRequestResource",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "type" : "FunctionDef",
+            "expression" : {
+               "locator" : "8:5-45:5",
+               "resultTypeName" : "{http://hl7.org/fhir}MedicationRequest",
+               "type" : "Query",
+               "source" : [ {
+                  "locator" : "8:5-8:23",
+                  "resultTypeName" : "{http://hl7.org/fhir}MedicationRequest",
+                  "alias" : "m",
+                  "expression" : {
+                     "locator" : "8:5-8:21",
+                     "resultTypeName" : "{http://hl7.org/fhir}MedicationRequest",
+                     "name" : "medicationRequest",
+                     "type" : "OperandRef"
+                  }
+               } ],
+               "relationship" : [ ],
+               "return" : {
+                  "locator" : "9:5-45:5",
+                  "resultTypeName" : "{http://hl7.org/fhir}MedicationRequest",
+                  "expression" : {
+                     "locator" : "9:12-45:5",
+                     "resultTypeName" : "{http://hl7.org/fhir}MedicationRequest",
+                     "classType" : "{http://hl7.org/fhir}MedicationRequest",
+                     "type" : "Instance",
+                     "element" : [ {
+                        "name" : "id",
+                        "value" : {
+                           "locator" : "10:13-10:42",
+                           "resultTypeName" : "{http://hl7.org/fhir}id",
+                           "classType" : "{http://hl7.org/fhir}id",
+                           "type" : "Instance",
+                           "element" : [ {
+                              "name" : "value",
+                              "value" : {
+                                 "locator" : "10:29-10:41",
+                                 "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                                 "type" : "Concatenate",
+                                 "operand" : [ {
+                                    "locator" : "10:29-10:34",
+                                    "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                                    "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                                    "value" : "LCR-",
+                                    "type" : "Literal"
+                                 }, {
+                                    "name" : "ToString",
+                                    "libraryName" : "FHIRHelpers",
+                                    "type" : "FunctionRef",
+                                    "operand" : [ {
+                                       "locator" : "10:38-10:41",
+                                       "resultTypeName" : "{http://hl7.org/fhir}id",
+                                       "path" : "id",
+                                       "scope" : "m",
+                                       "type" : "Property"
+                                    } ]
+                                 } ]
+                              }
+                           } ]
+                        }
+                     }, {
+                        "name" : "meta",
+                        "value" : {
+                           "locator" : "11:15-11:20",
+                           "resultTypeName" : "{http://hl7.org/fhir}Meta",
+                           "path" : "meta",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "extension",
+                        "value" : {
+                           "locator" : "12:20-12:30",
+                           "path" : "extension",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Extension",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "identifier",
+                        "value" : {
+                           "locator" : "13:21-13:32",
+                           "path" : "identifier",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Identifier",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "status",
+                        "value" : {
+                           "locator" : "14:17-14:24",
+                           "resultTypeName" : "{http://hl7.org/fhir}MedicationRequestStatus",
+                           "path" : "status",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "statusReason",
+                        "value" : {
+                           "locator" : "15:23-15:36",
+                           "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                           "path" : "statusReason",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "intent",
+                        "value" : {
+                           "locator" : "16:17-16:24",
+                           "resultTypeName" : "{http://hl7.org/fhir}MedicationRequestIntent",
+                           "path" : "intent",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "category",
+                        "value" : {
+                           "locator" : "17:19-17:28",
+                           "path" : "category",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "priority",
+                        "value" : {
+                           "locator" : "18:19-18:28",
+                           "resultTypeName" : "{http://hl7.org/fhir}MedicationRequestPriority",
+                           "path" : "priority",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "doNotPerform",
+                        "value" : {
+                           "locator" : "19:23-19:36",
+                           "resultTypeName" : "{http://hl7.org/fhir}boolean",
+                           "path" : "doNotPerform",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "reported",
+                        "value" : {
+                           "locator" : "20:19-20:28",
+                           "path" : "reported",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ChoiceTypeSpecifier",
+                              "choice" : [ {
+                                 "name" : "{http://hl7.org/fhir}boolean",
+                                 "type" : "NamedTypeSpecifier"
+                              }, {
+                                 "name" : "{http://hl7.org/fhir}Reference",
+                                 "type" : "NamedTypeSpecifier"
+                              } ]
+                           }
+                        }
+                     }, {
+                        "name" : "medication",
+                        "value" : {
+                           "locator" : "21:21-21:32",
+                           "path" : "medication",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ChoiceTypeSpecifier",
+                              "choice" : [ {
+                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "type" : "NamedTypeSpecifier"
+                              }, {
+                                 "name" : "{http://hl7.org/fhir}Reference",
+                                 "type" : "NamedTypeSpecifier"
+                              } ]
+                           }
+                        }
+                     }, {
+                        "name" : "subject",
+                        "value" : {
+                           "locator" : "22:18-22:26",
+                           "resultTypeName" : "{http://hl7.org/fhir}Reference",
+                           "path" : "subject",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "encounter",
+                        "value" : {
+                           "locator" : "23:20-23:30",
+                           "resultTypeName" : "{http://hl7.org/fhir}Reference",
+                           "path" : "encounter",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "supportingInformation",
+                        "value" : {
+                           "locator" : "24:32-24:54",
+                           "path" : "supportingInformation",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Reference",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "authoredOn",
+                        "value" : {
+                           "locator" : "25:21-25:32",
+                           "resultTypeName" : "{http://hl7.org/fhir}dateTime",
+                           "path" : "authoredOn",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "requester",
+                        "value" : {
+                           "locator" : "26:20-26:30",
+                           "resultTypeName" : "{http://hl7.org/fhir}Reference",
+                           "path" : "requester",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "performer",
+                        "value" : {
+                           "locator" : "27:20-27:30",
+                           "resultTypeName" : "{http://hl7.org/fhir}Reference",
+                           "path" : "performer",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "performerType",
+                        "value" : {
+                           "locator" : "28:24-28:38",
+                           "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                           "path" : "performerType",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "recorder",
+                        "value" : {
+                           "locator" : "29:19-29:28",
+                           "resultTypeName" : "{http://hl7.org/fhir}Reference",
+                           "path" : "recorder",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "reasonCode",
+                        "value" : {
+                           "locator" : "30:21-30:32",
+                           "path" : "reasonCode",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}CodeableConcept",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "reasonReference",
+                        "value" : {
+                           "locator" : "31:26-31:42",
+                           "path" : "reasonReference",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Reference",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "instantiatesCanonical",
+                        "value" : {
+                           "locator" : "32:32-32:54",
+                           "path" : "instantiatesCanonical",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}canonical",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "instantiatesUri",
+                        "value" : {
+                           "locator" : "33:26-33:42",
+                           "path" : "instantiatesUri",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}uri",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "basedOn",
+                        "value" : {
+                           "locator" : "34:18-34:26",
+                           "path" : "basedOn",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Reference",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "groupIdentifier",
+                        "value" : {
+                           "locator" : "35:26-35:42",
+                           "resultTypeName" : "{http://hl7.org/fhir}Identifier",
+                           "path" : "groupIdentifier",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "courseOfTherapyType",
+                        "value" : {
+                           "locator" : "36:30-36:50",
+                           "resultTypeName" : "{http://hl7.org/fhir}CodeableConcept",
+                           "path" : "courseOfTherapyType",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "insurance",
+                        "value" : {
+                           "locator" : "37:20-37:30",
+                           "path" : "insurance",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Reference",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "note",
+                        "value" : {
+                           "locator" : "38:15-38:20",
+                           "path" : "note",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Annotation",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "dosageInstruction",
+                        "value" : {
+                           "locator" : "39:28-39:46",
+                           "path" : "dosageInstruction",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Dosage",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "dispenseRequest",
+                        "value" : {
+                           "locator" : "40:26-40:42",
+                           "resultTypeName" : "{http://hl7.org/fhir}MedicationRequest.DispenseRequest",
+                           "path" : "dispenseRequest",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "substitution",
+                        "value" : {
+                           "locator" : "41:23-41:36",
+                           "resultTypeName" : "{http://hl7.org/fhir}MedicationRequest.Substitution",
+                           "path" : "substitution",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "priorPrescription",
+                        "value" : {
+                           "locator" : "42:28-42:46",
+                           "resultTypeName" : "{http://hl7.org/fhir}Reference",
+                           "path" : "priorPrescription",
+                           "scope" : "m",
+                           "type" : "Property"
+                        }
+                     }, {
+                        "name" : "detectedIssue",
+                        "value" : {
+                           "locator" : "43:24-43:38",
+                           "path" : "detectedIssue",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Reference",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     }, {
+                        "name" : "eventHistory",
+                        "value" : {
+                           "locator" : "44:23-44:36",
+                           "path" : "eventHistory",
+                           "scope" : "m",
+                           "type" : "Property",
+                           "resultTypeSpecifier" : {
+                              "type" : "ListTypeSpecifier",
+                              "elementType" : {
+                                 "name" : "{http://hl7.org/fhir}Reference",
+                                 "type" : "NamedTypeSpecifier"
+                              }
+                           }
+                        }
+                     } ]
+                  }
+               }
+            },
+            "operand" : [ {
+               "name" : "medicationRequest",
+               "operandTypeSpecifier" : {
+                  "locator" : "7:63-7:79",
+                  "resultTypeName" : "{http://hl7.org/fhir}MedicationRequest",
+                  "name" : "{http://hl7.org/fhir}MedicationRequest",
+                  "type" : "NamedTypeSpecifier"
+               }
+            } ]
+         } ]
+      }
+   }
+}
+

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -190,7 +190,7 @@ namespace Hl7.Cql.Compiler
 
                 if (Library.codeSystems != null)
                 {
-                    foreach(var codeSystem in Library.codeSystems)
+                    foreach (var codeSystem in Library.codeSystems)
                     {
                         if (codesByCodeSystemName.TryGetValue(codeSystem.name, out var codes))
                         {
@@ -377,7 +377,7 @@ namespace Hl7.Cql.Compiler
                                     if (!string.IsNullOrWhiteSpace(name))
                                     {
                                         var value = tag.value ?? string.Empty;
-                                        definitions.AddTag(ThisLibraryKey, def.name, functionParameterTypes ?? new Type[0], name, value);
+                                        definitions.AddTag(ThisLibraryKey, def.name, functionParameterTypes, name, value);
 
                                     }
                                 }
@@ -1617,7 +1617,7 @@ namespace Hl7.Cql.Compiler
             }
             else throw new InvalidOperationException($"CodeSystemRef {cr.name} is null");
         }
-        
+
 
         protected Expression Instance(Instance ine, ExpressionBuilderContext ctx)
         {

--- a/Cql/Cql.Firely/FhirTypeConverter.cs
+++ b/Cql/Cql.Firely/FhirTypeConverter.cs
@@ -50,12 +50,15 @@ namespace Hl7.Cql.Fhir
             add((M.FhirDecimal p) => p.Value);
             add((M.Date f) => f.TryToDate(out var date) ? new CqlDate(date!.Years!.Value, date.Months, date.Days) : null);
             add((M.Date f) => f.TryToDate(out var date) ? new CqlDateTime(date!.Years!.Value, date.Months, date.Days, 0, 0, 0, 0, 0, 0) : null);
+            add((M.Date f) => f.ToString());
             add((M.Time f) => f.TryToTime(out var time) ? new CqlTime(time!.Hours!.Value, time.Minutes, time.Seconds, time.Millis, null, null) : null);
+            add((M.Time f) => f.ToString());
             add((M.FhirDateTime f) => f.TryToDateTime(out var dt) ?
                 new CqlDateTime(
                     dt!.Years!.Value, dt.Months,
                     dt.Days, dt.Hours, dt.Minutes, dt.Seconds, dt.Millis,
                     dt.HasOffset ? dt.Offset!.Value.Hours : null, dt.HasOffset ? dt.Offset!.Value.Minutes : null) : null);
+            add((M.FhirDateTime f) => f.ToString());
             add((M.FhirDateTime f) => f.TryToDateTime(out var dt) ? new CqlDate(dt!.Years!.Value, dt.Months, dt.Days) : null);
             add((M.Quantity f) => new CqlQuantity(f.Value, f.Unit));
             add((M.Quantity f) => f.Value);
@@ -70,9 +73,15 @@ namespace Hl7.Cql.Fhir
                 lowClosed: true, highClosed: true));
             add((M.Range f) => new CqlInterval<int?>(converter.Convert<int?>(f.Low), converter.Convert<int?>(f.High), 
                 lowClosed: true, highClosed: true));
+            
             add((M.Id id) => id.Value);
+            
             add((M.PositiveInt pi) => new M.Integer(pi.Value));
+            add((M.PositiveInt pi) => pi.ToString());
             add((M.UnsignedInt ui) => new M.Integer(ui.Value));
+            add((M.UnsignedInt ui) => ui.ToString());
+
+            add((M.Canonical c) => c.ToString());
 
             addParametersToCqlPrimitivesConverters(toTypes);
             return converter;
@@ -258,18 +267,21 @@ namespace Hl7.Cql.Fhir
             void addEnumConversion(Type enumType)
             {
                 var codeType = typeof(Code<>).MakeGenericType(enumType);
+                var nullableEnumType = typeof(Nullable<>).MakeGenericType(enumType);
                 converter.AddConversion(codeType, typeof(CqlCode), (code) =>
                 {
                     var systemAndCode = (ISystemAndCode)code;
                     return new CqlCode(systemAndCode.Code, systemAndCode.System, null, null);
                 });
+                converter.AddConversion(codeType, nullableEnumType, (code) => 
+                    code.GetType().GetProperty("Value")!.GetValue(code)!);
+
                 converter.AddConversion(codeType, typeof(string), (code) =>
                 {
                     var systemAndCode = (ISystemAndCode)code;
                     return systemAndCode.Code;
                 });
 
-                var nullableEnumType = typeof(Nullable<>).MakeGenericType(enumType);
                 converter.AddConversion(nullableEnumType, typeof(string), (@enum) =>
                     Enum.GetName(nullableEnumType, @enum) ?? throw new InvalidOperationException($"Did not find enum member {@enum} on type {nullableEnumType}."));
             }

--- a/Cql/Cql.Operators/CqlOperators.StringOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.StringOperators.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Hl7.Cql.Runtime
@@ -86,7 +87,7 @@ namespace Hl7.Cql.Runtime
             if (argument == null)
                 return null;
             else
-                return argument.ToLower();
+                return argument.ToLower(culture: CultureInfo.InvariantCulture);
         }
 
         #endregion
@@ -178,7 +179,7 @@ namespace Hl7.Cql.Runtime
         public string? Upper(string argument)
         {
             if (argument == null) return null;
-            else return argument.ToUpper();
+            else return argument.ToUpper(CultureInfo.InvariantCulture);
         }
         #endregion
     }

--- a/Cql/Cql.Operators/CqlOperators.TypeOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.TypeOperators.cs
@@ -64,7 +64,7 @@ namespace Hl7.Cql.Runtime
         public int? ConvertBooleanToInteger(bool? b) => b == null ? null : (b.Value ? 1 : 0);
         public long? ConvertBooleanToLong(bool? b) => b == null ? null : (b.Value ? 1 : 0);
         public decimal? ConvertBooleanToDecimal(bool? b) => b == null ? null : (b.Value ? 1m : 0m);
-        public string? ConvertBooleanToString(bool? b) => b?.ToString()?.ToLower();
+        public string? ConvertBooleanToString(bool? b) => b?.ToString()?.ToLower(CultureInfo.InvariantCulture);
 
 
         public bool? ConvertIntegerToBoolean(int? i) => i == null ? null : (i.Value == 1 ? true : false);
@@ -92,7 +92,7 @@ namespace Hl7.Cql.Runtime
             if (s == null) return null;
             else
             {
-                switch (s.ToLower())
+                switch (s.ToLower(CultureInfo.InvariantCulture))
                 {
                     case "true":
                     case "t":

--- a/Cql/Cql.Runtime/DefinitionDictionaryExtensions.cs
+++ b/Cql/Cql.Runtime/DefinitionDictionaryExtensions.cs
@@ -44,7 +44,7 @@ namespace Hl7.Cql.Runtime
                         {
                             foreach (var visitor in visitors)
                             {
-                                lambda = visitor.Visit(lambda) as LambdaExpression;
+                                lambda = (LambdaExpression)visitor.Visit(lambda);
                             }
                         }
                         var @delegate = debug is not null ? lambda.Compile(debug) : lambda.Compile();


### PR DESCRIPTION
We haven't robustly tested the use case in #129 which requires round-tripping our conversions from FHIR model through CQL model back to FHIR model, which occurs when you attempt to create a FHIR resource in CQL, as is the case in the issue.

This PR:

- Adds conversions from `Code<T>` to `T?`
  - There may be a better way to do this
- Adds some FHIR type-to-string conversions
