### PR TITLE
feat: add elm library extensions

### DIFF
--- a/Cql/CoreTests/CoreTests.csproj
+++ b/Cql/CoreTests/CoreTests.csproj
@@ -37,6 +37,7 @@
 		<ProjectReference Include="..\Cql.Compiler\Cql.Compiler.csproj" />
 		<ProjectReference Include="..\Cql.Firely\Cql.Firely.csproj" />
 		<ProjectReference Include="..\Cql.Model\Cql.Model.csproj" />
+		<ProjectReference Include="..\Cql.Packaging\Cql.Packaging.csproj" />
 		<ProjectReference Include="..\Cql.Runtime\Cql.Runtime.csproj" />
 		<ProjectReference Include="..\ELM\ELM.csproj" />
 		<ProjectReference Include="..\Iso8601\Iso8601.csproj" />

--- a/Cql/CoreTests/CqlTypeToFhirTypeMapperTest.cs
+++ b/Cql/CoreTests/CqlTypeToFhirTypeMapperTest.cs
@@ -1,0 +1,65 @@
+﻿using Hl7.Cql.Fhir;
+using Hl7.Cql.Packaging;
+using Hl7.Cql.Primitives;
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests
+{
+    [TestClass]
+    [TestCategory("UnitTest")]
+    public class CqlTypeToFhirTypeMapperTest
+    {
+        #region Cql to FHIR
+        
+        [TestMethod]
+        public void CqlDate_MapToFhirType()
+        {
+            var cqlType = typeof(CqlDate);
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(cqlType);
+            Assert.IsNotNull(typeEntry, $"Unable to express {cqlType} as a FHIR type");
+            Assert.AreEqual(FHIRAllTypes.Date, typeEntry.FhirType.Value);
+        }
+
+        [TestMethod]
+        public void CqlIntervalOfDate_MapToFhirType()
+        {
+            var cqlType = typeof(CqlInterval<CqlDate>);
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(cqlType);
+            Assert.IsNotNull(typeEntry, $"Unable to express {cqlType} as a FHIR type");
+            Assert.AreEqual(FHIRAllTypes.Period, typeEntry.FhirType.Value);
+            Assert.AreEqual(FHIRAllTypes.Date, typeEntry.ElementType.FhirType.Value);
+        }
+
+        [TestMethod]
+        public void Claim_MapToFhirType()
+        {
+            var cqlType = typeof(Hl7.Fhir.Model.Claim);
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(cqlType);
+            Assert.IsNotNull(typeEntry, $"Unable to express {cqlType} as a FHIR type");
+            Assert.AreEqual(FHIRAllTypes.Claim, typeEntry.FhirType.Value);
+        }
+
+        #endregion
+
+
+        #region FHIR to CQL
+        [TestMethod]
+        public void FHIRDateTime_MapToCqlType()
+        {
+            var fhirType = typeof(FhirDateTime);
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(fhirType);
+            Assert.IsNotNull(typeEntry, $"Unable to express {fhirType} as a CQL type");
+            Assert.AreEqual(CqlPrimitiveType.DateTime, typeEntry.CqlType.Value);
+        }
+        #endregion
+    }
+}

--- a/Cql/Cql.Packaging/Constants.cs
+++ b/Cql/Cql.Packaging/Constants.cs
@@ -10,13 +10,7 @@ namespace Hl7.Cql.Packaging
 {
     internal static class Constants
     {
-        public const string MeasureGroupCodeSystem = "https://ncqa.org/fhir/CodeSystem/measure-group";
         public const string ParameterElementTypeExtensionUri = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.list-element-type";
-        public const string ParameterCanonicalUri = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.canonical-uri";
         public const string ParameterAccessLevel = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.access-level";
-        public const string ParameterCqlType = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-type";
-        public const string ParameterCqlElementType = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-element-type";
-        public const string ParameterCqlDefaultValue = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-default-value";
-        public const string ParameterCqlDefaultValueType = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.cql-default-type";
     }
 }

--- a/Cql/Cql.Packaging/ElmLibraryExtensions.cs
+++ b/Cql/Cql.Packaging/ElmLibraryExtensions.cs
@@ -1,0 +1,36 @@
+﻿using Hl7.Cql.Compiler;
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Runtime;
+using Hl7.Fhir.Model;
+using Microsoft.Extensions.Logging;
+using Library = Hl7.Cql.Elm.Library;
+
+namespace Hl7.Cql.Packaging
+{
+    /// <summary>
+    /// Helpers for ELM Libraries
+    /// </summary>
+    public static class ElmLibraryExtensions
+    {
+        /// <summary>
+        /// Evaluate the given expression for the given library and context
+        /// </summary>
+        /// <param name="library">the library</param>
+        /// <param name="expression">the expression to evaluate</param>
+        /// <param name="context">the context of the expression evaluation</param>
+        /// <param name="logFactory">logger</param>
+        /// <returns>the result of the expression</returns>
+        public static object? EvaluateExpression(this Library library, Elm.Expression expression, CqlContext context, ILoggerFactory logFactory)
+        {
+            var builderLogger = logFactory.CreateLogger<ExpressionBuilder>();
+            var typeResolver = new FhirTypeResolver(ModelInfo.ModelInspector);
+            var builder = new ExpressionBuilder(
+                new CqlOperatorsBinding(typeResolver, FhirTypeConverter.Create(ModelInfo.ModelInspector)),
+                new TypeManager(typeResolver),
+                library!, builderLogger, new(false));
+            var lambda = builder.Lambda(expression);
+            var func = lambda.Compile();
+            return func.DynamicInvoke(context);
+        }
+    }
+}

--- a/Cql/Cql.Packaging/LibraryPackager.cs
+++ b/Cql/Cql.Packaging/LibraryPackager.cs
@@ -190,7 +190,7 @@ namespace Hl7.Cql.Packaging
                 if (!assemblies.TryGetValue(library.NameAndVersion, out var assembly))
                     throw new InvalidOperationException($"No assembly for {library.NameAndVersion}");
                 var builder = new ExpressionBuilder(operatorBinding, typeManager, library, builderLogger, new(false));
-                var fhirLibrary = createLibraryResource(elmFile, cqlFile, assembly, typeCrosswalk, builder, canon, library);
+                var fhirLibrary = createLibraryResource(elmFile, cqlFile, assembly, typeCrosswalk, canon, library);
                 libraries.Add(library.NameAndVersion, fhirLibrary);
             }
 
@@ -279,7 +279,6 @@ namespace Hl7.Cql.Packaging
             FileInfo? cqlFile,
             AssemblyData assembly,
             CqlTypeToFhirTypeMapper typeCrosswalk,
-            ExpressionBuilder builder,
             Func<Resource, string> canon,
             elm.Library? elmLibrary = null)
         {

--- a/Cql/Cql.Packaging/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Packaging/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ Hl7.Cql.Packaging.CqlTypeToFhirTypeMapper.TypeEntryFor(Hl7.Cql.Primitives.CqlPri
 Hl7.Cql.Packaging.CqlTypeToFhirTypeMapper.TypeEntryFor(Hl7.Fhir.Model.FHIRAllTypes fhirType) -> Hl7.Cql.Packaging.CqlTypeToFhirMapping?
 Hl7.Cql.Packaging.CqlTypeToFhirTypeMapper.TypeEntryFor(string? name) -> Hl7.Cql.Packaging.CqlTypeToFhirMapping?
 Hl7.Cql.Packaging.CqlTypeToFhirTypeMapper.TypeEntryFor(System.Type! type) -> Hl7.Cql.Packaging.CqlTypeToFhirMapping?
+Hl7.Cql.Packaging.ElmLibraryExtensions
 Hl7.Cql.Packaging.LibraryPackager
 Hl7.Cql.Packaging.CqlTypeToFhirMapping
 Hl7.Cql.Packaging.CqlTypeToFhirMapping.CqlType.get -> Hl7.Cql.Primitives.CqlPrimitiveType?
@@ -39,6 +40,7 @@ override Hl7.Cql.Packaging.CqlTypeToFhirMapping.Equals(object? obj) -> bool
 override Hl7.Cql.Packaging.ResourceWriters.CSharpResourceWriter.WriteResources(System.Collections.Generic.IEnumerable<Hl7.Fhir.Model.Resource!>! resources) -> void
 override Hl7.Cql.Packaging.ResourceWriters.FhirResourceWriter.WriteResources(System.Collections.Generic.IEnumerable<Hl7.Fhir.Model.Resource!>! resources) -> void
 static Hl7.Cql.Packaging.AssemblyLoadContextExtensions.Run(this System.Runtime.Loader.AssemblyLoadContext! assemblyContext, string! library, string! version, Hl7.Cql.Runtime.CqlContext! ctx) -> System.Collections.Generic.IDictionary<string!, object?>!
+static Hl7.Cql.Packaging.ElmLibraryExtensions.EvaluateExpression(this Hl7.Cql.Elm.Library! library, Hl7.Cql.Elm.Expression! expression, Hl7.Cql.Runtime.CqlContext! context, Microsoft.Extensions.Logging.ILoggerFactory! logFactory) -> object?
 static Hl7.Cql.Packaging.LibraryPackager.LoadElm(System.IO.DirectoryInfo! elmDirectory, string! lib, string! version, Microsoft.Extensions.Logging.ILoggerFactory! logFactory) -> System.Runtime.Loader.AssemblyLoadContext!
 static Hl7.Cql.Packaging.LibraryPackager.LoadElm(System.IO.DirectoryInfo! elmDirectory, string! lib, string! version, Microsoft.Extensions.Logging.LogLevel logLevel = Microsoft.Extensions.Logging.LogLevel.Error) -> System.Runtime.Loader.AssemblyLoadContext!
 static Hl7.Cql.Packaging.LibraryPackager.LoadLibraries(System.IO.DirectoryInfo! elmDir) -> System.Collections.Generic.IDictionary<string!, Hl7.Cql.Elm.Library!>!

--- a/Cql/Elm/Library.cs
+++ b/Cql/Elm/Library.cs
@@ -30,6 +30,26 @@ namespace Hl7.Cql.Elm
             }
         }
 
+        public string? Name
+        {
+            get
+            {
+                if (identifier == null)
+                    return null;
+                return identifier.id;
+            }
+        }
+
+        public string? Version
+        {
+            get
+            {
+                if (identifier == null)
+                    return null;
+                return identifier.version;
+            }
+        }
+
         private static JsonSerializerOptions GetSerializerOptions(bool strict)
         {
             var options = new JsonSerializerOptions()
@@ -53,6 +73,22 @@ namespace Hl7.Cql.Elm
         public static Library LoadFromJson(Stream stream) =>
             JsonSerializer.Deserialize<Library>(stream, JsonSerializerOptions) ??
                 throw new ArgumentException($"Stream does not represent a valid {nameof(Library)}");
+
+        /// <summary>
+        /// Get a flat list of ELM libraries included in the set of libraries passed in. 
+        /// </summary>
+        /// <param name="libraries">top-level libraries</param>
+        /// <returns>flat list of all included libraries</returns>
+        public static IEnumerable<Library> GetIncludedElmLibraries(IEnumerable<Library> libraries)
+        {
+            var packageGraph = GetIncludedLibraries(libraries);
+            var elmLibraries = packageGraph.Nodes.Values
+                .Select(node => node.Properties?[LibraryNodeProperty] as Library)
+                .Where(p => p is not null)
+                .Select(p => p!)
+                .ToArray();
+            return elmLibraries;
+        }
 
         internal static DirectedGraph GetIncludedLibraries(IEnumerable<Library> libraries)
         {

--- a/Cql/Elm/PublicAPI.Unshipped.txt
+++ b/Cql/Elm/PublicAPI.Unshipped.txt
@@ -359,7 +359,9 @@ Hl7.Cql.Elm.LetClause
 Hl7.Cql.Elm.LetClause.LetClause() -> void
 Hl7.Cql.Elm.Library
 Hl7.Cql.Elm.Library.Library() -> void
+Hl7.Cql.Elm.Library.Name.get -> string?
 Hl7.Cql.Elm.Library.NameAndVersion.get -> string?
+Hl7.Cql.Elm.Library.Version.get -> string?
 Hl7.Cql.Elm.List
 Hl7.Cql.Elm.List.List() -> void
 Hl7.Cql.Elm.ListTypeSpecifier
@@ -711,6 +713,7 @@ Hl7.Cql.Elm.Xor
 Hl7.Cql.Elm.Xor.Xor() -> void
 static Hl7.Cql.Elm.ExtensionMethods.ListSortOrder(this Hl7.Cql.Elm.SortDirection direction) -> System.ComponentModel.ListSortDirection
 static Hl7.Cql.Elm.ExtensionMethods.NameAndVersion(this Hl7.Cql.Elm.IncludeDef! include) -> string?
+static Hl7.Cql.Elm.Library.GetIncludedElmLibraries(System.Collections.Generic.IEnumerable<Hl7.Cql.Elm.Library!>! libraries) -> System.Collections.Generic.IEnumerable<Hl7.Cql.Elm.Library!>!
 static Hl7.Cql.Elm.Library.LoadFromJson(System.IO.FileInfo! file) -> Hl7.Cql.Elm.Library!
 static Hl7.Cql.Elm.Library.LoadFromJson(System.IO.Stream! stream) -> Hl7.Cql.Elm.Library!
 static readonly Hl7.Cql.Elm.Library.JsonSerializerOptions -> System.Text.Json.JsonSerializerOptions!


### PR DESCRIPTION
At NCQA, we are extending the packager logic to add our use case-specific extensions to the FHIR resource. We are utilizing the existing extensibility point of the ResourcePackager to do so. One of these extensions is the default value of a CQL input parameter, which comes in the ELM classes as an Expression class. We need a method to evaluate the value of this expression. Rather than exposing the method on ExpressionBuilder publicly, I've added a new extension method for Elm.Library to evaluate an expression for that library. 

Additionally, I've added some unit tests and removed some NCQA specific constant values. 