### PR TITLE
fix:  CqlTypeToFhirTypeMapper bug fixes + tests

### DIFF
--- a/Cql/CoreTests/CqlTypeToFhirTypeMapperTest.cs
+++ b/Cql/CoreTests/CqlTypeToFhirTypeMapperTest.cs
@@ -3,6 +3,8 @@ using Hl7.Cql.Packaging;
 using Hl7.Cql.Primitives;
 using Hl7.Fhir.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace CoreTests
 {
@@ -44,6 +46,56 @@ namespace CoreTests
             var typeEntry = crosswalk.TypeEntryFor(cqlType);
             Assert.IsNotNull(typeEntry, $"Unable to express {cqlType} as a FHIR type");
             Assert.AreEqual(FHIRAllTypes.Claim, typeEntry.FhirType.Value);
+        }
+
+
+        [TestMethod]
+        public void String_MapToFhirType()
+        {
+            var cqlType = typeof(string);
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(cqlType);
+            Assert.IsNotNull(typeEntry, $"Unable to express {cqlType} as a FHIR type");
+            Assert.AreEqual(FHIRAllTypes.String, typeEntry.FhirType.Value);
+        }
+
+        [TestMethod]
+        public void Decimal_MapToFhirType()
+        {
+            var cqlType = typeof(decimal);
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(cqlType);
+            Assert.IsNotNull(typeEntry, $"Unable to express {cqlType} as a FHIR type");
+            Assert.AreEqual(FHIRAllTypes.Decimal, typeEntry.FhirType.Value);
+        }
+
+
+
+        [TestMethod]
+        public void Boolean_MapToFhirType()
+        {
+            var cqlType = typeof(bool);
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(cqlType);
+            Assert.IsNotNull(typeEntry, $"Unable to express {cqlType} as a FHIR type");
+            Assert.AreEqual(FHIRAllTypes.Boolean, typeEntry.FhirType.Value);
+        }
+        
+        [TestMethod]
+        public void LINQResult_MapToFhirType()
+        {
+            var list = new List<object> { new Claim() { Id = "claim1" } };
+
+            var linqResult = list.Cast<Claim>();
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(linqResult.GetType());
+            Assert.IsNotNull(typeEntry, $"Unable to express {linqResult.GetType()} as a FHIR type");
+            Assert.AreEqual(FHIRAllTypes.List, typeEntry.FhirType.Value);
+            Assert.AreEqual(FHIRAllTypes.Claim, typeEntry.ElementType.FhirType);
         }
 
         #endregion

--- a/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
+++ b/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
@@ -196,6 +196,14 @@ namespace Hl7.Cql.Packaging
         /// <returns>the Type mapping, or null</returns>
         public CqlTypeToFhirMapping? TypeEntryFor(Type type)
         {
+            if (type.IsPrimitive || type.IsValueType || type == typeof(string))
+            {
+                var fhirType = PrimitiveToFhir(type);
+                if (fhirType == null) return null;
+
+                return TypeEntryFor(fhirType.Value);
+            }
+
             var fhirTypeName = ModelInspector.GetFhirTypeNameForType(type);
             if (fhirTypeName is not null)
             {
@@ -226,17 +234,12 @@ namespace Hl7.Cql.Packaging
             if (IsOrImplementsIEnumerableOfT(type))
             {
                 var elementType = TypeResolver.GetListElementType(type);
+                if (elementType is null)
+                    return null;
                 var elementEntry = TypeEntryFor(elementType!);
                 if (elementEntry is null)
                     return null;
                 return TypeEntryFor(CqlPrimitiveType.List, elementEntry);
-            }
-            if (type.IsPrimitive || type.IsValueType || type == typeof(string))
-            {
-                var fhirType = PrimitiveToFhir(type);
-                if (fhirType == null) return null;
-
-                return TypeEntryFor(fhirType.Value);
             }
 
             return null;

--- a/Cql/Cql.Runtime/BaseTypeResolver.cs
+++ b/Cql/Cql.Runtime/BaseTypeResolver.cs
@@ -144,11 +144,11 @@ namespace Hl7.Cql.Runtime
             if (type.IsGenericType)
             {
                 var genericTypeDefinition = type.GetGenericTypeDefinition();
-                if (genericTypeDefinition == typeof(IEnumerable<>))
-                    return type.GetGenericArguments()[0];
-                else if (genericTypeDefinition == typeof(List<>))
-                    return type.GetGenericArguments()[0];
-                else if (genericTypeDefinition == typeof(ICollection<>))
+                if (genericTypeDefinition == typeof(IEnumerable<>) 
+                     || genericTypeDefinition == typeof(List<>) 
+                     || genericTypeDefinition == typeof(ICollection<>)
+                     || genericTypeDefinition.GetInterfaces().Contains(typeof(System.Collections.IEnumerable)) //Handle LINQ Iterator types
+                ) 
                     return type.GetGenericArguments()[0];
                 else if (@throw) throw new NotSupportedException();
                 else return null;

--- a/Cql/Cql.Runtime/BaseTypeResolver.cs
+++ b/Cql/Cql.Runtime/BaseTypeResolver.cs
@@ -150,8 +150,9 @@ namespace Hl7.Cql.Runtime
                 ) 
                     return type.GetGenericArguments()[0];
 
-                //Handle LINQ Iterator types
+                // handle LINQ cast iterators, where iterators, selects, etc.
                 if (genericTypeDefinition.GetInterfaces().Contains(typeof(System.Collections.IEnumerable)) 
+                    && genericTypeDefinition.Namespace == "System.Linq"
                     && type.GenericTypeArguments.Length == 1)
                     return type.GetGenericArguments()[0];
 

--- a/Cql/Cql.Runtime/BaseTypeResolver.cs
+++ b/Cql/Cql.Runtime/BaseTypeResolver.cs
@@ -147,9 +147,14 @@ namespace Hl7.Cql.Runtime
                 if (genericTypeDefinition == typeof(IEnumerable<>) 
                      || genericTypeDefinition == typeof(List<>) 
                      || genericTypeDefinition == typeof(ICollection<>)
-                     || genericTypeDefinition.GetInterfaces().Contains(typeof(System.Collections.IEnumerable)) //Handle LINQ Iterator types
                 ) 
                     return type.GetGenericArguments()[0];
+
+                //Handle LINQ Iterator types
+                if (genericTypeDefinition.GetInterfaces().Contains(typeof(System.Collections.IEnumerable)) 
+                    && type.GenericTypeArguments.Length == 1)
+                    return type.GetGenericArguments()[0];
+
                 else if (@throw) throw new NotSupportedException();
                 else return null;
             }


### PR DESCRIPTION
2 bugs were identified inside of the CQL -> FHIR type mapper logic.

1) String type was being returned from the TypeResolver as "Net.System.String" which the mapper logic was unable to handle. We had some logic to handle primitive types further down, so I moved it up to handle this case properly.
2) LINQ Result expressions, list CastIterator, etc. were not being handled correctly since they do not implement IEnumerable<T>, List<T>, etc. I added some logic to handle these by checking if the type implements the non-generic IEnumerable interface.  

Added some covering unit tests for these use cases.