### PR TITLE
Fix interval mapping for integer type

### DIFF
--- a/Cql/CoreTests/CqlTypeToFhirTypeMapperTest.cs
+++ b/Cql/CoreTests/CqlTypeToFhirTypeMapperTest.cs
@@ -54,6 +54,30 @@ namespace CoreTests
         }
 
         [TestMethod]
+        public void CqlIntervalOfInt_MapToFhirType()
+        {
+            var cqlType = typeof(CqlInterval<int>);
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(cqlType);
+            Assert.IsNotNull(typeEntry, $"Unable to express {cqlType} as a FHIR type");
+            Assert.AreEqual(FHIRAllTypes.Range, typeEntry.FhirType.Value);
+            Assert.AreEqual(FHIRAllTypes.Integer, typeEntry.ElementType.FhirType.Value);
+        }
+
+        [TestMethod]
+        public void CqlIntervalOfDecimal_MapToFhirType()
+        {
+            var cqlType = typeof(CqlInterval<decimal>);
+
+            var crosswalk = new CqlTypeToFhirTypeMapper(FhirTypeResolver.Default);
+            var typeEntry = crosswalk.TypeEntryFor(cqlType);
+            Assert.IsNotNull(typeEntry, $"Unable to express {cqlType} as a FHIR type");
+            Assert.AreEqual(FHIRAllTypes.Range, typeEntry.FhirType.Value);
+            Assert.AreEqual(FHIRAllTypes.Decimal, typeEntry.ElementType.FhirType.Value);
+        }
+
+        [TestMethod]
         public void Claim_MapToFhirType()
         {
             var cqlType = typeof(Hl7.Fhir.Model.Claim);

--- a/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
+++ b/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
@@ -149,7 +149,7 @@ namespace Hl7.Cql.Packaging
                         case CqlPrimitiveType.Decimal:
                             return new CqlTypeToFhirMapping(FHIRAllTypes.Range, cqlType, TypeEntryFor(FHIRAllTypes.Decimal));
                         case CqlPrimitiveType.Integer:
-                            return new CqlTypeToFhirMapping(FHIRAllTypes.Range, cqlType, TypeEntryFor(FHIRAllTypes.Decimal));
+                            return new CqlTypeToFhirMapping(FHIRAllTypes.Range, cqlType, TypeEntryFor(FHIRAllTypes.Integer));
                         case CqlPrimitiveType.Quantity:
                             return new CqlTypeToFhirMapping(FHIRAllTypes.Range, cqlType, TypeEntryFor(FHIRAllTypes.Quantity));
                         case CqlPrimitiveType.Ratio:


### PR DESCRIPTION
We found an issue during our testing around parameters being defined as Interval<int> but returning Interval<decimal>, which causes downstream casting exceptions. The error exists in the Cql mapper logic and appears to have just been a copy/paste error. 

Fixed the issue and added covering unit tests.