### PR TITLE
Fix for 'year' case of WholeCalendarPeriodsBetween()

### DIFF
--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -216,6 +216,12 @@ namespace CoreTests
             Assert.IsTrue(CqlDateTime.TryParse("2021-06-30", out cqlStartDate));
             boundariesBetween = new CqlDateTime(startDate).WholeCalendarPeriodsBetween(cqlStartDate, "year");
             Assert.AreEqual(1, boundariesBetween);
+
+            Assert.IsTrue(DateTimeIso8601.TryParse("2008-04-11", out startDate));
+            Assert.IsTrue(CqlDateTime.TryParse("2024-04-10", out cqlStartDate));
+            boundariesBetween = new CqlDateTime(startDate).WholeCalendarPeriodsBetween(cqlStartDate, "year");
+            Assert.AreEqual(15, boundariesBetween);
+
         }
 
         [TestMethod]

--- a/Cql/Cql.Primitives/CqlDateTimeMath.cs
+++ b/Cql/Cql.Primitives/CqlDateTimeMath.cs
@@ -142,7 +142,7 @@ namespace Hl7.Cql.Primitives
                     // for leap years, this normalizes 3-1 from being day 61 back to day 60.
                     if (DateTime.IsLeapYear(firstDto.Year) && firstDayInYear > 60)
                         firstDayInYear -= 1;
-                    else if (DateTime.IsLeapYear(secondDto.Year) && secondDayInYear > 60)
+                    if (DateTime.IsLeapYear(secondDto.Year) && secondDayInYear > 60)
                         secondDayInYear -= 1;
 
                     if (yearDiff > 0 && secondDayInYear < firstDayInYear)


### PR DESCRIPTION
Removed `else` on line 145 to allow both `if` conditions to be evaluated/applied. Allows cases where 'low' and 'high' arguments are leap years.

Added corresponding unit test to Primitives. Fix for issue #158.