### PR TITLE
Allow date to be overriden in resource library's json

### DIFF
--- a/Cql/Cql.Packaging/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Packaging/PublicAPI.Unshipped.txt
@@ -47,7 +47,7 @@ Hl7.Cql.Packaging.ResourcePackager.ResourcePackager(Microsoft.Extensions.Logging
 Hl7.Cql.Packaging.ResourceWriters.CSharpResourceWriter
 Hl7.Cql.Packaging.ResourceWriters.CSharpResourceWriter.CSharpResourceWriter(System.IO.DirectoryInfo! outDirectory, Microsoft.Extensions.Logging.ILogger! logger) -> void
 Hl7.Cql.Packaging.ResourceWriters.FhirResourceWriter
-Hl7.Cql.Packaging.ResourceWriters.FhirResourceWriter.FhirResourceWriter(System.IO.DirectoryInfo! outDirectory, Microsoft.Extensions.Logging.ILogger! logger) -> void
+Hl7.Cql.Packaging.ResourceWriters.FhirResourceWriter.FhirResourceWriter(System.IO.DirectoryInfo! outDirectory, Microsoft.Extensions.Logging.ILogger! logger, System.DateTime? overrideDate = null) -> void
 Hl7.Cql.Packaging.ResourceWriters.ResourceWriter
 Hl7.Cql.Packaging.ResourceWriters.ResourceWriter.EnsureDirectory(System.IO.DirectoryInfo! directory, int timeoutMs = 5000) -> void
 Hl7.Cql.Packaging.ResourceWriters.ResourceWriter.Logger.get -> Microsoft.Extensions.Logging.ILogger!

--- a/Cql/PackagerCLI/PackageOptions.cs
+++ b/Cql/PackagerCLI/PackageOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace Hl7.Cql.Packager;
+
+#pragma warning disable CS1591
+internal record PackageOptions
+{
+    public DirectoryInfo ElmDirectory { get; init; } = null!;
+    public DirectoryInfo CqlDirectory { get; init; } = null!;
+    public DirectoryInfo? CSharpDirectory { get; init; }
+    public DirectoryInfo? FhirDirectory { get; init; }
+    public bool Debug { get; init; }
+    public bool Force { get; init; }
+    public string? CanonicalRootUrl { get; init; }
+    public DateTime? OverrideUtcDateTime { get; init; }
+
+}

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -15,7 +15,7 @@ namespace Hl7.Cql.Packager
         public static int Main(string[] args)
         {
             if (args.Length == 0 ||
-                new[] { "-?", "-h", "-help" }.Any(args.Contains))
+                new[] { "-?", "-h", "-help" }.Any(s => args.Contains(s, StringComparer.InvariantCultureIgnoreCase)))
                 return ShowHelp();
 
             var switchMappings = new SortedDictionary<string, string>
@@ -150,7 +150,8 @@ namespace Hl7.Cql.Packager
                     [--canonical-root-url] <url>    The root url used for the resource canonical. 
                                                     If omitted a '#' will be used
                     [--override-utc-date-time] <utc-date-time>
-                                                    The date time to use for the library and resource last updated. 
+                                                    The date time to use for the library and resource last updated.
+                                                    (example: 2000-12-31T23:59:59.99Z) 
                                                     If omitted the current date time will be used.
                 """);
             return -1;

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -129,7 +129,7 @@ namespace Hl7.Cql.Packager
             if (fhirDir != null) resourceWriters.Add(new FhirResourceWriter(fhirDir, cliLogger, options.OverrideUtcDateTime));
             if (csDir != null) resourceWriters.Add(new CSharpResourceWriter(csDir, cliLogger));
 
-            var resourcePackager = new ResourcePackager(logFactory, [..resourceWriters]);
+            var resourcePackager = new ResourcePackager(logFactory, resourceWriters.ToArray());
             resourcePackager.Package(new PackageArgs(elmDir, cqlDir, resourceCanonicalRootUrl: resourceCanonicalRootUrl));
         }
 
@@ -225,5 +225,10 @@ namespace Hl7.Cql.Packager
         }
     }
 
-    file class ProcessOptionsException(string message) : Exception(message);
+    file class ProcessOptionsException : Exception
+    {
+        public ProcessOptionsException(string message) : base(message)
+        {
+        }
+    }
 }

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -139,15 +139,19 @@ namespace Hl7.Cql.Packager
                 """
                 Packager CLI Usage:
                 
-                    -?|-h|-help                   Show this help
+                    -?|-h|-help                     Show this help
                 
-                    --elm    <directory>          Library root directory
-                    --cql    <directory>          CQL root directory
-                    [--fhir] <file|directory>     Resource location, either file name or directory
-                    [--cs]   <file|directory>     C# output location, either file name or directory
-                    [--d]    <true|false>         Produce as a debug assembly
-                    [--f]    <true|false>         Force an overwrite even if the output file already exists
-                    [--canonical-root-url] <url>  The root url used for the resource canonical. If omitted a '#' will be used
+                    --elm       <directory>         Library root directory
+                    --cql       <directory>         CQL root directory
+                    [--fhir]    <file|directory>    Resource location, either file name or directory
+                    [--cs]      <file|directory>    C# output location, either file name or directory
+                    [--d]       <true|false>        Produce as a debug assembly
+                    [--f]       <true|false>        Force an overwrite even if the output file already exists
+                    [--canonical-root-url] <url>    The root url used for the resource canonical. 
+                                                    If omitted a '#' will be used
+                    [--override-utc-date-time] <utc-date-time>
+                                                    The date time to use for the library and resource last updated. 
+                                                    If omitted the current date time will be used.
                 """);
             return -1;
         }

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "PackagerCLI": {
       "commandName": "Project",
-      "commandLineArgs": "--override-utc-date-time \"2024-01-01\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(ProjectDir)/../../Demo/Elm/Json\" --cql \"$(ProjectDir)/../../Demo/Cql/input\" --fhir \"$(ProjectDir)/../../Demo/Test/Resources\" --cs \"$(ProjectDir)/../../Demo/Measures\" --f true"
+      "commandLineArgs": "--override-utc-date-time \"1970-01-01\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(ProjectDir)/../../Demo/Elm/Json\" --cql \"$(ProjectDir)/../../Demo/Cql/input\" --fhir \"$(ProjectDir)/../../Demo/Test/Resources\" --cs \"$(ProjectDir)/../../Demo/Measures\" --f true"
     }
   }
 }

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "PackagerCLI": {
       "commandName": "Project",
-      "commandLineArgs": "--override-utc-date-time \"2024-01-01\" --canonical-root-url \"https://fire.ly/fhir/\" --elm $(ProjectDir)/../../Demo/Elm/Json --cql $(ProjectDir)/../../Demo/Cql/input --fhir $(ProjectDir)/../../Demo/Test/Resources --cs $(ProjectDir)/../../Demo/Measures --f true"
+      "commandLineArgs": "--override-utc-date-time \"2024-01-01\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(ProjectDir)/../../Demo/Elm/Json\" --cql \"$(ProjectDir)/../../Demo/Cql/input\" --fhir \"$(ProjectDir)/../../Demo/Test/Resources\" --cs \"$(ProjectDir)/../../Demo/Measures\" --f true"
     }
   }
 }

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "PackagerCLI": {
       "commandName": "Project",
-      "commandLineArgs": "--canonical-root-url https://fire.ly/fhir/ --elm $(ProjectDir)/../../Demo/Elm/Json --cql $(ProjectDir)/../../Demo/Cql/input --fhir $(ProjectDir)/../../Demo/Test/Resources --cs $(ProjectDir)/../../Demo/Measures --f true"
+      "commandLineArgs": "--override-utc-date-time \"2024-01-01\" --canonical-root-url \"https://fire.ly/fhir/\" --elm $(ProjectDir)/../../Demo/Elm/Json --cql $(ProjectDir)/../../Demo/Cql/input --fhir $(ProjectDir)/../../Demo/Test/Resources --cs $(ProjectDir)/../../Demo/Measures --f true"
     }
   }
 }

--- a/build/templates/build.yml
+++ b/build/templates/build.yml
@@ -3,7 +3,7 @@
 
 parameters:
   # Default values
-  dotNetCoreVersion: '3.1.102' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
+  dotNetCoreVersion: '6.x' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
   useVersionSuffix: true
   restoreDependencies: false
   nuGetServiceConnections: #required when restoreDependies = true

--- a/build/templates/build.yml
+++ b/build/templates/build.yml
@@ -3,7 +3,7 @@
 
 parameters:
   # Default values
-  dotNetCoreVersion: '8.x' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
+  dotNetCoreVersion: '6.0.x' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
   useVersionSuffix: true
   restoreDependencies: false
   nuGetServiceConnections: #required when restoreDependies = true

--- a/build/templates/build.yml
+++ b/build/templates/build.yml
@@ -3,7 +3,7 @@
 
 parameters:
   # Default values
-  dotNetCoreVersion: '6.x' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
+  dotNetCoreVersion: '8.x' # can also be use with wildcards:  latest minor version of 3. , use '3.x'
   useVersionSuffix: true
   restoreDependencies: false
   nuGetServiceConnections: #required when restoreDependies = true

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -5,6 +5,6 @@
 variables:
   buildConfiguration: 'Release'
   vmImage: 'windows-latest'
-  DOTNET_CORE_SDK: '6.x'
+  DOTNET_CORE_SDK: '8.x'
   GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey) # key is set in variable group APIKeys
   NUGET_APIKEY: $(NuGetFhirPackagesAPIKey) # key is set in variable group APIKeys

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -5,6 +5,6 @@
 variables:
   buildConfiguration: 'Release'
   vmImage: 'windows-latest'
-  DOTNET_CORE_SDK: '8.0.x'
+  DOTNET_CORE_SDK: '6.x'
   GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey) # key is set in variable group APIKeys
   NUGET_APIKEY: $(NuGetFhirPackagesAPIKey) # key is set in variable group APIKeys

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -5,6 +5,6 @@
 variables:
   buildConfiguration: 'Release'
   vmImage: 'windows-latest'
-  DOTNET_CORE_SDK: '8.x'
+  DOTNET_CORE_SDK: '6.0.x'
   GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey) # key is set in variable group APIKeys
   NUGET_APIKEY: $(NuGetFhirPackagesAPIKey) # key is set in variable group APIKeys

--- a/build/variables.yml
+++ b/build/variables.yml
@@ -5,6 +5,6 @@
 variables:
   buildConfiguration: 'Release'
   vmImage: 'windows-latest'
-  DOTNET_CORE_SDK: '7.0.x'
+  DOTNET_CORE_SDK: '8.0.x'
   GITHUB_PACKAGES_APIKEY: $(GitHubPushPackagesAPIKey) # key is set in variable group APIKeys
   NUGET_APIKEY: $(NuGetFhirPackagesAPIKey) # key is set in variable group APIKeys

--- a/cql-sdk.props
+++ b/cql-sdk.props
@@ -35,7 +35,7 @@
 	<!-- Compiler settings -->
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<LangVersion>12.0</LangVersion>
+		<LangVersion>11.0</LangVersion>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Configurations>Debug;Release;FullDebug</Configurations>
 		<AnalysisLevelGlobalization>latest-recommended</AnalysisLevelGlobalization>

--- a/cql-sdk.props
+++ b/cql-sdk.props
@@ -35,7 +35,7 @@
 	<!-- Compiler settings -->
 	<PropertyGroup>
 		<Nullable>enable</Nullable>
-		<LangVersion>11.0</LangVersion>
+		<LangVersion>12.0</LangVersion>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Configurations>Debug;Release;FullDebug</Configurations>
 		<AnalysisLevelGlobalization>latest-recommended</AnalysisLevelGlobalization>


### PR DESCRIPTION
Refer to issue #169 for details.

A new argument `--override-utc-date-time` which overrides the date used in the resource library e.g. 
![image](https://github.com/FirelyTeam/firely-cql-sdk/assets/4639799/48e95d44-d04f-44a5-9f1b-4219aa49e331)
