### PR TITLE
Fix Cannot convert ObservationStatus? to Hl7.Fhir.Model.Code<T>

### DIFF
--- a/Cql/Cql.Firely/FhirTypeConverter.cs
+++ b/Cql/Cql.Firely/FhirTypeConverter.cs
@@ -314,10 +314,12 @@ namespace Hl7.Cql.Fhir
                 converter.AddConversion(codeType, typeof(CqlCode), (code) =>
                 {
                     var systemAndCode = (ISystemAndCode)code;
-                    return new CqlCode(systemAndCode.Code, systemAndCode.System, null, null);
+                    return new CqlCode(systemAndCode.Code, systemAndCode.System);
                 });
                 converter.AddConversion(codeType, nullableEnumType, (code) => 
                     code.GetType().GetProperty("ObjectValue")!.GetValue(code)!);
+                converter.AddConversion(enumType, codeType, enumValue => Activator.CreateInstance(codeType, enumValue)!);
+                converter.AddConversion(nullableEnumType, codeType, enumValue => Activator.CreateInstance(codeType, enumValue)!);
 
                 converter.AddConversion(codeType, typeof(string), (code) =>
                 {


### PR DESCRIPTION
Added conversion from an enum (and enum?) to the Code<T> POCO.

Fixes #147.
Re-issue of #156, which I pulled to the wrong (dead) branch.