### PR TITLE
1.1/166 generate c output files on the fly 2

### DIFF
--- a/Cql/Cql.Packaging/LibraryPackager.cs
+++ b/Cql/Cql.Packaging/LibraryPackager.cs
@@ -47,12 +47,12 @@ internal class LibraryPackager
         ExceptionDispatchInfo? exception = null;
         foreach (var (library, e) in GetSortedBuildElmLibraries(packageGraph))
         {
-            if (e is not null)
-            {
-                exception = e;
-                break;
-            }
-            elmLibraries.Add(library);
+            foreach (var library in GetSortedBuildElmLibraries(packageGraph))
+                elmLibraries.Add(library);
+        }
+        catch (Exception e)
+        {
+            ExceptionDispatchInfo.Capture(e);
         }
 
         var resources = new List<Resource>();
@@ -425,14 +425,14 @@ internal class LibraryPackager
         var allLibs = dependencies.AllLibraries();
         var asmContext = new AssemblyLoadContext($"{lib}-{version}");
         allLibs.LoadAssemblies(asmContext);
-        
+
         var tupleTypes = new FileInfo(Path.Combine(dir.FullName, "TupleTypes-Binary.json"));
         using var tupleFs = tupleTypes.OpenRead();
         var binaries = new[]
         {
                 tupleFs.ParseFhir<Binary>()
             };
-        
+
         binaries.LoadAssembles(asmContext);
         return asmContext;
     }

--- a/Cql/Cql.Packaging/LibraryPackager.cs
+++ b/Cql/Cql.Packaging/LibraryPackager.cs
@@ -45,7 +45,7 @@ internal class LibraryPackager
 
         List<Elm.Library> elmLibraries = new();
         ExceptionDispatchInfo? exception = null;
-        foreach (var (library, e) in GetSortedBuildElmLibraries(packageGraph))
+        try
         {
             foreach (var library in GetSortedBuildElmLibraries(packageGraph))
                 elmLibraries.Add(library);
@@ -174,7 +174,7 @@ internal class LibraryPackager
         return resources;
     }
 
-    private IEnumerable<(Elm.Library library, ExceptionDispatchInfo? exception)> GetSortedBuildElmLibraries(DirectedGraph packageGraph)
+    private IEnumerable<Elm.Library> GetSortedBuildElmLibraries(DirectedGraph packageGraph)
     {
         var elmLibraries =
             packageGraph
@@ -183,21 +183,21 @@ internal class LibraryPackager
                 .OfType<Elm.Library>()
                 .ToArray();
 
-        ExceptionDispatchInfo? exceptionDispatchInfo = null;
+        int i = 0;
         foreach (var library in elmLibraries)
         {
+            ++i;
             try
             {
-                _expressionBuilderService.BuildLibraryDefinitions(library!);
+                _expressionBuilderService.BuildLibraryDefinitions(library);
             }
             catch (Exception e)
             {
-                exceptionDispatchInfo = ExceptionDispatchInfo.Capture(e);
+                throw new InvalidOperationException(
+                    $"Failed building library {i} of {elmLibraries.Length} '{library.NameAndVersion}'. See InnerException for more details.",
+                    e);
             }
-            yield return (library, exceptionDispatchInfo);
-
-            if (exceptionDispatchInfo is not null)
-                break;
+            yield return library;
         }
     }
 


### PR DESCRIPTION
Related to #166

Moved the capturing of the ExceptionDispatchInfo closer, by putting it in the same method as where it is rethrown. This simplifies the GetSortedBuildElmLibraries method