### PR TITLE
Fix remaining errors

### DIFF
--- a/Cql/Cql.Compiler/ExpressionBuilder.TypeFor.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.TypeFor.cs
@@ -63,7 +63,7 @@ internal partial class ExpressionBuilder
             {
                 Type? sourceType = null;
                 if (propertyExpression.source != null)
-                    sourceType = TypeFor(propertyExpression.source!);
+                    sourceType = TypeFor(propertyExpression.source!, throwIfNotFound);
                 else if (propertyExpression.scope != null)
                 {
                     var scope = GetScope(propertyExpression.scope);

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -1030,7 +1030,16 @@ namespace Hl7.Cql.Compiler
                     }
                     else
                     {
-                        var expectedType = TypeFor(op)!;
+                        var expectedType = TypeFor(op, throwIfNotFound: false);
+                        
+                        // If we cannot determine the type from the ELM, let's try
+                        // if the POCO model can help us.
+                        if(expectedType == null)
+                        {
+                            expectedType = _typeManager.Resolver.GetProperty(source.Type, path)?.PropertyType
+                                ?? throw this.NewExpressionBuildingException("Cannot resolve type for expression");
+                        }
+                        
                         var result = PropertyHelper(source, path, expectedType);
                         return result;
                     }

--- a/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
+++ b/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
@@ -126,9 +126,28 @@ internal class CqlToResourcePackagingPipeline
     {
         string[] hardcodedSkipFiles = [
             
-            // Contains a union between incompatible tuples,
+            // These contain a union between incompatible tuples,
             // see https://chat.fhir.org/#narrow/stream/179220-cql/topic/Union.20of.20tuples.20with.20convertible.20types
             "AntithromboticTherapyByEndofHospitalDay2FHIR.json",
+            "IntensiveCareUnitVenousThromboembolismProphylaxisFHIR.json",
+            "VenousThromboembolismProphylaxisFHIR.json",
+            
+            // These uses choice types, move into a property on such a choice, and then calls an
+            // overloaded function, so we cannot find out which overload to call.
+            // A solution is to either a) Introduce choice types in our system instead of object, 
+            // b) introduce runtime resolution, based on the runtime types of the arguments when one of
+            // the arguments is a choice (=object).
+            "InitiationandEngagementofSubstanceUseDisorderTreatmentFHIR.json",
+            "PCSBMIScreenAndFollowUpFHIR.json",
+            
+            // This uses a multi-source query where one of the sources is a singleton,
+            // we still need to work on this issue - see https://github.com/FirelyTeam/firely-cql-sdk/issues/220
+            "UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR.json",
+            
+            // These files produce incorrect C#. Have not looked into it yet.
+            "CesareanBirthFHIR.json",
+            "HybridHospitalWideMortalityFHIR.json",
+            "HybridHospitalWideReadmissionFHIR.json",
         ];
         
         LibrarySet librarySet = new(_options.ElmDirectory.FullName);

--- a/Cql/Cql.Runtime/BaseTypeResolver.cs
+++ b/Cql/Cql.Runtime/BaseTypeResolver.cs
@@ -134,6 +134,7 @@ namespace Hl7.Cql.Runtime
             typeSpecifier switch
             {
                 "{http://hl7.org/fhir}NotDoneRecorded" => "{http://hl7.org/fhir}dateTime",
+                "{http://hl7.org/fhir}EncounterProcedureExtension" => "{http://hl7.org/fhir}Extension",
                 _ => typeSpecifier
             };
 

--- a/Demo/Measures-cms/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
+++ b/Demo/Measures-cms/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
@@ -1,0 +1,1596 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("AppropriateDXAScansForWomenUnder65FHIR", "0.0.000")]
+public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Amenorrhea;
+    internal Lazy<CqlValueSet> __Ankylosing_Spondylitis;
+    internal Lazy<CqlValueSet> __Aromatase_Inhibitors;
+    internal Lazy<CqlValueSet> __Bilateral_Oophorectomy;
+    internal Lazy<CqlValueSet> __Bone_Marrow_Transplant;
+    internal Lazy<CqlValueSet> __Chemotherapy;
+    internal Lazy<CqlValueSet> __Chronic_Liver_Disease;
+    internal Lazy<CqlValueSet> __Chronic_Malnutrition;
+    internal Lazy<CqlValueSet> __Cushings_Syndrome;
+    internal Lazy<CqlValueSet> __DXA__Dual_energy_Xray_Absorptiometry__Scan;
+    internal Lazy<CqlValueSet> __Eating_Disorders;
+    internal Lazy<CqlValueSet> __Ehlers_Danlos_Syndrome;
+    internal Lazy<CqlValueSet> __End_Stage_Renal_Disease;
+    internal Lazy<CqlValueSet> __Evidence_of_Bilateral_Oophorectomy;
+    internal Lazy<CqlValueSet> __Gastric_Bypass_Surgery;
+    internal Lazy<CqlValueSet> __Glucocorticoids__oral_only_;
+    internal Lazy<CqlValueSet> __History_of_hip_fracture_in_parent;
+    internal Lazy<CqlValueSet> __Hyperparathyroidism;
+    internal Lazy<CqlValueSet> __Hyperthyroidism;
+    internal Lazy<CqlValueSet> __Kidney_Transplant;
+    internal Lazy<CqlValueSet> __Lupus;
+    internal Lazy<CqlValueSet> __Major_Transplant;
+    internal Lazy<CqlValueSet> __Malabsorption_Syndromes;
+    internal Lazy<CqlValueSet> __Marfans_Syndrome;
+    internal Lazy<CqlValueSet> __Multiple_Myeloma;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Osteogenesis_Imperfecta;
+    internal Lazy<CqlValueSet> __Osteopenia;
+    internal Lazy<CqlValueSet> __Osteoporosis;
+    internal Lazy<CqlValueSet> __Osteoporotic_Fractures;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Premature_Menopause;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Psoriatic_Arthritis;
+    internal Lazy<CqlValueSet> __Rheumatoid_Arthritis;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Type_1_Diabetes;
+    internal Lazy<CqlValueSet> __Unilateral_Oophorectomy_Left;
+    internal Lazy<CqlValueSet> __Unilateral_Oophorectomy_Right;
+    internal Lazy<CqlValueSet> __Unilateral_Oophorectomy__Unspecified_Laterality;
+    internal Lazy<CqlCode> __Alcoholic_drinks_per_drinking_day___Reported;
+    internal Lazy<CqlCode> __Body_mass_index__BMI___Ratio_;
+    internal Lazy<CqlCode> __Female;
+    internal Lazy<CqlCode> __Left__qualifier_value_;
+    internal Lazy<CqlCode> __Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment;
+    internal Lazy<CqlCode> __Osteoporosis_Index_of_Risk_panel;
+    internal Lazy<CqlCode> __Osteoporosis_Risk_Assessment_Instrument;
+    internal Lazy<CqlCode> __Osteoporosis_Self_Assessment_Tool;
+    internal Lazy<CqlCode> __Right__qualifier_value_;
+    internal Lazy<CqlCode> __Unlisted_preventive_medicine_service;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __AdministrativeGender;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<Observation> __First_BMI_in_Measurement_Period;
+    internal Lazy<Observation> __First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2;
+    internal Lazy<Observation> __First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day;
+    internal Lazy<bool?> __Has_Risk_Factor_Active_During_the_Measurement_Period;
+    internal Lazy<bool?> __Has_Osteoporosis_Before_Measurement_Period;
+    internal Lazy<bool?> __Has_Osteopenia_Before_Measurement_Period;
+    internal Lazy<bool?> __Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period;
+    internal Lazy<IEnumerable<Observation>> __Parent_History_of_Hip_Fracture_Assessment;
+    internal Lazy<bool?> __Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period;
+    internal Lazy<int?> __Glucocorticoid_Active_Medication_Duration_in_Days;
+    internal Lazy<int?> __Glucocorticoid_Active_Medication_Days;
+    internal Lazy<bool?> __Has_90_or_More_Active_Glucocorticoid_Medication_Days;
+    internal Lazy<bool?> __Has_Double_or_Bilateral_Oophorectomy;
+    internal Lazy<bool?> __Has_Organ_Transplants;
+    internal Lazy<bool?> __Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<ServiceRequest>> __DXA_Scan_Order_During_Measurement_Period;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<IEnumerable<Observation>> __Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan;
+    internal Lazy<bool?> __Numerator_Exclusion;
+
+    #endregion
+    public AppropriateDXAScansForWomenUnder65FHIR_0_0_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        CumulativeMedicationDuration_4_0_000 = new CumulativeMedicationDuration_4_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+
+        __Amenorrhea = new Lazy<CqlValueSet>(this.Amenorrhea_Value);
+        __Ankylosing_Spondylitis = new Lazy<CqlValueSet>(this.Ankylosing_Spondylitis_Value);
+        __Aromatase_Inhibitors = new Lazy<CqlValueSet>(this.Aromatase_Inhibitors_Value);
+        __Bilateral_Oophorectomy = new Lazy<CqlValueSet>(this.Bilateral_Oophorectomy_Value);
+        __Bone_Marrow_Transplant = new Lazy<CqlValueSet>(this.Bone_Marrow_Transplant_Value);
+        __Chemotherapy = new Lazy<CqlValueSet>(this.Chemotherapy_Value);
+        __Chronic_Liver_Disease = new Lazy<CqlValueSet>(this.Chronic_Liver_Disease_Value);
+        __Chronic_Malnutrition = new Lazy<CqlValueSet>(this.Chronic_Malnutrition_Value);
+        __Cushings_Syndrome = new Lazy<CqlValueSet>(this.Cushings_Syndrome_Value);
+        __DXA__Dual_energy_Xray_Absorptiometry__Scan = new Lazy<CqlValueSet>(this.DXA__Dual_energy_Xray_Absorptiometry__Scan_Value);
+        __Eating_Disorders = new Lazy<CqlValueSet>(this.Eating_Disorders_Value);
+        __Ehlers_Danlos_Syndrome = new Lazy<CqlValueSet>(this.Ehlers_Danlos_Syndrome_Value);
+        __End_Stage_Renal_Disease = new Lazy<CqlValueSet>(this.End_Stage_Renal_Disease_Value);
+        __Evidence_of_Bilateral_Oophorectomy = new Lazy<CqlValueSet>(this.Evidence_of_Bilateral_Oophorectomy_Value);
+        __Gastric_Bypass_Surgery = new Lazy<CqlValueSet>(this.Gastric_Bypass_Surgery_Value);
+        __Glucocorticoids__oral_only_ = new Lazy<CqlValueSet>(this.Glucocorticoids__oral_only__Value);
+        __History_of_hip_fracture_in_parent = new Lazy<CqlValueSet>(this.History_of_hip_fracture_in_parent_Value);
+        __Hyperparathyroidism = new Lazy<CqlValueSet>(this.Hyperparathyroidism_Value);
+        __Hyperthyroidism = new Lazy<CqlValueSet>(this.Hyperthyroidism_Value);
+        __Kidney_Transplant = new Lazy<CqlValueSet>(this.Kidney_Transplant_Value);
+        __Lupus = new Lazy<CqlValueSet>(this.Lupus_Value);
+        __Major_Transplant = new Lazy<CqlValueSet>(this.Major_Transplant_Value);
+        __Malabsorption_Syndromes = new Lazy<CqlValueSet>(this.Malabsorption_Syndromes_Value);
+        __Marfans_Syndrome = new Lazy<CqlValueSet>(this.Marfans_Syndrome_Value);
+        __Multiple_Myeloma = new Lazy<CqlValueSet>(this.Multiple_Myeloma_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Osteogenesis_Imperfecta = new Lazy<CqlValueSet>(this.Osteogenesis_Imperfecta_Value);
+        __Osteopenia = new Lazy<CqlValueSet>(this.Osteopenia_Value);
+        __Osteoporosis = new Lazy<CqlValueSet>(this.Osteoporosis_Value);
+        __Osteoporotic_Fractures = new Lazy<CqlValueSet>(this.Osteoporotic_Fractures_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Premature_Menopause = new Lazy<CqlValueSet>(this.Premature_Menopause_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Psoriatic_Arthritis = new Lazy<CqlValueSet>(this.Psoriatic_Arthritis_Value);
+        __Rheumatoid_Arthritis = new Lazy<CqlValueSet>(this.Rheumatoid_Arthritis_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Type_1_Diabetes = new Lazy<CqlValueSet>(this.Type_1_Diabetes_Value);
+        __Unilateral_Oophorectomy_Left = new Lazy<CqlValueSet>(this.Unilateral_Oophorectomy_Left_Value);
+        __Unilateral_Oophorectomy_Right = new Lazy<CqlValueSet>(this.Unilateral_Oophorectomy_Right_Value);
+        __Unilateral_Oophorectomy__Unspecified_Laterality = new Lazy<CqlValueSet>(this.Unilateral_Oophorectomy__Unspecified_Laterality_Value);
+        __Alcoholic_drinks_per_drinking_day___Reported = new Lazy<CqlCode>(this.Alcoholic_drinks_per_drinking_day___Reported_Value);
+        __Body_mass_index__BMI___Ratio_ = new Lazy<CqlCode>(this.Body_mass_index__BMI___Ratio__Value);
+        __Female = new Lazy<CqlCode>(this.Female_Value);
+        __Left__qualifier_value_ = new Lazy<CqlCode>(this.Left__qualifier_value__Value);
+        __Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment = new Lazy<CqlCode>(this.Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment_Value);
+        __Osteoporosis_Index_of_Risk_panel = new Lazy<CqlCode>(this.Osteoporosis_Index_of_Risk_panel_Value);
+        __Osteoporosis_Risk_Assessment_Instrument = new Lazy<CqlCode>(this.Osteoporosis_Risk_Assessment_Instrument_Value);
+        __Osteoporosis_Self_Assessment_Tool = new Lazy<CqlCode>(this.Osteoporosis_Self_Assessment_Tool_Value);
+        __Right__qualifier_value_ = new Lazy<CqlCode>(this.Right__qualifier_value__Value);
+        __Unlisted_preventive_medicine_service = new Lazy<CqlCode>(this.Unlisted_preventive_medicine_service_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __AdministrativeGender = new Lazy<CqlCode[]>(this.AdministrativeGender_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __First_BMI_in_Measurement_Period = new Lazy<Observation>(this.First_BMI_in_Measurement_Period_Value);
+        __First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2 = new Lazy<Observation>(this.First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2_Value);
+        __First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day = new Lazy<Observation>(this.First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day_Value);
+        __Has_Risk_Factor_Active_During_the_Measurement_Period = new Lazy<bool?>(this.Has_Risk_Factor_Active_During_the_Measurement_Period_Value);
+        __Has_Osteoporosis_Before_Measurement_Period = new Lazy<bool?>(this.Has_Osteoporosis_Before_Measurement_Period_Value);
+        __Has_Osteopenia_Before_Measurement_Period = new Lazy<bool?>(this.Has_Osteopenia_Before_Measurement_Period_Value);
+        __Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period = new Lazy<bool?>(this.Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_Value);
+        __Parent_History_of_Hip_Fracture_Assessment = new Lazy<IEnumerable<Observation>>(this.Parent_History_of_Hip_Fracture_Assessment_Value);
+        __Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period = new Lazy<bool?>(this.Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period_Value);
+        __Glucocorticoid_Active_Medication_Duration_in_Days = new Lazy<int?>(this.Glucocorticoid_Active_Medication_Duration_in_Days_Value);
+        __Glucocorticoid_Active_Medication_Days = new Lazy<int?>(this.Glucocorticoid_Active_Medication_Days_Value);
+        __Has_90_or_More_Active_Glucocorticoid_Medication_Days = new Lazy<bool?>(this.Has_90_or_More_Active_Glucocorticoid_Medication_Days_Value);
+        __Has_Double_or_Bilateral_Oophorectomy = new Lazy<bool?>(this.Has_Double_or_Bilateral_Oophorectomy_Value);
+        __Has_Organ_Transplants = new Lazy<bool?>(this.Has_Organ_Transplants_Value);
+        __Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period = new Lazy<bool?>(this.Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __DXA_Scan_Order_During_Measurement_Period = new Lazy<IEnumerable<ServiceRequest>>(this.DXA_Scan_Order_During_Measurement_Period_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan = new Lazy<IEnumerable<Observation>>(this.Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan_Value);
+        __Numerator_Exclusion = new Lazy<bool?>(this.Numerator_Exclusion_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public CumulativeMedicationDuration_4_0_000 CumulativeMedicationDuration_4_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Amenorrhea_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022", null);
+
+    [CqlDeclaration("Amenorrhea")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022")]
+	public CqlValueSet Amenorrhea() => 
+		__Amenorrhea.Value;
+
+	private CqlValueSet Ankylosing_Spondylitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045", null);
+
+    [CqlDeclaration("Ankylosing Spondylitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045")]
+	public CqlValueSet Ankylosing_Spondylitis() => 
+		__Ankylosing_Spondylitis.Value;
+
+	private CqlValueSet Aromatase_Inhibitors_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265", null);
+
+    [CqlDeclaration("Aromatase Inhibitors")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265")]
+	public CqlValueSet Aromatase_Inhibitors() => 
+		__Aromatase_Inhibitors.Value;
+
+	private CqlValueSet Bilateral_Oophorectomy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471", null);
+
+    [CqlDeclaration("Bilateral Oophorectomy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471")]
+	public CqlValueSet Bilateral_Oophorectomy() => 
+		__Bilateral_Oophorectomy.Value;
+
+	private CqlValueSet Bone_Marrow_Transplant_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336", null);
+
+    [CqlDeclaration("Bone Marrow Transplant")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336")]
+	public CqlValueSet Bone_Marrow_Transplant() => 
+		__Bone_Marrow_Transplant.Value;
+
+	private CqlValueSet Chemotherapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485", null);
+
+    [CqlDeclaration("Chemotherapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485")]
+	public CqlValueSet Chemotherapy() => 
+		__Chemotherapy.Value;
+
+	private CqlValueSet Chronic_Liver_Disease_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035", null);
+
+    [CqlDeclaration("Chronic Liver Disease")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035")]
+	public CqlValueSet Chronic_Liver_Disease() => 
+		__Chronic_Liver_Disease.Value;
+
+	private CqlValueSet Chronic_Malnutrition_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036", null);
+
+    [CqlDeclaration("Chronic Malnutrition")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036")]
+	public CqlValueSet Chronic_Malnutrition() => 
+		__Chronic_Malnutrition.Value;
+
+	private CqlValueSet Cushings_Syndrome_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009", null);
+
+    [CqlDeclaration("Cushings Syndrome")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009")]
+	public CqlValueSet Cushings_Syndrome() => 
+		__Cushings_Syndrome.Value;
+
+	private CqlValueSet DXA__Dual_energy_Xray_Absorptiometry__Scan_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051", null);
+
+    [CqlDeclaration("DXA (Dual energy Xray Absorptiometry) Scan")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051")]
+	public CqlValueSet DXA__Dual_energy_Xray_Absorptiometry__Scan() => 
+		__DXA__Dual_energy_Xray_Absorptiometry__Scan.Value;
+
+	private CqlValueSet Eating_Disorders_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039", null);
+
+    [CqlDeclaration("Eating Disorders")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039")]
+	public CqlValueSet Eating_Disorders() => 
+		__Eating_Disorders.Value;
+
+	private CqlValueSet Ehlers_Danlos_Syndrome_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047", null);
+
+    [CqlDeclaration("Ehlers Danlos Syndrome")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047")]
+	public CqlValueSet Ehlers_Danlos_Syndrome() => 
+		__Ehlers_Danlos_Syndrome.Value;
+
+	private CqlValueSet End_Stage_Renal_Disease_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", null);
+
+    [CqlDeclaration("End Stage Renal Disease")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
+	public CqlValueSet End_Stage_Renal_Disease() => 
+		__End_Stage_Renal_Disease.Value;
+
+	private CqlValueSet Evidence_of_Bilateral_Oophorectomy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048", null);
+
+    [CqlDeclaration("Evidence of Bilateral Oophorectomy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048")]
+	public CqlValueSet Evidence_of_Bilateral_Oophorectomy() => 
+		__Evidence_of_Bilateral_Oophorectomy.Value;
+
+	private CqlValueSet Gastric_Bypass_Surgery_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050", null);
+
+    [CqlDeclaration("Gastric Bypass Surgery")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050")]
+	public CqlValueSet Gastric_Bypass_Surgery() => 
+		__Gastric_Bypass_Surgery.Value;
+
+	private CqlValueSet Glucocorticoids__oral_only__Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266", null);
+
+    [CqlDeclaration("Glucocorticoids (oral only)")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266")]
+	public CqlValueSet Glucocorticoids__oral_only_() => 
+		__Glucocorticoids__oral_only_.Value;
+
+	private CqlValueSet History_of_hip_fracture_in_parent_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040", null);
+
+    [CqlDeclaration("History of hip fracture in parent")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040")]
+	public CqlValueSet History_of_hip_fracture_in_parent() => 
+		__History_of_hip_fracture_in_parent.Value;
+
+	private CqlValueSet Hyperparathyroidism_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016", null);
+
+    [CqlDeclaration("Hyperparathyroidism")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016")]
+	public CqlValueSet Hyperparathyroidism() => 
+		__Hyperparathyroidism.Value;
+
+	private CqlValueSet Hyperthyroidism_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015", null);
+
+    [CqlDeclaration("Hyperthyroidism")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015")]
+	public CqlValueSet Hyperthyroidism() => 
+		__Hyperthyroidism.Value;
+
+	private CqlValueSet Kidney_Transplant_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012", null);
+
+    [CqlDeclaration("Kidney Transplant")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012")]
+	public CqlValueSet Kidney_Transplant() => 
+		__Kidney_Transplant.Value;
+
+	private CqlValueSet Lupus_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010", null);
+
+    [CqlDeclaration("Lupus")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010")]
+	public CqlValueSet Lupus() => 
+		__Lupus.Value;
+
+	private CqlValueSet Major_Transplant_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075", null);
+
+    [CqlDeclaration("Major Transplant")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075")]
+	public CqlValueSet Major_Transplant() => 
+		__Major_Transplant.Value;
+
+	private CqlValueSet Malabsorption_Syndromes_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050", null);
+
+    [CqlDeclaration("Malabsorption Syndromes")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050")]
+	public CqlValueSet Malabsorption_Syndromes() => 
+		__Malabsorption_Syndromes.Value;
+
+	private CqlValueSet Marfans_Syndrome_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048", null);
+
+    [CqlDeclaration("Marfan's Syndrome")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048")]
+	public CqlValueSet Marfans_Syndrome() => 
+		__Marfans_Syndrome.Value;
+
+	private CqlValueSet Multiple_Myeloma_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011", null);
+
+    [CqlDeclaration("Multiple Myeloma")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011")]
+	public CqlValueSet Multiple_Myeloma() => 
+		__Multiple_Myeloma.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Osteogenesis_Imperfecta_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044", null);
+
+    [CqlDeclaration("Osteogenesis Imperfecta")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044")]
+	public CqlValueSet Osteogenesis_Imperfecta() => 
+		__Osteogenesis_Imperfecta.Value;
+
+	private CqlValueSet Osteopenia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049", null);
+
+    [CqlDeclaration("Osteopenia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049")]
+	public CqlValueSet Osteopenia() => 
+		__Osteopenia.Value;
+
+	private CqlValueSet Osteoporosis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038", null);
+
+    [CqlDeclaration("Osteoporosis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038")]
+	public CqlValueSet Osteoporosis() => 
+		__Osteoporosis.Value;
+
+	private CqlValueSet Osteoporotic_Fractures_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050", null);
+
+    [CqlDeclaration("Osteoporotic Fractures")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050")]
+	public CqlValueSet Osteoporotic_Fractures() => 
+		__Osteoporotic_Fractures.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Premature_Menopause_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013", null);
+
+    [CqlDeclaration("Premature Menopause")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013")]
+	public CqlValueSet Premature_Menopause() => 
+		__Premature_Menopause.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Psoriatic_Arthritis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046", null);
+
+    [CqlDeclaration("Psoriatic Arthritis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046")]
+	public CqlValueSet Psoriatic_Arthritis() => 
+		__Psoriatic_Arthritis.Value;
+
+	private CqlValueSet Rheumatoid_Arthritis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005", null);
+
+    [CqlDeclaration("Rheumatoid Arthritis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005")]
+	public CqlValueSet Rheumatoid_Arthritis() => 
+		__Rheumatoid_Arthritis.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlValueSet Type_1_Diabetes_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020", null);
+
+    [CqlDeclaration("Type 1 Diabetes")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020")]
+	public CqlValueSet Type_1_Diabetes() => 
+		__Type_1_Diabetes.Value;
+
+	private CqlValueSet Unilateral_Oophorectomy_Left_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028", null);
+
+    [CqlDeclaration("Unilateral Oophorectomy Left")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028")]
+	public CqlValueSet Unilateral_Oophorectomy_Left() => 
+		__Unilateral_Oophorectomy_Left.Value;
+
+	private CqlValueSet Unilateral_Oophorectomy_Right_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032", null);
+
+    [CqlDeclaration("Unilateral Oophorectomy Right")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032")]
+	public CqlValueSet Unilateral_Oophorectomy_Right() => 
+		__Unilateral_Oophorectomy_Right.Value;
+
+	private CqlValueSet Unilateral_Oophorectomy__Unspecified_Laterality_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035", null);
+
+    [CqlDeclaration("Unilateral Oophorectomy, Unspecified Laterality")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035")]
+	public CqlValueSet Unilateral_Oophorectomy__Unspecified_Laterality() => 
+		__Unilateral_Oophorectomy__Unspecified_Laterality.Value;
+
+	private CqlCode Alcoholic_drinks_per_drinking_day___Reported_Value() => 
+		new CqlCode("11287-0", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Alcoholic drinks per drinking day - Reported")]
+	public CqlCode Alcoholic_drinks_per_drinking_day___Reported() => 
+		__Alcoholic_drinks_per_drinking_day___Reported.Value;
+
+	private CqlCode Body_mass_index__BMI___Ratio__Value() => 
+		new CqlCode("39156-5", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Body mass index (BMI) [Ratio]")]
+	public CqlCode Body_mass_index__BMI___Ratio_() => 
+		__Body_mass_index__BMI___Ratio_.Value;
+
+	private CqlCode Female_Value() => 
+		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null);
+
+    [CqlDeclaration("Female")]
+	public CqlCode Female() => 
+		__Female.Value;
+
+	private CqlCode Left__qualifier_value__Value() => 
+		new CqlCode("7771000", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Left (qualifier value)")]
+	public CqlCode Left__qualifier_value_() => 
+		__Left__qualifier_value_.Value;
+
+	private CqlCode Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment_Value() => 
+		new CqlCode("90265-0", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Major osteoporotic fracture 10-year probability [Likelihood] Fracture Risk Assessment")]
+	public CqlCode Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment() => 
+		__Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment.Value;
+
+	private CqlCode Osteoporosis_Index_of_Risk_panel_Value() => 
+		new CqlCode("98133-2", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Osteoporosis Index of Risk panel")]
+	public CqlCode Osteoporosis_Index_of_Risk_panel() => 
+		__Osteoporosis_Index_of_Risk_panel.Value;
+
+	private CqlCode Osteoporosis_Risk_Assessment_Instrument_Value() => 
+		new CqlCode("98139-9", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Osteoporosis Risk Assessment Instrument")]
+	public CqlCode Osteoporosis_Risk_Assessment_Instrument() => 
+		__Osteoporosis_Risk_Assessment_Instrument.Value;
+
+	private CqlCode Osteoporosis_Self_Assessment_Tool_Value() => 
+		new CqlCode("98146-4", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Osteoporosis Self-Assessment Tool")]
+	public CqlCode Osteoporosis_Self_Assessment_Tool() => 
+		__Osteoporosis_Self_Assessment_Tool.Value;
+
+	private CqlCode Right__qualifier_value__Value() => 
+		new CqlCode("24028007", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Right (qualifier value)")]
+	public CqlCode Right__qualifier_value_() => 
+		__Right__qualifier_value_.Value;
+
+	private CqlCode Unlisted_preventive_medicine_service_Value() => 
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Unlisted preventive medicine service")]
+	public CqlCode Unlisted_preventive_medicine_service() => 
+		__Unlisted_preventive_medicine_service.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("11287-0", "http://loinc.org", null, null),
+			new CqlCode("39156-5", "http://loinc.org", null, null),
+			new CqlCode("90265-0", "http://loinc.org", null, null),
+			new CqlCode("98133-2", "http://loinc.org", null, null),
+			new CqlCode("98139-9", "http://loinc.org", null, null),
+			new CqlCode("98146-4", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] AdministrativeGender_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("AdministrativeGender")]
+	public CqlCode[] AdministrativeGender() => 
+		__AdministrativeGender.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("7771000", "http://snomed.info/sct", null, null),
+			new CqlCode("24028007", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("AppropriateDXAScansForWomenUnder65FHIR-0.0.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		bool? g_(Encounter E)
+		{
+			CqlConcept x_(CodeableConcept @this)
+			{
+				var ac_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return ac_;
+			};
+			var y_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, x_);
+			bool? z_(CqlConcept T)
+			{
+				var ad_ = this.Unlisted_preventive_medicine_service();
+				var ae_ = context.Operators.ConvertCodeToConcept(ad_);
+				var af_ = context.Operators.Equivalent(T, ae_);
+
+				return af_;
+			};
+			var aa_ = context.Operators.WhereOrNull<CqlConcept>(y_, z_);
+			var ab_ = context.Operators.ExistsInList<CqlConcept>(aa_);
+
+			return ab_;
+		};
+		var h_ = context.Operators.WhereOrNull<Encounter>(f_, g_);
+		var i_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
+		var k_ = context.Operators.ListUnion<Encounter>(h_, j_);
+		var l_ = context.Operators.ListUnion<Encounter>(e_, k_);
+		var m_ = this.Outpatient_Consultation();
+		var n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		var o_ = this.Online_Assessments();
+		var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+		var q_ = context.Operators.ListUnion<Encounter>(n_, p_);
+		var r_ = context.Operators.ListUnion<Encounter>(l_, q_);
+		var s_ = this.Telephone_Visits();
+		var t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
+		var u_ = context.Operators.ListUnion<Encounter>(r_, t_);
+		bool? v_(Encounter ValidEncounters)
+		{
+			var ag_ = this.Measurement_Period();
+			var ah_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounters?.Period);
+			var ai_ = QICoreCommon_2_0_000.ToInterval((ah_ as object));
+			var aj_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ag_, ai_, "day");
+
+			return aj_;
+		};
+		var w_ = context.Operators.WhereOrNull<Encounter>(u_, v_);
+
+		return w_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter")]
+	public IEnumerable<Encounter> Qualifying_Encounter() => 
+		__Qualifying_Encounter.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)50, (int?)63, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var j_ = context.Operators.EnumEqualsString(a_?.GenderElement?.Value, "female");
+		var k_ = context.Operators.And(h_, j_);
+		var l_ = this.Qualifying_Encounter();
+		var m_ = context.Operators.ExistsInList<Encounter>(l_);
+		var n_ = context.Operators.And(k_, m_);
+
+		return n_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private Observation First_BMI_in_Measurement_Period_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		var b_ = Status_1_6_000.BMI(a_);
+		bool? c_(Observation BMIRatio)
+		{
+			var h_ = this.Measurement_Period();
+			var i_ = FHIRHelpers_4_3_000.ToValue(BMIRatio?.Effective);
+			var j_ = QICoreCommon_2_0_000.ToInterval(i_);
+			var k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, null);
+			var l_ = context.Operators.Convert<Quantity>(BMIRatio?.Value);
+			var m_ = FHIRHelpers_4_3_000.ToQuantity(l_);
+			var n_ = context.Operators.Not((bool?)((m_ as CqlQuantity) is null));
+			var o_ = context.Operators.And(k_, n_);
+
+			return o_;
+		};
+		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
+		object e_(Observation @this)
+		{
+			var p_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var q_ = QICoreCommon_2_0_000.ToInterval(p_);
+			var r_ = context.Operators.Start(q_);
+
+			return r_;
+		};
+		var f_ = context.Operators.ListSortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		var g_ = context.Operators.FirstOfList<Observation>(f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("First BMI in Measurement Period")]
+	public Observation First_BMI_in_Measurement_Period() => 
+		__First_BMI_in_Measurement_Period.Value;
+
+	private Observation First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2_Value()
+	{
+		var a_ = this.First_BMI_in_Measurement_Period();
+		var b_ = new Observation[]
+		{
+			a_,
+		};
+		bool? c_(Observation FirstBMI)
+		{
+			var f_ = context.Operators.Convert<Quantity>(FirstBMI?.Value);
+			var g_ = FHIRHelpers_4_3_000.ToQuantity(f_);
+			var h_ = context.Operators.Quantity(20m, "kg/m2");
+			var i_ = context.Operators.LessOrEqual((g_ as CqlQuantity), h_);
+
+			return i_;
+		};
+		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
+		var e_ = context.Operators.SingleOrNull<Observation>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("First BMI in Measurement Period Less Than or Equal to 20 kg m2")]
+	public Observation First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2() => 
+		__First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2.Value;
+
+	private Observation First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day_Value()
+	{
+		var a_ = this.Alcoholic_drinks_per_drinking_day___Reported();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		bool? e_(Observation AverageDrinks)
+		{
+			var j_ = FHIRHelpers_4_3_000.ToValue(AverageDrinks?.Effective);
+			var k_ = QICoreCommon_2_0_000.ToInterval(j_);
+			var l_ = context.Operators.Start(k_);
+			var m_ = this.Measurement_Period();
+			var n_ = context.Operators.ElementInInterval<CqlDateTime>(l_, m_, null);
+			var o_ = FHIRHelpers_4_3_000.ToValue(AverageDrinks?.Value);
+			var p_ = context.Operators.Quantity(2m, "{drinks}/d");
+			var q_ = context.Operators.Greater((o_ as CqlQuantity), p_);
+			var r_ = context.Operators.And(n_, q_);
+
+			return r_;
+		};
+		var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+		object g_(Observation @this)
+		{
+			var s_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var t_ = QICoreCommon_2_0_000.ToInterval(s_);
+			var u_ = context.Operators.Start(t_);
+
+			return u_;
+		};
+		var h_ = context.Operators.ListSortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+		var i_ = context.Operators.FirstOfList<Observation>(h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("First Average Number of Drinks Assessments Indicating More Than Two Per Day")]
+	public Observation First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day() => 
+		__First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day.Value;
+
+	private bool? Has_Risk_Factor_Active_During_the_Measurement_Period_Value()
+	{
+		var a_ = this.First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2();
+		var b_ = context.Operators.Not((bool?)(a_ is null));
+		var c_ = this.First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day();
+		var d_ = context.Operators.Not((bool?)(c_ is null));
+		var e_ = context.Operators.Or(b_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Risk Factor Active During the Measurement Period")]
+	public bool? Has_Risk_Factor_Active_During_the_Measurement_Period() => 
+		__Has_Risk_Factor_Active_During_the_Measurement_Period.Value;
+
+	private bool? Has_Osteoporosis_Before_Measurement_Period_Value()
+	{
+		var a_ = this.Osteoporosis();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition OsteoporosisDiagnosis)
+		{
+			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteoporosisDiagnosis);
+			var g_ = context.Operators.Start(f_);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.Before(g_, i_, null);
+
+			return j_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Osteoporosis Before Measurement Period")]
+	public bool? Has_Osteoporosis_Before_Measurement_Period() => 
+		__Has_Osteoporosis_Before_Measurement_Period.Value;
+
+	private bool? Has_Osteopenia_Before_Measurement_Period_Value()
+	{
+		var a_ = this.Osteopenia();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition OsteopeniaDiagnosis)
+		{
+			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteopeniaDiagnosis);
+			var g_ = context.Operators.Start(f_);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.Before(g_, i_, null);
+
+			return j_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Osteopenia Before Measurement Period")]
+	public bool? Has_Osteopenia_Before_Measurement_Period() => 
+		__Has_Osteopenia_Before_Measurement_Period.Value;
+
+	private bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_Value()
+	{
+		var a_ = this.Has_Osteoporosis_Before_Measurement_Period();
+		var b_ = this.Has_Osteopenia_Before_Measurement_Period();
+		var c_ = context.Operators.Or(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Has Risk Factor Any Time in History Prior to Measurement Period")]
+	public bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period() => 
+		__Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period.Value;
+
+	private IEnumerable<Observation> Parent_History_of_Hip_Fracture_Assessment_Value()
+	{
+		var a_ = this.History_of_hip_fracture_in_parent();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.Final_Survey_Observation(b_);
+		bool? d_(Observation ParentFractureHistory)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToValue(ParentFractureHistory?.Effective);
+			var g_ = QICoreCommon_2_0_000.ToInterval(f_);
+			var h_ = context.Operators.Start(g_);
+			var i_ = this.Measurement_Period();
+			var j_ = context.Operators.Start(i_);
+			var k_ = context.Operators.Before(h_, j_, null);
+
+			return k_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Parent History of Hip Fracture Assessment")]
+	public IEnumerable<Observation> Parent_History_of_Hip_Fracture_Assessment() => 
+		__Parent_History_of_Hip_Fracture_Assessment.Value;
+
+	private bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period_Value()
+	{
+		var a_ = this.Gastric_Bypass_Surgery();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		bool? d_(Procedure GastricBypass)
+		{
+			var aa_ = FHIRHelpers_4_3_000.ToValue(GastricBypass?.Performed);
+			var ab_ = QICoreCommon_2_0_000.ToInterval(aa_);
+			var ac_ = context.Operators.End(ab_);
+			var ad_ = this.Measurement_Period();
+			var ae_ = context.Operators.Start(ad_);
+			var af_ = context.Operators.Before(ac_, ae_, null);
+
+			return af_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+		var f_ = this.Aromatase_Inhibitors();
+		var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		var j_ = context.Operators.ListUnion<MedicationRequest>(g_, i_);
+		var k_ = Status_1_6_000.Active_Medication(j_);
+		bool? l_(MedicationRequest AromataseInhibitorActive)
+		{
+			var ag_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(AromataseInhibitorActive);
+			var ah_ = context.Operators.Start(ag_);
+			var ai_ = context.Operators.ConvertDateToDateTime(ah_);
+			var aj_ = this.Measurement_Period();
+			var ak_ = context.Operators.Start(aj_);
+			var al_ = context.Operators.Before(ai_, ak_, null);
+
+			return al_;
+		};
+		var m_ = context.Operators.WhereOrNull<MedicationRequest>(k_, l_);
+		var n_ = context.Operators.ListUnion<object>((e_ as IEnumerable<object>), (m_ as IEnumerable<object>));
+		var p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		var r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		var s_ = context.Operators.ListUnion<MedicationRequest>(p_, r_);
+		var t_ = Status_1_6_000.Active_or_Completed_Medication_Request(s_);
+		bool? u_(MedicationRequest AromataseInhibitorOrder)
+		{
+			var am_ = context.Operators.Convert<CqlDateTime>(AromataseInhibitorOrder?.AuthoredOnElement);
+			var an_ = QICoreCommon_2_0_000.ToInterval((am_ as object));
+			CqlInterval<CqlDateTime> ao_()
+			{
+				if ((context.Operators.Start(this.Measurement_Period()) is null))
+				{
+					return null;
+				}
+				else
+				{
+					var aq_ = this.Measurement_Period();
+					var ar_ = context.Operators.Start(aq_);
+					var at_ = context.Operators.Start(aq_);
+					var au_ = context.Operators.Interval(ar_, at_, true, true);
+
+					return au_;
+				};
+			};
+			var ap_ = context.Operators.IntervalBeforeInterval(an_, ao_(), null);
+
+			return ap_;
+		};
+		var v_ = context.Operators.WhereOrNull<MedicationRequest>(t_, u_);
+		var w_ = context.Operators.ListUnion<object>((n_ as IEnumerable<object>), (v_ as IEnumerable<object>));
+		var x_ = this.Parent_History_of_Hip_Fracture_Assessment();
+		var y_ = context.Operators.ListUnion<object>((w_ as IEnumerable<object>), (x_ as IEnumerable<object>));
+		var z_ = context.Operators.ExistsInList<object>(y_);
+
+		return z_;
+	}
+
+    [CqlDeclaration("Has Risk Factor Any Time in History Prior to Measurement Period and Do Not Need to be Active During Measurement Period")]
+	public bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period() => 
+		__Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period.Value;
+
+	private int? Glucocorticoid_Active_Medication_Duration_in_Days_Value()
+	{
+		var a_ = this.Glucocorticoids__oral_only_();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = Status_1_6_000.Active_Medication(e_);
+		bool? g_(MedicationRequest OralGlucocorticoid)
+		{
+			var l_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OralGlucocorticoid);
+			var m_ = context.Operators.Start(l_);
+			var n_ = context.Operators.ConvertDateToDateTime(m_);
+			var o_ = this.Measurement_Period();
+			var p_ = context.Operators.End(o_);
+			var q_ = context.Operators.Before(n_, p_, null);
+
+			return q_;
+		};
+		var h_ = context.Operators.WhereOrNull<MedicationRequest>(f_, g_);
+		CqlInterval<CqlDate> i_(MedicationRequest Glucocorticoid)
+		{
+			var r_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(Glucocorticoid);
+			var s_ = this.Patient();
+			var t_ = context.Operators.ConvertStringToDate(s_?.BirthDateElement?.Value);
+			var u_ = this.Measurement_Period();
+			var v_ = context.Operators.End(u_);
+			var w_ = context.Operators.DateFrom(v_);
+			var x_ = context.Operators.Interval(t_, w_, true, true);
+			var y_ = context.Operators.IntervalIntersectsInterval<CqlDate>(r_, x_);
+
+			return y_;
+		};
+		var j_ = context.Operators.SelectOrNull<MedicationRequest, CqlInterval<CqlDate>>(h_, i_);
+		var k_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Glucocorticoid Active Medication Duration in Days")]
+	public int? Glucocorticoid_Active_Medication_Duration_in_Days() => 
+		__Glucocorticoid_Active_Medication_Duration_in_Days.Value;
+
+	private int? Glucocorticoid_Active_Medication_Days_Value()
+	{
+		var a_ = this.Glucocorticoid_Active_Medication_Duration_in_Days();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Glucocorticoid Active Medication Days")]
+	public int? Glucocorticoid_Active_Medication_Days() => 
+		__Glucocorticoid_Active_Medication_Days.Value;
+
+	private bool? Has_90_or_More_Active_Glucocorticoid_Medication_Days_Value()
+	{
+		var a_ = this.Glucocorticoid_Active_Medication_Days();
+		var b_ = context.Operators.GreaterOrEqual(a_, (int?)90);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Has 90 or More Active Glucocorticoid Medication Days")]
+	public bool? Has_90_or_More_Active_Glucocorticoid_Medication_Days() => 
+		__Has_90_or_More_Active_Glucocorticoid_Medication_Days.Value;
+
+    [CqlDeclaration("DiagnosisInPatientHistory")]
+	public IEnumerable<Condition> DiagnosisInPatientHistory(IEnumerable<Condition> Condition)
+	{
+		bool? a_(Condition Dx)
+		{
+			var c_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Dx);
+			var d_ = context.Operators.Start(c_);
+			var e_ = this.Measurement_Period();
+			var f_ = context.Operators.End(e_);
+			var g_ = context.Operators.SameOrBefore(d_, f_, "day");
+
+			return g_;
+		};
+		var b_ = context.Operators.WhereOrNull<Condition>(Condition, a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("ProcedureInPatientHistory")]
+	public IEnumerable<Procedure> ProcedureInPatientHistory(IEnumerable<Procedure> Procedure)
+	{
+		var a_ = Status_1_6_000.Completed_Procedure(Procedure);
+		bool? b_(Procedure Proc)
+		{
+			var d_ = FHIRHelpers_4_3_000.ToValue(Proc?.Performed);
+			var e_ = QICoreCommon_2_0_000.ToInterval(d_);
+			var f_ = context.Operators.End(e_);
+			var g_ = this.Measurement_Period();
+			var h_ = context.Operators.End(g_);
+			var i_ = context.Operators.SameOrBefore(f_, h_, "day");
+
+			return i_;
+		};
+		var c_ = context.Operators.WhereOrNull<Procedure>(a_, b_);
+
+		return c_;
+	}
+
+	private bool? Has_Double_or_Bilateral_Oophorectomy_Value()
+	{
+		var a_ = this.Bilateral_Oophorectomy();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = this.ProcedureInPatientHistory(b_);
+		var d_ = context.Operators.ExistsInList<Procedure>(c_);
+		var e_ = this.Evidence_of_Bilateral_Oophorectomy();
+		var f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
+		var g_ = this.ProcedureInPatientHistory(f_);
+		var h_ = context.Operators.ExistsInList<Procedure>(g_);
+		var i_ = context.Operators.Or(d_, h_);
+		var j_ = this.Unilateral_Oophorectomy__Unspecified_Laterality();
+		var k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
+		bool? l_(Procedure UnilateralOophorectomy)
+		{
+			CqlConcept ad_(CodeableConcept @this)
+			{
+				var ai_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return ai_;
+			};
+			var ae_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(UnilateralOophorectomy?.BodySite, ad_);
+			bool? af_(CqlConcept C)
+			{
+				var aj_ = this.Right__qualifier_value_();
+				var ak_ = context.Operators.ConvertCodeToConcept(aj_);
+				var al_ = context.Operators.Equivalent(C, ak_);
+
+				return al_;
+			};
+			var ag_ = context.Operators.WhereOrNull<CqlConcept>(ae_, af_);
+			var ah_ = context.Operators.ExistsInList<CqlConcept>(ag_);
+
+			return ah_;
+		};
+		var m_ = context.Operators.WhereOrNull<Procedure>(k_, l_);
+		var n_ = this.Unilateral_Oophorectomy_Right();
+		var o_ = context.Operators.RetrieveByValueSet<Procedure>(n_, null);
+		var p_ = context.Operators.ListUnion<Procedure>(m_, o_);
+		var q_ = this.ProcedureInPatientHistory(p_);
+		var r_ = context.Operators.ExistsInList<Procedure>(q_);
+		var t_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
+		bool? u_(Procedure UnilateralOophorectomy)
+		{
+			CqlConcept am_(CodeableConcept @this)
+			{
+				var ar_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return ar_;
+			};
+			var an_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(UnilateralOophorectomy?.BodySite, am_);
+			bool? ao_(CqlConcept D)
+			{
+				var as_ = this.Left__qualifier_value_();
+				var at_ = context.Operators.ConvertCodeToConcept(as_);
+				var au_ = context.Operators.Equivalent(D, at_);
+
+				return au_;
+			};
+			var ap_ = context.Operators.WhereOrNull<CqlConcept>(an_, ao_);
+			var aq_ = context.Operators.ExistsInList<CqlConcept>(ap_);
+
+			return aq_;
+		};
+		var v_ = context.Operators.WhereOrNull<Procedure>(t_, u_);
+		var w_ = this.Unilateral_Oophorectomy_Left();
+		var x_ = context.Operators.RetrieveByValueSet<Procedure>(w_, null);
+		var y_ = context.Operators.ListUnion<Procedure>(v_, x_);
+		var z_ = this.ProcedureInPatientHistory(y_);
+		var aa_ = context.Operators.ExistsInList<Procedure>(z_);
+		var ab_ = context.Operators.And(r_, aa_);
+		var ac_ = context.Operators.Or(i_, ab_);
+
+		return ac_;
+	}
+
+    [CqlDeclaration("Has Double or Bilateral Oophorectomy")]
+	public bool? Has_Double_or_Bilateral_Oophorectomy() => 
+		__Has_Double_or_Bilateral_Oophorectomy.Value;
+
+	private bool? Has_Organ_Transplants_Value()
+	{
+		var a_ = this.Major_Transplant();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = this.Kidney_Transplant();
+		var d_ = context.Operators.RetrieveByValueSet<Procedure>(c_, null);
+		var e_ = context.Operators.ListUnion<Procedure>(b_, d_);
+		var f_ = this.Bone_Marrow_Transplant();
+		var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		var h_ = context.Operators.ListUnion<Procedure>(e_, g_);
+		var i_ = this.ProcedureInPatientHistory(h_);
+		var j_ = context.Operators.ExistsInList<Procedure>(i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Has Organ Transplants")]
+	public bool? Has_Organ_Transplants() => 
+		__Has_Organ_Transplants.Value;
+
+	private bool? Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period_Value()
+	{
+		var a_ = this.Has_90_or_More_Active_Glucocorticoid_Medication_Days();
+		var b_ = this.Osteoporotic_Fractures();
+		var c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		var d_ = this.Malabsorption_Syndromes();
+		var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+		var f_ = context.Operators.ListUnion<Condition>(c_, e_);
+		var g_ = this.Chronic_Malnutrition();
+		var h_ = context.Operators.RetrieveByValueSet<Condition>(g_, null);
+		var i_ = this.Chronic_Liver_Disease();
+		var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+		var k_ = context.Operators.ListUnion<Condition>(h_, j_);
+		var l_ = context.Operators.ListUnion<Condition>(f_, k_);
+		var m_ = this.Rheumatoid_Arthritis();
+		var n_ = context.Operators.RetrieveByValueSet<Condition>(m_, null);
+		var o_ = this.Hyperthyroidism();
+		var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		var q_ = context.Operators.ListUnion<Condition>(n_, p_);
+		var r_ = context.Operators.ListUnion<Condition>(l_, q_);
+		var s_ = this.Type_1_Diabetes();
+		var t_ = context.Operators.RetrieveByValueSet<Condition>(s_, null);
+		var u_ = this.End_Stage_Renal_Disease();
+		var v_ = context.Operators.RetrieveByValueSet<Condition>(u_, null);
+		var w_ = context.Operators.ListUnion<Condition>(t_, v_);
+		var x_ = context.Operators.ListUnion<Condition>(r_, w_);
+		var y_ = this.Osteogenesis_Imperfecta();
+		var z_ = context.Operators.RetrieveByValueSet<Condition>(y_, null);
+		var aa_ = this.Ankylosing_Spondylitis();
+		var ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, null);
+		var ac_ = context.Operators.ListUnion<Condition>(z_, ab_);
+		var ad_ = context.Operators.ListUnion<Condition>(x_, ac_);
+		var ae_ = this.Psoriatic_Arthritis();
+		var af_ = context.Operators.RetrieveByValueSet<Condition>(ae_, null);
+		var ag_ = this.Ehlers_Danlos_Syndrome();
+		var ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, null);
+		var ai_ = context.Operators.ListUnion<Condition>(af_, ah_);
+		var aj_ = context.Operators.ListUnion<Condition>(ad_, ai_);
+		var ak_ = this.Cushings_Syndrome();
+		var al_ = context.Operators.RetrieveByValueSet<Condition>(ak_, null);
+		var am_ = this.Hyperparathyroidism();
+		var an_ = context.Operators.RetrieveByValueSet<Condition>(am_, null);
+		var ao_ = context.Operators.ListUnion<Condition>(al_, an_);
+		var ap_ = context.Operators.ListUnion<Condition>(aj_, ao_);
+		var aq_ = this.Marfans_Syndrome();
+		var ar_ = context.Operators.RetrieveByValueSet<Condition>(aq_, null);
+		var as_ = this.Lupus();
+		var at_ = context.Operators.RetrieveByValueSet<Condition>(as_, null);
+		var au_ = context.Operators.ListUnion<Condition>(ar_, at_);
+		var av_ = context.Operators.ListUnion<Condition>(ap_, au_);
+		var aw_ = this.Multiple_Myeloma();
+		var ax_ = context.Operators.RetrieveByValueSet<Condition>(aw_, null);
+		var ay_ = this.Premature_Menopause();
+		var az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, null);
+		var ba_ = context.Operators.ListUnion<Condition>(ax_, az_);
+		var bb_ = context.Operators.ListUnion<Condition>(av_, ba_);
+		var bc_ = this.Eating_Disorders();
+		var bd_ = context.Operators.RetrieveByValueSet<Condition>(bc_, null);
+		var be_ = this.Amenorrhea();
+		var bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, null);
+		var bg_ = context.Operators.ListUnion<Condition>(bd_, bf_);
+		var bh_ = context.Operators.ListUnion<Condition>(bb_, bg_);
+		var bi_ = this.DiagnosisInPatientHistory(bh_);
+		var bj_ = context.Operators.ExistsInList<Condition>(bi_);
+		var bk_ = context.Operators.Or(a_, bj_);
+		var bl_ = this.Chemotherapy();
+		var bm_ = context.Operators.RetrieveByValueSet<Procedure>(bl_, null);
+		var bn_ = this.ProcedureInPatientHistory(bm_);
+		var bo_ = context.Operators.ExistsInList<Procedure>(bn_);
+		var bp_ = context.Operators.Or(bk_, bo_);
+		var bq_ = this.Has_Double_or_Bilateral_Oophorectomy();
+		var br_ = context.Operators.Or(bp_, bq_);
+		var bs_ = this.Has_Organ_Transplants();
+		var bt_ = context.Operators.Or(br_, bs_);
+
+		return bt_;
+	}
+
+    [CqlDeclaration("Has Risk Factor Any Time in History or During Measurement Period")]
+	public bool? Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period() => 
+		__Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = this.Has_Risk_Factor_Active_During_the_Measurement_Period();
+		var b_ = this.Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = this.Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period();
+		var e_ = context.Operators.Or(c_, d_);
+		var f_ = this.Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period();
+		var g_ = context.Operators.Or(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<ServiceRequest> DXA_Scan_Order_During_Measurement_Period_Value()
+	{
+		var a_ = this.DXA__Dual_energy_Xray_Absorptiometry__Scan();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
+		bool? d_(ServiceRequest DXA)
+		{
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Convert<CqlDateTime>(DXA?.AuthoredOnElement);
+			var j_ = QICoreCommon_2_0_000.ToInterval((i_ as object));
+			var k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, null);
+
+			return k_;
+		};
+		var e_ = context.Operators.WhereOrNull<ServiceRequest>(c_, d_);
+		object f_(ServiceRequest @this)
+		{
+			var l_ = context.Operators.Convert<CqlDateTime>(@this?.AuthoredOnElement);
+
+			return l_;
+		};
+		var g_ = context.Operators.ListSortBy<ServiceRequest>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+
+		return g_;
+	}
+
+    [CqlDeclaration("DXA Scan Order During Measurement Period")]
+	public IEnumerable<ServiceRequest> DXA_Scan_Order_During_Measurement_Period() => 
+		__DXA_Scan_Order_During_Measurement_Period.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.DXA_Scan_Order_During_Measurement_Period();
+		var b_ = context.Operators.ExistsInList<ServiceRequest>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private IEnumerable<Observation> Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan_Value()
+	{
+		var a_ = this.Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		bool? e_(Observation FRAX)
+		{
+			var ad_ = FHIRHelpers_4_3_000.ToValue(FRAX?.Value);
+			var ae_ = context.Operators.Quantity(8.4m, "%");
+			var af_ = context.Operators.GreaterOrEqual((ad_ as CqlQuantity), ae_);
+
+			return af_;
+		};
+		var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+		var g_ = this.Osteoporosis_Risk_Assessment_Instrument();
+		var h_ = context.Operators.ToList<CqlCode>(g_);
+		var i_ = context.Operators.RetrieveByCodes<Observation>(h_, null);
+		var j_ = Status_1_6_000.Final_Survey_Observation(i_);
+		bool? k_(Observation ORAI)
+		{
+			var ag_ = FHIRHelpers_4_3_000.ToValue(ORAI?.Value);
+			var ah_ = context.Operators.GreaterOrEqual((int?)ag_, (int?)9);
+
+			return ah_;
+		};
+		var l_ = context.Operators.WhereOrNull<Observation>(j_, k_);
+		var m_ = context.Operators.ListUnion<Observation>(f_, l_);
+		var n_ = this.Osteoporosis_Index_of_Risk_panel();
+		var o_ = context.Operators.ToList<CqlCode>(n_);
+		var p_ = context.Operators.RetrieveByCodes<Observation>(o_, null);
+		var q_ = Status_1_6_000.Final_Survey_Observation(p_);
+		bool? r_(Observation OSIRIS)
+		{
+			var ai_ = FHIRHelpers_4_3_000.ToValue(OSIRIS?.Value);
+			var aj_ = context.Operators.ConvertDecimalToQuantity((decimal?)1.0m);
+			var ak_ = context.Operators.Less((ai_ as CqlQuantity), aj_);
+
+			return ak_;
+		};
+		var s_ = context.Operators.WhereOrNull<Observation>(q_, r_);
+		var t_ = this.Osteoporosis_Self_Assessment_Tool();
+		var u_ = context.Operators.ToList<CqlCode>(t_);
+		var v_ = context.Operators.RetrieveByCodes<Observation>(u_, null);
+		var w_ = Status_1_6_000.Final_Survey_Observation(v_);
+		bool? x_(Observation OST)
+		{
+			var al_ = FHIRHelpers_4_3_000.ToValue(OST?.Value);
+			var am_ = context.Operators.ConvertDecimalToQuantity((decimal?)2.0m);
+			var an_ = context.Operators.Less((al_ as CqlQuantity), am_);
+
+			return an_;
+		};
+		var y_ = context.Operators.WhereOrNull<Observation>(w_, x_);
+		var z_ = context.Operators.ListUnion<Observation>(s_, y_);
+		var aa_ = context.Operators.ListUnion<Observation>(m_, z_);
+		bool? ab_(Observation RiskAssessment)
+		{
+			var ao_ = FHIRHelpers_4_3_000.ToValue(RiskAssessment?.Effective);
+			var ap_ = QICoreCommon_2_0_000.ToInterval(ao_);
+			var aq_ = context.Operators.Start(ap_);
+			var ar_ = this.DXA_Scan_Order_During_Measurement_Period();
+			var as_ = context.Operators.FirstOfList<ServiceRequest>(ar_);
+			var at_ = context.Operators.Convert<CqlDateTime>(as_?.AuthoredOnElement);
+			var au_ = context.Operators.Before(aq_, at_, null);
+
+			return au_;
+		};
+		var ac_ = context.Operators.WhereOrNull<Observation>(aa_, ab_);
+
+		return ac_;
+	}
+
+    [CqlDeclaration("Osteoporosis Fracture Risk Assessment Prior to First DXA Scan")]
+	public IEnumerable<Observation> Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan() => 
+		__Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan.Value;
+
+	private bool? Numerator_Exclusion_Value()
+	{
+		var a_ = this.Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan();
+		var b_ = context.Operators.ExistsInList<Observation>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Numerator Exclusion")]
+	public bool? Numerator_Exclusion() => 
+		__Numerator_Exclusion.Value;
+
+    [CqlDeclaration("Final Survey Observation")]
+	public IEnumerable<Observation> Final_Survey_Observation(IEnumerable<Observation> Obs)
+	{
+		bool? a_(Observation O)
+		{
+			var c_ = context.Operators.Convert<Code<ObservationStatus>>(O?.StatusElement?.Value);
+			var d_ = context.Operators.Convert<string>(c_);
+			var e_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var f_ = context.Operators.InList<string>(d_, (e_ as IEnumerable<string>));
+			CqlConcept g_(CodeableConcept @this)
+			{
+				var k_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return k_;
+			};
+			var h_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(O?.Category, g_);
+			var i_ = context.Operators.ExistsInList<CqlConcept>(h_);
+			var j_ = context.Operators.And(f_, i_);
+
+			return j_;
+		};
+		var b_ = context.Operators.WhereOrNull<Observation>(Obs, a_);
+
+		return b_;
+	}
+
+}

--- a/Demo/Measures-cms/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
@@ -1,0 +1,862 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("AppropriateTestingforPharyngitisFHIR", "0.1.000")]
+public class AppropriateTestingforPharyngitisFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Acute_Pharyngitis;
+    internal Lazy<CqlValueSet> __Acute_Tonsillitis;
+    internal Lazy<CqlValueSet> __Antibiotic_Medications_for_Pharyngitis;
+    internal Lazy<CqlValueSet> __Comorbid_Conditions_for_Respiratory_Conditions;
+    internal Lazy<CqlValueSet> __Competing_Conditions_for_Respiratory_Conditions;
+    internal Lazy<CqlValueSet> __Discharge_Services_Observation_Care;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Group_A_Streptococcus_Test;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Initial_Hospital_Observation_Care;
+    internal Lazy<CqlValueSet> __Medical_Disability_Exam;
+    internal Lazy<CqlValueSet> __Observation;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Group_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Individual_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care__Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlCode> __Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___;
+    internal Lazy<CqlCode> __Unlisted_preventive_medicine_service;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_With_Antibiotic_Ordered_Within_Three_Days;
+    internal Lazy<IEnumerable<Condition>> __Pharyngitis_or_Tonsillitis;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __In_Hospice;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Observation>> __Group_A_Streptococcus_Lab_Test_With_Result;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<IEnumerable<Encounter>> __Stratification_1;
+    internal Lazy<IEnumerable<Encounter>> __Stratification_2;
+    internal Lazy<IEnumerable<Encounter>> __Stratification_3;
+
+    #endregion
+    public AppropriateTestingforPharyngitisFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Antibiotic_1_5_000 = new Antibiotic_1_5_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Acute_Pharyngitis = new Lazy<CqlValueSet>(this.Acute_Pharyngitis_Value);
+        __Acute_Tonsillitis = new Lazy<CqlValueSet>(this.Acute_Tonsillitis_Value);
+        __Antibiotic_Medications_for_Pharyngitis = new Lazy<CqlValueSet>(this.Antibiotic_Medications_for_Pharyngitis_Value);
+        __Comorbid_Conditions_for_Respiratory_Conditions = new Lazy<CqlValueSet>(this.Comorbid_Conditions_for_Respiratory_Conditions_Value);
+        __Competing_Conditions_for_Respiratory_Conditions = new Lazy<CqlValueSet>(this.Competing_Conditions_for_Respiratory_Conditions_Value);
+        __Discharge_Services_Observation_Care = new Lazy<CqlValueSet>(this.Discharge_Services_Observation_Care_Value);
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value);
+        __Group_A_Streptococcus_Test = new Lazy<CqlValueSet>(this.Group_A_Streptococcus_Test_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Initial_Hospital_Observation_Care = new Lazy<CqlValueSet>(this.Initial_Hospital_Observation_Care_Value);
+        __Medical_Disability_Exam = new Lazy<CqlValueSet>(this.Medical_Disability_Exam_Value);
+        __Observation = new Lazy<CqlValueSet>(this.Observation_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Group_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Group_Counseling_Value);
+        __Preventive_Care_Services_Individual_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Individual_Counseling_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value);
+        __Preventive_Care__Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Established_Office_Visit__0_to_17_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___ = new Lazy<CqlCode>(this.Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate____Value);
+        __Unlisted_preventive_medicine_service = new Lazy<CqlCode>(this.Unlisted_preventive_medicine_service_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_Value);
+        __Encounter_With_Antibiotic_Ordered_Within_Three_Days = new Lazy<IEnumerable<Encounter>>(this.Encounter_With_Antibiotic_Ordered_Within_Three_Days_Value);
+        __Pharyngitis_or_Tonsillitis = new Lazy<IEnumerable<Condition>>(this.Pharyngitis_or_Tonsillitis_Value);
+        __Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic = new Lazy<IEnumerable<Encounter>>(this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __In_Hospice = new Lazy<IEnumerable<Encounter>>(this.In_Hospice_Value);
+        __Denominator_Exclusions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exclusions_Value);
+        __Group_A_Streptococcus_Lab_Test_With_Result = new Lazy<IEnumerable<Observation>>(this.Group_A_Streptococcus_Lab_Test_With_Result_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+        __Stratification_1 = new Lazy<IEnumerable<Encounter>>(this.Stratification_1_Value);
+        __Stratification_2 = new Lazy<IEnumerable<Encounter>>(this.Stratification_2_Value);
+        __Stratification_3 = new Lazy<IEnumerable<Encounter>>(this.Stratification_3_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Antibiotic_1_5_000 Antibiotic_1_5_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Acute_Pharyngitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011", null);
+
+    [CqlDeclaration("Acute Pharyngitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011")]
+	public CqlValueSet Acute_Pharyngitis() => 
+		__Acute_Pharyngitis.Value;
+
+	private CqlValueSet Acute_Tonsillitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012", null);
+
+    [CqlDeclaration("Acute Tonsillitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012")]
+	public CqlValueSet Acute_Tonsillitis() => 
+		__Acute_Tonsillitis.Value;
+
+	private CqlValueSet Antibiotic_Medications_for_Pharyngitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", null);
+
+    [CqlDeclaration("Antibiotic Medications for Pharyngitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001")]
+	public CqlValueSet Antibiotic_Medications_for_Pharyngitis() => 
+		__Antibiotic_Medications_for_Pharyngitis.Value;
+
+	private CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", null);
+
+    [CqlDeclaration("Comorbid Conditions for Respiratory Conditions")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025")]
+	public CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions() => 
+		__Comorbid_Conditions_for_Respiratory_Conditions.Value;
+
+	private CqlValueSet Competing_Conditions_for_Respiratory_Conditions_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", null);
+
+    [CqlDeclaration("Competing Conditions for Respiratory Conditions")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017")]
+	public CqlValueSet Competing_Conditions_for_Respiratory_Conditions() => 
+		__Competing_Conditions_for_Respiratory_Conditions.Value;
+
+	private CqlValueSet Discharge_Services_Observation_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039", null);
+
+    [CqlDeclaration("Discharge Services Observation Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039")]
+	public CqlValueSet Discharge_Services_Observation_Care() => 
+		__Discharge_Services_Observation_Care.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
+
+    [CqlDeclaration("Emergency Department Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit.Value;
+
+	private CqlValueSet Group_A_Streptococcus_Test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012", null);
+
+    [CqlDeclaration("Group A Streptococcus Test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012")]
+	public CqlValueSet Group_A_Streptococcus_Test() => 
+		__Group_A_Streptococcus_Test.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", null);
+
+    [CqlDeclaration("Initial Hospital Observation Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
+	public CqlValueSet Initial_Hospital_Observation_Care() => 
+		__Initial_Hospital_Observation_Care.Value;
+
+	private CqlValueSet Medical_Disability_Exam_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", null);
+
+    [CqlDeclaration("Medical Disability Exam")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073")]
+	public CqlValueSet Medical_Disability_Exam() => 
+		__Medical_Disability_Exam.Value;
+
+	private CqlValueSet Observation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+
+    [CqlDeclaration("Observation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
+	public CqlValueSet Observation() => 
+		__Observation.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+
+    [CqlDeclaration("Preventive Care Services Group Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
+	public CqlValueSet Preventive_Care_Services_Group_Counseling() => 
+		__Preventive_Care_Services_Group_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+
+    [CqlDeclaration("Preventive Care Services Individual Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
+	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
+		__Preventive_Care_Services_Individual_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+
+    [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
+	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+
+    [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
+	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
+		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlCode Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate____Value() => 
+		new CqlCode("99217", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Observation care discharge day management (This code is to be utilized to report all services provided to a patient on discharge from outpatient hospital observation status if the discharge is on other than the initial date of observation status. To report services to a patient designated as observation status or inpatient status and discharged on the same date, use the codes for Observation or Inpatient Care Services [including Admission and Discharge Services, 99234-99236 as appropriate.])")]
+	public CqlCode Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___() => 
+		__Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___.Value;
+
+	private CqlCode Unlisted_preventive_medicine_service_Value() => 
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Unlisted preventive medicine service")]
+	public CqlCode Unlisted_preventive_medicine_service() => 
+		__Unlisted_preventive_medicine_service.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("99217", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("AppropriateTestingforPharyngitisFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_Value()
+	{
+		var a_ = this.Emergency_Department_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		bool? d_(Encounter E)
+		{
+			CqlConcept bg_(CodeableConcept @this)
+			{
+				var bl_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return bl_;
+			};
+			var bh_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, bg_);
+			bool? bi_(CqlConcept T)
+			{
+				var bm_ = this.Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___();
+				var bn_ = context.Operators.ConvertCodeToConcept(bm_);
+				var bo_ = context.Operators.Equivalent(T, bn_);
+
+				return bo_;
+			};
+			var bj_ = context.Operators.WhereOrNull<CqlConcept>(bh_, bi_);
+			var bk_ = context.Operators.ExistsInList<CqlConcept>(bj_);
+
+			return bk_;
+		};
+		var e_ = context.Operators.WhereOrNull<Encounter>(c_, d_);
+		var f_ = context.Operators.ListUnion<Encounter>(b_, e_);
+		var h_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var i_ = this.Home_Healthcare_Services();
+		var j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
+		var k_ = context.Operators.ListUnion<Encounter>(h_, j_);
+		var l_ = context.Operators.ListUnion<Encounter>(f_, k_);
+		var m_ = this.Initial_Hospital_Observation_Care();
+		var n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		var o_ = this.Medical_Disability_Exam();
+		var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+		var q_ = context.Operators.ListUnion<Encounter>(n_, p_);
+		var r_ = context.Operators.ListUnion<Encounter>(l_, q_);
+		var s_ = this.Observation();
+		var t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
+		var u_ = this.Office_Visit();
+		var v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, null);
+		var w_ = context.Operators.ListUnion<Encounter>(t_, v_);
+		var x_ = context.Operators.ListUnion<Encounter>(r_, w_);
+		var y_ = this.Telephone_Visits();
+		var z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
+		var aa_ = this.Online_Assessments();
+		var ab_ = context.Operators.RetrieveByValueSet<Encounter>(aa_, null);
+		var ac_ = context.Operators.ListUnion<Encounter>(z_, ab_);
+		var ad_ = context.Operators.ListUnion<Encounter>(x_, ac_);
+		var ae_ = this.Outpatient_Consultation();
+		var af_ = context.Operators.RetrieveByValueSet<Encounter>(ae_, null);
+		var ag_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var ah_ = context.Operators.RetrieveByValueSet<Encounter>(ag_, null);
+		var ai_ = context.Operators.ListUnion<Encounter>(af_, ah_);
+		var aj_ = context.Operators.ListUnion<Encounter>(ad_, ai_);
+		var ak_ = this.Preventive_Care_Services_Group_Counseling();
+		var al_ = context.Operators.RetrieveByValueSet<Encounter>(ak_, null);
+		bool? an_(Encounter E)
+		{
+			CqlConcept bp_(CodeableConcept @this)
+			{
+				var bu_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return bu_;
+			};
+			var bq_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, bp_);
+			bool? br_(CqlConcept T)
+			{
+				var bv_ = this.Unlisted_preventive_medicine_service();
+				var bw_ = context.Operators.ConvertCodeToConcept(bv_);
+				var bx_ = context.Operators.Equivalent(T, bw_);
+
+				return bx_;
+			};
+			var bs_ = context.Operators.WhereOrNull<CqlConcept>(bq_, br_);
+			var bt_ = context.Operators.ExistsInList<CqlConcept>(bs_);
+
+			return bt_;
+		};
+		var ao_ = context.Operators.WhereOrNull<Encounter>(c_, an_);
+		var ap_ = context.Operators.ListUnion<Encounter>(al_, ao_);
+		var aq_ = context.Operators.ListUnion<Encounter>(aj_, ap_);
+		var ar_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var as_ = context.Operators.RetrieveByValueSet<Encounter>(ar_, null);
+		var at_ = this.Preventive_Care_Services_Individual_Counseling();
+		var au_ = context.Operators.RetrieveByValueSet<Encounter>(at_, null);
+		var av_ = context.Operators.ListUnion<Encounter>(as_, au_);
+		var aw_ = context.Operators.ListUnion<Encounter>(aq_, av_);
+		var ax_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var ay_ = context.Operators.RetrieveByValueSet<Encounter>(ax_, null);
+		var az_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var ba_ = context.Operators.RetrieveByValueSet<Encounter>(az_, null);
+		var bb_ = context.Operators.ListUnion<Encounter>(ay_, ba_);
+		var bc_ = context.Operators.ListUnion<Encounter>(aw_, bb_);
+		var bd_ = Status_1_6_000.Finished_Encounter(bc_);
+		bool? be_(Encounter ValidEncounter)
+		{
+			var by_ = this.Measurement_Period();
+			var bz_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var ca_ = QICoreCommon_2_0_000.ToInterval((bz_ as object));
+			var cb_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(by_, ca_, null);
+
+			return cb_;
+		};
+		var bf_ = context.Operators.WhereOrNull<Encounter>(bd_, be_);
+
+		return bf_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter")]
+	public IEnumerable<Encounter> Qualifying_Encounter() => 
+		__Qualifying_Encounter.Value;
+
+	private IEnumerable<Encounter> Encounter_With_Antibiotic_Ordered_Within_Three_Days_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> b_(Encounter EDOrAmbulatoryVisit)
+		{
+			var d_ = this.Antibiotic_Medications_for_Pharyngitis();
+			var e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			var h_ = context.Operators.ListUnion<MedicationRequest>(e_, g_);
+			var i_ = Status_1_6_000.Active_Medication(h_);
+			bool? j_(MedicationRequest AntibioticOrdered)
+			{
+				var n_ = FHIRHelpers_4_3_000.ToInterval(EDOrAmbulatoryVisit?.Period);
+				var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+				var p_ = context.Operators.Start(o_);
+				var q_ = context.Operators.Convert<CqlDateTime>(AntibioticOrdered?.AuthoredOnElement);
+				var r_ = context.Operators.Quantity(3m, "days");
+				var s_ = context.Operators.Subtract(q_, r_);
+				var u_ = context.Operators.Interval(s_, q_, true, true);
+				var v_ = context.Operators.ElementInInterval<CqlDateTime>(p_, u_, null);
+				var x_ = context.Operators.Not((bool?)(q_ is null));
+				var y_ = context.Operators.And(v_, x_);
+
+				return y_;
+			};
+			var k_ = context.Operators.WhereOrNull<MedicationRequest>(i_, j_);
+			Encounter l_(MedicationRequest AntibioticOrdered) => 
+				EDOrAmbulatoryVisit;
+			var m_ = context.Operators.SelectOrNull<MedicationRequest, Encounter>(k_, l_);
+
+			return m_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter With Antibiotic Ordered Within Three Days")]
+	public IEnumerable<Encounter> Encounter_With_Antibiotic_Ordered_Within_Three_Days() => 
+		__Encounter_With_Antibiotic_Ordered_Within_Three_Days.Value;
+
+	private IEnumerable<Condition> Pharyngitis_or_Tonsillitis_Value()
+	{
+		var a_ = this.Acute_Pharyngitis();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = this.Acute_Tonsillitis();
+		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		var e_ = context.Operators.ListUnion<Condition>(b_, d_);
+		var f_ = Status_1_6_000.Active_Condition(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Pharyngitis or Tonsillitis")]
+	public IEnumerable<Condition> Pharyngitis_or_Tonsillitis() => 
+		__Pharyngitis_or_Tonsillitis.Value;
+
+	private IEnumerable<Encounter> Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic_Value()
+	{
+		var a_ = this.Encounter_With_Antibiotic_Ordered_Within_Three_Days();
+		IEnumerable<Condition> b_(Encounter _VisitWithAntibiotic)
+		{
+			var i_ = this.Pharyngitis_or_Tonsillitis();
+
+			return i_;
+		};
+		Tuples.Tuple_GCVGMbOiaNAaiRPIPICSbUPeC c_(Encounter _VisitWithAntibiotic, Condition _AcutePharyngitisTonsillitis)
+		{
+			var j_ = new Tuples.Tuple_GCVGMbOiaNAaiRPIPICSbUPeC
+			{
+				VisitWithAntibiotic = _VisitWithAntibiotic,
+				AcutePharyngitisTonsillitis = _AcutePharyngitisTonsillitis,
+			};
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Condition, Tuples.Tuple_GCVGMbOiaNAaiRPIPICSbUPeC>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_GCVGMbOiaNAaiRPIPICSbUPeC tuple_gcvgmboianaairpipicsbupec)
+		{
+			var k_ = QICoreCommon_2_0_000.ToPrevalenceInterval(tuple_gcvgmboianaairpipicsbupec.AcutePharyngitisTonsillitis);
+			var l_ = context.Operators.Start(k_);
+			var m_ = FHIRHelpers_4_3_000.ToInterval(tuple_gcvgmboianaairpipicsbupec.VisitWithAntibiotic?.Period);
+			var n_ = QICoreCommon_2_0_000.ToInterval((m_ as object));
+			var o_ = context.Operators.ElementInInterval<CqlDateTime>(l_, n_, null);
+
+			return o_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_GCVGMbOiaNAaiRPIPICSbUPeC>(d_, e_);
+		Encounter g_(Tuples.Tuple_GCVGMbOiaNAaiRPIPICSbUPeC tuple_gcvgmboianaairpipicsbupec) => 
+			tuple_gcvgmboianaairpipicsbupec.VisitWithAntibiotic;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_GCVGMbOiaNAaiRPIPICSbUPeC, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter With Pharyngitis or Tonsillitis With Antibiotic")]
+	public IEnumerable<Encounter> Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic() => 
+		__Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		bool? b_(Encounter EncounterWithPharyngitis)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			var l_ = context.Operators.GreaterOrEqual(k_, (int?)3);
+
+			return l_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter EncounterWithPharyngitis) => 
+			EncounterWithPharyngitis;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Encounter> In_Hospice_Value()
+	{
+		var a_ = this.Initial_Population();
+		bool? b_(Encounter EligibleEncounters)
+		{
+			var d_ = Hospice_6_9_000.Has_Hospice_Services();
+
+			return d_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("In Hospice")]
+	public IEnumerable<Encounter> In_Hospice() => 
+		__In_Hospice.Value;
+
+	private IEnumerable<Encounter> Denominator_Exclusions_Value()
+	{
+		var a_ = this.In_Hospice();
+		var b_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		var c_ = this.Antibiotic_Medications_for_Pharyngitis();
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, null);
+		var f_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, null);
+		var g_ = context.Operators.ListUnion<MedicationRequest>(d_, f_);
+		var h_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, g_);
+		var i_ = context.Operators.ListUnion<Encounter>(a_, h_);
+		var k_ = this.Competing_Conditions_for_Respiratory_Conditions();
+		var l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+		var m_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, l_);
+		var o_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
+		var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		var q_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, p_);
+		var r_ = context.Operators.ListUnion<Encounter>(m_, q_);
+		var s_ = context.Operators.ListUnion<Encounter>(i_, r_);
+
+		return s_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public IEnumerable<Encounter> Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<Observation> Group_A_Streptococcus_Lab_Test_With_Result_Value()
+	{
+		var a_ = this.Group_A_Streptococcus_Test();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.Final_Lab_Observation(b_);
+		bool? d_(Observation GroupAStreptococcusTest)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToValue(GroupAStreptococcusTest?.Value);
+			var g_ = context.Operators.Not((bool?)(f_ is null));
+
+			return g_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Group A Streptococcus Lab Test With Result")]
+	public IEnumerable<Observation> Group_A_Streptococcus_Lab_Test_With_Result() => 
+		__Group_A_Streptococcus_Lab_Test_With_Result.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = this.Group_A_Streptococcus_Lab_Test_With_Result();
+		IEnumerable<Encounter> b_(Observation _GroupAStreptococcusTest)
+		{
+			var i_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+
+			return i_;
+		};
+		Tuples.Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV c_(Observation _GroupAStreptococcusTest, Encounter _EncounterWithPharyngitis)
+		{
+			var j_ = new Tuples.Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV
+			{
+				GroupAStreptococcusTest = _GroupAStreptococcusTest,
+				EncounterWithPharyngitis = _EncounterWithPharyngitis,
+			};
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Observation, Encounter, Tuples.Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV tuple_ferjikqtqgcpbsywqkeabbeev)
+		{
+			var k_ = FHIRHelpers_4_3_000.ToValue(tuple_ferjikqtqgcpbsywqkeabbeev.GroupAStreptococcusTest?.Effective);
+			var l_ = QICoreCommon_2_0_000.ToInterval(k_);
+			var m_ = context.Operators.Start(l_);
+			var n_ = FHIRHelpers_4_3_000.ToInterval(tuple_ferjikqtqgcpbsywqkeabbeev.EncounterWithPharyngitis?.Period);
+			var o_ = context.Operators.End(n_);
+			var p_ = context.Operators.Quantity(3m, "days");
+			var q_ = context.Operators.Subtract(o_, p_);
+			var s_ = context.Operators.End(n_);
+			var u_ = context.Operators.Add(s_, p_);
+			var v_ = context.Operators.Interval(q_, u_, true, true);
+			var w_ = context.Operators.ElementInInterval<CqlDateTime>(m_, v_, "day");
+
+			return w_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV>(d_, e_);
+		Encounter g_(Tuples.Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV tuple_ferjikqtqgcpbsywqkeabbeev) => 
+			tuple_ferjikqtqgcpbsywqkeabbeev.EncounterWithPharyngitis;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+	private IEnumerable<Encounter> Stratification_1_Value()
+	{
+		var a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		bool? b_(Encounter EncounterWithPharyngitis)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			var l_ = context.Operators.Interval((int?)3, (int?)17, true, true);
+			var m_ = context.Operators.ElementInInterval<int?>(k_, l_, null);
+
+			return m_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter EncounterWithPharyngitis) => 
+			EncounterWithPharyngitis;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Stratification 1")]
+	public IEnumerable<Encounter> Stratification_1() => 
+		__Stratification_1.Value;
+
+	private IEnumerable<Encounter> Stratification_2_Value()
+	{
+		var a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		bool? b_(Encounter EncounterWithPharyngitis)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			var l_ = context.Operators.Interval((int?)18, (int?)64, true, true);
+			var m_ = context.Operators.ElementInInterval<int?>(k_, l_, null);
+
+			return m_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter EncounterWithPharyngitis) => 
+			EncounterWithPharyngitis;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Stratification 2")]
+	public IEnumerable<Encounter> Stratification_2() => 
+		__Stratification_2.Value;
+
+	private IEnumerable<Encounter> Stratification_3_Value()
+	{
+		var a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		bool? b_(Encounter EncounterWithPharyngitis)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			var l_ = context.Operators.GreaterOrEqual(k_, (int?)65);
+
+			return l_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter EncounterWithPharyngitis) => 
+			EncounterWithPharyngitis;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Stratification 3")]
+	public IEnumerable<Encounter> Stratification_3() => 
+		__Stratification_3.Value;
+
+}

--- a/Demo/Measures-cms/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
+++ b/Demo/Measures-cms/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
@@ -1,0 +1,1285 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("AppropriateTreatmentforSTEMIFHIR", "1.0.000")]
+public class AppropriateTreatmentforSTEMIFHIR_1_0_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis;
+    internal Lazy<CqlValueSet> __Active_Peptic_Ulcer;
+    internal Lazy<CqlValueSet> __Adverse_reaction_to_thrombolytics;
+    internal Lazy<CqlValueSet> __Allergy_to_thrombolytics;
+    internal Lazy<CqlValueSet> __Oral_Anticoagulant_Medications;
+    internal Lazy<CqlValueSet> __Aortic_Dissection_and_Rupture;
+    internal Lazy<CqlValueSet> __birth_date;
+    internal Lazy<CqlValueSet> __Cardiopulmonary_Arrest;
+    internal Lazy<CqlValueSet> __Cerebral_Vascular_Lesion;
+    internal Lazy<CqlValueSet> __Closed_Head_and_Facial_Trauma;
+    internal Lazy<CqlValueSet> __Dementia;
+    internal Lazy<CqlValueSet> __Discharge_To_Acute_Care_Facility;
+    internal Lazy<CqlValueSet> __ED;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Endotracheal_Intubation;
+    internal Lazy<CqlValueSet> __Fibrinolytic_Therapy;
+    internal Lazy<CqlValueSet> __Intracranial_or_Intraspinal_surgery;
+    internal Lazy<CqlValueSet> __Ischemic_Stroke;
+    internal Lazy<CqlValueSet> __Major_Surgical_Procedure;
+    internal Lazy<CqlValueSet> __Malignant_Intracranial_Neoplasm_Group;
+    internal Lazy<CqlValueSet> __Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device;
+    internal Lazy<CqlValueSet> __Neurologic_impairment;
+    internal Lazy<CqlValueSet> __Patient_Expired;
+    internal Lazy<CqlValueSet> __Percutaneous_Coronary_Intervention;
+    internal Lazy<CqlValueSet> __Pregnancy_ICD10_SNOMEDCT;
+    internal Lazy<CqlValueSet> __STEMI;
+    internal Lazy<CqlValueSet> __Thrombolytic_medications;
+    internal Lazy<CqlCode> __Birthdate;
+    internal Lazy<CqlCode> __Emergency_Department;
+    internal Lazy<CqlCode> __Patient_transfer__procedure_;
+    internal Lazy<CqlCode> __Streptokinase_adverse_reaction__disorder_;
+    internal Lazy<CqlCode> __EMER;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __HSLOC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __ActCode;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __ED_Encounter_with_Encounter_Diagnosis_of_STEMI;
+    internal Lazy<IEnumerable<Encounter>> __ED_Encounter_with_Diagnosis_of_STEMI;
+    internal Lazy<IEnumerable<Encounter>> __ED_Encounter_with_STEMI_Diagnosis;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start;
+    internal Lazy<IEnumerable<Encounter>> __Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start;
+    internal Lazy<IEnumerable<Encounter>> __Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __ED_Encounter_with_Discharge_Disposition_as_Patient_Expired;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Encounter>> __Fibrinolytic_Therapy_within_30_Minutes_of_Arrival;
+    internal Lazy<IEnumerable<Encounter>> __PCI_within_90_Minutes_of_Arrival;
+    internal Lazy<IEnumerable<Encounter>> __ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public AppropriateTreatmentforSTEMIFHIR_1_0_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+
+        __Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis = new Lazy<CqlValueSet>(this.Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis_Value);
+        __Active_Peptic_Ulcer = new Lazy<CqlValueSet>(this.Active_Peptic_Ulcer_Value);
+        __Adverse_reaction_to_thrombolytics = new Lazy<CqlValueSet>(this.Adverse_reaction_to_thrombolytics_Value);
+        __Allergy_to_thrombolytics = new Lazy<CqlValueSet>(this.Allergy_to_thrombolytics_Value);
+        __Oral_Anticoagulant_Medications = new Lazy<CqlValueSet>(this.Oral_Anticoagulant_Medications_Value);
+        __Aortic_Dissection_and_Rupture = new Lazy<CqlValueSet>(this.Aortic_Dissection_and_Rupture_Value);
+        __birth_date = new Lazy<CqlValueSet>(this.birth_date_Value);
+        __Cardiopulmonary_Arrest = new Lazy<CqlValueSet>(this.Cardiopulmonary_Arrest_Value);
+        __Cerebral_Vascular_Lesion = new Lazy<CqlValueSet>(this.Cerebral_Vascular_Lesion_Value);
+        __Closed_Head_and_Facial_Trauma = new Lazy<CqlValueSet>(this.Closed_Head_and_Facial_Trauma_Value);
+        __Dementia = new Lazy<CqlValueSet>(this.Dementia_Value);
+        __Discharge_To_Acute_Care_Facility = new Lazy<CqlValueSet>(this.Discharge_To_Acute_Care_Facility_Value);
+        __ED = new Lazy<CqlValueSet>(this.ED_Value);
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value);
+        __Endotracheal_Intubation = new Lazy<CqlValueSet>(this.Endotracheal_Intubation_Value);
+        __Fibrinolytic_Therapy = new Lazy<CqlValueSet>(this.Fibrinolytic_Therapy_Value);
+        __Intracranial_or_Intraspinal_surgery = new Lazy<CqlValueSet>(this.Intracranial_or_Intraspinal_surgery_Value);
+        __Ischemic_Stroke = new Lazy<CqlValueSet>(this.Ischemic_Stroke_Value);
+        __Major_Surgical_Procedure = new Lazy<CqlValueSet>(this.Major_Surgical_Procedure_Value);
+        __Malignant_Intracranial_Neoplasm_Group = new Lazy<CqlValueSet>(this.Malignant_Intracranial_Neoplasm_Group_Value);
+        __Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device = new Lazy<CqlValueSet>(this.Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device_Value);
+        __Neurologic_impairment = new Lazy<CqlValueSet>(this.Neurologic_impairment_Value);
+        __Patient_Expired = new Lazy<CqlValueSet>(this.Patient_Expired_Value);
+        __Percutaneous_Coronary_Intervention = new Lazy<CqlValueSet>(this.Percutaneous_Coronary_Intervention_Value);
+        __Pregnancy_ICD10_SNOMEDCT = new Lazy<CqlValueSet>(this.Pregnancy_ICD10_SNOMEDCT_Value);
+        __STEMI = new Lazy<CqlValueSet>(this.STEMI_Value);
+        __Thrombolytic_medications = new Lazy<CqlValueSet>(this.Thrombolytic_medications_Value);
+        __Birthdate = new Lazy<CqlCode>(this.Birthdate_Value);
+        __Emergency_Department = new Lazy<CqlCode>(this.Emergency_Department_Value);
+        __Patient_transfer__procedure_ = new Lazy<CqlCode>(this.Patient_transfer__procedure__Value);
+        __Streptokinase_adverse_reaction__disorder_ = new Lazy<CqlCode>(this.Streptokinase_adverse_reaction__disorder__Value);
+        __EMER = new Lazy<CqlCode>(this.EMER_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __HSLOC = new Lazy<CqlCode[]>(this.HSLOC_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __ActCode = new Lazy<CqlCode[]>(this.ActCode_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __ED_Encounter_with_Encounter_Diagnosis_of_STEMI = new Lazy<IEnumerable<Encounter>>(this.ED_Encounter_with_Encounter_Diagnosis_of_STEMI_Value);
+        __ED_Encounter_with_Diagnosis_of_STEMI = new Lazy<IEnumerable<Encounter>>(this.ED_Encounter_with_Diagnosis_of_STEMI_Value);
+        __ED_Encounter_with_STEMI_Diagnosis = new Lazy<IEnumerable<Encounter>>(this.ED_Encounter_with_STEMI_Diagnosis_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter = new Lazy<IEnumerable<Encounter>>(this.Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter_Value);
+        __Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter = new Lazy<IEnumerable<Encounter>>(this.Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter_Value);
+        __Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter = new Lazy<IEnumerable<Encounter>>(this.Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter_Value);
+        __Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter = new Lazy<IEnumerable<Encounter>>(this.Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter_Value);
+        __Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start = new Lazy<IEnumerable<Encounter>>(this.Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start_Value);
+        __Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter = new Lazy<IEnumerable<Encounter>>(this.Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter_Value);
+        __Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start = new Lazy<IEnumerable<Encounter>>(this.Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start_Value);
+        __Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter = new Lazy<IEnumerable<Encounter>>(this.Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter_Value);
+        __Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter = new Lazy<IEnumerable<Encounter>>(this.Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter_Value);
+        __ED_Encounter_with_Discharge_Disposition_as_Patient_Expired = new Lazy<IEnumerable<Encounter>>(this.ED_Encounter_with_Discharge_Disposition_as_Patient_Expired_Value);
+        __Denominator_Exclusions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exclusions_Value);
+        __Fibrinolytic_Therapy_within_30_Minutes_of_Arrival = new Lazy<IEnumerable<Encounter>>(this.Fibrinolytic_Therapy_within_30_Minutes_of_Arrival_Value);
+        __PCI_within_90_Minutes_of_Arrival = new Lazy<IEnumerable<Encounter>>(this.PCI_within_90_Minutes_of_Arrival_Value);
+        __ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival = new Lazy<IEnumerable<Encounter>>(this.ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036", null);
+
+    [CqlDeclaration("Active Bleeding Excluding Menses or Bleeding Diathesis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036")]
+	public CqlValueSet Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis() => 
+		__Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis.Value;
+
+	private CqlValueSet Active_Peptic_Ulcer_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031", null);
+
+    [CqlDeclaration("Active Peptic Ulcer")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031")]
+	public CqlValueSet Active_Peptic_Ulcer() => 
+		__Active_Peptic_Ulcer.Value;
+
+	private CqlValueSet Adverse_reaction_to_thrombolytics_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6", null);
+
+    [CqlDeclaration("Adverse reaction to thrombolytics")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6")]
+	public CqlValueSet Adverse_reaction_to_thrombolytics() => 
+		__Adverse_reaction_to_thrombolytics.Value;
+
+	private CqlValueSet Allergy_to_thrombolytics_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5", null);
+
+    [CqlDeclaration("Allergy to thrombolytics")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5")]
+	public CqlValueSet Allergy_to_thrombolytics() => 
+		__Allergy_to_thrombolytics.Value;
+
+	private CqlValueSet Oral_Anticoagulant_Medications_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045", null);
+
+    [CqlDeclaration("Oral Anticoagulant Medications")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045")]
+	public CqlValueSet Oral_Anticoagulant_Medications() => 
+		__Oral_Anticoagulant_Medications.Value;
+
+	private CqlValueSet Aortic_Dissection_and_Rupture_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028", null);
+
+    [CqlDeclaration("Aortic Dissection and Rupture")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028")]
+	public CqlValueSet Aortic_Dissection_and_Rupture() => 
+		__Aortic_Dissection_and_Rupture.Value;
+
+	private CqlValueSet birth_date_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
+
+    [CqlDeclaration("birth date")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
+	public CqlValueSet birth_date() => 
+		__birth_date.Value;
+
+	private CqlValueSet Cardiopulmonary_Arrest_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048", null);
+
+    [CqlDeclaration("Cardiopulmonary Arrest")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048")]
+	public CqlValueSet Cardiopulmonary_Arrest() => 
+		__Cardiopulmonary_Arrest.Value;
+
+	private CqlValueSet Cerebral_Vascular_Lesion_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025", null);
+
+    [CqlDeclaration("Cerebral Vascular Lesion")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025")]
+	public CqlValueSet Cerebral_Vascular_Lesion() => 
+		__Cerebral_Vascular_Lesion.Value;
+
+	private CqlValueSet Closed_Head_and_Facial_Trauma_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026", null);
+
+    [CqlDeclaration("Closed Head and Facial Trauma")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026")]
+	public CqlValueSet Closed_Head_and_Facial_Trauma() => 
+		__Closed_Head_and_Facial_Trauma.Value;
+
+	private CqlValueSet Dementia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043", null);
+
+    [CqlDeclaration("Dementia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043")]
+	public CqlValueSet Dementia() => 
+		__Dementia.Value;
+
+	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+
+    [CqlDeclaration("Discharge To Acute Care Facility")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
+	public CqlValueSet Discharge_To_Acute_Care_Facility() => 
+		__Discharge_To_Acute_Care_Facility.Value;
+
+	private CqlValueSet ED_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085", null);
+
+    [CqlDeclaration("ED")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085")]
+	public CqlValueSet ED() => 
+		__ED.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+
+    [CqlDeclaration("Emergency Department Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit.Value;
+
+	private CqlValueSet Endotracheal_Intubation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69", null);
+
+    [CqlDeclaration("Endotracheal Intubation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69")]
+	public CqlValueSet Endotracheal_Intubation() => 
+		__Endotracheal_Intubation.Value;
+
+	private CqlValueSet Fibrinolytic_Therapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020", null);
+
+    [CqlDeclaration("Fibrinolytic Therapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020")]
+	public CqlValueSet Fibrinolytic_Therapy() => 
+		__Fibrinolytic_Therapy.Value;
+
+	private CqlValueSet Intracranial_or_Intraspinal_surgery_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2", null);
+
+    [CqlDeclaration("Intracranial or Intraspinal surgery")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2")]
+	public CqlValueSet Intracranial_or_Intraspinal_surgery() => 
+		__Intracranial_or_Intraspinal_surgery.Value;
+
+	private CqlValueSet Ischemic_Stroke_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024", null);
+
+    [CqlDeclaration("Ischemic Stroke")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024")]
+	public CqlValueSet Ischemic_Stroke() => 
+		__Ischemic_Stroke.Value;
+
+	private CqlValueSet Major_Surgical_Procedure_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056", null);
+
+    [CqlDeclaration("Major Surgical Procedure")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056")]
+	public CqlValueSet Major_Surgical_Procedure() => 
+		__Major_Surgical_Procedure.Value;
+
+	private CqlValueSet Malignant_Intracranial_Neoplasm_Group_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3", null);
+
+    [CqlDeclaration("Malignant Intracranial Neoplasm Group")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3")]
+	public CqlValueSet Malignant_Intracranial_Neoplasm_Group() => 
+		__Malignant_Intracranial_Neoplasm_Group.Value;
+
+	private CqlValueSet Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052", null);
+
+    [CqlDeclaration("Insertion or Replacement of Mechanical Circulatory Assist Device")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052")]
+	public CqlValueSet Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device() => 
+		__Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device.Value;
+
+	private CqlValueSet Neurologic_impairment_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012", null);
+
+    [CqlDeclaration("Neurologic impairment")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012")]
+	public CqlValueSet Neurologic_impairment() => 
+		__Neurologic_impairment.Value;
+
+	private CqlValueSet Patient_Expired_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+
+    [CqlDeclaration("Patient Expired")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
+	public CqlValueSet Patient_Expired() => 
+		__Patient_Expired.Value;
+
+	private CqlValueSet Percutaneous_Coronary_Intervention_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5", null);
+
+    [CqlDeclaration("Percutaneous Coronary Intervention")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5")]
+	public CqlValueSet Percutaneous_Coronary_Intervention() => 
+		__Percutaneous_Coronary_Intervention.Value;
+
+	private CqlValueSet Pregnancy_ICD10_SNOMEDCT_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055", null);
+
+    [CqlDeclaration("Pregnancy ICD10 SNOMEDCT")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055")]
+	public CqlValueSet Pregnancy_ICD10_SNOMEDCT() => 
+		__Pregnancy_ICD10_SNOMEDCT.Value;
+
+	private CqlValueSet STEMI_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017", null);
+
+    [CqlDeclaration("STEMI")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017")]
+	public CqlValueSet STEMI() => 
+		__STEMI.Value;
+
+	private CqlValueSet Thrombolytic_medications_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4", null);
+
+    [CqlDeclaration("Thrombolytic medications")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4")]
+	public CqlValueSet Thrombolytic_medications() => 
+		__Thrombolytic_medications.Value;
+
+	private CqlCode Birthdate_Value() => 
+		new CqlCode("21112-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Birthdate")]
+	public CqlCode Birthdate() => 
+		__Birthdate.Value;
+
+	private CqlCode Emergency_Department_Value() => 
+		new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", null, null);
+
+    [CqlDeclaration("Emergency Department")]
+	public CqlCode Emergency_Department() => 
+		__Emergency_Department.Value;
+
+	private CqlCode Patient_transfer__procedure__Value() => 
+		new CqlCode("107724000", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Patient transfer (procedure)")]
+	public CqlCode Patient_transfer__procedure_() => 
+		__Patient_transfer__procedure_.Value;
+
+	private CqlCode Streptokinase_adverse_reaction__disorder__Value() => 
+		new CqlCode("293571007", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Streptokinase adverse reaction (disorder)")]
+	public CqlCode Streptokinase_adverse_reaction__disorder_() => 
+		__Streptokinase_adverse_reaction__disorder_.Value;
+
+	private CqlCode EMER_Value() => 
+		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+
+    [CqlDeclaration("EMER")]
+	public CqlCode EMER() => 
+		__EMER.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("21112-8", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] HSLOC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("HSLOC")]
+	public CqlCode[] HSLOC() => 
+		__HSLOC.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("107724000", "http://snomed.info/sct", null, null),
+			new CqlCode("293571007", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] ActCode_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ActCode")]
+	public CqlCode[] ActCode() => 
+		__ActCode.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("AppropriateTreatmentforSTEMIFHIR-1.0.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> ED_Encounter_with_Encounter_Diagnosis_of_STEMI_Value()
+	{
+		var a_ = this.ED();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter EDEncounter)
+		{
+			var e_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(EDEncounter?.StatusElement?.Value);
+			var f_ = context.Operators.Equal(e_, "finished");
+			var g_ = FHIRHelpers_4_3_000.ToCode(EDEncounter?.Class);
+			var h_ = this.EMER();
+			var i_ = context.Operators.Equivalent(g_, h_);
+			var j_ = context.Operators.And(f_, i_);
+			CqlConcept k_(CodeableConcept @this)
+			{
+				var y_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return y_;
+			};
+			var l_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(EDEncounter?.ReasonCode, k_);
+			var m_ = this.STEMI();
+			var n_ = context.Operators.ConceptsInValueSet(l_, m_);
+			var o_ = CQMCommon_2_0_000.encounterDiagnosis(EDEncounter);
+			bool? p_(Condition EncDiagnosis)
+			{
+				var z_ = FHIRHelpers_4_3_000.ToConcept(EncDiagnosis?.Code);
+				var aa_ = this.STEMI();
+				var ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+
+				return ab_;
+			};
+			var q_ = context.Operators.WhereOrNull<Condition>(o_, p_);
+			var r_ = context.Operators.ExistsInList<Condition>(q_);
+			var s_ = context.Operators.Or(n_, r_);
+			var t_ = context.Operators.And(j_, s_);
+			var u_ = this.Measurement_Period();
+			var v_ = FHIRHelpers_4_3_000.ToInterval(EDEncounter?.Period);
+			var w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, v_, null);
+			var x_ = context.Operators.And(t_, w_);
+
+			return x_;
+		};
+		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("ED Encounter with Encounter Diagnosis of STEMI")]
+	public IEnumerable<Encounter> ED_Encounter_with_Encounter_Diagnosis_of_STEMI() => 
+		__ED_Encounter_with_Encounter_Diagnosis_of_STEMI.Value;
+
+	private IEnumerable<Encounter> ED_Encounter_with_Diagnosis_of_STEMI_Value()
+	{
+		var a_ = this.ED();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> c_(Encounter EDEncounter)
+		{
+			var e_ = this.STEMI();
+			var f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
+			bool? g_(Condition DxSTEMI)
+			{
+				var k_ = FHIRHelpers_4_3_000.ToConcept(DxSTEMI?.ClinicalStatus);
+				var l_ = QICoreCommon_2_0_000.active();
+				var m_ = context.Operators.ConvertCodeToConcept(l_);
+				var n_ = context.Operators.Equivalent(k_, m_);
+				var o_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(EDEncounter?.StatusElement?.Value);
+				var p_ = context.Operators.Equal(o_, "finished");
+				var q_ = context.Operators.And(n_, p_);
+				var r_ = FHIRHelpers_4_3_000.ToCode(EDEncounter?.Class);
+				var s_ = this.EMER();
+				var t_ = context.Operators.Equivalent(r_, s_);
+				var u_ = context.Operators.And(q_, t_);
+				var v_ = QICoreCommon_2_0_000.prevalenceInterval(DxSTEMI);
+				var w_ = context.Operators.Start(v_);
+				var x_ = FHIRHelpers_4_3_000.ToInterval(EDEncounter?.Period);
+				var y_ = context.Operators.ElementInInterval<CqlDateTime>(w_, x_, null);
+				var z_ = context.Operators.And(u_, y_);
+				var aa_ = this.Measurement_Period();
+				var ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aa_, x_, "day");
+				var ad_ = context.Operators.And(z_, ac_);
+
+				return ad_;
+			};
+			var h_ = context.Operators.WhereOrNull<Condition>(f_, g_);
+			Encounter i_(Condition DxSTEMI) => 
+				EDEncounter;
+			var j_ = context.Operators.SelectOrNull<Condition, Encounter>(h_, i_);
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("ED Encounter with Diagnosis of STEMI")]
+	public IEnumerable<Encounter> ED_Encounter_with_Diagnosis_of_STEMI() => 
+		__ED_Encounter_with_Diagnosis_of_STEMI.Value;
+
+	private IEnumerable<Encounter> ED_Encounter_with_STEMI_Diagnosis_Value()
+	{
+		var a_ = this.ED_Encounter_with_Encounter_Diagnosis_of_STEMI();
+		var b_ = this.ED_Encounter_with_Diagnosis_of_STEMI();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("ED Encounter with STEMI Diagnosis")]
+	public IEnumerable<Encounter> ED_Encounter_with_STEMI_Diagnosis() => 
+		__ED_Encounter_with_STEMI_Diagnosis.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		bool? b_(Encounter EDwithSTEMI)
+		{
+			var d_ = this.Patient();
+			var e_ = context.Operators.Convert<CqlDate>(d_?.BirthDateElement?.Value);
+			var f_ = FHIRHelpers_4_3_000.ToInterval(EDwithSTEMI?.Period);
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.DateFrom(g_);
+			var i_ = context.Operators.CalculateAgeAt(e_, h_, "year");
+			var j_ = context.Operators.GreaterOrEqual(i_, (int?)18);
+
+			return j_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Encounter> Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
+		{
+			var d_ = this.Thrombolytic_medications();
+			var e_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(d_, null);
+			bool? f_(AllergyIntolerance ThrombolyticAllergy)
+			{
+				var j_ = FHIRHelpers_4_3_000.ToConcept(ThrombolyticAllergy?.ClinicalStatus);
+				var k_ = QICoreCommon_2_0_000.allergy_active();
+				var l_ = context.Operators.ConvertCodeToConcept(k_);
+				var m_ = context.Operators.Equivalent(j_, l_);
+				var n_ = FHIRHelpers_4_3_000.ToValue(ThrombolyticAllergy?.Onset);
+				var o_ = QICoreCommon_2_0_000.toInterval(n_);
+				var p_ = FHIRHelpers_4_3_000.ToInterval(EDwSTEMI?.Period);
+				var q_ = context.Operators.Overlaps(o_, p_, null);
+				var r_ = context.Operators.And(m_, q_);
+
+				return r_;
+			};
+			var g_ = context.Operators.WhereOrNull<AllergyIntolerance>(e_, f_);
+			Encounter h_(AllergyIntolerance ThrombolyticAllergy) => 
+				EDwSTEMI;
+			var i_ = context.Operators.SelectOrNull<AllergyIntolerance, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Allergy or Intolerance to Thrombolytic Medications Overlaps ED Encounter")]
+	public IEnumerable<Encounter> Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter() => 
+		__Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter.Value;
+
+	private IEnumerable<Encounter> Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
+		{
+			var d_ = this.Adverse_reaction_to_thrombolytics();
+			var e_ = context.Operators.RetrieveByValueSet<AdverseEvent>(d_, null);
+			bool? f_(AdverseEvent ThrombolyticAdverseEvent)
+			{
+				var j_ = context.Operators.Convert<CqlDateTime>(ThrombolyticAdverseEvent?.RecordedDateElement);
+				var k_ = FHIRHelpers_4_3_000.ToInterval(EDwSTEMI?.Period);
+				var l_ = context.Operators.End(k_);
+				var m_ = context.Operators.Before(j_, l_, null);
+				var n_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(ThrombolyticAdverseEvent?.ActualityElement?.Value);
+				var o_ = context.Operators.Equal(n_, "actual");
+				var p_ = context.Operators.And(m_, o_);
+
+				return p_;
+			};
+			var g_ = context.Operators.WhereOrNull<AdverseEvent>(e_, f_);
+			Encounter h_(AdverseEvent ThrombolyticAdverseEvent) => 
+				EDwSTEMI;
+			var i_ = context.Operators.SelectOrNull<AdverseEvent, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Adverse Effect to Thrombolytic Medications Before End of ED Encounter")]
+	public IEnumerable<Encounter> Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter() => 
+		__Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter.Value;
+
+	private IEnumerable<Encounter> Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
+		{
+			var d_ = this.Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis();
+			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			var f_ = this.Malignant_Intracranial_Neoplasm_Group();
+			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			var h_ = context.Operators.ListUnion<Condition>(e_, g_);
+			var i_ = this.Cerebral_Vascular_Lesion();
+			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			var k_ = this.Dementia();
+			var l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+			var m_ = context.Operators.ListUnion<Condition>(j_, l_);
+			var n_ = context.Operators.ListUnion<Condition>(h_, m_);
+			var o_ = this.Pregnancy_ICD10_SNOMEDCT();
+			var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+			var q_ = this.Allergy_to_thrombolytics();
+			var r_ = context.Operators.RetrieveByValueSet<Condition>(q_, null);
+			var s_ = context.Operators.ListUnion<Condition>(p_, r_);
+			var t_ = context.Operators.ListUnion<Condition>(n_, s_);
+			bool? u_(Condition ActiveExclusionDx)
+			{
+				var y_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveExclusionDx);
+				var z_ = FHIRHelpers_4_3_000.ToInterval(EDwithSTEMI?.Period);
+				var aa_ = context.Operators.OverlapsBefore(y_, z_, null);
+
+				return aa_;
+			};
+			var v_ = context.Operators.WhereOrNull<Condition>(t_, u_);
+			Encounter w_(Condition ActiveExclusionDx) => 
+				EDwithSTEMI;
+			var x_ = context.Operators.SelectOrNull<Condition, Encounter>(v_, w_);
+
+			return x_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Active Exclusion Diagnosis at Start of ED Encounter")]
+	public IEnumerable<Encounter> Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter() => 
+		__Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter.Value;
+
+	private IEnumerable<Encounter> Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
+		{
+			var d_ = this.Oral_Anticoagulant_Medications();
+			var e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			var h_ = context.Operators.ListUnion<MedicationRequest>(e_, g_);
+			bool? i_(MedicationRequest OralAnticoagulant)
+			{
+				var m_ = context.Operators.EnumEqualsString(OralAnticoagulant?.StatusElement?.Value, "active");
+				var n_ = context.Operators.EnumEqualsString(OralAnticoagulant?.IntentElement?.Value, "order");
+				var o_ = context.Operators.And(m_, n_);
+				var p_ = context.Operators.Convert<CqlDateTime>(OralAnticoagulant?.AuthoredOnElement);
+				var q_ = FHIRHelpers_4_3_000.ToInterval(EDwithSTEMI?.Period);
+				var r_ = context.Operators.Start(q_);
+				var s_ = context.Operators.SameOrBefore(p_, r_, null);
+				var t_ = context.Operators.And(o_, s_);
+
+				return t_;
+			};
+			var j_ = context.Operators.WhereOrNull<MedicationRequest>(h_, i_);
+			Encounter k_(MedicationRequest OralAnticoagulant) => 
+				EDwithSTEMI;
+			var l_ = context.Operators.SelectOrNull<MedicationRequest, Encounter>(j_, k_);
+
+			return l_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Active Oral Anticoagulant Medication at the Start of ED Encounter")]
+	public IEnumerable<Encounter> Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter() => 
+		__Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter.Value;
+
+	private IEnumerable<Encounter> Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
+		{
+			var d_ = this.Aortic_Dissection_and_Rupture();
+			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			var f_ = this.Neurologic_impairment();
+			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			var h_ = context.Operators.ListUnion<Condition>(e_, g_);
+			var i_ = this.Cardiopulmonary_Arrest();
+			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			var k_ = context.Operators.ListUnion<Condition>(h_, j_);
+			bool? l_(Condition ExclusionDiagnosis)
+			{
+				var p_ = QICoreCommon_2_0_000.prevalenceInterval(ExclusionDiagnosis);
+				var q_ = context.Operators.Start(p_);
+				var r_ = FHIRHelpers_4_3_000.ToInterval(EDwithSTEMI?.Period);
+				var s_ = context.Operators.ElementInInterval<CqlDateTime>(q_, r_, null);
+				var u_ = context.Operators.Start(p_);
+				var w_ = context.Operators.Start(r_);
+				var x_ = context.Operators.Quantity(24m, "hours");
+				var y_ = context.Operators.Subtract(w_, x_);
+				var aa_ = context.Operators.Start(r_);
+				var ab_ = context.Operators.Interval(y_, aa_, true, false);
+				var ac_ = context.Operators.ElementInInterval<CqlDateTime>(u_, ab_, null);
+				var ae_ = context.Operators.Start(r_);
+				var af_ = context.Operators.Not((bool?)(ae_ is null));
+				var ag_ = context.Operators.And(ac_, af_);
+				var ah_ = context.Operators.Or(s_, ag_);
+
+				return ah_;
+			};
+			var m_ = context.Operators.WhereOrNull<Condition>(k_, l_);
+			Encounter n_(Condition ExclusionDiagnosis) => 
+				EDwithSTEMI;
+			var o_ = context.Operators.SelectOrNull<Condition, Encounter>(m_, n_);
+
+			return o_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Exclusion Diagnosis During ED Encounter or Within 24 Hours of ED Encounter Start")]
+	public IEnumerable<Encounter> Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start() => 
+		__Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start.Value;
+
+	private IEnumerable<Encounter> Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
+		{
+			var d_ = this.Major_Surgical_Procedure();
+			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			bool? f_(Procedure MajorSurgery)
+			{
+				var j_ = FHIRHelpers_4_3_000.ToValue(MajorSurgery?.Performed);
+				var k_ = QICoreCommon_2_0_000.toInterval(j_);
+				var l_ = context.Operators.Start(k_);
+				var m_ = FHIRHelpers_4_3_000.ToInterval(EDwithSTEMI?.Period);
+				var n_ = context.Operators.Start(m_);
+				var o_ = context.Operators.Quantity(21m, "days");
+				var p_ = context.Operators.Subtract(n_, o_);
+				var r_ = context.Operators.Start(m_);
+				var s_ = context.Operators.Interval(p_, r_, true, false);
+				var t_ = context.Operators.ElementInInterval<CqlDateTime>(l_, s_, null);
+				var v_ = context.Operators.Start(m_);
+				var w_ = context.Operators.Not((bool?)(v_ is null));
+				var x_ = context.Operators.And(t_, w_);
+				var y_ = context.Operators.EnumEqualsString(MajorSurgery?.StatusElement?.Value, "completed");
+				var z_ = context.Operators.And(x_, y_);
+
+				return z_;
+			};
+			var g_ = context.Operators.WhereOrNull<Procedure>(e_, f_);
+			Encounter h_(Procedure MajorSurgery) => 
+				EDwithSTEMI;
+			var i_ = context.Operators.SelectOrNull<Procedure, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Major Surgical Procedure 21 Days or Less Before Start of or Starts During ED Encounter")]
+	public IEnumerable<Encounter> Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter() => 
+		__Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter.Value;
+
+	private IEnumerable<Encounter> Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
+		{
+			var d_ = this.Endotracheal_Intubation();
+			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			var f_ = this.Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device();
+			var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+			var h_ = context.Operators.ListUnion<Procedure>(e_, g_);
+			bool? i_(Procedure AirwayProcedure)
+			{
+				var m_ = FHIRHelpers_4_3_000.ToValue(AirwayProcedure?.Performed);
+				var n_ = QICoreCommon_2_0_000.toInterval(m_);
+				var o_ = context.Operators.Start(n_);
+				var p_ = FHIRHelpers_4_3_000.ToInterval(EDwithSTEMI?.Period);
+				var q_ = context.Operators.ElementInInterval<CqlDateTime>(o_, p_, null);
+				var s_ = QICoreCommon_2_0_000.toInterval(m_);
+				var t_ = context.Operators.Start(s_);
+				var v_ = context.Operators.Start(p_);
+				var w_ = context.Operators.Quantity(24m, "hours");
+				var x_ = context.Operators.Subtract(v_, w_);
+				var z_ = context.Operators.Start(p_);
+				var aa_ = context.Operators.Interval(x_, z_, true, false);
+				var ab_ = context.Operators.ElementInInterval<CqlDateTime>(t_, aa_, null);
+				var ad_ = context.Operators.Start(p_);
+				var ae_ = context.Operators.Not((bool?)(ad_ is null));
+				var af_ = context.Operators.And(ab_, ae_);
+				var ag_ = context.Operators.Or(q_, af_);
+				var ah_ = context.Operators.EnumEqualsString(AirwayProcedure?.StatusElement?.Value, "completed");
+				var ai_ = context.Operators.And(ag_, ah_);
+
+				return ai_;
+			};
+			var j_ = context.Operators.WhereOrNull<Procedure>(h_, i_);
+			Encounter k_(Procedure AirwayProcedure) => 
+				EDwithSTEMI;
+			var l_ = context.Operators.SelectOrNull<Procedure, Encounter>(j_, k_);
+
+			return l_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Intubation or Mechanical Circulatory Assist Procedure During ED Encounter or Within 24 Hours of ED Encounter Start")]
+	public IEnumerable<Encounter> Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start() => 
+		__Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start.Value;
+
+	private IEnumerable<Encounter> Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
+		{
+			var d_ = this.Ischemic_Stroke();
+			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			var f_ = this.Closed_Head_and_Facial_Trauma();
+			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			var h_ = context.Operators.ListUnion<Condition>(e_, g_);
+			var i_ = this.Active_Peptic_Ulcer();
+			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			var k_ = this.Cardiopulmonary_Arrest();
+			var l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+			var m_ = context.Operators.ListUnion<Condition>(j_, l_);
+			var n_ = context.Operators.ListUnion<Condition>(h_, m_);
+			bool? o_(Condition ExclusionCondition)
+			{
+				var s_ = QICoreCommon_2_0_000.prevalenceInterval(ExclusionCondition);
+				var t_ = context.Operators.Start(s_);
+				var u_ = FHIRHelpers_4_3_000.ToInterval(EDwSTEMI?.Period);
+				var v_ = context.Operators.Start(u_);
+				var w_ = context.Operators.Quantity(90m, "days");
+				var x_ = context.Operators.Subtract(v_, w_);
+				var z_ = context.Operators.Start(u_);
+				var aa_ = context.Operators.Interval(x_, z_, true, true);
+				var ab_ = context.Operators.ElementInInterval<CqlDateTime>(t_, aa_, null);
+
+				return ab_;
+			};
+			var p_ = context.Operators.WhereOrNull<Condition>(n_, o_);
+			Encounter q_(Condition ExclusionCondition) => 
+				EDwSTEMI;
+			var r_ = context.Operators.SelectOrNull<Condition, Encounter>(p_, q_);
+
+			return r_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Active Exclusion Diagnosis Within 90 Days Before or At the Start of ED Encounter")]
+	public IEnumerable<Encounter> Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter() => 
+		__Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter.Value;
+
+	private IEnumerable<Encounter> Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
+		{
+			var d_ = this.Intracranial_or_Intraspinal_surgery();
+			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			bool? f_(Procedure CranialorSpinalSurgery)
+			{
+				var j_ = FHIRHelpers_4_3_000.ToValue(CranialorSpinalSurgery?.Performed);
+				var k_ = QICoreCommon_2_0_000.toInterval(j_);
+				var l_ = context.Operators.Start(k_);
+				var m_ = FHIRHelpers_4_3_000.ToInterval(EDwithSTEMI?.Period);
+				var n_ = context.Operators.Start(m_);
+				var o_ = context.Operators.Quantity(90m, "days");
+				var p_ = context.Operators.Subtract(n_, o_);
+				var r_ = context.Operators.Start(m_);
+				var s_ = context.Operators.Interval(p_, r_, true, false);
+				var t_ = context.Operators.ElementInInterval<CqlDateTime>(l_, s_, null);
+				var v_ = context.Operators.Start(m_);
+				var w_ = context.Operators.Not((bool?)(v_ is null));
+				var x_ = context.Operators.And(t_, w_);
+				var y_ = context.Operators.EnumEqualsString(CranialorSpinalSurgery?.StatusElement?.Value, "completed");
+				var z_ = context.Operators.And(x_, y_);
+
+				return z_;
+			};
+			var g_ = context.Operators.WhereOrNull<Procedure>(e_, f_);
+			Encounter h_(Procedure CranialorSpinalSurgery) => 
+				EDwithSTEMI;
+			var i_ = context.Operators.SelectOrNull<Procedure, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Intracranial or Intraspinal Procedure 90 Days or Less Before Start of ED Encounter")]
+	public IEnumerable<Encounter> Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter() => 
+		__Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter.Value;
+
+	private IEnumerable<Encounter> ED_Encounter_with_Discharge_Disposition_as_Patient_Expired_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		bool? b_(Encounter EDwithSTEMI)
+		{
+			var d_ = FHIRHelpers_4_3_000.ToConcept(EDwithSTEMI?.Hospitalization?.DischargeDisposition);
+			var e_ = this.Patient_Expired();
+			var f_ = context.Operators.ConceptInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("ED Encounter with Discharge Disposition as Patient Expired")]
+	public IEnumerable<Encounter> ED_Encounter_with_Discharge_Disposition_as_Patient_Expired() => 
+		__ED_Encounter_with_Discharge_Disposition_as_Patient_Expired.Value;
+
+	private IEnumerable<Encounter> Denominator_Exclusions_Value()
+	{
+		var a_ = this.Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter();
+		var b_ = this.Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+		var d_ = this.Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter();
+		var e_ = this.Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter();
+		var f_ = context.Operators.ListUnion<Encounter>(d_, e_);
+		var g_ = context.Operators.ListUnion<Encounter>(c_, f_);
+		var h_ = this.Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start();
+		var i_ = this.Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter();
+		var j_ = context.Operators.ListUnion<Encounter>(h_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(g_, j_);
+		var l_ = this.Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start();
+		var m_ = this.Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter();
+		var n_ = context.Operators.ListUnion<Encounter>(l_, m_);
+		var o_ = context.Operators.ListUnion<Encounter>(k_, n_);
+		var p_ = this.Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter();
+		var q_ = this.ED_Encounter_with_Discharge_Disposition_as_Patient_Expired();
+		var r_ = context.Operators.ListUnion<Encounter>(p_, q_);
+		var s_ = context.Operators.ListUnion<Encounter>(o_, r_);
+
+		return s_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public IEnumerable<Encounter> Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+    [CqlDeclaration("currentemergencyDepartmentArrivalTime")]
+    [CqlTag("description", "Returns the emergency department arrival time for the encounter.")]
+	public CqlDateTime currentemergencyDepartmentArrivalTime(Encounter EDEncounter)
+	{
+		bool? a_(Encounter.LocationComponent EDLocation)
+		{
+			var f_ = CQMCommon_2_0_000.GetLocation(EDLocation?.Location);
+			CqlConcept g_(CodeableConcept @this)
+			{
+				var k_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return k_;
+			};
+			var h_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(f_?.Type, g_);
+			var i_ = this.Emergency_Department_Visit();
+			var j_ = context.Operators.ConceptsInValueSet(h_, i_);
+
+			return j_;
+		};
+		var b_ = context.Operators.WhereOrNull<Encounter.LocationComponent>((EDEncounter?.Location as IEnumerable<Encounter.LocationComponent>), a_);
+		var c_ = context.Operators.SingleOrNull<Encounter.LocationComponent>(b_);
+		var d_ = FHIRHelpers_4_3_000.ToInterval(c_?.Period);
+		var e_ = context.Operators.Start(d_);
+
+		return e_;
+	}
+
+	private IEnumerable<Encounter> Fibrinolytic_Therapy_within_30_Minutes_of_Arrival_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
+		{
+			var d_ = this.Fibrinolytic_Therapy();
+			var e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, null);
+			var g_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, null);
+			var h_ = context.Operators.ListUnion<MedicationAdministration>(e_, g_);
+			bool? i_(MedicationAdministration Fibrinolytic)
+			{
+				var m_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(Fibrinolytic?.StatusElement?.Value);
+				var n_ = context.Operators.Equal(m_, "completed");
+				var o_ = FHIRHelpers_4_3_000.ToValue(Fibrinolytic?.Effective);
+				var p_ = QICoreCommon_2_0_000.toInterval(o_);
+				var q_ = context.Operators.Start(p_);
+				var r_ = this.currentemergencyDepartmentArrivalTime(EDwithSTEMI);
+				var t_ = context.Operators.Quantity(30m, "minutes");
+				var u_ = context.Operators.Add(r_, t_);
+				var v_ = context.Operators.Interval(r_, u_, false, true);
+				var w_ = context.Operators.ElementInInterval<CqlDateTime>(q_, v_, null);
+				var y_ = context.Operators.Not((bool?)(r_ is null));
+				var z_ = context.Operators.And(w_, y_);
+				var aa_ = context.Operators.And(n_, z_);
+
+				return aa_;
+			};
+			var j_ = context.Operators.WhereOrNull<MedicationAdministration>(h_, i_);
+			Encounter k_(MedicationAdministration Fibrinolytic) => 
+				EDwithSTEMI;
+			var l_ = context.Operators.SelectOrNull<MedicationAdministration, Encounter>(j_, k_);
+
+			return l_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Fibrinolytic Therapy within 30 Minutes of Arrival")]
+	public IEnumerable<Encounter> Fibrinolytic_Therapy_within_30_Minutes_of_Arrival() => 
+		__Fibrinolytic_Therapy_within_30_Minutes_of_Arrival.Value;
+
+	private IEnumerable<Encounter> PCI_within_90_Minutes_of_Arrival_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
+		{
+			var d_ = this.Percutaneous_Coronary_Intervention();
+			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			bool? f_(Procedure PCI)
+			{
+				var j_ = FHIRHelpers_4_3_000.ToValue(PCI?.Performed);
+				var k_ = QICoreCommon_2_0_000.toInterval(j_);
+				var l_ = context.Operators.Start(k_);
+				var m_ = this.currentemergencyDepartmentArrivalTime(EDwithSTEMI);
+				var o_ = context.Operators.Quantity(90m, "minutes");
+				var p_ = context.Operators.Add(m_, o_);
+				var q_ = context.Operators.Interval(m_, p_, false, true);
+				var r_ = context.Operators.ElementInInterval<CqlDateTime>(l_, q_, null);
+				var t_ = context.Operators.Not((bool?)(m_ is null));
+				var u_ = context.Operators.And(r_, t_);
+				var v_ = context.Operators.EnumEqualsString(PCI?.StatusElement?.Value, "completed");
+				var w_ = context.Operators.And(u_, v_);
+
+				return w_;
+			};
+			var g_ = context.Operators.WhereOrNull<Procedure>(e_, f_);
+			Encounter h_(Procedure PCI) => 
+				EDwithSTEMI;
+			var i_ = context.Operators.SelectOrNull<Procedure, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("PCI within 90 Minutes of Arrival")]
+	public IEnumerable<Encounter> PCI_within_90_Minutes_of_Arrival() => 
+		__PCI_within_90_Minutes_of_Arrival.Value;
+
+	private IEnumerable<Encounter> ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival_Value()
+	{
+		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		bool? b_(Encounter EDwithSTEMI)
+		{
+			var d_ = FHIRHelpers_4_3_000.ToInterval(EDwithSTEMI?.Period);
+			var e_ = context.Operators.End(d_);
+			var g_ = context.Operators.Start(d_);
+			var i_ = context.Operators.Start(d_);
+			var j_ = context.Operators.Quantity(45m, "minutes");
+			var k_ = context.Operators.Add(i_, j_);
+			var l_ = context.Operators.Interval(g_, k_, false, true);
+			var m_ = context.Operators.ElementInInterval<CqlDateTime>(e_, l_, null);
+			var o_ = context.Operators.Start(d_);
+			var p_ = context.Operators.Not((bool?)(o_ is null));
+			var q_ = context.Operators.And(m_, p_);
+			var r_ = FHIRHelpers_4_3_000.ToConcept(EDwithSTEMI?.Hospitalization?.DischargeDisposition);
+			var s_ = this.Discharge_To_Acute_Care_Facility();
+			var t_ = context.Operators.ConceptInValueSet(r_, s_);
+			var u_ = context.Operators.And(q_, t_);
+
+			return u_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("ED Departure with Transfer to Acute Care Facility Within 45 Minutes of Arrival")]
+	public IEnumerable<Encounter> ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival() => 
+		__ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = this.Fibrinolytic_Therapy_within_30_Minutes_of_Arrival();
+		var b_ = this.PCI_within_90_Minutes_of_Arrival();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+		var d_ = this.ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival();
+		var e_ = context.Operators.ListUnion<Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
@@ -1,0 +1,727 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR", "0.1.000")]
+public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Antibiotic_Medications_for_Upper_Respiratory_Infection;
+    internal Lazy<CqlValueSet> __Comorbid_Conditions_for_Respiratory_Conditions;
+    internal Lazy<CqlValueSet> __Competing_Conditions_for_Respiratory_Conditions;
+    internal Lazy<CqlValueSet> __Emergency_Department_Evaluation_and_Management_Visit;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Initial_Hospital_Observation_Care;
+    internal Lazy<CqlValueSet> __Medical_Disability_Exam;
+    internal Lazy<CqlValueSet> __Observation;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Group_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Individual_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care__Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Upper_Respiratory_Infection;
+    internal Lazy<CqlCode> __Unlisted_preventive_medicine_service;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Upper_Respiratory_Infection;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Encounters_and_Assessments_with_Hospice_Patient;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<IEnumerable<Encounter>> __Stratification_1;
+    internal Lazy<IEnumerable<Encounter>> __Stratification_2;
+    internal Lazy<IEnumerable<Encounter>> __Stratification_3;
+
+    #endregion
+    public AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        Antibiotic_1_5_000 = new Antibiotic_1_5_000(context);
+
+        __Antibiotic_Medications_for_Upper_Respiratory_Infection = new Lazy<CqlValueSet>(this.Antibiotic_Medications_for_Upper_Respiratory_Infection_Value);
+        __Comorbid_Conditions_for_Respiratory_Conditions = new Lazy<CqlValueSet>(this.Comorbid_Conditions_for_Respiratory_Conditions_Value);
+        __Competing_Conditions_for_Respiratory_Conditions = new Lazy<CqlValueSet>(this.Competing_Conditions_for_Respiratory_Conditions_Value);
+        __Emergency_Department_Evaluation_and_Management_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Evaluation_and_Management_Visit_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Initial_Hospital_Observation_Care = new Lazy<CqlValueSet>(this.Initial_Hospital_Observation_Care_Value);
+        __Medical_Disability_Exam = new Lazy<CqlValueSet>(this.Medical_Disability_Exam_Value);
+        __Observation = new Lazy<CqlValueSet>(this.Observation_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Group_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Group_Counseling_Value);
+        __Preventive_Care_Services_Individual_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Individual_Counseling_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value);
+        __Preventive_Care__Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Established_Office_Visit__0_to_17_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Upper_Respiratory_Infection = new Lazy<CqlValueSet>(this.Upper_Respiratory_Infection_Value);
+        __Unlisted_preventive_medicine_service = new Lazy<CqlCode>(this.Unlisted_preventive_medicine_service_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value);
+        __Encounter_with_Upper_Respiratory_Infection = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Upper_Respiratory_Infection_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Encounters_and_Assessments_with_Hospice_Patient = new Lazy<IEnumerable<Encounter>>(this.Encounters_and_Assessments_with_Hospice_Patient_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exclusions_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+        __Stratification_1 = new Lazy<IEnumerable<Encounter>>(this.Stratification_1_Value);
+        __Stratification_2 = new Lazy<IEnumerable<Encounter>>(this.Stratification_2_Value);
+        __Stratification_3 = new Lazy<IEnumerable<Encounter>>(this.Stratification_3_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public Antibiotic_1_5_000 Antibiotic_1_5_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Antibiotic_Medications_for_Upper_Respiratory_Infection_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", null);
+
+    [CqlDeclaration("Antibiotic Medications for Upper Respiratory Infection")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001")]
+	public CqlValueSet Antibiotic_Medications_for_Upper_Respiratory_Infection() => 
+		__Antibiotic_Medications_for_Upper_Respiratory_Infection.Value;
+
+	private CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", null);
+
+    [CqlDeclaration("Comorbid Conditions for Respiratory Conditions")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025")]
+	public CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions() => 
+		__Comorbid_Conditions_for_Respiratory_Conditions.Value;
+
+	private CqlValueSet Competing_Conditions_for_Respiratory_Conditions_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", null);
+
+    [CqlDeclaration("Competing Conditions for Respiratory Conditions")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017")]
+	public CqlValueSet Competing_Conditions_for_Respiratory_Conditions() => 
+		__Competing_Conditions_for_Respiratory_Conditions.Value;
+
+	private CqlValueSet Emergency_Department_Evaluation_and_Management_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
+
+    [CqlDeclaration("Emergency Department Evaluation and Management Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
+	public CqlValueSet Emergency_Department_Evaluation_and_Management_Visit() => 
+		__Emergency_Department_Evaluation_and_Management_Visit.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", null);
+
+    [CqlDeclaration("Initial Hospital Observation Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
+	public CqlValueSet Initial_Hospital_Observation_Care() => 
+		__Initial_Hospital_Observation_Care.Value;
+
+	private CqlValueSet Medical_Disability_Exam_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", null);
+
+    [CqlDeclaration("Medical Disability Exam")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073")]
+	public CqlValueSet Medical_Disability_Exam() => 
+		__Medical_Disability_Exam.Value;
+
+	private CqlValueSet Observation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+
+    [CqlDeclaration("Observation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
+	public CqlValueSet Observation() => 
+		__Observation.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+
+    [CqlDeclaration("Preventive Care Services Group Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
+	public CqlValueSet Preventive_Care_Services_Group_Counseling() => 
+		__Preventive_Care_Services_Group_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+
+    [CqlDeclaration("Preventive Care Services Individual Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
+	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
+		__Preventive_Care_Services_Individual_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+
+    [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
+	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+
+    [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
+	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
+		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlValueSet Upper_Respiratory_Infection_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022", null);
+
+    [CqlDeclaration("Upper Respiratory Infection")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022")]
+	public CqlValueSet Upper_Respiratory_Infection() => 
+		__Upper_Respiratory_Infection.Value;
+
+	private CqlCode Unlisted_preventive_medicine_service_Value() => 
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Unlisted preventive medicine service")]
+	public CqlCode Unlisted_preventive_medicine_service() => 
+		__Unlisted_preventive_medicine_service.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value()
+	{
+		var a_ = this.Emergency_Department_Evaluation_and_Management_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Home_Healthcare_Services();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Initial_Hospital_Observation_Care();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Medical_Disability_Exam();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Observation();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Office_Visit();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Outpatient_Consultation();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = this.Preventive_Care_Services_Group_Counseling();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
+		var x_ = this.Preventive_Care_Services_Individual_Counseling();
+		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		var z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		var ab_ = context.Operators.ListUnion<Encounter>(y_, aa_);
+		var ac_ = context.Operators.ListUnion<Encounter>(w_, ab_);
+		var ad_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		var af_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		var ah_ = context.Operators.ListUnion<Encounter>(ae_, ag_);
+		var ai_ = context.Operators.ListUnion<Encounter>(ac_, ah_);
+		var aj_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, null);
+		var al_ = this.Telephone_Visits();
+		var am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		var an_ = context.Operators.ListUnion<Encounter>(ak_, am_);
+		var ao_ = context.Operators.ListUnion<Encounter>(ai_, an_);
+		var ap_ = this.Online_Assessments();
+		var aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, null);
+		var ar_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		bool? as_(Encounter E)
+		{
+			CqlConcept az_(CodeableConcept @this)
+			{
+				var be_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return be_;
+			};
+			var ba_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, az_);
+			bool? bb_(CqlConcept T)
+			{
+				var bf_ = this.Unlisted_preventive_medicine_service();
+				var bg_ = context.Operators.ConvertCodeToConcept(bf_);
+				var bh_ = context.Operators.Equivalent(T, bg_);
+
+				return bh_;
+			};
+			var bc_ = context.Operators.WhereOrNull<CqlConcept>(ba_, bb_);
+			var bd_ = context.Operators.ExistsInList<CqlConcept>(bc_);
+
+			return bd_;
+		};
+		var at_ = context.Operators.WhereOrNull<Encounter>(ar_, as_);
+		var au_ = context.Operators.ListUnion<Encounter>(aq_, at_);
+		var av_ = context.Operators.ListUnion<Encounter>(ao_, au_);
+		var aw_ = Status_1_6_000.Finished_Encounter(av_);
+		bool? ax_(Encounter ValidEncounter)
+		{
+			var bi_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var bj_ = QICoreCommon_2_0_000.ToInterval((bi_ as object));
+			var bk_ = context.Operators.End(bj_);
+			var bl_ = this.Measurement_Period();
+			var bm_ = context.Operators.Start(bl_);
+			var bo_ = context.Operators.End(bl_);
+			var bp_ = context.Operators.Quantity(3m, "days");
+			var bq_ = context.Operators.Subtract(bo_, bp_);
+			var br_ = context.Operators.Interval(bm_, bq_, true, true);
+			var bs_ = context.Operators.ElementInInterval<CqlDateTime>(bk_, br_, "day");
+
+			return bs_;
+		};
+		var ay_ = context.Operators.WhereOrNull<Encounter>(aw_, ax_);
+
+		return ay_;
+	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Upper_Respiratory_Infection_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<Condition> b_(Encounter _QualifyingEncounters)
+		{
+			var i_ = this.Upper_Respiratory_Infection();
+			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW c_(Encounter _QualifyingEncounters, Condition _URI)
+		{
+			var k_ = new Tuples.Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW
+			{
+				QualifyingEncounters = _QualifyingEncounters,
+				URI = _URI,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Condition, Tuples.Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW tuple_clqrpffcjgifzuvdvediikexw)
+		{
+			var l_ = QICoreCommon_2_0_000.ToPrevalenceInterval(tuple_clqrpffcjgifzuvdvediikexw.URI);
+			var m_ = context.Operators.Start(l_);
+			var n_ = FHIRHelpers_4_3_000.ToInterval(tuple_clqrpffcjgifzuvdvediikexw.QualifyingEncounters?.Period);
+			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			var p_ = context.Operators.ElementInInterval<CqlDateTime>(m_, o_, "day");
+			var s_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			var t_ = context.Operators.OverlapsBefore(l_, s_, null);
+			var u_ = context.Operators.Or(p_, t_);
+
+			return u_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW>(d_, e_);
+		Encounter g_(Tuples.Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW tuple_clqrpffcjgifzuvdvediikexw) => 
+			tuple_clqrpffcjgifzuvdvediikexw.QualifyingEncounters;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Upper Respiratory Infection")]
+	public IEnumerable<Encounter> Encounter_with_Upper_Respiratory_Infection() => 
+		__Encounter_with_Upper_Respiratory_Infection.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		bool? b_(Encounter EncounterWithURI)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "month");
+			var l_ = context.Operators.GreaterOrEqual(k_, (int?)3);
+
+			return l_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter EncounterWithURI) => 
+			EncounterWithURI;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Encounters_and_Assessments_with_Hospice_Patient_Value()
+	{
+		var a_ = this.Initial_Population();
+		bool? b_(Encounter EligibleEncounters)
+		{
+			var d_ = Hospice_6_9_000.Has_Hospice_Services();
+
+			return d_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounters and Assessments with Hospice Patient")]
+	public IEnumerable<Encounter> Encounters_and_Assessments_with_Hospice_Patient() => 
+		__Encounters_and_Assessments_with_Hospice_Patient.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Encounter> Denominator_Exclusions_Value()
+	{
+		var a_ = this.Encounters_and_Assessments_with_Hospice_Patient();
+		var b_ = this.Encounter_with_Upper_Respiratory_Infection();
+		var c_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
+		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		var e_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, d_);
+		var f_ = context.Operators.ListUnion<Encounter>(a_, e_);
+		var h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
+		var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+		var k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+		var l_ = context.Operators.ListUnion<MedicationRequest>(i_, k_);
+		var m_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, l_);
+		var o_ = this.Competing_Conditions_for_Respiratory_Conditions();
+		var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		var q_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, p_);
+		var r_ = context.Operators.ListUnion<Encounter>(m_, q_);
+		var s_ = context.Operators.ListUnion<Encounter>(f_, r_);
+
+		return s_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public IEnumerable<Encounter> Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		IEnumerable<Encounter> c_(Encounter EncounterWithURI)
+		{
+			var h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
+			var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+			var k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+			var l_ = context.Operators.ListUnion<MedicationRequest>(i_, k_);
+			bool? m_(MedicationRequest OrderedAntibiotic)
+			{
+				var q_ = context.Operators.Convert<CqlDateTime>(OrderedAntibiotic?.AuthoredOnElement);
+				var r_ = FHIRHelpers_4_3_000.ToInterval(EncounterWithURI?.Period);
+				var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+				var t_ = context.Operators.Start(s_);
+				var v_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+				var w_ = context.Operators.Start(v_);
+				var x_ = context.Operators.Quantity(3m, "days");
+				var y_ = context.Operators.Add(w_, x_);
+				var z_ = context.Operators.Interval(t_, y_, true, true);
+				var aa_ = context.Operators.ElementInInterval<CqlDateTime>(q_, z_, null);
+				var ac_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+				var ad_ = context.Operators.Start(ac_);
+				var ae_ = context.Operators.Not((bool?)(ad_ is null));
+				var af_ = context.Operators.And(aa_, ae_);
+
+				return af_;
+			};
+			var n_ = context.Operators.WhereOrNull<MedicationRequest>(l_, m_);
+			Encounter o_(MedicationRequest OrderedAntibiotic) => 
+				EncounterWithURI;
+			var p_ = context.Operators.SelectOrNull<MedicationRequest, Encounter>(n_, o_);
+
+			return p_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, c_);
+		var e_ = context.Operators.ListExcept<Encounter>(a_, d_);
+		Encounter f_(Encounter EncounterWithURI) => 
+			EncounterWithURI;
+		var g_ = context.Operators.SelectOrNull<Encounter, Encounter>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+	private IEnumerable<Encounter> Stratification_1_Value()
+	{
+		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		bool? b_(Encounter EncounterWithURI)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "month");
+			var l_ = context.Operators.GreaterOrEqual(k_, (int?)3);
+			var n_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var p_ = context.Operators.Start(h_);
+			var q_ = context.Operators.DateFrom(p_);
+			var r_ = context.Operators.CalculateAgeAt(n_, q_, "year");
+			var s_ = context.Operators.LessOrEqual(r_, (int?)17);
+			var t_ = context.Operators.And(l_, s_);
+
+			return t_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter EncounterWithURI) => 
+			EncounterWithURI;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Stratification 1")]
+	public IEnumerable<Encounter> Stratification_1() => 
+		__Stratification_1.Value;
+
+	private IEnumerable<Encounter> Stratification_2_Value()
+	{
+		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		bool? b_(Encounter EncounterWithURI)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			var l_ = context.Operators.Interval((int?)18, (int?)64, true, true);
+			var m_ = context.Operators.ElementInInterval<int?>(k_, l_, null);
+
+			return m_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter EncounterWithURI) => 
+			EncounterWithURI;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Stratification 2")]
+	public IEnumerable<Encounter> Stratification_2() => 
+		__Stratification_2.Value;
+
+	private IEnumerable<Encounter> Stratification_3_Value()
+	{
+		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		bool? b_(Encounter EncounterWithURI)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			var l_ = context.Operators.GreaterOrEqual(k_, (int?)65);
+
+			return l_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter EncounterWithURI) => 
+			EncounterWithURI;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Stratification 3")]
+	public IEnumerable<Encounter> Stratification_3() => 
+		__Stratification_3.Value;
+
+}

--- a/Demo/Measures-cms/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
+++ b/Demo/Measures-cms/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
@@ -1,0 +1,407 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("CRLReceiptofSpecialistReportFHIR", "0.2.000")]
+public class CRLReceiptofSpecialistReportFHIR_0_2_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Consultant_Report;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Ophthalmological_Services;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care__Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Referral;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<bool?> __Has_Encounter_during_Measurement_Period;
+    internal Lazy<Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK> __First_Referral_during_First_10_Months_of_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<bool?> __Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public CRLReceiptofSpecialistReportFHIR_0_2_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Consultant_Report = new Lazy<CqlValueSet>(this.Consultant_Report_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Ophthalmological_Services = new Lazy<CqlValueSet>(this.Ophthalmological_Services_Value);
+        __Preventive_Care_Services___Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Preventive_Care__Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Established_Office_Visit__0_to_17_Value);
+        __Referral = new Lazy<CqlValueSet>(this.Referral_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Has_Encounter_during_Measurement_Period = new Lazy<bool?>(this.Has_Encounter_during_Measurement_Period_Value);
+        __First_Referral_during_First_10_Months_of_Measurement_Period = new Lazy<Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK>(this.First_Referral_during_First_10_Months_of_Measurement_Period_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop = new Lazy<bool?>(this.Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Consultant_Report_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006", null);
+
+    [CqlDeclaration("Consultant Report")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006")]
+	public CqlValueSet Consultant_Report() => 
+		__Consultant_Report.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Ophthalmological_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+
+    [CqlDeclaration("Ophthalmological Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
+	public CqlValueSet Ophthalmological_Services() => 
+		__Ophthalmological_Services.Value;
+
+	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+
+    [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
+	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+
+    [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
+	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
+		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Referral_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046", null);
+
+    [CqlDeclaration("Referral")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046")]
+	public CqlValueSet Referral() => 
+		__Referral.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("CRLReceiptofSpecialistReportFHIR-0.2.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private bool? Has_Encounter_during_Measurement_Period_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Ophthalmological_Services();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		bool? r_(Encounter Encounter)
+		{
+			var u_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(Encounter?.StatusElement?.Value);
+			var v_ = context.Operators.Equal(u_, "finished");
+			var w_ = this.Measurement_Period();
+			var x_ = FHIRHelpers_4_3_000.ToInterval(Encounter?.Period);
+			var y_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, x_, "day");
+			var z_ = context.Operators.And(v_, y_);
+
+			return z_;
+		};
+		var s_ = context.Operators.WhereOrNull<Encounter>(q_, r_);
+		var t_ = context.Operators.ExistsInList<Encounter>(s_);
+
+		return t_;
+	}
+
+    [CqlDeclaration("Has Encounter during Measurement Period")]
+	public bool? Has_Encounter_during_Measurement_Period() => 
+		__Has_Encounter_during_Measurement_Period.Value;
+
+	private Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK First_Referral_during_First_10_Months_of_Measurement_Period_Value()
+	{
+		var a_ = this.Referral();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		bool? c_(ServiceRequest ReferralOrder)
+		{
+			var j_ = context.Operators.Convert<Code<RequestStatus>>(ReferralOrder?.StatusElement?.Value);
+			var k_ = context.Operators.Convert<string>(j_);
+			var l_ = new string[]
+			{
+				"active",
+				"completed",
+			};
+			var m_ = context.Operators.InList<string>(k_, (l_ as IEnumerable<string>));
+			var n_ = context.Operators.Convert<Code<RequestIntent>>(ReferralOrder?.IntentElement?.Value);
+			var o_ = context.Operators.Equal(n_, "order");
+			var p_ = context.Operators.And(m_, o_);
+			var q_ = context.Operators.Convert<CqlDateTime>(ReferralOrder?.AuthoredOnElement);
+			var r_ = this.Measurement_Period();
+			var s_ = context.Operators.Start(r_);
+			var u_ = context.Operators.Start(r_);
+			var v_ = context.Operators.ComponentFrom(u_, "year");
+			var w_ = context.Operators.Date(v_, (int?)10, (int?)31);
+			var x_ = context.Operators.ConvertDateToDateTime(w_);
+			var y_ = context.Operators.Interval(s_, x_, true, true);
+			var z_ = context.Operators.ElementInInterval<CqlDateTime>(q_, y_, "day");
+			var aa_ = context.Operators.And(p_, z_);
+
+			return aa_;
+		};
+		var d_ = context.Operators.WhereOrNull<ServiceRequest>(b_, c_);
+		Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK e_(ServiceRequest ReferralOrder)
+		{
+			var ab_ = context.Operators.Convert<CqlDateTime>(ReferralOrder?.AuthoredOnElement);
+			var ac_ = new Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK
+			{
+				ID = ReferralOrder?.IdElement?.Value,
+				AuthorDate = ab_,
+			};
+
+			return ac_;
+		};
+		var f_ = context.Operators.SelectOrNull<ServiceRequest, Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK>(d_, e_);
+		object g_(Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK @this) => 
+			@this?.AuthorDate;
+		var h_ = context.Operators.ListSortBy<Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+		var i_ = context.Operators.FirstOfList<Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK>(h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("First Referral during First 10 Months of Measurement Period")]
+	public Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK First_Referral_during_First_10_Months_of_Measurement_Period() => 
+		__First_Referral_during_First_10_Months_of_Measurement_Period.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Has_Encounter_during_Measurement_Period();
+		var b_ = this.First_Referral_during_First_10_Months_of_Measurement_Period();
+		var c_ = context.Operators.Not((bool?)(b_ is null));
+		var d_ = context.Operators.And(a_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+    [CqlDeclaration("TaskGetRequestID")]
+	public IEnumerable<string> TaskGetRequestID(Task task)
+	{
+		string a_(ResourceReference Task)
+		{
+			var c_ = QICoreCommon_2_0_000.GetId(Task?.ReferenceElement?.Value);
+
+			return c_;
+		};
+		var b_ = context.Operators.SelectOrNull<ResourceReference, string>((task?.BasedOn as IEnumerable<ResourceReference>), a_);
+
+		return b_;
+	}
+
+	private bool? Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop_Value()
+	{
+		var a_ = this.Consultant_Report();
+		var b_ = context.Operators.RetrieveByValueSet<Task>(a_, null);
+		IEnumerable<Task> c_(Task ConsultantReportObtained)
+		{
+			var f_ = this.First_Referral_during_First_10_Months_of_Measurement_Period();
+			var g_ = new Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK[]
+			{
+				f_,
+			};
+			bool? h_(Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK FirstReferral)
+			{
+				var l_ = this.TaskGetRequestID(ConsultantReportObtained);
+				var m_ = context.Operators.InList<string>(FirstReferral?.ID, l_);
+				var n_ = FHIRHelpers_4_3_000.ToInterval(ConsultantReportObtained?.ExecutionPeriod);
+				var o_ = context.Operators.End(n_);
+				var p_ = context.Operators.After(o_, FirstReferral?.AuthorDate, null);
+				var q_ = context.Operators.And(m_, p_);
+				var r_ = context.Operators.Convert<Code<Task.TaskStatus>>(ConsultantReportObtained?.StatusElement?.Value);
+				var s_ = context.Operators.Equal(r_, "completed");
+				var t_ = context.Operators.And(q_, s_);
+				var v_ = context.Operators.End(n_);
+				var w_ = this.Measurement_Period();
+				var x_ = context.Operators.ElementInInterval<CqlDateTime>(v_, w_, "day");
+				var y_ = context.Operators.And(t_, x_);
+
+				return y_;
+			};
+			var i_ = context.Operators.WhereOrNull<Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK>(g_, h_);
+			Task j_(Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK FirstReferral) => 
+				ConsultantReportObtained;
+			var k_ = context.Operators.SelectOrNull<Tuples.Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK, Task>(i_, j_);
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Task, Task>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Task>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Referring Clinician Receives Consultant Report to Close Referral Loop")]
+	public bool? Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop() => 
+		__Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+}

--- a/Demo/Measures-cms/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
@@ -1,0 +1,1064 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("Cataracts2040BCVAwithin90DaysFHIR", "0.1.000")]
+public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Acute_and_Subacute_Iridocyclitis;
+    internal Lazy<CqlValueSet> __Amblyopia;
+    internal Lazy<CqlValueSet> __Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart;
+    internal Lazy<CqlValueSet> __Burn_Confined_to_Eye_and_Adnexa;
+    internal Lazy<CqlValueSet> __Cataract_Congenital;
+    internal Lazy<CqlValueSet> __Cataract_Mature_or_Hypermature;
+    internal Lazy<CqlValueSet> __Cataract_Posterior_Polar;
+    internal Lazy<CqlValueSet> __Cataract_Secondary_to_Ocular_Disorders;
+    internal Lazy<CqlValueSet> __Cataract_Surgery;
+    internal Lazy<CqlValueSet> __Central_Corneal_Ulcer;
+    internal Lazy<CqlValueSet> __Certain_Types_of_Iridocyclitis;
+    internal Lazy<CqlValueSet> __Choroidal_Degenerations;
+    internal Lazy<CqlValueSet> __Choroidal_Detachment;
+    internal Lazy<CqlValueSet> __Choroidal_Hemorrhage_and_Rupture;
+    internal Lazy<CqlValueSet> __Chronic_Iridocyclitis;
+    internal Lazy<CqlValueSet> __Cloudy_Cornea;
+    internal Lazy<CqlValueSet> __Corneal_Edema;
+    internal Lazy<CqlValueSet> __Degeneration_of_Macula_and_Posterior_Pole;
+    internal Lazy<CqlValueSet> __Degenerative_Disorders_of_Globe;
+    internal Lazy<CqlValueSet> __Diabetic_Macular_Edema;
+    internal Lazy<CqlValueSet> __Diabetic_Retinopathy;
+    internal Lazy<CqlValueSet> __Disorders_of_Cornea_Including_Corneal_Opacity;
+    internal Lazy<CqlValueSet> __Disorders_of_Optic_Chiasm;
+    internal Lazy<CqlValueSet> __Disorders_of_Visual_Cortex;
+    internal Lazy<CqlValueSet> __Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis;
+    internal Lazy<CqlValueSet> __Focal_Chorioretinitis_and_Focal_Retinochoroiditis;
+    internal Lazy<CqlValueSet> __Glaucoma;
+    internal Lazy<CqlValueSet> __Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes;
+    internal Lazy<CqlValueSet> __Hereditary_Choroidal_Dystrophies;
+    internal Lazy<CqlValueSet> __Hereditary_Corneal_Dystrophies;
+    internal Lazy<CqlValueSet> __Hereditary_Retinal_Dystrophies;
+    internal Lazy<CqlValueSet> __Hypotony_of_Eye;
+    internal Lazy<CqlValueSet> __Injury_to_Optic_Nerve_and_Pathways;
+    internal Lazy<CqlValueSet> __Macular_Scar_of_Posterior_Polar;
+    internal Lazy<CqlValueSet> __Morgagnian_Cataract;
+    internal Lazy<CqlValueSet> __Nystagmus_and_Other_Irregular_Eye_Movements;
+    internal Lazy<CqlValueSet> __Open_Wound_of_Eyeball;
+    internal Lazy<CqlValueSet> __Optic_Atrophy;
+    internal Lazy<CqlValueSet> __Optic_Neuritis;
+    internal Lazy<CqlValueSet> __Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis;
+    internal Lazy<CqlValueSet> __Other_Background_Retinopathy_and_Retinal_Vascular_Changes;
+    internal Lazy<CqlValueSet> __Other_Disorders_of_Optic_Nerve;
+    internal Lazy<CqlValueSet> __Other_Endophthalmitis;
+    internal Lazy<CqlValueSet> __Other_Proliferative_Retinopathy;
+    internal Lazy<CqlValueSet> __Pathologic_Myopia;
+    internal Lazy<CqlValueSet> __Posterior_Lenticonus;
+    internal Lazy<CqlValueSet> __Prior_Penetrating_Keratoplasty;
+    internal Lazy<CqlValueSet> __Purulent_Endophthalmitis;
+    internal Lazy<CqlValueSet> __Retinal_Detachment_with_Retinal_Defect;
+    internal Lazy<CqlValueSet> __Retinal_Vascular_Occlusion;
+    internal Lazy<CqlValueSet> __Retrolental_Fibroplasias;
+    internal Lazy<CqlValueSet> __Scleritis;
+    internal Lazy<CqlValueSet> __Separation_of_Retinal_Layers;
+    internal Lazy<CqlValueSet> __Traumatic_Cataract;
+    internal Lazy<CqlValueSet> __Uveitis;
+    internal Lazy<CqlValueSet> __Vascular_Disorders_of_Iris_and_Ciliary_Body;
+    internal Lazy<CqlValueSet> __Visual_Acuity_20_40_or_Better;
+    internal Lazy<CqlValueSet> __Visual_Field_Defects;
+    internal Lazy<CqlCode> __Best_corrected_visual_acuity__observable_entity_;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Procedure>> __Cataract_Surgery_Between_January_and_September_of_Measurement_Period;
+    internal Lazy<IEnumerable<Procedure>> __Initial_Population;
+    internal Lazy<IEnumerable<Procedure>> __Denominator;
+    internal Lazy<IEnumerable<Procedure>> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Procedure>> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public Cataracts2040BCVAwithin90DaysFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Acute_and_Subacute_Iridocyclitis = new Lazy<CqlValueSet>(this.Acute_and_Subacute_Iridocyclitis_Value);
+        __Amblyopia = new Lazy<CqlValueSet>(this.Amblyopia_Value);
+        __Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart = new Lazy<CqlValueSet>(this.Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart_Value);
+        __Burn_Confined_to_Eye_and_Adnexa = new Lazy<CqlValueSet>(this.Burn_Confined_to_Eye_and_Adnexa_Value);
+        __Cataract_Congenital = new Lazy<CqlValueSet>(this.Cataract_Congenital_Value);
+        __Cataract_Mature_or_Hypermature = new Lazy<CqlValueSet>(this.Cataract_Mature_or_Hypermature_Value);
+        __Cataract_Posterior_Polar = new Lazy<CqlValueSet>(this.Cataract_Posterior_Polar_Value);
+        __Cataract_Secondary_to_Ocular_Disorders = new Lazy<CqlValueSet>(this.Cataract_Secondary_to_Ocular_Disorders_Value);
+        __Cataract_Surgery = new Lazy<CqlValueSet>(this.Cataract_Surgery_Value);
+        __Central_Corneal_Ulcer = new Lazy<CqlValueSet>(this.Central_Corneal_Ulcer_Value);
+        __Certain_Types_of_Iridocyclitis = new Lazy<CqlValueSet>(this.Certain_Types_of_Iridocyclitis_Value);
+        __Choroidal_Degenerations = new Lazy<CqlValueSet>(this.Choroidal_Degenerations_Value);
+        __Choroidal_Detachment = new Lazy<CqlValueSet>(this.Choroidal_Detachment_Value);
+        __Choroidal_Hemorrhage_and_Rupture = new Lazy<CqlValueSet>(this.Choroidal_Hemorrhage_and_Rupture_Value);
+        __Chronic_Iridocyclitis = new Lazy<CqlValueSet>(this.Chronic_Iridocyclitis_Value);
+        __Cloudy_Cornea = new Lazy<CqlValueSet>(this.Cloudy_Cornea_Value);
+        __Corneal_Edema = new Lazy<CqlValueSet>(this.Corneal_Edema_Value);
+        __Degeneration_of_Macula_and_Posterior_Pole = new Lazy<CqlValueSet>(this.Degeneration_of_Macula_and_Posterior_Pole_Value);
+        __Degenerative_Disorders_of_Globe = new Lazy<CqlValueSet>(this.Degenerative_Disorders_of_Globe_Value);
+        __Diabetic_Macular_Edema = new Lazy<CqlValueSet>(this.Diabetic_Macular_Edema_Value);
+        __Diabetic_Retinopathy = new Lazy<CqlValueSet>(this.Diabetic_Retinopathy_Value);
+        __Disorders_of_Cornea_Including_Corneal_Opacity = new Lazy<CqlValueSet>(this.Disorders_of_Cornea_Including_Corneal_Opacity_Value);
+        __Disorders_of_Optic_Chiasm = new Lazy<CqlValueSet>(this.Disorders_of_Optic_Chiasm_Value);
+        __Disorders_of_Visual_Cortex = new Lazy<CqlValueSet>(this.Disorders_of_Visual_Cortex_Value);
+        __Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis = new Lazy<CqlValueSet>(this.Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis_Value);
+        __Focal_Chorioretinitis_and_Focal_Retinochoroiditis = new Lazy<CqlValueSet>(this.Focal_Chorioretinitis_and_Focal_Retinochoroiditis_Value);
+        __Glaucoma = new Lazy<CqlValueSet>(this.Glaucoma_Value);
+        __Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes = new Lazy<CqlValueSet>(this.Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes_Value);
+        __Hereditary_Choroidal_Dystrophies = new Lazy<CqlValueSet>(this.Hereditary_Choroidal_Dystrophies_Value);
+        __Hereditary_Corneal_Dystrophies = new Lazy<CqlValueSet>(this.Hereditary_Corneal_Dystrophies_Value);
+        __Hereditary_Retinal_Dystrophies = new Lazy<CqlValueSet>(this.Hereditary_Retinal_Dystrophies_Value);
+        __Hypotony_of_Eye = new Lazy<CqlValueSet>(this.Hypotony_of_Eye_Value);
+        __Injury_to_Optic_Nerve_and_Pathways = new Lazy<CqlValueSet>(this.Injury_to_Optic_Nerve_and_Pathways_Value);
+        __Macular_Scar_of_Posterior_Polar = new Lazy<CqlValueSet>(this.Macular_Scar_of_Posterior_Polar_Value);
+        __Morgagnian_Cataract = new Lazy<CqlValueSet>(this.Morgagnian_Cataract_Value);
+        __Nystagmus_and_Other_Irregular_Eye_Movements = new Lazy<CqlValueSet>(this.Nystagmus_and_Other_Irregular_Eye_Movements_Value);
+        __Open_Wound_of_Eyeball = new Lazy<CqlValueSet>(this.Open_Wound_of_Eyeball_Value);
+        __Optic_Atrophy = new Lazy<CqlValueSet>(this.Optic_Atrophy_Value);
+        __Optic_Neuritis = new Lazy<CqlValueSet>(this.Optic_Neuritis_Value);
+        __Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis = new Lazy<CqlValueSet>(this.Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis_Value);
+        __Other_Background_Retinopathy_and_Retinal_Vascular_Changes = new Lazy<CqlValueSet>(this.Other_Background_Retinopathy_and_Retinal_Vascular_Changes_Value);
+        __Other_Disorders_of_Optic_Nerve = new Lazy<CqlValueSet>(this.Other_Disorders_of_Optic_Nerve_Value);
+        __Other_Endophthalmitis = new Lazy<CqlValueSet>(this.Other_Endophthalmitis_Value);
+        __Other_Proliferative_Retinopathy = new Lazy<CqlValueSet>(this.Other_Proliferative_Retinopathy_Value);
+        __Pathologic_Myopia = new Lazy<CqlValueSet>(this.Pathologic_Myopia_Value);
+        __Posterior_Lenticonus = new Lazy<CqlValueSet>(this.Posterior_Lenticonus_Value);
+        __Prior_Penetrating_Keratoplasty = new Lazy<CqlValueSet>(this.Prior_Penetrating_Keratoplasty_Value);
+        __Purulent_Endophthalmitis = new Lazy<CqlValueSet>(this.Purulent_Endophthalmitis_Value);
+        __Retinal_Detachment_with_Retinal_Defect = new Lazy<CqlValueSet>(this.Retinal_Detachment_with_Retinal_Defect_Value);
+        __Retinal_Vascular_Occlusion = new Lazy<CqlValueSet>(this.Retinal_Vascular_Occlusion_Value);
+        __Retrolental_Fibroplasias = new Lazy<CqlValueSet>(this.Retrolental_Fibroplasias_Value);
+        __Scleritis = new Lazy<CqlValueSet>(this.Scleritis_Value);
+        __Separation_of_Retinal_Layers = new Lazy<CqlValueSet>(this.Separation_of_Retinal_Layers_Value);
+        __Traumatic_Cataract = new Lazy<CqlValueSet>(this.Traumatic_Cataract_Value);
+        __Uveitis = new Lazy<CqlValueSet>(this.Uveitis_Value);
+        __Vascular_Disorders_of_Iris_and_Ciliary_Body = new Lazy<CqlValueSet>(this.Vascular_Disorders_of_Iris_and_Ciliary_Body_Value);
+        __Visual_Acuity_20_40_or_Better = new Lazy<CqlValueSet>(this.Visual_Acuity_20_40_or_Better_Value);
+        __Visual_Field_Defects = new Lazy<CqlValueSet>(this.Visual_Field_Defects_Value);
+        __Best_corrected_visual_acuity__observable_entity_ = new Lazy<CqlCode>(this.Best_corrected_visual_acuity__observable_entity__Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Cataract_Surgery_Between_January_and_September_of_Measurement_Period = new Lazy<IEnumerable<Procedure>>(this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period_Value);
+        __Initial_Population = new Lazy<IEnumerable<Procedure>>(this.Initial_Population_Value);
+        __Denominator = new Lazy<IEnumerable<Procedure>>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<IEnumerable<Procedure>>(this.Denominator_Exclusions_Value);
+        __Numerator = new Lazy<IEnumerable<Procedure>>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Acute_and_Subacute_Iridocyclitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241", null);
+
+    [CqlDeclaration("Acute and Subacute Iridocyclitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241")]
+	public CqlValueSet Acute_and_Subacute_Iridocyclitis() => 
+		__Acute_and_Subacute_Iridocyclitis.Value;
+
+	private CqlValueSet Amblyopia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448", null);
+
+    [CqlDeclaration("Amblyopia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448")]
+	public CqlValueSet Amblyopia() => 
+		__Amblyopia.Value;
+
+	private CqlValueSet Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560", null);
+
+    [CqlDeclaration("Best Corrected Visual Acuity Exam Using Snellen Chart")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560")]
+	public CqlValueSet Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart() => 
+		__Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart.Value;
+
+	private CqlValueSet Burn_Confined_to_Eye_and_Adnexa_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409", null);
+
+    [CqlDeclaration("Burn Confined to Eye and Adnexa")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409")]
+	public CqlValueSet Burn_Confined_to_Eye_and_Adnexa() => 
+		__Burn_Confined_to_Eye_and_Adnexa.Value;
+
+	private CqlValueSet Cataract_Congenital_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412", null);
+
+    [CqlDeclaration("Cataract Congenital")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412")]
+	public CqlValueSet Cataract_Congenital() => 
+		__Cataract_Congenital.Value;
+
+	private CqlValueSet Cataract_Mature_or_Hypermature_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413", null);
+
+    [CqlDeclaration("Cataract Mature or Hypermature")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413")]
+	public CqlValueSet Cataract_Mature_or_Hypermature() => 
+		__Cataract_Mature_or_Hypermature.Value;
+
+	private CqlValueSet Cataract_Posterior_Polar_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414", null);
+
+    [CqlDeclaration("Cataract Posterior Polar")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414")]
+	public CqlValueSet Cataract_Posterior_Polar() => 
+		__Cataract_Posterior_Polar.Value;
+
+	private CqlValueSet Cataract_Secondary_to_Ocular_Disorders_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410", null);
+
+    [CqlDeclaration("Cataract Secondary to Ocular Disorders")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410")]
+	public CqlValueSet Cataract_Secondary_to_Ocular_Disorders() => 
+		__Cataract_Secondary_to_Ocular_Disorders.Value;
+
+	private CqlValueSet Cataract_Surgery_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411", null);
+
+    [CqlDeclaration("Cataract Surgery")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411")]
+	public CqlValueSet Cataract_Surgery() => 
+		__Cataract_Surgery.Value;
+
+	private CqlValueSet Central_Corneal_Ulcer_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428", null);
+
+    [CqlDeclaration("Central Corneal Ulcer")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428")]
+	public CqlValueSet Central_Corneal_Ulcer() => 
+		__Central_Corneal_Ulcer.Value;
+
+	private CqlValueSet Certain_Types_of_Iridocyclitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415", null);
+
+    [CqlDeclaration("Certain Types of Iridocyclitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415")]
+	public CqlValueSet Certain_Types_of_Iridocyclitis() => 
+		__Certain_Types_of_Iridocyclitis.Value;
+
+	private CqlValueSet Choroidal_Degenerations_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450", null);
+
+    [CqlDeclaration("Choroidal Degenerations")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450")]
+	public CqlValueSet Choroidal_Degenerations() => 
+		__Choroidal_Degenerations.Value;
+
+	private CqlValueSet Choroidal_Detachment_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451", null);
+
+    [CqlDeclaration("Choroidal Detachment")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451")]
+	public CqlValueSet Choroidal_Detachment() => 
+		__Choroidal_Detachment.Value;
+
+	private CqlValueSet Choroidal_Hemorrhage_and_Rupture_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452", null);
+
+    [CqlDeclaration("Choroidal Hemorrhage and Rupture")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452")]
+	public CqlValueSet Choroidal_Hemorrhage_and_Rupture() => 
+		__Choroidal_Hemorrhage_and_Rupture.Value;
+
+	private CqlValueSet Chronic_Iridocyclitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416", null);
+
+    [CqlDeclaration("Chronic Iridocyclitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416")]
+	public CqlValueSet Chronic_Iridocyclitis() => 
+		__Chronic_Iridocyclitis.Value;
+
+	private CqlValueSet Cloudy_Cornea_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417", null);
+
+    [CqlDeclaration("Cloudy Cornea")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417")]
+	public CqlValueSet Cloudy_Cornea() => 
+		__Cloudy_Cornea.Value;
+
+	private CqlValueSet Corneal_Edema_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418", null);
+
+    [CqlDeclaration("Corneal Edema")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418")]
+	public CqlValueSet Corneal_Edema() => 
+		__Corneal_Edema.Value;
+
+	private CqlValueSet Degeneration_of_Macula_and_Posterior_Pole_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453", null);
+
+    [CqlDeclaration("Degeneration of Macula and Posterior Pole")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453")]
+	public CqlValueSet Degeneration_of_Macula_and_Posterior_Pole() => 
+		__Degeneration_of_Macula_and_Posterior_Pole.Value;
+
+	private CqlValueSet Degenerative_Disorders_of_Globe_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454", null);
+
+    [CqlDeclaration("Degenerative Disorders of Globe")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454")]
+	public CqlValueSet Degenerative_Disorders_of_Globe() => 
+		__Degenerative_Disorders_of_Globe.Value;
+
+	private CqlValueSet Diabetic_Macular_Edema_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455", null);
+
+    [CqlDeclaration("Diabetic Macular Edema")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455")]
+	public CqlValueSet Diabetic_Macular_Edema() => 
+		__Diabetic_Macular_Edema.Value;
+
+	private CqlValueSet Diabetic_Retinopathy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
+
+    [CqlDeclaration("Diabetic Retinopathy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
+	public CqlValueSet Diabetic_Retinopathy() => 
+		__Diabetic_Retinopathy.Value;
+
+	private CqlValueSet Disorders_of_Cornea_Including_Corneal_Opacity_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419", null);
+
+    [CqlDeclaration("Disorders of Cornea Including Corneal Opacity")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419")]
+	public CqlValueSet Disorders_of_Cornea_Including_Corneal_Opacity() => 
+		__Disorders_of_Cornea_Including_Corneal_Opacity.Value;
+
+	private CqlValueSet Disorders_of_Optic_Chiasm_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457", null);
+
+    [CqlDeclaration("Disorders of Optic Chiasm")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457")]
+	public CqlValueSet Disorders_of_Optic_Chiasm() => 
+		__Disorders_of_Optic_Chiasm.Value;
+
+	private CqlValueSet Disorders_of_Visual_Cortex_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458", null);
+
+    [CqlDeclaration("Disorders of Visual Cortex")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458")]
+	public CqlValueSet Disorders_of_Visual_Cortex() => 
+		__Disorders_of_Visual_Cortex.Value;
+
+	private CqlValueSet Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459", null);
+
+    [CqlDeclaration("Disseminated Chorioretinitis and Disseminated Retinochoroiditis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459")]
+	public CqlValueSet Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis() => 
+		__Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis.Value;
+
+	private CqlValueSet Focal_Chorioretinitis_and_Focal_Retinochoroiditis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460", null);
+
+    [CqlDeclaration("Focal Chorioretinitis and Focal Retinochoroiditis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460")]
+	public CqlValueSet Focal_Chorioretinitis_and_Focal_Retinochoroiditis() => 
+		__Focal_Chorioretinitis_and_Focal_Retinochoroiditis.Value;
+
+	private CqlValueSet Glaucoma_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423", null);
+
+    [CqlDeclaration("Glaucoma")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423")]
+	public CqlValueSet Glaucoma() => 
+		__Glaucoma.Value;
+
+	private CqlValueSet Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461", null);
+
+    [CqlDeclaration("Glaucoma Associated with Congenital Anomalies and Dystrophies and Systemic Syndromes")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461")]
+	public CqlValueSet Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes() => 
+		__Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes.Value;
+
+	private CqlValueSet Hereditary_Choroidal_Dystrophies_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462", null);
+
+    [CqlDeclaration("Hereditary Choroidal Dystrophies")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462")]
+	public CqlValueSet Hereditary_Choroidal_Dystrophies() => 
+		__Hereditary_Choroidal_Dystrophies.Value;
+
+	private CqlValueSet Hereditary_Corneal_Dystrophies_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424", null);
+
+    [CqlDeclaration("Hereditary Corneal Dystrophies")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424")]
+	public CqlValueSet Hereditary_Corneal_Dystrophies() => 
+		__Hereditary_Corneal_Dystrophies.Value;
+
+	private CqlValueSet Hereditary_Retinal_Dystrophies_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463", null);
+
+    [CqlDeclaration("Hereditary Retinal Dystrophies")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463")]
+	public CqlValueSet Hereditary_Retinal_Dystrophies() => 
+		__Hereditary_Retinal_Dystrophies.Value;
+
+	private CqlValueSet Hypotony_of_Eye_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426", null);
+
+    [CqlDeclaration("Hypotony of Eye")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426")]
+	public CqlValueSet Hypotony_of_Eye() => 
+		__Hypotony_of_Eye.Value;
+
+	private CqlValueSet Injury_to_Optic_Nerve_and_Pathways_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427", null);
+
+    [CqlDeclaration("Injury to Optic Nerve and Pathways")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427")]
+	public CqlValueSet Injury_to_Optic_Nerve_and_Pathways() => 
+		__Injury_to_Optic_Nerve_and_Pathways.Value;
+
+	private CqlValueSet Macular_Scar_of_Posterior_Polar_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559", null);
+
+    [CqlDeclaration("Macular Scar of Posterior Polar")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559")]
+	public CqlValueSet Macular_Scar_of_Posterior_Polar() => 
+		__Macular_Scar_of_Posterior_Polar.Value;
+
+	private CqlValueSet Morgagnian_Cataract_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558", null);
+
+    [CqlDeclaration("Morgagnian Cataract")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558")]
+	public CqlValueSet Morgagnian_Cataract() => 
+		__Morgagnian_Cataract.Value;
+
+	private CqlValueSet Nystagmus_and_Other_Irregular_Eye_Movements_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465", null);
+
+    [CqlDeclaration("Nystagmus and Other Irregular Eye Movements")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465")]
+	public CqlValueSet Nystagmus_and_Other_Irregular_Eye_Movements() => 
+		__Nystagmus_and_Other_Irregular_Eye_Movements.Value;
+
+	private CqlValueSet Open_Wound_of_Eyeball_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430", null);
+
+    [CqlDeclaration("Open Wound of Eyeball")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430")]
+	public CqlValueSet Open_Wound_of_Eyeball() => 
+		__Open_Wound_of_Eyeball.Value;
+
+	private CqlValueSet Optic_Atrophy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466", null);
+
+    [CqlDeclaration("Optic Atrophy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466")]
+	public CqlValueSet Optic_Atrophy() => 
+		__Optic_Atrophy.Value;
+
+	private CqlValueSet Optic_Neuritis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467", null);
+
+    [CqlDeclaration("Optic Neuritis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467")]
+	public CqlValueSet Optic_Neuritis() => 
+		__Optic_Neuritis.Value;
+
+	private CqlValueSet Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468", null);
+
+    [CqlDeclaration("Other and Unspecified Forms of Chorioretinitis and Retinochoroiditis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468")]
+	public CqlValueSet Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis() => 
+		__Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis.Value;
+
+	private CqlValueSet Other_Background_Retinopathy_and_Retinal_Vascular_Changes_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469", null);
+
+    [CqlDeclaration("Other Background Retinopathy and Retinal Vascular Changes")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469")]
+	public CqlValueSet Other_Background_Retinopathy_and_Retinal_Vascular_Changes() => 
+		__Other_Background_Retinopathy_and_Retinal_Vascular_Changes.Value;
+
+	private CqlValueSet Other_Disorders_of_Optic_Nerve_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471", null);
+
+    [CqlDeclaration("Other Disorders of Optic Nerve")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471")]
+	public CqlValueSet Other_Disorders_of_Optic_Nerve() => 
+		__Other_Disorders_of_Optic_Nerve.Value;
+
+	private CqlValueSet Other_Endophthalmitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473", null);
+
+    [CqlDeclaration("Other Endophthalmitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473")]
+	public CqlValueSet Other_Endophthalmitis() => 
+		__Other_Endophthalmitis.Value;
+
+	private CqlValueSet Other_Proliferative_Retinopathy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480", null);
+
+    [CqlDeclaration("Other Proliferative Retinopathy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480")]
+	public CqlValueSet Other_Proliferative_Retinopathy() => 
+		__Other_Proliferative_Retinopathy.Value;
+
+	private CqlValueSet Pathologic_Myopia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432", null);
+
+    [CqlDeclaration("Pathologic Myopia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432")]
+	public CqlValueSet Pathologic_Myopia() => 
+		__Pathologic_Myopia.Value;
+
+	private CqlValueSet Posterior_Lenticonus_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433", null);
+
+    [CqlDeclaration("Posterior Lenticonus")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433")]
+	public CqlValueSet Posterior_Lenticonus() => 
+		__Posterior_Lenticonus.Value;
+
+	private CqlValueSet Prior_Penetrating_Keratoplasty_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475", null);
+
+    [CqlDeclaration("Prior Penetrating Keratoplasty")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475")]
+	public CqlValueSet Prior_Penetrating_Keratoplasty() => 
+		__Prior_Penetrating_Keratoplasty.Value;
+
+	private CqlValueSet Purulent_Endophthalmitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477", null);
+
+    [CqlDeclaration("Purulent Endophthalmitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477")]
+	public CqlValueSet Purulent_Endophthalmitis() => 
+		__Purulent_Endophthalmitis.Value;
+
+	private CqlValueSet Retinal_Detachment_with_Retinal_Defect_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478", null);
+
+    [CqlDeclaration("Retinal Detachment with Retinal Defect")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478")]
+	public CqlValueSet Retinal_Detachment_with_Retinal_Defect() => 
+		__Retinal_Detachment_with_Retinal_Defect.Value;
+
+	private CqlValueSet Retinal_Vascular_Occlusion_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479", null);
+
+    [CqlDeclaration("Retinal Vascular Occlusion")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479")]
+	public CqlValueSet Retinal_Vascular_Occlusion() => 
+		__Retinal_Vascular_Occlusion.Value;
+
+	private CqlValueSet Retrolental_Fibroplasias_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438", null);
+
+    [CqlDeclaration("Retrolental Fibroplasias")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438")]
+	public CqlValueSet Retrolental_Fibroplasias() => 
+		__Retrolental_Fibroplasias.Value;
+
+	private CqlValueSet Scleritis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1", null);
+
+    [CqlDeclaration("Scleritis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1")]
+	public CqlValueSet Scleritis() => 
+		__Scleritis.Value;
+
+	private CqlValueSet Separation_of_Retinal_Layers_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482", null);
+
+    [CqlDeclaration("Separation of Retinal Layers")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482")]
+	public CqlValueSet Separation_of_Retinal_Layers() => 
+		__Separation_of_Retinal_Layers.Value;
+
+	private CqlValueSet Traumatic_Cataract_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443", null);
+
+    [CqlDeclaration("Traumatic Cataract")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443")]
+	public CqlValueSet Traumatic_Cataract() => 
+		__Traumatic_Cataract.Value;
+
+	private CqlValueSet Uveitis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444", null);
+
+    [CqlDeclaration("Uveitis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444")]
+	public CqlValueSet Uveitis() => 
+		__Uveitis.Value;
+
+	private CqlValueSet Vascular_Disorders_of_Iris_and_Ciliary_Body_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445", null);
+
+    [CqlDeclaration("Vascular Disorders of Iris and Ciliary Body")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445")]
+	public CqlValueSet Vascular_Disorders_of_Iris_and_Ciliary_Body() => 
+		__Vascular_Disorders_of_Iris_and_Ciliary_Body.Value;
+
+	private CqlValueSet Visual_Acuity_20_40_or_Better_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483", null);
+
+    [CqlDeclaration("Visual Acuity 20/40 or Better")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483")]
+	public CqlValueSet Visual_Acuity_20_40_or_Better() => 
+		__Visual_Acuity_20_40_or_Better.Value;
+
+	private CqlValueSet Visual_Field_Defects_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446", null);
+
+    [CqlDeclaration("Visual Field Defects")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446")]
+	public CqlValueSet Visual_Field_Defects() => 
+		__Visual_Field_Defects.Value;
+
+	private CqlCode Best_corrected_visual_acuity__observable_entity__Value() => 
+		new CqlCode("419775003", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Best corrected visual acuity (observable entity)")]
+	public CqlCode Best_corrected_visual_acuity__observable_entity_() => 
+		__Best_corrected_visual_acuity__observable_entity_.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("419775003", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("Cataracts2040BCVAwithin90DaysFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Procedure> Cataract_Surgery_Between_January_and_September_of_Measurement_Period_Value()
+	{
+		var a_ = this.Cataract_Surgery();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		bool? c_(Procedure CataractSurgery)
+		{
+			var e_ = this.Measurement_Period();
+			var f_ = FHIRHelpers_4_3_000.ToValue(CataractSurgery?.Performed);
+			var g_ = QICoreCommon_2_0_000.toInterval(f_);
+			var h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, null);
+			var j_ = QICoreCommon_2_0_000.toInterval(f_);
+			var k_ = context.Operators.Start(j_);
+			var m_ = context.Operators.End(e_);
+			var n_ = context.Operators.Quantity(92m, "days");
+			var o_ = context.Operators.Subtract(m_, n_);
+			var p_ = context.Operators.SameOrBefore(k_, o_, null);
+			var q_ = context.Operators.And(h_, p_);
+			var r_ = context.Operators.EnumEqualsString(CataractSurgery?.StatusElement?.Value, "completed");
+			var s_ = context.Operators.And(q_, r_);
+
+			return s_;
+		};
+		var d_ = context.Operators.WhereOrNull<Procedure>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Cataract Surgery Between January and September of Measurement Period")]
+	public IEnumerable<Procedure> Cataract_Surgery_Between_January_and_September_of_Measurement_Period() => 
+		__Cataract_Surgery_Between_January_and_September_of_Measurement_Period.Value;
+
+	private IEnumerable<Procedure> Initial_Population_Value()
+	{
+		var a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period();
+		bool? b_(Procedure CataractSurgeryPerformed)
+		{
+			var d_ = this.Patient();
+			var e_ = context.Operators.Convert<CqlDate>(d_?.BirthDateElement?.Value);
+			var f_ = this.Measurement_Period();
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.DateFrom(g_);
+			var i_ = context.Operators.CalculateAgeAt(e_, h_, "year");
+			var j_ = context.Operators.GreaterOrEqual(i_, (int?)18);
+
+			return j_;
+		};
+		var c_ = context.Operators.WhereOrNull<Procedure>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Procedure> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Procedure> Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Procedure> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Procedure> Denominator_Exclusions_Value()
+	{
+		var a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period();
+		IEnumerable<Procedure> b_(Procedure CataractSurgeryPerformed)
+		{
+			var d_ = this.Acute_and_Subacute_Iridocyclitis();
+			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			var f_ = this.Amblyopia();
+			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			var h_ = context.Operators.ListUnion<Condition>(e_, g_);
+			var i_ = this.Burn_Confined_to_Eye_and_Adnexa();
+			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			var k_ = this.Cataract_Secondary_to_Ocular_Disorders();
+			var l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+			var m_ = context.Operators.ListUnion<Condition>(j_, l_);
+			var n_ = context.Operators.ListUnion<Condition>(h_, m_);
+			var o_ = this.Cataract_Congenital();
+			var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+			var q_ = this.Cataract_Mature_or_Hypermature();
+			var r_ = context.Operators.RetrieveByValueSet<Condition>(q_, null);
+			var s_ = context.Operators.ListUnion<Condition>(p_, r_);
+			var t_ = context.Operators.ListUnion<Condition>(n_, s_);
+			var u_ = this.Cataract_Posterior_Polar();
+			var v_ = context.Operators.RetrieveByValueSet<Condition>(u_, null);
+			var w_ = this.Central_Corneal_Ulcer();
+			var x_ = context.Operators.RetrieveByValueSet<Condition>(w_, null);
+			var y_ = context.Operators.ListUnion<Condition>(v_, x_);
+			var z_ = context.Operators.ListUnion<Condition>(t_, y_);
+			var aa_ = this.Certain_Types_of_Iridocyclitis();
+			var ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, null);
+			var ac_ = this.Choroidal_Degenerations();
+			var ad_ = context.Operators.RetrieveByValueSet<Condition>(ac_, null);
+			var ae_ = context.Operators.ListUnion<Condition>(ab_, ad_);
+			var af_ = context.Operators.ListUnion<Condition>(z_, ae_);
+			var ag_ = this.Choroidal_Detachment();
+			var ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, null);
+			var ai_ = this.Choroidal_Hemorrhage_and_Rupture();
+			var aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, null);
+			var ak_ = context.Operators.ListUnion<Condition>(ah_, aj_);
+			var al_ = context.Operators.ListUnion<Condition>(af_, ak_);
+			var am_ = this.Chronic_Iridocyclitis();
+			var an_ = context.Operators.RetrieveByValueSet<Condition>(am_, null);
+			var ao_ = this.Cloudy_Cornea();
+			var ap_ = context.Operators.RetrieveByValueSet<Condition>(ao_, null);
+			var aq_ = context.Operators.ListUnion<Condition>(an_, ap_);
+			var ar_ = context.Operators.ListUnion<Condition>(al_, aq_);
+			var as_ = this.Corneal_Edema();
+			var at_ = context.Operators.RetrieveByValueSet<Condition>(as_, null);
+			var au_ = this.Disorders_of_Cornea_Including_Corneal_Opacity();
+			var av_ = context.Operators.RetrieveByValueSet<Condition>(au_, null);
+			var aw_ = context.Operators.ListUnion<Condition>(at_, av_);
+			var ax_ = context.Operators.ListUnion<Condition>(ar_, aw_);
+			var ay_ = this.Degeneration_of_Macula_and_Posterior_Pole();
+			var az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, null);
+			var ba_ = this.Degenerative_Disorders_of_Globe();
+			var bb_ = context.Operators.RetrieveByValueSet<Condition>(ba_, null);
+			var bc_ = context.Operators.ListUnion<Condition>(az_, bb_);
+			var bd_ = context.Operators.ListUnion<Condition>(ax_, bc_);
+			var be_ = this.Diabetic_Macular_Edema();
+			var bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, null);
+			var bg_ = this.Diabetic_Retinopathy();
+			var bh_ = context.Operators.RetrieveByValueSet<Condition>(bg_, null);
+			var bi_ = context.Operators.ListUnion<Condition>(bf_, bh_);
+			var bj_ = context.Operators.ListUnion<Condition>(bd_, bi_);
+			var bk_ = this.Disorders_of_Optic_Chiasm();
+			var bl_ = context.Operators.RetrieveByValueSet<Condition>(bk_, null);
+			var bm_ = this.Disorders_of_Visual_Cortex();
+			var bn_ = context.Operators.RetrieveByValueSet<Condition>(bm_, null);
+			var bo_ = context.Operators.ListUnion<Condition>(bl_, bn_);
+			var bp_ = context.Operators.ListUnion<Condition>(bj_, bo_);
+			var bq_ = this.Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis();
+			var br_ = context.Operators.RetrieveByValueSet<Condition>(bq_, null);
+			var bs_ = this.Focal_Chorioretinitis_and_Focal_Retinochoroiditis();
+			var bt_ = context.Operators.RetrieveByValueSet<Condition>(bs_, null);
+			var bu_ = context.Operators.ListUnion<Condition>(br_, bt_);
+			var bv_ = context.Operators.ListUnion<Condition>(bp_, bu_);
+			var bw_ = this.Glaucoma();
+			var bx_ = context.Operators.RetrieveByValueSet<Condition>(bw_, null);
+			var by_ = this.Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes();
+			var bz_ = context.Operators.RetrieveByValueSet<Condition>(by_, null);
+			var ca_ = context.Operators.ListUnion<Condition>(bx_, bz_);
+			var cb_ = context.Operators.ListUnion<Condition>(bv_, ca_);
+			var cc_ = this.Hereditary_Choroidal_Dystrophies();
+			var cd_ = context.Operators.RetrieveByValueSet<Condition>(cc_, null);
+			var ce_ = this.Hereditary_Corneal_Dystrophies();
+			var cf_ = context.Operators.RetrieveByValueSet<Condition>(ce_, null);
+			var cg_ = context.Operators.ListUnion<Condition>(cd_, cf_);
+			var ch_ = context.Operators.ListUnion<Condition>(cb_, cg_);
+			var ci_ = this.Hereditary_Retinal_Dystrophies();
+			var cj_ = context.Operators.RetrieveByValueSet<Condition>(ci_, null);
+			var ck_ = this.Hypotony_of_Eye();
+			var cl_ = context.Operators.RetrieveByValueSet<Condition>(ck_, null);
+			var cm_ = context.Operators.ListUnion<Condition>(cj_, cl_);
+			var cn_ = context.Operators.ListUnion<Condition>(ch_, cm_);
+			var co_ = this.Injury_to_Optic_Nerve_and_Pathways();
+			var cp_ = context.Operators.RetrieveByValueSet<Condition>(co_, null);
+			var cq_ = this.Macular_Scar_of_Posterior_Polar();
+			var cr_ = context.Operators.RetrieveByValueSet<Condition>(cq_, null);
+			var cs_ = context.Operators.ListUnion<Condition>(cp_, cr_);
+			var ct_ = context.Operators.ListUnion<Condition>(cn_, cs_);
+			var cu_ = this.Morgagnian_Cataract();
+			var cv_ = context.Operators.RetrieveByValueSet<Condition>(cu_, null);
+			var cw_ = this.Nystagmus_and_Other_Irregular_Eye_Movements();
+			var cx_ = context.Operators.RetrieveByValueSet<Condition>(cw_, null);
+			var cy_ = context.Operators.ListUnion<Condition>(cv_, cx_);
+			var cz_ = context.Operators.ListUnion<Condition>(ct_, cy_);
+			var da_ = this.Open_Wound_of_Eyeball();
+			var db_ = context.Operators.RetrieveByValueSet<Condition>(da_, null);
+			var dc_ = this.Optic_Atrophy();
+			var dd_ = context.Operators.RetrieveByValueSet<Condition>(dc_, null);
+			var de_ = context.Operators.ListUnion<Condition>(db_, dd_);
+			var df_ = context.Operators.ListUnion<Condition>(cz_, de_);
+			var dg_ = this.Optic_Neuritis();
+			var dh_ = context.Operators.RetrieveByValueSet<Condition>(dg_, null);
+			var di_ = this.Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis();
+			var dj_ = context.Operators.RetrieveByValueSet<Condition>(di_, null);
+			var dk_ = context.Operators.ListUnion<Condition>(dh_, dj_);
+			var dl_ = context.Operators.ListUnion<Condition>(df_, dk_);
+			var dm_ = this.Other_Background_Retinopathy_and_Retinal_Vascular_Changes();
+			var dn_ = context.Operators.RetrieveByValueSet<Condition>(dm_, null);
+			var do_ = this.Other_Disorders_of_Optic_Nerve();
+			var dp_ = context.Operators.RetrieveByValueSet<Condition>(do_, null);
+			var dq_ = context.Operators.ListUnion<Condition>(dn_, dp_);
+			var dr_ = context.Operators.ListUnion<Condition>(dl_, dq_);
+			var ds_ = this.Other_Endophthalmitis();
+			var dt_ = context.Operators.RetrieveByValueSet<Condition>(ds_, null);
+			var du_ = this.Other_Proliferative_Retinopathy();
+			var dv_ = context.Operators.RetrieveByValueSet<Condition>(du_, null);
+			var dw_ = context.Operators.ListUnion<Condition>(dt_, dv_);
+			var dx_ = context.Operators.ListUnion<Condition>(dr_, dw_);
+			var dy_ = this.Pathologic_Myopia();
+			var dz_ = context.Operators.RetrieveByValueSet<Condition>(dy_, null);
+			var ea_ = this.Posterior_Lenticonus();
+			var eb_ = context.Operators.RetrieveByValueSet<Condition>(ea_, null);
+			var ec_ = context.Operators.ListUnion<Condition>(dz_, eb_);
+			var ed_ = context.Operators.ListUnion<Condition>(dx_, ec_);
+			var ee_ = this.Prior_Penetrating_Keratoplasty();
+			var ef_ = context.Operators.RetrieveByValueSet<Condition>(ee_, null);
+			var eg_ = this.Purulent_Endophthalmitis();
+			var eh_ = context.Operators.RetrieveByValueSet<Condition>(eg_, null);
+			var ei_ = context.Operators.ListUnion<Condition>(ef_, eh_);
+			var ej_ = context.Operators.ListUnion<Condition>(ed_, ei_);
+			var ek_ = this.Retinal_Detachment_with_Retinal_Defect();
+			var el_ = context.Operators.RetrieveByValueSet<Condition>(ek_, null);
+			var em_ = this.Retinal_Vascular_Occlusion();
+			var en_ = context.Operators.RetrieveByValueSet<Condition>(em_, null);
+			var eo_ = context.Operators.ListUnion<Condition>(el_, en_);
+			var ep_ = context.Operators.ListUnion<Condition>(ej_, eo_);
+			var eq_ = this.Retrolental_Fibroplasias();
+			var er_ = context.Operators.RetrieveByValueSet<Condition>(eq_, null);
+			var es_ = this.Scleritis();
+			var et_ = context.Operators.RetrieveByValueSet<Condition>(es_, null);
+			var eu_ = context.Operators.ListUnion<Condition>(er_, et_);
+			var ev_ = context.Operators.ListUnion<Condition>(ep_, eu_);
+			var ew_ = this.Separation_of_Retinal_Layers();
+			var ex_ = context.Operators.RetrieveByValueSet<Condition>(ew_, null);
+			var ey_ = this.Traumatic_Cataract();
+			var ez_ = context.Operators.RetrieveByValueSet<Condition>(ey_, null);
+			var fa_ = context.Operators.ListUnion<Condition>(ex_, ez_);
+			var fb_ = context.Operators.ListUnion<Condition>(ev_, fa_);
+			var fc_ = this.Uveitis();
+			var fd_ = context.Operators.RetrieveByValueSet<Condition>(fc_, null);
+			var fe_ = this.Vascular_Disorders_of_Iris_and_Ciliary_Body();
+			var ff_ = context.Operators.RetrieveByValueSet<Condition>(fe_, null);
+			var fg_ = context.Operators.ListUnion<Condition>(fd_, ff_);
+			var fh_ = context.Operators.ListUnion<Condition>(fb_, fg_);
+			var fi_ = this.Visual_Field_Defects();
+			var fj_ = context.Operators.RetrieveByValueSet<Condition>(fi_, null);
+			var fk_ = context.Operators.ListUnion<Condition>(fh_, fj_);
+			bool? fl_(Condition ComorbidDiagnosis)
+			{
+				var fp_ = QICoreCommon_2_0_000.prevalenceInterval(ComorbidDiagnosis);
+				var fq_ = FHIRHelpers_4_3_000.ToValue(CataractSurgeryPerformed?.Performed);
+				var fr_ = QICoreCommon_2_0_000.toInterval(fq_);
+				var fs_ = context.Operators.OverlapsBefore(fp_, fr_, null);
+				var ft_ = QICoreCommon_2_0_000.isActive(ComorbidDiagnosis);
+				var fu_ = context.Operators.And(fs_, ft_);
+
+				return fu_;
+			};
+			var fm_ = context.Operators.WhereOrNull<Condition>(fk_, fl_);
+			Procedure fn_(Condition ComorbidDiagnosis) => 
+				CataractSurgeryPerformed;
+			var fo_ = context.Operators.SelectOrNull<Condition, Procedure>(fm_, fn_);
+
+			return fo_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public IEnumerable<Procedure> Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<Procedure> Numerator_Value()
+	{
+		var a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period();
+		IEnumerable<Procedure> b_(Procedure CataractSurgeryPerformed)
+		{
+			var d_ = this.Best_corrected_visual_acuity__observable_entity_();
+			var e_ = context.Operators.ToList<CqlCode>(d_);
+			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			var g_ = this.Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart();
+			var h_ = context.Operators.RetrieveByValueSet<Observation>(g_, null);
+			var i_ = context.Operators.ListUnion<Observation>(f_, h_);
+			bool? j_(Observation VisualAcuityExamPerformed)
+			{
+				var n_ = FHIRHelpers_4_3_000.ToValue(VisualAcuityExamPerformed?.Effective);
+				var o_ = QICoreCommon_2_0_000.toInterval(n_);
+				var p_ = context.Operators.Start(o_);
+				var q_ = FHIRHelpers_4_3_000.ToValue(CataractSurgeryPerformed?.Performed);
+				var r_ = QICoreCommon_2_0_000.toInterval(q_);
+				var s_ = context.Operators.End(r_);
+				var u_ = QICoreCommon_2_0_000.toInterval(q_);
+				var v_ = context.Operators.End(u_);
+				var w_ = context.Operators.Quantity(90m, "days");
+				var x_ = context.Operators.Add(v_, w_);
+				var y_ = context.Operators.Interval(s_, x_, false, true);
+				var z_ = context.Operators.ElementInInterval<CqlDateTime>(p_, y_, "day");
+				var ab_ = QICoreCommon_2_0_000.toInterval(q_);
+				var ac_ = context.Operators.End(ab_);
+				var ad_ = context.Operators.Not((bool?)(ac_ is null));
+				var ae_ = context.Operators.And(z_, ad_);
+				var af_ = context.Operators.Convert<Code<ObservationStatus>>(VisualAcuityExamPerformed?.StatusElement?.Value);
+				var ag_ = context.Operators.Convert<string>(af_);
+				var ah_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+					"preliminary",
+				};
+				var ai_ = context.Operators.InList<string>(ag_, (ah_ as IEnumerable<string>));
+				var aj_ = context.Operators.And(ae_, ai_);
+				var ak_ = FHIRHelpers_4_3_000.ToValue(VisualAcuityExamPerformed?.Value);
+				var al_ = this.Visual_Acuity_20_40_or_Better();
+				var am_ = context.Operators.ConceptInValueSet((ak_ as CqlConcept), al_);
+				var an_ = context.Operators.And(aj_, am_);
+
+				return an_;
+			};
+			var k_ = context.Operators.WhereOrNull<Observation>(i_, j_);
+			Procedure l_(Observation VisualAcuityExamPerformed) => 
+				CataractSurgeryPerformed;
+			var m_ = context.Operators.SelectOrNull<Observation, Procedure>(k_, l_);
+
+			return m_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Procedure> Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/CervicalCancerScreeningFHIR-0.0.001.g.cs
+++ b/Demo/Measures-cms/CervicalCancerScreeningFHIR-0.0.001.g.cs
@@ -1,0 +1,530 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("CervicalCancerScreeningFHIR", "0.0.001")]
+public class CervicalCancerScreeningFHIR_0_0_001
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Congenital_or_Acquired_Absence_of_Cervix;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __HPV_Test;
+    internal Lazy<CqlValueSet> __Hysterectomy_with_No_Residual_Cervix;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Pap_Test;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<object>> __Absence_of_Cervix;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Observation>> __Cervical_Cytology_Within_3_Years;
+    internal Lazy<IEnumerable<Observation>> __HPV_Test_Within_5_Years_for_Women_Age_30_and_Older;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public CervicalCancerScreeningFHIR_0_0_001(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        PalliativeCare_1_9_000 = new PalliativeCare_1_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+
+        __Congenital_or_Acquired_Absence_of_Cervix = new Lazy<CqlValueSet>(this.Congenital_or_Acquired_Absence_of_Cervix_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __HPV_Test = new Lazy<CqlValueSet>(this.HPV_Test_Value);
+        __Hysterectomy_with_No_Residual_Cervix = new Lazy<CqlValueSet>(this.Hysterectomy_with_No_Residual_Cervix_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Pap_Test = new Lazy<CqlValueSet>(this.Pap_Test_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Absence_of_Cervix = new Lazy<IEnumerable<object>>(this.Absence_of_Cervix_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Cervical_Cytology_Within_3_Years = new Lazy<IEnumerable<Observation>>(this.Cervical_Cytology_Within_3_Years_Value);
+        __HPV_Test_Within_5_Years_for_Women_Age_30_and_Older = new Lazy<IEnumerable<Observation>>(this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public PalliativeCare_1_9_000 PalliativeCare_1_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Congenital_or_Acquired_Absence_of_Cervix_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", null);
+
+    [CqlDeclaration("Congenital or Acquired Absence of Cervix")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016")]
+	public CqlValueSet Congenital_or_Acquired_Absence_of_Cervix() => 
+		__Congenital_or_Acquired_Absence_of_Cervix.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet HPV_Test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", null);
+
+    [CqlDeclaration("HPV Test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059")]
+	public CqlValueSet HPV_Test() => 
+		__HPV_Test.Value;
+
+	private CqlValueSet Hysterectomy_with_No_Residual_Cervix_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", null);
+
+    [CqlDeclaration("Hysterectomy with No Residual Cervix")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014")]
+	public CqlValueSet Hysterectomy_with_No_Residual_Cervix() => 
+		__Hysterectomy_with_No_Residual_Cervix.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Pap_Test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", null);
+
+    [CqlDeclaration("Pap Test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
+	public CqlValueSet Pap_Test() => 
+		__Pap_Test.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("CervicalCancerScreeningFHIR-0.0.001", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Home_Healthcare_Services();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Telephone_Visits();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Online_Assessments();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = Status_1_6_000.isEncounterPerformed(q_);
+		bool? s_(Encounter ValidEncounters)
+		{
+			var u_ = this.Measurement_Period();
+			var v_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounters?.Period);
+			var w_ = QICoreCommon_2_0_000.toInterval((v_ as object));
+			var x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, "day");
+
+			return x_;
+		};
+		var t_ = context.Operators.WhereOrNull<Encounter>(r_, s_);
+
+		return t_;
+	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)24, (int?)64, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var j_ = context.Operators.EnumEqualsString(a_?.GenderElement?.Value, "female");
+		var k_ = context.Operators.And(h_, j_);
+		var l_ = this.Qualifying_Encounters();
+		var m_ = context.Operators.ExistsInList<Encounter>(l_);
+		var n_ = context.Operators.And(k_, m_);
+
+		return n_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<object> Absence_of_Cervix_Value()
+	{
+		var a_ = this.Hysterectomy_with_No_Residual_Cervix();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.isProcedurePerformed(b_);
+		bool? d_(Procedure NoCervixProcedure)
+		{
+			var k_ = FHIRHelpers_4_3_000.ToValue(NoCervixProcedure?.Performed);
+			var l_ = QICoreCommon_2_0_000.toInterval(k_);
+			var m_ = context.Operators.End(l_);
+			var n_ = this.Measurement_Period();
+			var o_ = context.Operators.End(n_);
+			var p_ = context.Operators.SameOrBefore(m_, o_, null);
+
+			return p_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+		var f_ = this.Congenital_or_Acquired_Absence_of_Cervix();
+		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		bool? h_(Condition NoCervixDiagnosis)
+		{
+			var q_ = QICoreCommon_2_0_000.prevalenceInterval(NoCervixDiagnosis);
+			var r_ = context.Operators.Start(q_);
+			var s_ = this.Measurement_Period();
+			var t_ = context.Operators.End(s_);
+			var u_ = context.Operators.SameOrBefore(r_, t_, null);
+
+			return u_;
+		};
+		var i_ = context.Operators.WhereOrNull<Condition>(g_, h_);
+		var j_ = context.Operators.ListUnion<object>((e_ as IEnumerable<object>), (i_ as IEnumerable<object>));
+
+		return j_;
+	}
+
+    [CqlDeclaration("Absence of Cervix")]
+	public IEnumerable<object> Absence_of_Cervix() => 
+		__Absence_of_Cervix.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = this.Absence_of_Cervix();
+		var c_ = context.Operators.ExistsInList<object>(b_);
+		var d_ = context.Operators.Or(a_, c_);
+		var e_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		var f_ = context.Operators.Or(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years_Value()
+	{
+		var a_ = this.Pap_Test();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
+		bool? d_(Observation CervicalCytology)
+		{
+			object f_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(CervicalCytology?.Effective) is CqlDateTime)
+				{
+					var s_ = FHIRHelpers_4_3_000.ToValue(CervicalCytology?.Effective);
+
+					return ((s_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(CervicalCytology?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var t_ = FHIRHelpers_4_3_000.ToValue(CervicalCytology?.Effective);
+
+					return ((t_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(CervicalCytology?.Effective) is CqlDateTime)
+				{
+					var u_ = FHIRHelpers_4_3_000.ToValue(CervicalCytology?.Effective);
+
+					return ((u_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var g_ = QICoreCommon_2_0_000.latest(f_());
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.Quantity(2m, "years");
+			var k_ = context.Operators.Subtract(i_, j_);
+			var m_ = context.Operators.End(h_);
+			var n_ = context.Operators.Interval(k_, m_, true, true);
+			var o_ = context.Operators.ElementInInterval<CqlDateTime>(g_, n_, "day");
+			var p_ = FHIRHelpers_4_3_000.ToValue(CervicalCytology?.Value);
+			var q_ = context.Operators.Not((bool?)(p_ is null));
+			var r_ = context.Operators.And(o_, q_);
+
+			return r_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Cervical Cytology Within 3 Years")]
+	public IEnumerable<Observation> Cervical_Cytology_Within_3_Years() => 
+		__Cervical_Cytology_Within_3_Years.Value;
+
+	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value()
+	{
+		var a_ = this.HPV_Test();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
+		bool? d_(Observation HPVTest)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			object h_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective) is CqlDateTime)
+				{
+					var aa_ = FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective);
+
+					return ((aa_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var ab_ = FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective);
+
+					return ((ab_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective) is CqlDateTime)
+				{
+					var ac_ = FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective);
+
+					return ((ac_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var i_ = QICoreCommon_2_0_000.latest(h_());
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			var l_ = context.Operators.GreaterOrEqual(k_, (int?)30);
+			object m_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective) is CqlDateTime)
+				{
+					var ad_ = FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective);
+
+					return ((ad_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var ae_ = FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective);
+
+					return ((ae_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective) is CqlDateTime)
+				{
+					var af_ = FHIRHelpers_4_3_000.ToValue(HPVTest?.Effective);
+
+					return ((af_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var n_ = QICoreCommon_2_0_000.latest(m_());
+			var o_ = this.Measurement_Period();
+			var p_ = context.Operators.Start(o_);
+			var q_ = context.Operators.Quantity(4m, "years");
+			var r_ = context.Operators.Subtract(p_, q_);
+			var t_ = context.Operators.End(o_);
+			var u_ = context.Operators.Interval(r_, t_, true, true);
+			var v_ = context.Operators.ElementInInterval<CqlDateTime>(n_, u_, "day");
+			var w_ = context.Operators.And(l_, v_);
+			var x_ = FHIRHelpers_4_3_000.ToValue(HPVTest?.Value);
+			var y_ = context.Operators.Not((bool?)(x_ is null));
+			var z_ = context.Operators.And(w_, y_);
+
+			return z_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("HPV Test Within 5 Years for Women Age 30 and Older")]
+	public IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older() => 
+		__HPV_Test_Within_5_Years_for_Women_Age_30_and_Older.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Cervical_Cytology_Within_3_Years();
+		var b_ = context.Operators.ExistsInList<Observation>(a_);
+		var c_ = this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older();
+		var d_ = context.Operators.ExistsInList<Observation>(c_);
+		var e_ = context.Operators.Or(b_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
@@ -1,0 +1,456 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR", "0.1.000")]
+public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Group_Psychotherapy;
+    internal Lazy<CqlValueSet> __Major_Depressive_Disorder_Active;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Psych_Visit_Diagnostic_Evaluation;
+    internal Lazy<CqlValueSet> __Psych_Visit_for_Family_Psychotherapy;
+    internal Lazy<CqlValueSet> __Psych_Visit_Psychotherapy;
+    internal Lazy<CqlValueSet> __Psychoanalysis;
+    internal Lazy<CqlValueSet> __Telehealth_Services;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode> __Suicide_risk_assessment__procedure_;
+    internal Lazy<CqlCode> __AMB;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __ActCode;
+    internal Lazy<CqlCode[]> __ICD10CM;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Major_Depressive_Disorder_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+
+    #endregion
+    public ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+
+        __Group_Psychotherapy = new Lazy<CqlValueSet>(this.Group_Psychotherapy_Value);
+        __Major_Depressive_Disorder_Active = new Lazy<CqlValueSet>(this.Major_Depressive_Disorder_Active_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Psych_Visit_Diagnostic_Evaluation = new Lazy<CqlValueSet>(this.Psych_Visit_Diagnostic_Evaluation_Value);
+        __Psych_Visit_for_Family_Psychotherapy = new Lazy<CqlValueSet>(this.Psych_Visit_for_Family_Psychotherapy_Value);
+        __Psych_Visit_Psychotherapy = new Lazy<CqlValueSet>(this.Psych_Visit_Psychotherapy_Value);
+        __Psychoanalysis = new Lazy<CqlValueSet>(this.Psychoanalysis_Value);
+        __Telehealth_Services = new Lazy<CqlValueSet>(this.Telehealth_Services_Value);
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value);
+        __Suicide_risk_assessment__procedure_ = new Lazy<CqlCode>(this.Suicide_risk_assessment__procedure__Value);
+        __AMB = new Lazy<CqlCode>(this.AMB_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __ActCode = new Lazy<CqlCode[]>(this.ActCode_Value);
+        __ICD10CM = new Lazy<CqlCode[]>(this.ICD10CM_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Major_Depressive_Disorder_Encounter = new Lazy<IEnumerable<Encounter>>(this.Major_Depressive_Disorder_Encounter_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+    }
+    #region Dependencies
+
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Group_Psychotherapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187", null);
+
+    [CqlDeclaration("Group Psychotherapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187")]
+	public CqlValueSet Group_Psychotherapy() => 
+		__Group_Psychotherapy.Value;
+
+	private CqlValueSet Major_Depressive_Disorder_Active_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491", null);
+
+    [CqlDeclaration("Major Depressive Disorder Active")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491")]
+	public CqlValueSet Major_Depressive_Disorder_Active() => 
+		__Major_Depressive_Disorder_Active.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
+
+    [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
+	public CqlValueSet Psych_Visit_Diagnostic_Evaluation() => 
+		__Psych_Visit_Diagnostic_Evaluation.Value;
+
+	private CqlValueSet Psych_Visit_for_Family_Psychotherapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018", null);
+
+    [CqlDeclaration("Psych Visit for Family Psychotherapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018")]
+	public CqlValueSet Psych_Visit_for_Family_Psychotherapy() => 
+		__Psych_Visit_for_Family_Psychotherapy.Value;
+
+	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
+
+    [CqlDeclaration("Psych Visit Psychotherapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
+	public CqlValueSet Psych_Visit_Psychotherapy() => 
+		__Psych_Visit_Psychotherapy.Value;
+
+	private CqlValueSet Psychoanalysis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", null);
+
+    [CqlDeclaration("Psychoanalysis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141")]
+	public CqlValueSet Psychoanalysis() => 
+		__Psychoanalysis.Value;
+
+	private CqlValueSet Telehealth_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", null);
+
+    [CqlDeclaration("Telehealth Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031")]
+	public CqlValueSet Telehealth_Services() => 
+		__Telehealth_Services.Value;
+
+	private CqlCode Birth_date_Value() => 
+		new CqlCode("21112-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date.Value;
+
+	private CqlCode Suicide_risk_assessment__procedure__Value() => 
+		new CqlCode("225337009", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Suicide risk assessment (procedure)")]
+	public CqlCode Suicide_risk_assessment__procedure_() => 
+		__Suicide_risk_assessment__procedure_.Value;
+
+	private CqlCode AMB_Value() => 
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+
+    [CqlDeclaration("AMB")]
+	public CqlCode AMB() => 
+		__AMB.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("21112-8", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("225337009", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] ActCode_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ActCode")]
+	public CqlCode[] ActCode() => 
+		__ActCode.Value;
+
+	private CqlCode[] ICD10CM_Value()
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
+    [CqlDeclaration("ICD10CM")]
+	public CqlCode[] ICD10CM() => 
+		__ICD10CM.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Major_Depressive_Disorder_Encounter_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Outpatient_Consultation();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Psych_Visit_Diagnostic_Evaluation();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Psych_Visit_for_Family_Psychotherapy();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Psych_Visit_Psychotherapy();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Psychoanalysis();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Group_Psychotherapy();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = this.Telehealth_Services();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
+		bool? x_(Encounter ValidEncounter)
+		{
+			var z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ValidEncounter?.StatusElement?.Value);
+			var aa_ = context.Operators.Equal(z_, "finished");
+			CqlConcept ab_(CodeableConcept @this)
+			{
+				var ap_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return ap_;
+			};
+			var ac_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(ValidEncounter?.ReasonCode, ab_);
+			var ad_ = this.Major_Depressive_Disorder_Active();
+			var ae_ = context.Operators.ConceptsInValueSet(ac_, ad_);
+			var af_ = CQMCommon_2_0_000.EncounterDiagnosis(ValidEncounter);
+			bool? ag_(Condition EncounterDiagnosis)
+			{
+				var aq_ = FHIRHelpers_4_3_000.ToConcept(EncounterDiagnosis?.Code);
+				var ar_ = this.Major_Depressive_Disorder_Active();
+				var as_ = context.Operators.ConceptInValueSet(aq_, ar_);
+
+				return as_;
+			};
+			var ah_ = context.Operators.WhereOrNull<Condition>(af_, ag_);
+			var ai_ = context.Operators.ExistsInList<Condition>(ah_);
+			var aj_ = context.Operators.Or(ae_, ai_);
+			var ak_ = context.Operators.And(aa_, aj_);
+			var al_ = this.Measurement_Period();
+			var am_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var an_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(al_, am_, null);
+			var ao_ = context.Operators.And(ak_, an_);
+
+			return ao_;
+		};
+		var y_ = context.Operators.WhereOrNull<Encounter>(w_, x_);
+
+		return y_;
+	}
+
+    [CqlDeclaration("Major Depressive Disorder Encounter")]
+	public IEnumerable<Encounter> Major_Depressive_Disorder_Encounter() => 
+		__Major_Depressive_Disorder_Encounter.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.Major_Depressive_Disorder_Encounter();
+		bool? b_(Encounter MDDEncounter)
+		{
+			var d_ = this.Patient();
+			var e_ = context.Operators.Convert<CqlDate>(d_?.BirthDateElement?.Value);
+			var f_ = this.Measurement_Period();
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.DateFrom(g_);
+			var i_ = context.Operators.CalculateAgeAt(e_, h_, "year");
+			var j_ = context.Operators.GreaterOrEqual(i_, (int?)6);
+			var l_ = context.Operators.Convert<CqlDate>(d_?.BirthDateElement?.Value);
+			var n_ = context.Operators.Start(f_);
+			var o_ = context.Operators.DateFrom(n_);
+			var p_ = context.Operators.CalculateAgeAt(l_, o_, "year");
+			var q_ = context.Operators.LessOrEqual(p_, (int?)16);
+			var r_ = context.Operators.And(j_, q_);
+
+			return r_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = this.Major_Depressive_Disorder_Encounter();
+		IEnumerable<Encounter> b_(Encounter MDDEncounter)
+		{
+			var d_ = this.Suicide_risk_assessment__procedure_();
+			var e_ = context.Operators.ToList<CqlCode>(d_);
+			var f_ = context.Operators.RetrieveByCodes<Procedure>(e_, null);
+			bool? g_(Procedure SuicideRiskAssessment)
+			{
+				var k_ = context.Operators.EnumEqualsString(SuicideRiskAssessment?.StatusElement?.Value, "completed");
+				var l_ = FHIRHelpers_4_3_000.ToInterval(MDDEncounter?.Period);
+				var m_ = FHIRHelpers_4_3_000.ToValue(SuicideRiskAssessment?.Performed);
+				var n_ = QICoreCommon_2_0_000.ToInterval(m_);
+				var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, null);
+				var p_ = context.Operators.And(k_, o_);
+
+				return p_;
+			};
+			var h_ = context.Operators.WhereOrNull<Procedure>(f_, g_);
+			Encounter i_(Procedure SuicideRiskAssessment) => 
+				MDDEncounter;
+			var j_ = context.Operators.SelectOrNull<Procedure, Encounter>(h_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+}

--- a/Demo/Measures-cms/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
@@ -1,0 +1,3010 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("ChildhoodImmunizationStatusFHIR", "0.1.000")]
+public class ChildhoodImmunizationStatusFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Anaphylactic_Reaction_to_DTaP_Vaccine;
+    internal Lazy<CqlValueSet> __Disorders_of_the_Immune_System;
+    internal Lazy<CqlValueSet> __DTaP_Vaccine;
+    internal Lazy<CqlValueSet> __DTaP_Vaccine_Administered;
+    internal Lazy<CqlValueSet> __Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered;
+    internal Lazy<CqlValueSet> __Hepatitis_A;
+    internal Lazy<CqlValueSet> __Hepatitis_A_Vaccine;
+    internal Lazy<CqlValueSet> __Hepatitis_A_Vaccine_Administered;
+    internal Lazy<CqlValueSet> __Hepatitis_B;
+    internal Lazy<CqlValueSet> __Hepatitis_B_Vaccine;
+    internal Lazy<CqlValueSet> __Hepatitis_B_Vaccine_Administered;
+    internal Lazy<CqlValueSet> __Hib_Vaccine__3_dose_schedule_;
+    internal Lazy<CqlValueSet> __Hib_Vaccine__3_dose_schedule__Administered;
+    internal Lazy<CqlValueSet> __Hib_Vaccine__4_dose_schedule_;
+    internal Lazy<CqlValueSet> __Hib_Vaccine__4_dose_schedule__Administered;
+    internal Lazy<CqlValueSet> __HIV;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Hospice_care_ambulatory;
+    internal Lazy<CqlValueSet> __Inactivated_Polio_Vaccine__IPV_;
+    internal Lazy<CqlValueSet> __Inactivated_Polio_Vaccine__IPV__Administered;
+    internal Lazy<CqlValueSet> __Child_Influenza_Immunization_Administered;
+    internal Lazy<CqlValueSet> __Child_Influenza_Vaccine_Administered;
+    internal Lazy<CqlValueSet> __Influenza_Virus_LAIV_Immunization;
+    internal Lazy<CqlValueSet> __Influenza_Virus_LAIV_Procedure;
+    internal Lazy<CqlValueSet> __Intussusception;
+    internal Lazy<CqlValueSet> __Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue;
+    internal Lazy<CqlValueSet> __Measles;
+    internal Lazy<CqlValueSet> __Measles__Mumps_and_Rubella__MMR__Vaccine;
+    internal Lazy<CqlValueSet> __Measles__Mumps_and_Rubella__MMR__Vaccine_Administered;
+    internal Lazy<CqlValueSet> __Mumps;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Pneumococcal_Conjugate_Vaccine;
+    internal Lazy<CqlValueSet> __Pneumococcal_Conjugate_Vaccine_Administered;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care__Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Rotavirus_Vaccine__2_dose_schedule__Administered;
+    internal Lazy<CqlValueSet> __Rotavirus_Vaccine__3_dose_schedule_;
+    internal Lazy<CqlValueSet> __Rotavirus_Vaccine__3_dose_schedule__Administered;
+    internal Lazy<CqlValueSet> __Rubella;
+    internal Lazy<CqlValueSet> __Severe_Combined_Immunodeficiency;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Varicella_Zoster;
+    internal Lazy<CqlValueSet> __Varicella_Zoster_Vaccine__VZV_;
+    internal Lazy<CqlValueSet> __Varicella_Zoster_Vaccine__VZV__Administered;
+    internal Lazy<CqlCode> __Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_;
+    internal Lazy<CqlCode> __Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_;
+    internal Lazy<CqlCode> __Anaphylaxis_due_to_rotavirus_vaccine__disorder_;
+    internal Lazy<CqlCode> __Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional;
+    internal Lazy<CqlCode> __rotavirus__live__monovalent_vaccine;
+    internal Lazy<CqlCode> __Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_;
+    internal Lazy<CqlCode> __Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach;
+    internal Lazy<CqlCode> __Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_;
+    internal Lazy<CqlCode> __Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_;
+    internal Lazy<CqlCode> __Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_;
+    internal Lazy<CqlCode> __Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_;
+    internal Lazy<CqlCode> __Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlCode[]> __CVX;
+    internal Lazy<CqlCode[]> __ICD10;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<CqlDate> __Date_of_Second_Birthday;
+    internal Lazy<CqlInterval<CqlDate>> __First_Two_Years;
+    internal Lazy<bool?> __Has_Severe_Combined_Immunodeficiency;
+    internal Lazy<bool?> __Has_Immunodeficiency;
+    internal Lazy<bool?> __Has_HIV;
+    internal Lazy<bool?> __Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia;
+    internal Lazy<bool?> __Has_Intussusception;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<CqlInterval<CqlDate>> __Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old;
+    internal Lazy<IEnumerable<CqlDate>> __DTaP_Immunizations_or_Procedures;
+    internal Lazy<IEnumerable<CqlDate>> __Four_DTaP_Vaccinations;
+    internal Lazy<IEnumerable<Condition>> __DTaP_Numerator_Inclusion_Conditions;
+    internal Lazy<IEnumerable<CqlDate>> __Polio_Immunizations_or_Procedures;
+    internal Lazy<IEnumerable<CqlDate>> __Three_Polio_Vaccinations;
+    internal Lazy<IEnumerable<Condition>> __Polio_Numerator_Inclusion_Conditions;
+    internal Lazy<CqlDate> __Date_of_First_Birthday;
+    internal Lazy<CqlInterval<CqlDate>> __Date_of_First_Birthday_to_Date_of_Second_Birthday;
+    internal Lazy<IEnumerable<object>> __One_MMR_Vaccination;
+    internal Lazy<IEnumerable<Condition>> __MMR_Numerator_Inclusion_Conditions;
+    internal Lazy<IEnumerable<Condition>> __Measles_Indicators;
+    internal Lazy<IEnumerable<Condition>> __Mumps_Indicators;
+    internal Lazy<IEnumerable<Condition>> __Rubella_Indicators;
+    internal Lazy<IEnumerable<CqlDate>> __Hib_3_Dose_Immunizations_or_Procedures;
+    internal Lazy<IEnumerable<CqlDate>> __Hib_4_Dose_Immunizations_or_Procedures;
+    internal Lazy<IEnumerable<CqlDate>> __Hib_3_or_4_Dose_Immunizations;
+    internal Lazy<IEnumerable<CqlDate>> __All_Hib_Vaccinations;
+    internal Lazy<bool?> __Has_Appropriate_Number_of_Hib_Immunizations;
+    internal Lazy<IEnumerable<Condition>> __Hib_Numerator_Inclusion_Conditions;
+    internal Lazy<IEnumerable<CqlDate>> __Hepatitis_B_Immunizations_or_Procedures;
+    internal Lazy<IEnumerable<CqlDate>> __Three_Hepatitis_B_Vaccinations;
+    internal Lazy<IEnumerable<CqlDate>> __NewBorn_Vaccine_Requirement;
+    internal Lazy<IEnumerable<CqlDate>> __Meets_HepB_Vaccination_Requirement;
+    internal Lazy<IEnumerable<Condition>> __Hepatitis_B_Numerator_Inclusion_Conditions;
+    internal Lazy<IEnumerable<object>> __One_Chicken_Pox_Vaccination;
+    internal Lazy<IEnumerable<Condition>> __Varicella_Zoster_Numerator_Inclusion_Conditions;
+    internal Lazy<IEnumerable<CqlDate>> __Pneumococcal_Conjugate_Immunizations_or_Procedures;
+    internal Lazy<IEnumerable<CqlDate>> __Four_Pneumococcal_Conjugate_Vaccinations;
+    internal Lazy<IEnumerable<Condition>> __Pneumococcal_Conjugate_Numerator_Inclusion_Conditions;
+    internal Lazy<IEnumerable<object>> __One_Hepatitis_A_Vaccinations;
+    internal Lazy<IEnumerable<Condition>> __Hepatitis_A_Numerator_Inclusion_Conditions;
+    internal Lazy<IEnumerable<CqlDate>> __Rotavirus_2_Dose_Immunizations_or_Procedures;
+    internal Lazy<IEnumerable<CqlDate>> __Rotavirus_3_Dose_Immunizations_or_Procedures;
+    internal Lazy<IEnumerable<CqlDate>> __Rotavirus_2_or_3_Dose_Immunizations;
+    internal Lazy<IEnumerable<CqlDate>> __All_Rotavirus_Vaccinations;
+    internal Lazy<bool?> __Has_Appropriate_Number_of_Rotavirus_Immunizations;
+    internal Lazy<IEnumerable<Condition>> __Rotavirus_Numerator_Inclusion_Conditions;
+    internal Lazy<CqlInterval<CqlDate>> __Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old;
+    internal Lazy<IEnumerable<CqlDate>> __Influenza_Immunizations_or_Procedures;
+    internal Lazy<IEnumerable<CqlDate>> __Two_Influenza_Vaccinations;
+    internal Lazy<IEnumerable<CqlDate>> __LAIV_Vaccinations;
+    internal Lazy<bool?> __Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination;
+    internal Lazy<IEnumerable<Condition>> __Influenza_Numerator_Inclusion_Conditions;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public ChildhoodImmunizationStatusFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Anaphylactic_Reaction_to_DTaP_Vaccine = new Lazy<CqlValueSet>(this.Anaphylactic_Reaction_to_DTaP_Vaccine_Value);
+        __Disorders_of_the_Immune_System = new Lazy<CqlValueSet>(this.Disorders_of_the_Immune_System_Value);
+        __DTaP_Vaccine = new Lazy<CqlValueSet>(this.DTaP_Vaccine_Value);
+        __DTaP_Vaccine_Administered = new Lazy<CqlValueSet>(this.DTaP_Vaccine_Administered_Value);
+        __Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine = new Lazy<CqlValueSet>(this.Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered = new Lazy<CqlValueSet>(this.Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered_Value);
+        __Hepatitis_A = new Lazy<CqlValueSet>(this.Hepatitis_A_Value);
+        __Hepatitis_A_Vaccine = new Lazy<CqlValueSet>(this.Hepatitis_A_Vaccine_Value);
+        __Hepatitis_A_Vaccine_Administered = new Lazy<CqlValueSet>(this.Hepatitis_A_Vaccine_Administered_Value);
+        __Hepatitis_B = new Lazy<CqlValueSet>(this.Hepatitis_B_Value);
+        __Hepatitis_B_Vaccine = new Lazy<CqlValueSet>(this.Hepatitis_B_Vaccine_Value);
+        __Hepatitis_B_Vaccine_Administered = new Lazy<CqlValueSet>(this.Hepatitis_B_Vaccine_Administered_Value);
+        __Hib_Vaccine__3_dose_schedule_ = new Lazy<CqlValueSet>(this.Hib_Vaccine__3_dose_schedule__Value);
+        __Hib_Vaccine__3_dose_schedule__Administered = new Lazy<CqlValueSet>(this.Hib_Vaccine__3_dose_schedule__Administered_Value);
+        __Hib_Vaccine__4_dose_schedule_ = new Lazy<CqlValueSet>(this.Hib_Vaccine__4_dose_schedule__Value);
+        __Hib_Vaccine__4_dose_schedule__Administered = new Lazy<CqlValueSet>(this.Hib_Vaccine__4_dose_schedule__Administered_Value);
+        __HIV = new Lazy<CqlValueSet>(this.HIV_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Hospice_care_ambulatory = new Lazy<CqlValueSet>(this.Hospice_care_ambulatory_Value);
+        __Inactivated_Polio_Vaccine__IPV_ = new Lazy<CqlValueSet>(this.Inactivated_Polio_Vaccine__IPV__Value);
+        __Inactivated_Polio_Vaccine__IPV__Administered = new Lazy<CqlValueSet>(this.Inactivated_Polio_Vaccine__IPV__Administered_Value);
+        __Child_Influenza_Immunization_Administered = new Lazy<CqlValueSet>(this.Child_Influenza_Immunization_Administered_Value);
+        __Child_Influenza_Vaccine_Administered = new Lazy<CqlValueSet>(this.Child_Influenza_Vaccine_Administered_Value);
+        __Influenza_Virus_LAIV_Immunization = new Lazy<CqlValueSet>(this.Influenza_Virus_LAIV_Immunization_Value);
+        __Influenza_Virus_LAIV_Procedure = new Lazy<CqlValueSet>(this.Influenza_Virus_LAIV_Procedure_Value);
+        __Intussusception = new Lazy<CqlValueSet>(this.Intussusception_Value);
+        __Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue = new Lazy<CqlValueSet>(this.Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue_Value);
+        __Measles = new Lazy<CqlValueSet>(this.Measles_Value);
+        __Measles__Mumps_and_Rubella__MMR__Vaccine = new Lazy<CqlValueSet>(this.Measles__Mumps_and_Rubella__MMR__Vaccine_Value);
+        __Measles__Mumps_and_Rubella__MMR__Vaccine_Administered = new Lazy<CqlValueSet>(this.Measles__Mumps_and_Rubella__MMR__Vaccine_Administered_Value);
+        __Mumps = new Lazy<CqlValueSet>(this.Mumps_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Pneumococcal_Conjugate_Vaccine = new Lazy<CqlValueSet>(this.Pneumococcal_Conjugate_Vaccine_Value);
+        __Pneumococcal_Conjugate_Vaccine_Administered = new Lazy<CqlValueSet>(this.Pneumococcal_Conjugate_Vaccine_Administered_Value);
+        __Preventive_Care_Services__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value);
+        __Preventive_Care__Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Established_Office_Visit__0_to_17_Value);
+        __Rotavirus_Vaccine__2_dose_schedule__Administered = new Lazy<CqlValueSet>(this.Rotavirus_Vaccine__2_dose_schedule__Administered_Value);
+        __Rotavirus_Vaccine__3_dose_schedule_ = new Lazy<CqlValueSet>(this.Rotavirus_Vaccine__3_dose_schedule__Value);
+        __Rotavirus_Vaccine__3_dose_schedule__Administered = new Lazy<CqlValueSet>(this.Rotavirus_Vaccine__3_dose_schedule__Administered_Value);
+        __Rubella = new Lazy<CqlValueSet>(this.Rubella_Value);
+        __Severe_Combined_Immunodeficiency = new Lazy<CqlValueSet>(this.Severe_Combined_Immunodeficiency_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Varicella_Zoster = new Lazy<CqlValueSet>(this.Varicella_Zoster_Value);
+        __Varicella_Zoster_Vaccine__VZV_ = new Lazy<CqlValueSet>(this.Varicella_Zoster_Vaccine__VZV__Value);
+        __Varicella_Zoster_Vaccine__VZV__Administered = new Lazy<CqlValueSet>(this.Varicella_Zoster_Vaccine__VZV__Administered_Value);
+        __Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_ = new Lazy<CqlCode>(this.Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder__Value);
+        __Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_ = new Lazy<CqlCode>(this.Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder__Value);
+        __Anaphylaxis_due_to_rotavirus_vaccine__disorder_ = new Lazy<CqlCode>(this.Anaphylaxis_due_to_rotavirus_vaccine__disorder__Value);
+        __Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional = new Lazy<CqlCode>(this.Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional_Value);
+        __rotavirus__live__monovalent_vaccine = new Lazy<CqlCode>(this.rotavirus__live__monovalent_vaccine_Value);
+        __Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_ = new Lazy<CqlCode>(this.Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder__Value);
+        __Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach = new Lazy<CqlCode>(this.Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach_Value);
+        __Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_ = new Lazy<CqlCode>(this.Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder__Value);
+        __Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_ = new Lazy<CqlCode>(this.Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder__Value);
+        __Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_ = new Lazy<CqlCode>(this.Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder__Value);
+        __Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_ = new Lazy<CqlCode>(this.Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder__Value);
+        __Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_ = new Lazy<CqlCode>(this.Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder__Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __CVX = new Lazy<CqlCode[]>(this.CVX_Value);
+        __ICD10 = new Lazy<CqlCode[]>(this.ICD10_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Date_of_Second_Birthday = new Lazy<CqlDate>(this.Date_of_Second_Birthday_Value);
+        __First_Two_Years = new Lazy<CqlInterval<CqlDate>>(this.First_Two_Years_Value);
+        __Has_Severe_Combined_Immunodeficiency = new Lazy<bool?>(this.Has_Severe_Combined_Immunodeficiency_Value);
+        __Has_Immunodeficiency = new Lazy<bool?>(this.Has_Immunodeficiency_Value);
+        __Has_HIV = new Lazy<bool?>(this.Has_HIV_Value);
+        __Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia = new Lazy<bool?>(this.Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia_Value);
+        __Has_Intussusception = new Lazy<bool?>(this.Has_Intussusception_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old = new Lazy<CqlInterval<CqlDate>>(this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old_Value);
+        __DTaP_Immunizations_or_Procedures = new Lazy<IEnumerable<CqlDate>>(this.DTaP_Immunizations_or_Procedures_Value);
+        __Four_DTaP_Vaccinations = new Lazy<IEnumerable<CqlDate>>(this.Four_DTaP_Vaccinations_Value);
+        __DTaP_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.DTaP_Numerator_Inclusion_Conditions_Value);
+        __Polio_Immunizations_or_Procedures = new Lazy<IEnumerable<CqlDate>>(this.Polio_Immunizations_or_Procedures_Value);
+        __Three_Polio_Vaccinations = new Lazy<IEnumerable<CqlDate>>(this.Three_Polio_Vaccinations_Value);
+        __Polio_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.Polio_Numerator_Inclusion_Conditions_Value);
+        __Date_of_First_Birthday = new Lazy<CqlDate>(this.Date_of_First_Birthday_Value);
+        __Date_of_First_Birthday_to_Date_of_Second_Birthday = new Lazy<CqlInterval<CqlDate>>(this.Date_of_First_Birthday_to_Date_of_Second_Birthday_Value);
+        __One_MMR_Vaccination = new Lazy<IEnumerable<object>>(this.One_MMR_Vaccination_Value);
+        __MMR_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.MMR_Numerator_Inclusion_Conditions_Value);
+        __Measles_Indicators = new Lazy<IEnumerable<Condition>>(this.Measles_Indicators_Value);
+        __Mumps_Indicators = new Lazy<IEnumerable<Condition>>(this.Mumps_Indicators_Value);
+        __Rubella_Indicators = new Lazy<IEnumerable<Condition>>(this.Rubella_Indicators_Value);
+        __Hib_3_Dose_Immunizations_or_Procedures = new Lazy<IEnumerable<CqlDate>>(this.Hib_3_Dose_Immunizations_or_Procedures_Value);
+        __Hib_4_Dose_Immunizations_or_Procedures = new Lazy<IEnumerable<CqlDate>>(this.Hib_4_Dose_Immunizations_or_Procedures_Value);
+        __Hib_3_or_4_Dose_Immunizations = new Lazy<IEnumerable<CqlDate>>(this.Hib_3_or_4_Dose_Immunizations_Value);
+        __All_Hib_Vaccinations = new Lazy<IEnumerable<CqlDate>>(this.All_Hib_Vaccinations_Value);
+        __Has_Appropriate_Number_of_Hib_Immunizations = new Lazy<bool?>(this.Has_Appropriate_Number_of_Hib_Immunizations_Value);
+        __Hib_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.Hib_Numerator_Inclusion_Conditions_Value);
+        __Hepatitis_B_Immunizations_or_Procedures = new Lazy<IEnumerable<CqlDate>>(this.Hepatitis_B_Immunizations_or_Procedures_Value);
+        __Three_Hepatitis_B_Vaccinations = new Lazy<IEnumerable<CqlDate>>(this.Three_Hepatitis_B_Vaccinations_Value);
+        __NewBorn_Vaccine_Requirement = new Lazy<IEnumerable<CqlDate>>(this.NewBorn_Vaccine_Requirement_Value);
+        __Meets_HepB_Vaccination_Requirement = new Lazy<IEnumerable<CqlDate>>(this.Meets_HepB_Vaccination_Requirement_Value);
+        __Hepatitis_B_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.Hepatitis_B_Numerator_Inclusion_Conditions_Value);
+        __One_Chicken_Pox_Vaccination = new Lazy<IEnumerable<object>>(this.One_Chicken_Pox_Vaccination_Value);
+        __Varicella_Zoster_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.Varicella_Zoster_Numerator_Inclusion_Conditions_Value);
+        __Pneumococcal_Conjugate_Immunizations_or_Procedures = new Lazy<IEnumerable<CqlDate>>(this.Pneumococcal_Conjugate_Immunizations_or_Procedures_Value);
+        __Four_Pneumococcal_Conjugate_Vaccinations = new Lazy<IEnumerable<CqlDate>>(this.Four_Pneumococcal_Conjugate_Vaccinations_Value);
+        __Pneumococcal_Conjugate_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.Pneumococcal_Conjugate_Numerator_Inclusion_Conditions_Value);
+        __One_Hepatitis_A_Vaccinations = new Lazy<IEnumerable<object>>(this.One_Hepatitis_A_Vaccinations_Value);
+        __Hepatitis_A_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.Hepatitis_A_Numerator_Inclusion_Conditions_Value);
+        __Rotavirus_2_Dose_Immunizations_or_Procedures = new Lazy<IEnumerable<CqlDate>>(this.Rotavirus_2_Dose_Immunizations_or_Procedures_Value);
+        __Rotavirus_3_Dose_Immunizations_or_Procedures = new Lazy<IEnumerable<CqlDate>>(this.Rotavirus_3_Dose_Immunizations_or_Procedures_Value);
+        __Rotavirus_2_or_3_Dose_Immunizations = new Lazy<IEnumerable<CqlDate>>(this.Rotavirus_2_or_3_Dose_Immunizations_Value);
+        __All_Rotavirus_Vaccinations = new Lazy<IEnumerable<CqlDate>>(this.All_Rotavirus_Vaccinations_Value);
+        __Has_Appropriate_Number_of_Rotavirus_Immunizations = new Lazy<bool?>(this.Has_Appropriate_Number_of_Rotavirus_Immunizations_Value);
+        __Rotavirus_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.Rotavirus_Numerator_Inclusion_Conditions_Value);
+        __Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old = new Lazy<CqlInterval<CqlDate>>(this.Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old_Value);
+        __Influenza_Immunizations_or_Procedures = new Lazy<IEnumerable<CqlDate>>(this.Influenza_Immunizations_or_Procedures_Value);
+        __Two_Influenza_Vaccinations = new Lazy<IEnumerable<CqlDate>>(this.Two_Influenza_Vaccinations_Value);
+        __LAIV_Vaccinations = new Lazy<IEnumerable<CqlDate>>(this.LAIV_Vaccinations_Value);
+        __Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination = new Lazy<bool?>(this.Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination_Value);
+        __Influenza_Numerator_Inclusion_Conditions = new Lazy<IEnumerable<Condition>>(this.Influenza_Numerator_Inclusion_Conditions_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Anaphylactic_Reaction_to_DTaP_Vaccine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031", null);
+
+    [CqlDeclaration("Anaphylactic Reaction to DTaP Vaccine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031")]
+	public CqlValueSet Anaphylactic_Reaction_to_DTaP_Vaccine() => 
+		__Anaphylactic_Reaction_to_DTaP_Vaccine.Value;
+
+	private CqlValueSet Disorders_of_the_Immune_System_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001", null);
+
+    [CqlDeclaration("Disorders of the Immune System")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001")]
+	public CqlValueSet Disorders_of_the_Immune_System() => 
+		__Disorders_of_the_Immune_System.Value;
+
+	private CqlValueSet DTaP_Vaccine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214", null);
+
+    [CqlDeclaration("DTaP Vaccine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214")]
+	public CqlValueSet DTaP_Vaccine() => 
+		__DTaP_Vaccine.Value;
+
+	private CqlValueSet DTaP_Vaccine_Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022", null);
+
+    [CqlDeclaration("DTaP Vaccine Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022")]
+	public CqlValueSet DTaP_Vaccine_Administered() => 
+		__DTaP_Vaccine_Administered.Value;
+
+	private CqlValueSet Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164", null);
+
+    [CqlDeclaration("Encephalitis Due to Diphtheria, Tetanus or Pertussis Vaccine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164")]
+	public CqlValueSet Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine() => 
+		__Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043", null);
+
+    [CqlDeclaration("Haemophilus Influenzae Type B (Hib) Vaccine Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043")]
+	public CqlValueSet Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered() => 
+		__Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered.Value;
+
+	private CqlValueSet Hepatitis_A_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", null);
+
+    [CqlDeclaration("Hepatitis A")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024")]
+	public CqlValueSet Hepatitis_A() => 
+		__Hepatitis_A.Value;
+
+	private CqlValueSet Hepatitis_A_Vaccine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215", null);
+
+    [CqlDeclaration("Hepatitis A Vaccine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215")]
+	public CqlValueSet Hepatitis_A_Vaccine() => 
+		__Hepatitis_A_Vaccine.Value;
+
+	private CqlValueSet Hepatitis_A_Vaccine_Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041", null);
+
+    [CqlDeclaration("Hepatitis A Vaccine Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041")]
+	public CqlValueSet Hepatitis_A_Vaccine_Administered() => 
+		__Hepatitis_A_Vaccine_Administered.Value;
+
+	private CqlValueSet Hepatitis_B_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025", null);
+
+    [CqlDeclaration("Hepatitis B")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025")]
+	public CqlValueSet Hepatitis_B() => 
+		__Hepatitis_B.Value;
+
+	private CqlValueSet Hepatitis_B_Vaccine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216", null);
+
+    [CqlDeclaration("Hepatitis B Vaccine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216")]
+	public CqlValueSet Hepatitis_B_Vaccine() => 
+		__Hepatitis_B_Vaccine.Value;
+
+	private CqlValueSet Hepatitis_B_Vaccine_Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042", null);
+
+    [CqlDeclaration("Hepatitis B Vaccine Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042")]
+	public CqlValueSet Hepatitis_B_Vaccine_Administered() => 
+		__Hepatitis_B_Vaccine_Administered.Value;
+
+	private CqlValueSet Hib_Vaccine__3_dose_schedule__Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083", null);
+
+    [CqlDeclaration("Hib Vaccine (3 dose schedule)")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083")]
+	public CqlValueSet Hib_Vaccine__3_dose_schedule_() => 
+		__Hib_Vaccine__3_dose_schedule_.Value;
+
+	private CqlValueSet Hib_Vaccine__3_dose_schedule__Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084", null);
+
+    [CqlDeclaration("Hib Vaccine (3 dose schedule) Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084")]
+	public CqlValueSet Hib_Vaccine__3_dose_schedule__Administered() => 
+		__Hib_Vaccine__3_dose_schedule__Administered.Value;
+
+	private CqlValueSet Hib_Vaccine__4_dose_schedule__Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085", null);
+
+    [CqlDeclaration("Hib Vaccine (4 dose schedule)")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085")]
+	public CqlValueSet Hib_Vaccine__4_dose_schedule_() => 
+		__Hib_Vaccine__4_dose_schedule_.Value;
+
+	private CqlValueSet Hib_Vaccine__4_dose_schedule__Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086", null);
+
+    [CqlDeclaration("Hib Vaccine (4 dose schedule) Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086")]
+	public CqlValueSet Hib_Vaccine__4_dose_schedule__Administered() => 
+		__Hib_Vaccine__4_dose_schedule__Administered.Value;
+
+	private CqlValueSet HIV_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+
+    [CqlDeclaration("HIV")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
+	public CqlValueSet HIV() => 
+		__HIV.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Hospice_care_ambulatory_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+
+    [CqlDeclaration("Hospice care ambulatory")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
+	public CqlValueSet Hospice_care_ambulatory() => 
+		__Hospice_care_ambulatory.Value;
+
+	private CqlValueSet Inactivated_Polio_Vaccine__IPV__Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219", null);
+
+    [CqlDeclaration("Inactivated Polio Vaccine (IPV)")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219")]
+	public CqlValueSet Inactivated_Polio_Vaccine__IPV_() => 
+		__Inactivated_Polio_Vaccine__IPV_.Value;
+
+	private CqlValueSet Inactivated_Polio_Vaccine__IPV__Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045", null);
+
+    [CqlDeclaration("Inactivated Polio Vaccine (IPV) Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045")]
+	public CqlValueSet Inactivated_Polio_Vaccine__IPV__Administered() => 
+		__Inactivated_Polio_Vaccine__IPV__Administered.Value;
+
+	private CqlValueSet Child_Influenza_Immunization_Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218", null);
+
+    [CqlDeclaration("Child Influenza Immunization Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218")]
+	public CqlValueSet Child_Influenza_Immunization_Administered() => 
+		__Child_Influenza_Immunization_Administered.Value;
+
+	private CqlValueSet Child_Influenza_Vaccine_Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044", null);
+
+    [CqlDeclaration("Child Influenza Vaccine Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044")]
+	public CqlValueSet Child_Influenza_Vaccine_Administered() => 
+		__Child_Influenza_Vaccine_Administered.Value;
+
+	private CqlValueSet Influenza_Virus_LAIV_Immunization_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087", null);
+
+    [CqlDeclaration("Influenza Virus LAIV Immunization")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087")]
+	public CqlValueSet Influenza_Virus_LAIV_Immunization() => 
+		__Influenza_Virus_LAIV_Immunization.Value;
+
+	private CqlValueSet Influenza_Virus_LAIV_Procedure_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088", null);
+
+    [CqlDeclaration("Influenza Virus LAIV Procedure")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088")]
+	public CqlValueSet Influenza_Virus_LAIV_Procedure() => 
+		__Influenza_Virus_LAIV_Procedure.Value;
+
+	private CqlValueSet Intussusception_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056", null);
+
+    [CqlDeclaration("Intussusception")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056")]
+	public CqlValueSet Intussusception() => 
+		__Intussusception.Value;
+
+	private CqlValueSet Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009", null);
+
+    [CqlDeclaration("Malignant Neoplasm of Lymphatic and Hematopoietic Tissue")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009")]
+	public CqlValueSet Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue() => 
+		__Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue.Value;
+
+	private CqlValueSet Measles_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053", null);
+
+    [CqlDeclaration("Measles")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053")]
+	public CqlValueSet Measles() => 
+		__Measles.Value;
+
+	private CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224", null);
+
+    [CqlDeclaration("Measles, Mumps and Rubella (MMR) Vaccine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224")]
+	public CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine() => 
+		__Measles__Mumps_and_Rubella__MMR__Vaccine.Value;
+
+	private CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031", null);
+
+    [CqlDeclaration("Measles, Mumps and Rubella (MMR) Vaccine Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031")]
+	public CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Administered() => 
+		__Measles__Mumps_and_Rubella__MMR__Vaccine_Administered.Value;
+
+	private CqlValueSet Mumps_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032", null);
+
+    [CqlDeclaration("Mumps")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032")]
+	public CqlValueSet Mumps() => 
+		__Mumps.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Pneumococcal_Conjugate_Vaccine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221", null);
+
+    [CqlDeclaration("Pneumococcal Conjugate Vaccine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221")]
+	public CqlValueSet Pneumococcal_Conjugate_Vaccine() => 
+		__Pneumococcal_Conjugate_Vaccine.Value;
+
+	private CqlValueSet Pneumococcal_Conjugate_Vaccine_Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046", null);
+
+    [CqlDeclaration("Pneumococcal Conjugate Vaccine Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046")]
+	public CqlValueSet Pneumococcal_Conjugate_Vaccine_Administered() => 
+		__Pneumococcal_Conjugate_Vaccine_Administered.Value;
+
+	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+
+    [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
+	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+
+    [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
+	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
+		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Rotavirus_Vaccine__2_dose_schedule__Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048", null);
+
+    [CqlDeclaration("Rotavirus Vaccine (2 dose schedule) Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048")]
+	public CqlValueSet Rotavirus_Vaccine__2_dose_schedule__Administered() => 
+		__Rotavirus_Vaccine__2_dose_schedule__Administered.Value;
+
+	private CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223", null);
+
+    [CqlDeclaration("Rotavirus Vaccine (3 dose schedule)")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223")]
+	public CqlValueSet Rotavirus_Vaccine__3_dose_schedule_() => 
+		__Rotavirus_Vaccine__3_dose_schedule_.Value;
+
+	private CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047", null);
+
+    [CqlDeclaration("Rotavirus Vaccine (3 dose schedule) Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047")]
+	public CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Administered() => 
+		__Rotavirus_Vaccine__3_dose_schedule__Administered.Value;
+
+	private CqlValueSet Rubella_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037", null);
+
+    [CqlDeclaration("Rubella")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037")]
+	public CqlValueSet Rubella() => 
+		__Rubella.Value;
+
+	private CqlValueSet Severe_Combined_Immunodeficiency_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007", null);
+
+    [CqlDeclaration("Severe Combined Immunodeficiency")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007")]
+	public CqlValueSet Severe_Combined_Immunodeficiency() => 
+		__Severe_Combined_Immunodeficiency.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlValueSet Varicella_Zoster_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039", null);
+
+    [CqlDeclaration("Varicella Zoster")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039")]
+	public CqlValueSet Varicella_Zoster() => 
+		__Varicella_Zoster.Value;
+
+	private CqlValueSet Varicella_Zoster_Vaccine__VZV__Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170", null);
+
+    [CqlDeclaration("Varicella Zoster Vaccine (VZV)")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170")]
+	public CqlValueSet Varicella_Zoster_Vaccine__VZV_() => 
+		__Varicella_Zoster_Vaccine__VZV_.Value;
+
+	private CqlValueSet Varicella_Zoster_Vaccine__VZV__Administered_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040", null);
+
+    [CqlDeclaration("Varicella Zoster Vaccine (VZV) Administered")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040")]
+	public CqlValueSet Varicella_Zoster_Vaccine__VZV__Administered() => 
+		__Varicella_Zoster_Vaccine__VZV__Administered.Value;
+
+	private CqlCode Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder__Value() => 
+		new CqlCode("433621000124101", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Anaphylaxis due to Haemophilus influenzae type b vaccine (disorder)")]
+	public CqlCode Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_() => 
+		__Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_.Value;
+
+	private CqlCode Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder__Value() => 
+		new CqlCode("428321000124101", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Anaphylaxis due to Hepatitis B vaccine (disorder)")]
+	public CqlCode Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_() => 
+		__Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_.Value;
+
+	private CqlCode Anaphylaxis_due_to_rotavirus_vaccine__disorder__Value() => 
+		new CqlCode("428331000124103", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Anaphylaxis due to rotavirus vaccine (disorder)")]
+	public CqlCode Anaphylaxis_due_to_rotavirus_vaccine__disorder_() => 
+		__Anaphylaxis_due_to_rotavirus_vaccine__disorder_.Value;
+
+	private CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional_Value() => 
+		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Office or other outpatient visit for the evaluation and management of an established patient that may not require the presence of a physician or other qualified health care professional")]
+	public CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional() => 
+		__Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional.Value;
+
+	private CqlCode rotavirus__live__monovalent_vaccine_Value() => 
+		new CqlCode("119", "http://hl7.org/fhir/sid/cvx", null, null);
+
+    [CqlDeclaration("rotavirus, live, monovalent vaccine")]
+	public CqlCode rotavirus__live__monovalent_vaccine() => 
+		__rotavirus__live__monovalent_vaccine.Value;
+
+	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder__Value() => 
+		new CqlCode("471311000124103", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Anaphylaxis caused by vaccine product containing Hepatitis A virus antigen (disorder)")]
+	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_() => 
+		__Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_.Value;
+
+	private CqlCode Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach_Value() => 
+		new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", null, null);
+
+    [CqlDeclaration("Introduction of Serum, Toxoid and Vaccine into Muscle, Percutaneous Approach")]
+	public CqlCode Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach() => 
+		__Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach.Value;
+
+	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder__Value() => 
+		new CqlCode("471361000124100", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Anaphylaxis caused by vaccine product containing Influenza virus antigen (disorder)")]
+	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_() => 
+		__Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_.Value;
+
+	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder__Value() => 
+		new CqlCode("471331000124109", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Anaphylaxis caused by vaccine product containing Measles morbillivirus and Mumps orthorubulavirus and Rubella virus antigens (disorder)")]
+	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_() => 
+		__Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_.Value;
+
+	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder__Value() => 
+		new CqlCode("471141000124102", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Anaphylaxis caused by vaccine product containing Streptococcus pneumoniae antigen (disorder)")]
+	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_() => 
+		__Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_.Value;
+
+	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder__Value() => 
+		new CqlCode("471321000124106", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Anaphylaxis caused by vaccine product containing human poliovirus antigen (disorder)")]
+	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_() => 
+		__Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_.Value;
+
+	private CqlCode Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder__Value() => 
+		new CqlCode("471341000124104", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Anaphylaxis caused by vaccine containing Human alphaherpesvirus 3 antigen (disorder)")]
+	public CqlCode Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_() => 
+		__Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("433621000124101", "http://snomed.info/sct", null, null),
+			new CqlCode("428321000124101", "http://snomed.info/sct", null, null),
+			new CqlCode("428331000124103", "http://snomed.info/sct", null, null),
+			new CqlCode("471311000124103", "http://snomed.info/sct", null, null),
+			new CqlCode("471361000124100", "http://snomed.info/sct", null, null),
+			new CqlCode("471331000124109", "http://snomed.info/sct", null, null),
+			new CqlCode("471141000124102", "http://snomed.info/sct", null, null),
+			new CqlCode("471321000124106", "http://snomed.info/sct", null, null),
+			new CqlCode("471341000124104", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlCode[] CVX_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("119", "http://hl7.org/fhir/sid/cvx", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("CVX")]
+	public CqlCode[] CVX() => 
+		__CVX.Value;
+
+	private CqlCode[] ICD10_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ICD10")]
+	public CqlCode[] ICD10() => 
+		__ICD10.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("ChildhoodImmunizationStatusFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Home_Healthcare_Services();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		bool? m_(Encounter E)
+		{
+			CqlConcept y_(CodeableConcept @this)
+			{
+				var ad_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return ad_;
+			};
+			var z_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, y_);
+			bool? aa_(CqlConcept T)
+			{
+				var ae_ = this.Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional();
+				var af_ = context.Operators.ConvertCodeToConcept(ae_);
+				var ag_ = context.Operators.Equivalent(T, af_);
+
+				return ag_;
+			};
+			var ab_ = context.Operators.WhereOrNull<CqlConcept>(z_, aa_);
+			var ac_ = context.Operators.ExistsInList<CqlConcept>(ab_);
+
+			return ac_;
+		};
+		var n_ = context.Operators.WhereOrNull<Encounter>(l_, m_);
+		var o_ = this.Online_Assessments();
+		var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+		var q_ = context.Operators.ListUnion<Encounter>(n_, p_);
+		var r_ = context.Operators.ListUnion<Encounter>(k_, q_);
+		var s_ = this.Telephone_Visits();
+		var t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
+		var u_ = context.Operators.ListUnion<Encounter>(r_, t_);
+		var v_ = Status_1_6_000.Finished_Encounter(u_);
+		bool? w_(Encounter ValidEncounters)
+		{
+			var ah_ = this.Measurement_Period();
+			var ai_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounters?.Period);
+			var aj_ = QICoreCommon_2_0_000.ToInterval((ai_ as object));
+			var ak_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ah_, aj_, "day");
+
+			return ak_;
+		};
+		var x_ = context.Operators.WhereOrNull<Encounter>(v_, w_);
+
+		return x_;
+	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Equal(f_, (int?)2);
+		var h_ = this.Qualifying_Encounters();
+		var i_ = context.Operators.ExistsInList<Encounter>(h_);
+		var j_ = context.Operators.And(g_, i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private CqlDate Date_of_Second_Birthday_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
+		var c_ = context.Operators.Quantity(2m, "years");
+		var d_ = context.Operators.Add(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Date of Second Birthday")]
+	public CqlDate Date_of_Second_Birthday() => 
+		__Date_of_Second_Birthday.Value;
+
+	private CqlInterval<CqlDate> First_Two_Years_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
+		var c_ = context.Operators.ConvertDateToDateTime(b_);
+		var d_ = context.Operators.DateFrom(c_);
+		var e_ = this.Date_of_Second_Birthday();
+		var f_ = context.Operators.Interval(d_, e_, true, true);
+
+		return f_;
+	}
+
+    [CqlDeclaration("First Two Years")]
+	public CqlInterval<CqlDate> First_Two_Years() => 
+		__First_Two_Years.Value;
+
+	private bool? Has_Severe_Combined_Immunodeficiency_Value()
+	{
+		var a_ = this.Severe_Combined_Immunodeficiency();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition SevereImmuneDisorder)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(SevereImmuneDisorder);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Condition>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Severe Combined Immunodeficiency")]
+	public bool? Has_Severe_Combined_Immunodeficiency() => 
+		__Has_Severe_Combined_Immunodeficiency.Value;
+
+	private bool? Has_Immunodeficiency_Value()
+	{
+		var a_ = this.Disorders_of_the_Immune_System();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition ImmuneDisorder)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(ImmuneDisorder);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Condition>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Immunodeficiency")]
+	public bool? Has_Immunodeficiency() => 
+		__Has_Immunodeficiency.Value;
+
+	private bool? Has_HIV_Value()
+	{
+		var a_ = this.HIV();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition HIV)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HIV);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Condition>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has HIV")]
+	public bool? Has_HIV() => 
+		__Has_HIV.Value;
+
+	private bool? Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia_Value()
+	{
+		var a_ = this.Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition LymphaticMalignantNeoplasm)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(LymphaticMalignantNeoplasm);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Condition>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Lymphoreticular Cancer, Multiple Myeloma or Leukemia")]
+	public bool? Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia() => 
+		__Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia.Value;
+
+	private bool? Has_Intussusception_Value()
+	{
+		var a_ = this.Intussusception();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition IntussusceptionDisorder)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(IntussusceptionDisorder);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Condition>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Intussusception")]
+	public bool? Has_Intussusception() => 
+		__Has_Intussusception.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = this.Has_Severe_Combined_Immunodeficiency();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = this.Has_Immunodeficiency();
+		var e_ = context.Operators.Or(c_, d_);
+		var f_ = this.Has_HIV();
+		var g_ = context.Operators.Or(e_, f_);
+		var h_ = this.Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia();
+		var i_ = context.Operators.Or(g_, h_);
+		var j_ = this.Has_Intussusception();
+		var k_ = context.Operators.Or(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private CqlInterval<CqlDate> Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
+		var c_ = context.Operators.ConvertDateToDateTime(b_);
+		var d_ = context.Operators.DateFrom(c_);
+		var e_ = context.Operators.Quantity(42m, "days");
+		var f_ = context.Operators.Add(d_, e_);
+		var g_ = this.Date_of_Second_Birthday();
+		var h_ = context.Operators.Interval(f_, g_, true, true);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Vaccine Administration Interval - 42 Days up to 2 Years Old")]
+	public CqlInterval<CqlDate> Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old() => 
+		__Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old.Value;
+
+	private IEnumerable<CqlDate> DTaP_Immunizations_or_Procedures_Value()
+	{
+		var a_ = this.DTaP_Vaccine();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization DTaPVaccination)
+		{
+			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var q_ = context.Operators.LateBoundProperty<CqlDateTime>(DTaPVaccination?.Occurrence, "value");
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = CQMCommon_2_0_000.ToDateInterval(r_);
+			var t_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, s_, "day");
+
+			return t_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		CqlDate f_(Immunization DTaPVaccination)
+		{
+			var u_ = context.Operators.LateBoundProperty<CqlDateTime>(DTaPVaccination?.Occurrence, "value");
+			var v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
+			var w_ = CQMCommon_2_0_000.ToDateInterval(v_);
+			var x_ = context.Operators.Start(w_);
+			var y_ = context.Operators.ConvertDateToDateTime(x_);
+			var z_ = context.Operators.DateFrom(y_);
+
+			return z_;
+		};
+		var g_ = context.Operators.SelectOrNull<Immunization, CqlDate>(e_, f_);
+		var h_ = this.DTaP_Vaccine_Administered();
+		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		bool? k_(Procedure DTaPProcedure)
+		{
+			var aa_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var ab_ = FHIRHelpers_4_3_000.ToValue(DTaPProcedure?.Performed);
+			var ac_ = QICoreCommon_2_0_000.ToInterval(ab_);
+			var ad_ = CQMCommon_2_0_000.ToDateInterval(ac_);
+			var ae_ = context.Operators.IntervalIncludesInterval<CqlDate>(aa_, ad_, "day");
+
+			return ae_;
+		};
+		var l_ = context.Operators.WhereOrNull<Procedure>(j_, k_);
+		CqlDate m_(Procedure DTaPProcedure)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(DTaPProcedure?.Performed);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
+			var ai_ = context.Operators.Start(ah_);
+			var aj_ = context.Operators.ConvertDateToDateTime(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+
+			return ak_;
+		};
+		var n_ = context.Operators.SelectOrNull<Procedure, CqlDate>(l_, m_);
+		var o_ = context.Operators.ListUnion<CqlDate>(g_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("DTaP Immunizations or Procedures")]
+	public IEnumerable<CqlDate> DTaP_Immunizations_or_Procedures() => 
+		__DTaP_Immunizations_or_Procedures.Value;
+
+	private IEnumerable<CqlDate> Four_DTaP_Vaccinations_Value()
+	{
+		var a_ = this.DTaP_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> b_(CqlDate _DTaPVaccination1)
+		{
+			var o_ = this.DTaP_Immunizations_or_Procedures();
+
+			return o_;
+		};
+		Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS c_(CqlDate _DTaPVaccination1, CqlDate _DTaPVaccination2)
+		{
+			var p_ = new Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS
+			{
+				DTaPVaccination1 = _DTaPVaccination1,
+				DTaPVaccination2 = _DTaPVaccination2,
+			};
+
+			return p_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<CqlDate, CqlDate, Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS _DTaPVaccination1DTaPVaccination2)
+		{
+			var q_ = this.DTaP_Immunizations_or_Procedures();
+
+			return q_;
+		};
+		Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS f_(Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS DTaPVaccination1DTaPVaccination2, CqlDate _DTaPVaccination3)
+		{
+			var r_ = new Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS
+			{
+				DTaPVaccination1 = DTaPVaccination1DTaPVaccination2.DTaPVaccination1,
+				DTaPVaccination2 = DTaPVaccination1DTaPVaccination2.DTaPVaccination2,
+				DTaPVaccination3 = _DTaPVaccination3,
+			};
+
+			return r_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS, CqlDate, Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS>(d_, e_, f_);
+		IEnumerable<CqlDate> h_(Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS _DTaPVaccination1DTaPVaccination2DTaPVaccination3)
+		{
+			var s_ = this.DTaP_Immunizations_or_Procedures();
+
+			return s_;
+		};
+		Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS i_(Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS DTaPVaccination1DTaPVaccination2DTaPVaccination3, CqlDate _DTaPVaccination4)
+		{
+			var t_ = new Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS
+			{
+				DTaPVaccination1 = DTaPVaccination1DTaPVaccination2DTaPVaccination3.DTaPVaccination1,
+				DTaPVaccination2 = DTaPVaccination1DTaPVaccination2DTaPVaccination3.DTaPVaccination2,
+				DTaPVaccination3 = DTaPVaccination1DTaPVaccination2DTaPVaccination3.DTaPVaccination3,
+				DTaPVaccination4 = _DTaPVaccination4,
+			};
+
+			return t_;
+		};
+		var j_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS, CqlDate, Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS>(g_, h_, i_);
+		bool? k_(Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS tuple_edfaenkghpzdhfzcdmcgebfcs)
+		{
+			var u_ = context.Operators.Quantity(1m, "day");
+			var v_ = context.Operators.Add(tuple_edfaenkghpzdhfzcdmcgebfcs.DTaPVaccination1, u_);
+			var w_ = context.Operators.SameOrAfter(tuple_edfaenkghpzdhfzcdmcgebfcs.DTaPVaccination2, v_, "day");
+			var y_ = context.Operators.Add(tuple_edfaenkghpzdhfzcdmcgebfcs.DTaPVaccination2, u_);
+			var z_ = context.Operators.SameOrAfter(tuple_edfaenkghpzdhfzcdmcgebfcs.DTaPVaccination3, y_, "day");
+			var aa_ = context.Operators.And(w_, z_);
+			var ac_ = context.Operators.Add(tuple_edfaenkghpzdhfzcdmcgebfcs.DTaPVaccination3, u_);
+			var ad_ = context.Operators.SameOrAfter(tuple_edfaenkghpzdhfzcdmcgebfcs.DTaPVaccination4, ac_, "day");
+			var ae_ = context.Operators.And(aa_, ad_);
+
+			return ae_;
+		};
+		var l_ = context.Operators.WhereOrNull<Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS>(j_, k_);
+		CqlDate m_(Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS tuple_edfaenkghpzdhfzcdmcgebfcs) => 
+			tuple_edfaenkghpzdhfzcdmcgebfcs.DTaPVaccination1;
+		var n_ = context.Operators.SelectOrNull<Tuples.Tuple_EDFAENKgHPZdhfZCdMcGebfcS, CqlDate>(l_, m_);
+
+		return n_;
+	}
+
+    [CqlDeclaration("Four DTaP Vaccinations")]
+	public IEnumerable<CqlDate> Four_DTaP_Vaccinations() => 
+		__Four_DTaP_Vaccinations.Value;
+
+	private IEnumerable<Condition> DTaP_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Anaphylactic_Reaction_to_DTaP_Vaccine();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = this.Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine();
+		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		var e_ = context.Operators.ListUnion<Condition>(b_, d_);
+		var f_ = Status_1_6_000.Active_Condition(e_);
+		bool? g_(Condition DTaPConditions)
+		{
+			var i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(DTaPConditions);
+			var j_ = context.Operators.Start(i_);
+			var k_ = context.Operators.DateFrom(j_);
+			var l_ = this.First_Two_Years();
+			var m_ = context.Operators.ElementInInterval<CqlDate>(k_, l_, "day");
+
+			return m_;
+		};
+		var h_ = context.Operators.WhereOrNull<Condition>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("DTaP Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> DTaP_Numerator_Inclusion_Conditions() => 
+		__DTaP_Numerator_Inclusion_Conditions.Value;
+
+	private IEnumerable<CqlDate> Polio_Immunizations_or_Procedures_Value()
+	{
+		var a_ = this.Inactivated_Polio_Vaccine__IPV_();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization PolioVaccination)
+		{
+			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var q_ = context.Operators.LateBoundProperty<CqlDateTime>(PolioVaccination?.Occurrence, "value");
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = CQMCommon_2_0_000.ToDateInterval(r_);
+			var t_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, s_, "day");
+
+			return t_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		CqlDate f_(Immunization PolioVaccination)
+		{
+			var u_ = context.Operators.LateBoundProperty<CqlDateTime>(PolioVaccination?.Occurrence, "value");
+			var v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
+			var w_ = CQMCommon_2_0_000.ToDateInterval(v_);
+			var x_ = context.Operators.Start(w_);
+			var y_ = context.Operators.ConvertDateToDateTime(x_);
+			var z_ = context.Operators.DateFrom(y_);
+
+			return z_;
+		};
+		var g_ = context.Operators.SelectOrNull<Immunization, CqlDate>(e_, f_);
+		var h_ = this.Inactivated_Polio_Vaccine__IPV__Administered();
+		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		bool? k_(Procedure PolioProcedure)
+		{
+			var aa_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var ab_ = FHIRHelpers_4_3_000.ToValue(PolioProcedure?.Performed);
+			var ac_ = QICoreCommon_2_0_000.ToInterval(ab_);
+			var ad_ = CQMCommon_2_0_000.ToDateInterval(ac_);
+			var ae_ = context.Operators.IntervalIncludesInterval<CqlDate>(aa_, ad_, "day");
+
+			return ae_;
+		};
+		var l_ = context.Operators.WhereOrNull<Procedure>(j_, k_);
+		CqlDate m_(Procedure PolioProcedure)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(PolioProcedure?.Performed);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
+			var ai_ = context.Operators.Start(ah_);
+			var aj_ = context.Operators.ConvertDateToDateTime(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+
+			return ak_;
+		};
+		var n_ = context.Operators.SelectOrNull<Procedure, CqlDate>(l_, m_);
+		var o_ = context.Operators.ListUnion<CqlDate>(g_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("Polio Immunizations or Procedures")]
+	public IEnumerable<CqlDate> Polio_Immunizations_or_Procedures() => 
+		__Polio_Immunizations_or_Procedures.Value;
+
+	private IEnumerable<CqlDate> Three_Polio_Vaccinations_Value()
+	{
+		var a_ = this.Polio_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> b_(CqlDate _PolioVaccination1)
+		{
+			var l_ = this.Polio_Immunizations_or_Procedures();
+
+			return l_;
+		};
+		Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS c_(CqlDate _PolioVaccination1, CqlDate _PolioVaccination2)
+		{
+			var m_ = new Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS
+			{
+				PolioVaccination1 = _PolioVaccination1,
+				PolioVaccination2 = _PolioVaccination2,
+			};
+
+			return m_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<CqlDate, CqlDate, Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS _PolioVaccination1PolioVaccination2)
+		{
+			var n_ = this.Polio_Immunizations_or_Procedures();
+
+			return n_;
+		};
+		Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS f_(Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS PolioVaccination1PolioVaccination2, CqlDate _PolioVaccination3)
+		{
+			var o_ = new Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS
+			{
+				PolioVaccination1 = PolioVaccination1PolioVaccination2.PolioVaccination1,
+				PolioVaccination2 = PolioVaccination1PolioVaccination2.PolioVaccination2,
+				PolioVaccination3 = _PolioVaccination3,
+			};
+
+			return o_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS, CqlDate, Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS tuple_goxkbgtpjadgqhxfdgxgtmijs)
+		{
+			var p_ = context.Operators.Quantity(1m, "day");
+			var q_ = context.Operators.Add(tuple_goxkbgtpjadgqhxfdgxgtmijs.PolioVaccination1, p_);
+			var r_ = context.Operators.SameOrAfter(tuple_goxkbgtpjadgqhxfdgxgtmijs.PolioVaccination2, q_, "day");
+			var t_ = context.Operators.Add(tuple_goxkbgtpjadgqhxfdgxgtmijs.PolioVaccination2, p_);
+			var u_ = context.Operators.SameOrAfter(tuple_goxkbgtpjadgqhxfdgxgtmijs.PolioVaccination3, t_, "day");
+			var v_ = context.Operators.And(r_, u_);
+
+			return v_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS>(g_, h_);
+		CqlDate j_(Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS tuple_goxkbgtpjadgqhxfdgxgtmijs) => 
+			tuple_goxkbgtpjadgqhxfdgxgtmijs.PolioVaccination1;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_GOXKBgTPjADgQhXfdgXgTMIJS, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Three Polio Vaccinations")]
+	public IEnumerable<CqlDate> Three_Polio_Vaccinations() => 
+		__Three_Polio_Vaccinations.Value;
+
+	private IEnumerable<Condition> Polio_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		var d_ = Status_1_6_000.Active_Condition(c_);
+		bool? e_(Condition PolioConditions)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(PolioConditions);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Polio Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> Polio_Numerator_Inclusion_Conditions() => 
+		__Polio_Numerator_Inclusion_Conditions.Value;
+
+	private CqlDate Date_of_First_Birthday_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
+		var c_ = context.Operators.ConvertDateToDateTime(b_);
+		var d_ = context.Operators.DateFrom(c_);
+		var e_ = context.Operators.Quantity(1m, "year");
+		var f_ = context.Operators.Add(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Date of First Birthday")]
+	public CqlDate Date_of_First_Birthday() => 
+		__Date_of_First_Birthday.Value;
+
+	private CqlInterval<CqlDate> Date_of_First_Birthday_to_Date_of_Second_Birthday_Value()
+	{
+		var a_ = this.Date_of_First_Birthday();
+		var b_ = this.Date_of_Second_Birthday();
+		var c_ = context.Operators.Interval(a_, b_, true, true);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Date of First Birthday to Date of Second Birthday")]
+	public CqlInterval<CqlDate> Date_of_First_Birthday_to_Date_of_Second_Birthday() => 
+		__Date_of_First_Birthday_to_Date_of_Second_Birthday.Value;
+
+	private IEnumerable<object> One_MMR_Vaccination_Value()
+	{
+		var a_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization MMRVaccination)
+		{
+			var l_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			var m_ = context.Operators.LateBoundProperty<CqlDateTime>(MMRVaccination?.Occurrence, "value");
+			var n_ = QICoreCommon_2_0_000.ToInterval((m_ as object));
+			var o_ = CQMCommon_2_0_000.ToDateInterval(n_);
+			var p_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, o_, null);
+
+			return p_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		var f_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine_Administered();
+		var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		var h_ = Status_1_6_000.Completed_Procedure(g_);
+		bool? i_(Procedure MMRProcedure)
+		{
+			var q_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			var r_ = FHIRHelpers_4_3_000.ToValue(MMRProcedure?.Performed);
+			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(q_, t_, null);
+
+			return u_;
+		};
+		var j_ = context.Operators.WhereOrNull<Procedure>(h_, i_);
+		var k_ = context.Operators.ListUnion<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
+
+		return k_;
+	}
+
+    [CqlDeclaration("One MMR Vaccination")]
+	public IEnumerable<object> One_MMR_Vaccination() => 
+		__One_MMR_Vaccination.Value;
+
+	private IEnumerable<Condition> MMR_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		var d_ = Status_1_6_000.Active_Condition(c_);
+		bool? e_(Condition MMRConditions)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MMRConditions);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("MMR Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> MMR_Numerator_Inclusion_Conditions() => 
+		__MMR_Numerator_Inclusion_Conditions.Value;
+
+	private IEnumerable<Condition> Measles_Indicators_Value()
+	{
+		var a_ = this.Measles();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition MeaslesDiagnosis)
+		{
+			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MeaslesDiagnosis);
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.DateFrom(g_);
+			var i_ = this.First_Two_Years();
+			var j_ = context.Operators.ElementInInterval<CqlDate>(h_, i_, "day");
+
+			return j_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Measles Indicators")]
+	public IEnumerable<Condition> Measles_Indicators() => 
+		__Measles_Indicators.Value;
+
+	private IEnumerable<Condition> Mumps_Indicators_Value()
+	{
+		var a_ = this.Mumps();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition MumpsDiagnosis)
+		{
+			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MumpsDiagnosis);
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.DateFrom(g_);
+			var i_ = this.First_Two_Years();
+			var j_ = context.Operators.ElementInInterval<CqlDate>(h_, i_, "day");
+
+			return j_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Mumps Indicators")]
+	public IEnumerable<Condition> Mumps_Indicators() => 
+		__Mumps_Indicators.Value;
+
+	private IEnumerable<Condition> Rubella_Indicators_Value()
+	{
+		var a_ = this.Rubella();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition RubellaDiagnosis)
+		{
+			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(RubellaDiagnosis);
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.DateFrom(g_);
+			var i_ = this.First_Two_Years();
+			var j_ = context.Operators.ElementInInterval<CqlDate>(h_, i_, "day");
+
+			return j_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Rubella Indicators")]
+	public IEnumerable<Condition> Rubella_Indicators() => 
+		__Rubella_Indicators.Value;
+
+	private IEnumerable<CqlDate> Hib_3_Dose_Immunizations_or_Procedures_Value()
+	{
+		var a_ = this.Hib_Vaccine__3_dose_schedule_();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization ThreeDoseHibVaccine)
+		{
+			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var q_ = context.Operators.LateBoundProperty<CqlDateTime>(ThreeDoseHibVaccine?.Occurrence, "value");
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = CQMCommon_2_0_000.ToDateInterval(r_);
+			var t_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, s_, "day");
+
+			return t_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		CqlDate f_(Immunization ThreeDoseHibVaccine)
+		{
+			var u_ = context.Operators.LateBoundProperty<CqlDateTime>(ThreeDoseHibVaccine?.Occurrence, "value");
+			var v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
+			var w_ = CQMCommon_2_0_000.ToDateInterval(v_);
+			var x_ = context.Operators.Start(w_);
+			var y_ = context.Operators.ConvertDateToDateTime(x_);
+			var z_ = context.Operators.DateFrom(y_);
+
+			return z_;
+		};
+		var g_ = context.Operators.SelectOrNull<Immunization, CqlDate>(e_, f_);
+		var h_ = this.Hib_Vaccine__3_dose_schedule__Administered();
+		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		bool? k_(Procedure ThreeDoseHibProcedure)
+		{
+			var aa_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var ab_ = FHIRHelpers_4_3_000.ToValue(ThreeDoseHibProcedure?.Performed);
+			var ac_ = QICoreCommon_2_0_000.ToInterval(ab_);
+			var ad_ = CQMCommon_2_0_000.ToDateInterval(ac_);
+			var ae_ = context.Operators.IntervalIncludesInterval<CqlDate>(aa_, ad_, "day");
+
+			return ae_;
+		};
+		var l_ = context.Operators.WhereOrNull<Procedure>(j_, k_);
+		CqlDate m_(Procedure ThreeDoseHibProcedure)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(ThreeDoseHibProcedure?.Performed);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
+			var ai_ = context.Operators.Start(ah_);
+			var aj_ = context.Operators.ConvertDateToDateTime(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+
+			return ak_;
+		};
+		var n_ = context.Operators.SelectOrNull<Procedure, CqlDate>(l_, m_);
+		var o_ = context.Operators.ListUnion<CqlDate>(g_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("Hib 3 Dose Immunizations or Procedures")]
+	public IEnumerable<CqlDate> Hib_3_Dose_Immunizations_or_Procedures() => 
+		__Hib_3_Dose_Immunizations_or_Procedures.Value;
+
+	private IEnumerable<CqlDate> Hib_4_Dose_Immunizations_or_Procedures_Value()
+	{
+		var a_ = this.Hib_Vaccine__4_dose_schedule_();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization HibVaccine)
+		{
+			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var q_ = context.Operators.LateBoundProperty<CqlDateTime>(HibVaccine?.Occurrence, "value");
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = CQMCommon_2_0_000.ToDateInterval(r_);
+			var t_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, s_, "day");
+
+			return t_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		CqlDate f_(Immunization HibVaccine)
+		{
+			var u_ = context.Operators.LateBoundProperty<CqlDateTime>(HibVaccine?.Occurrence, "value");
+			var v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
+			var w_ = CQMCommon_2_0_000.ToDateInterval(v_);
+			var x_ = context.Operators.Start(w_);
+			var y_ = context.Operators.ConvertDateToDateTime(x_);
+			var z_ = context.Operators.DateFrom(y_);
+
+			return z_;
+		};
+		var g_ = context.Operators.SelectOrNull<Immunization, CqlDate>(e_, f_);
+		var h_ = this.Hib_Vaccine__4_dose_schedule__Administered();
+		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		bool? k_(Procedure HibProcedure)
+		{
+			var aa_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var ab_ = FHIRHelpers_4_3_000.ToValue(HibProcedure?.Performed);
+			var ac_ = QICoreCommon_2_0_000.ToInterval(ab_);
+			var ad_ = CQMCommon_2_0_000.ToDateInterval(ac_);
+			var ae_ = context.Operators.IntervalIncludesInterval<CqlDate>(aa_, ad_, "day");
+
+			return ae_;
+		};
+		var l_ = context.Operators.WhereOrNull<Procedure>(j_, k_);
+		CqlDate m_(Procedure HibProcedure)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(HibProcedure?.Performed);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
+			var ai_ = context.Operators.Start(ah_);
+			var aj_ = context.Operators.ConvertDateToDateTime(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+
+			return ak_;
+		};
+		var n_ = context.Operators.SelectOrNull<Procedure, CqlDate>(l_, m_);
+		var o_ = context.Operators.ListUnion<CqlDate>(g_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("Hib 4 Dose Immunizations or Procedures")]
+	public IEnumerable<CqlDate> Hib_4_Dose_Immunizations_or_Procedures() => 
+		__Hib_4_Dose_Immunizations_or_Procedures.Value;
+
+	private IEnumerable<CqlDate> Hib_3_or_4_Dose_Immunizations_Value()
+	{
+		var a_ = this.Hib_3_Dose_Immunizations_or_Procedures();
+		var b_ = this.Hib_4_Dose_Immunizations_or_Procedures();
+		var c_ = context.Operators.ListUnion<CqlDate>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Hib 3 or 4 Dose Immunizations")]
+	public IEnumerable<CqlDate> Hib_3_or_4_Dose_Immunizations() => 
+		__Hib_3_or_4_Dose_Immunizations.Value;
+
+	private IEnumerable<CqlDate> All_Hib_Vaccinations_Value()
+	{
+		var a_ = this.Hib_3_or_4_Dose_Immunizations();
+		IEnumerable<CqlDate> c_(CqlDate AllHibDoses1)
+		{
+			var f_ = this.Hib_3_or_4_Dose_Immunizations();
+			bool? g_(CqlDate AllHibDoses2)
+			{
+				var k_ = context.Operators.Quantity(1m, "day");
+				var l_ = context.Operators.Subtract(AllHibDoses2, k_);
+				var m_ = context.Operators.Interval(l_, AllHibDoses2, false, false);
+				var n_ = context.Operators.ElementInInterval<CqlDate>(AllHibDoses1, m_, null);
+
+				return n_;
+			};
+			var h_ = context.Operators.WhereOrNull<CqlDate>(f_, g_);
+			CqlDate i_(CqlDate AllHibDoses2) => 
+				AllHibDoses1;
+			var j_ = context.Operators.SelectOrNull<CqlDate, CqlDate>(h_, i_);
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<CqlDate, CqlDate>(a_, c_);
+		var e_ = context.Operators.ListExcept<CqlDate>(a_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("All Hib Vaccinations")]
+	public IEnumerable<CqlDate> All_Hib_Vaccinations() => 
+		__All_Hib_Vaccinations.Value;
+
+	private bool? Has_Appropriate_Number_of_Hib_Immunizations_Value()
+	{
+		var a_ = this.All_Hib_Vaccinations();
+		bool? b_(CqlDate HibImmunization)
+		{
+			var e_ = this.Hib_4_Dose_Immunizations_or_Procedures();
+			var f_ = context.Operators.CountOrNull<CqlDate>(e_);
+			var g_ = context.Operators.Greater(f_, (int?)0);
+			var h_ = this.All_Hib_Vaccinations();
+			CqlDate i_(CqlDate HibVaccinations) => 
+				HibVaccinations;
+			var j_ = context.Operators.SelectOrNull<CqlDate, CqlDate>(h_, i_);
+			var k_ = context.Operators.ListDistinct<CqlDate>(j_);
+			var l_ = context.Operators.CountOrNull<CqlDate>(k_);
+			var m_ = context.Operators.GreaterOrEqual(l_, (int?)4);
+			var n_ = context.Operators.And(g_, m_);
+			var p_ = context.Operators.CountOrNull<CqlDate>(e_);
+			var q_ = context.Operators.Greater(p_, (int?)0);
+			var r_ = context.Operators.IsFalse(q_);
+			var u_ = context.Operators.SelectOrNull<CqlDate, CqlDate>(h_, i_);
+			var v_ = context.Operators.ListDistinct<CqlDate>(u_);
+			var w_ = context.Operators.CountOrNull<CqlDate>(v_);
+			var x_ = context.Operators.GreaterOrEqual(w_, (int?)3);
+			var y_ = context.Operators.And(r_, x_);
+			var z_ = context.Operators.Or(n_, y_);
+
+			return z_;
+		};
+		var c_ = context.Operators.WhereOrNull<CqlDate>(a_, b_);
+		var d_ = context.Operators.ExistsInList<CqlDate>(c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Has Appropriate Number of Hib Immunizations")]
+	public bool? Has_Appropriate_Number_of_Hib_Immunizations() => 
+		__Has_Appropriate_Number_of_Hib_Immunizations.Value;
+
+	private IEnumerable<Condition> Hib_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		var d_ = Status_1_6_000.Active_Condition(c_);
+		bool? e_(Condition HibReaction)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HibReaction);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Hib Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> Hib_Numerator_Inclusion_Conditions() => 
+		__Hib_Numerator_Inclusion_Conditions.Value;
+
+	private IEnumerable<CqlDate> Hepatitis_B_Immunizations_or_Procedures_Value()
+	{
+		var a_ = this.Hepatitis_B_Vaccine();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization HepatitisBVaccination)
+		{
+			var p_ = this.First_Two_Years();
+			var q_ = context.Operators.LateBoundProperty<CqlDateTime>(HepatitisBVaccination?.Occurrence, "value");
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = CQMCommon_2_0_000.ToDateInterval(r_);
+			var t_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, s_, "day");
+
+			return t_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		CqlDate f_(Immunization HepatitisBVaccination)
+		{
+			var u_ = context.Operators.LateBoundProperty<CqlDateTime>(HepatitisBVaccination?.Occurrence, "value");
+			var v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
+			var w_ = CQMCommon_2_0_000.ToDateInterval(v_);
+			var x_ = context.Operators.Start(w_);
+			var y_ = context.Operators.ConvertDateToDateTime(x_);
+			var z_ = context.Operators.DateFrom(y_);
+
+			return z_;
+		};
+		var g_ = context.Operators.SelectOrNull<Immunization, CqlDate>(e_, f_);
+		var h_ = this.Hepatitis_B_Vaccine_Administered();
+		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		bool? k_(Procedure HepatitisBProcedure)
+		{
+			var aa_ = this.First_Two_Years();
+			var ab_ = FHIRHelpers_4_3_000.ToValue(HepatitisBProcedure?.Performed);
+			var ac_ = QICoreCommon_2_0_000.ToInterval(ab_);
+			var ad_ = CQMCommon_2_0_000.ToDateInterval(ac_);
+			var ae_ = context.Operators.IntervalIncludesInterval<CqlDate>(aa_, ad_, "day");
+
+			return ae_;
+		};
+		var l_ = context.Operators.WhereOrNull<Procedure>(j_, k_);
+		CqlDate m_(Procedure HepatitisBProcedure)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(HepatitisBProcedure?.Performed);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
+			var ai_ = context.Operators.Start(ah_);
+			var aj_ = context.Operators.ConvertDateToDateTime(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+
+			return ak_;
+		};
+		var n_ = context.Operators.SelectOrNull<Procedure, CqlDate>(l_, m_);
+		var o_ = context.Operators.ListUnion<CqlDate>(g_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("Hepatitis B Immunizations or Procedures")]
+	public IEnumerable<CqlDate> Hepatitis_B_Immunizations_or_Procedures() => 
+		__Hepatitis_B_Immunizations_or_Procedures.Value;
+
+	private IEnumerable<CqlDate> Three_Hepatitis_B_Vaccinations_Value()
+	{
+		var a_ = this.Hepatitis_B_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> b_(CqlDate _HepatitisBVaccination1)
+		{
+			var l_ = this.Hepatitis_B_Immunizations_or_Procedures();
+
+			return l_;
+		};
+		Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg c_(CqlDate _HepatitisBVaccination1, CqlDate _HepatitisBVaccination2)
+		{
+			var m_ = new Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg
+			{
+				HepatitisBVaccination1 = _HepatitisBVaccination1,
+				HepatitisBVaccination2 = _HepatitisBVaccination2,
+			};
+
+			return m_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<CqlDate, CqlDate, Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg _HepatitisBVaccination1HepatitisBVaccination2)
+		{
+			var n_ = this.Hepatitis_B_Immunizations_or_Procedures();
+
+			return n_;
+		};
+		Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg f_(Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg HepatitisBVaccination1HepatitisBVaccination2, CqlDate _HepatitisBVaccination3)
+		{
+			var o_ = new Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg
+			{
+				HepatitisBVaccination1 = HepatitisBVaccination1HepatitisBVaccination2.HepatitisBVaccination1,
+				HepatitisBVaccination2 = HepatitisBVaccination1HepatitisBVaccination2.HepatitisBVaccination2,
+				HepatitisBVaccination3 = _HepatitisBVaccination3,
+			};
+
+			return o_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg, CqlDate, Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg tuple_bgioadwjfavaafwakdfwjcfog)
+		{
+			var p_ = context.Operators.Quantity(1m, "day");
+			var q_ = context.Operators.Add(tuple_bgioadwjfavaafwakdfwjcfog.HepatitisBVaccination1, p_);
+			var r_ = context.Operators.SameOrAfter(tuple_bgioadwjfavaafwakdfwjcfog.HepatitisBVaccination2, q_, "day");
+			var t_ = context.Operators.Add(tuple_bgioadwjfavaafwakdfwjcfog.HepatitisBVaccination2, p_);
+			var u_ = context.Operators.SameOrAfter(tuple_bgioadwjfavaafwakdfwjcfog.HepatitisBVaccination3, t_, "day");
+			var v_ = context.Operators.And(r_, u_);
+
+			return v_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg>(g_, h_);
+		CqlDate j_(Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg tuple_bgioadwjfavaafwakdfwjcfog) => 
+			tuple_bgioadwjfavaafwakdfwjcfog.HepatitisBVaccination1;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Three Hepatitis B Vaccinations")]
+	public IEnumerable<CqlDate> Three_Hepatitis_B_Vaccinations() => 
+		__Three_Hepatitis_B_Vaccinations.Value;
+
+	private IEnumerable<CqlDate> NewBorn_Vaccine_Requirement_Value()
+	{
+		var a_ = this.Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Procedure>(b_, null);
+		var d_ = Status_1_6_000.Completed_Procedure(c_);
+		bool? e_(Procedure NewBornVaccine)
+		{
+			var i_ = this.Patient();
+			var j_ = context.Operators.ConvertStringToDate(i_?.BirthDateElement?.Value);
+			var k_ = context.Operators.ConvertDateToDateTime(j_);
+			var l_ = context.Operators.DateFrom(k_);
+			var n_ = context.Operators.ConvertStringToDate(i_?.BirthDateElement?.Value);
+			var o_ = context.Operators.ConvertDateToDateTime(n_);
+			var p_ = context.Operators.DateFrom(o_);
+			var q_ = context.Operators.Quantity(7m, "days");
+			var r_ = context.Operators.Add(p_, q_);
+			var s_ = context.Operators.Interval(l_, r_, true, true);
+			var t_ = FHIRHelpers_4_3_000.ToValue(NewBornVaccine?.Performed);
+			var u_ = QICoreCommon_2_0_000.ToInterval(t_);
+			var v_ = CQMCommon_2_0_000.ToDateInterval(u_);
+			var w_ = context.Operators.IntervalIncludesInterval<CqlDate>(s_, v_, "day");
+
+			return w_;
+		};
+		var f_ = context.Operators.WhereOrNull<Procedure>(d_, e_);
+		CqlDate g_(Procedure NewBornVaccine)
+		{
+			var x_ = FHIRHelpers_4_3_000.ToValue(NewBornVaccine?.Performed);
+			var y_ = QICoreCommon_2_0_000.ToInterval(x_);
+			var z_ = context.Operators.Start(y_);
+			var aa_ = context.Operators.DateFrom(z_);
+
+			return aa_;
+		};
+		var h_ = context.Operators.SelectOrNull<Procedure, CqlDate>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("NewBorn Vaccine Requirement")]
+	public IEnumerable<CqlDate> NewBorn_Vaccine_Requirement() => 
+		__NewBorn_Vaccine_Requirement.Value;
+
+	private IEnumerable<CqlDate> Meets_HepB_Vaccination_Requirement_Value()
+	{
+		var a_ = this.Hepatitis_B_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> b_(CqlDate _HepatitisBVaccination1)
+		{
+			var l_ = this.Hepatitis_B_Immunizations_or_Procedures();
+
+			return l_;
+		};
+		Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH c_(CqlDate _HepatitisBVaccination1, CqlDate _HepatitisBVaccination2)
+		{
+			var m_ = new Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH
+			{
+				HepatitisBVaccination1 = _HepatitisBVaccination1,
+				HepatitisBVaccination2 = _HepatitisBVaccination2,
+			};
+
+			return m_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<CqlDate, CqlDate, Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH _HepatitisBVaccination1HepatitisBVaccination2)
+		{
+			var n_ = this.NewBorn_Vaccine_Requirement();
+
+			return n_;
+		};
+		Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH f_(Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH HepatitisBVaccination1HepatitisBVaccination2, CqlDate _NewBornVaccine3)
+		{
+			var o_ = new Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH
+			{
+				HepatitisBVaccination1 = HepatitisBVaccination1HepatitisBVaccination2.HepatitisBVaccination1,
+				HepatitisBVaccination2 = HepatitisBVaccination1HepatitisBVaccination2.HepatitisBVaccination2,
+				NewBornVaccine3 = _NewBornVaccine3,
+			};
+
+			return o_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH, CqlDate, Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH tuple_bbghrjamveqthbctrucdhsbqh)
+		{
+			var p_ = context.Operators.Quantity(1m, "day");
+			var q_ = context.Operators.Add(tuple_bbghrjamveqthbctrucdhsbqh.HepatitisBVaccination1, p_);
+			var r_ = context.Operators.SameOrAfter(tuple_bbghrjamveqthbctrucdhsbqh.HepatitisBVaccination2, q_, "day");
+			var t_ = context.Operators.Add(tuple_bbghrjamveqthbctrucdhsbqh.NewBornVaccine3, p_);
+			var u_ = context.Operators.SameOrAfter(tuple_bbghrjamveqthbctrucdhsbqh.HepatitisBVaccination1, t_, "day");
+			var v_ = context.Operators.And(r_, u_);
+			var x_ = context.Operators.Add(tuple_bbghrjamveqthbctrucdhsbqh.NewBornVaccine3, p_);
+			var y_ = context.Operators.SameOrAfter(tuple_bbghrjamveqthbctrucdhsbqh.HepatitisBVaccination2, x_, "day");
+			var z_ = context.Operators.And(v_, y_);
+
+			return z_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH>(g_, h_);
+		CqlDate j_(Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH tuple_bbghrjamveqthbctrucdhsbqh) => 
+			tuple_bbghrjamveqthbctrucdhsbqh.HepatitisBVaccination1;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_BbghRjaMVeQThBCTRUcdHSBQH, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Meets HepB Vaccination Requirement")]
+	public IEnumerable<CqlDate> Meets_HepB_Vaccination_Requirement() => 
+		__Meets_HepB_Vaccination_Requirement.Value;
+
+	private IEnumerable<Condition> Hepatitis_B_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		var d_ = this.Hepatitis_B();
+		var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+		var f_ = context.Operators.ListUnion<Condition>(c_, e_);
+		var g_ = Status_1_6_000.Active_Condition(f_);
+		bool? h_(Condition HepBConditions)
+		{
+			var j_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HepBConditions);
+			var k_ = context.Operators.Start(j_);
+			var l_ = context.Operators.DateFrom(k_);
+			var m_ = this.First_Two_Years();
+			var n_ = context.Operators.ElementInInterval<CqlDate>(l_, m_, "day");
+
+			return n_;
+		};
+		var i_ = context.Operators.WhereOrNull<Condition>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Hepatitis B Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> Hepatitis_B_Numerator_Inclusion_Conditions() => 
+		__Hepatitis_B_Numerator_Inclusion_Conditions.Value;
+
+	private IEnumerable<object> One_Chicken_Pox_Vaccination_Value()
+	{
+		var a_ = this.Varicella_Zoster_Vaccine__VZV_();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization ChickenPoxVaccination)
+		{
+			var l_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			var m_ = context.Operators.LateBoundProperty<CqlDateTime>(ChickenPoxVaccination?.Occurrence, "value");
+			var n_ = QICoreCommon_2_0_000.ToInterval((m_ as object));
+			var o_ = CQMCommon_2_0_000.ToDateInterval(n_);
+			var p_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, o_, null);
+
+			return p_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		var f_ = this.Varicella_Zoster_Vaccine__VZV__Administered();
+		var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		var h_ = Status_1_6_000.Completed_Procedure(g_);
+		bool? i_(Procedure ChickenPoxProcedure)
+		{
+			var q_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			var r_ = FHIRHelpers_4_3_000.ToValue(ChickenPoxProcedure?.Performed);
+			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(q_, t_, null);
+
+			return u_;
+		};
+		var j_ = context.Operators.WhereOrNull<Procedure>(h_, i_);
+		var k_ = context.Operators.ListUnion<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
+
+		return k_;
+	}
+
+    [CqlDeclaration("One Chicken Pox Vaccination")]
+	public IEnumerable<object> One_Chicken_Pox_Vaccination() => 
+		__One_Chicken_Pox_Vaccination.Value;
+
+	private IEnumerable<Condition> Varicella_Zoster_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Varicella_Zoster();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = this.Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_();
+		var d_ = context.Operators.ToList<CqlCode>(c_);
+		var e_ = context.Operators.RetrieveByCodes<Condition>(d_, null);
+		var f_ = context.Operators.ListUnion<Condition>(b_, e_);
+		var g_ = Status_1_6_000.Active_Condition(f_);
+		bool? h_(Condition VaricellaZoster)
+		{
+			var j_ = QICoreCommon_2_0_000.ToPrevalenceInterval(VaricellaZoster);
+			var k_ = context.Operators.Start(j_);
+			var l_ = context.Operators.DateFrom(k_);
+			var m_ = this.First_Two_Years();
+			var n_ = context.Operators.ElementInInterval<CqlDate>(l_, m_, "day");
+
+			return n_;
+		};
+		var i_ = context.Operators.WhereOrNull<Condition>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Varicella Zoster Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> Varicella_Zoster_Numerator_Inclusion_Conditions() => 
+		__Varicella_Zoster_Numerator_Inclusion_Conditions.Value;
+
+	private IEnumerable<CqlDate> Pneumococcal_Conjugate_Immunizations_or_Procedures_Value()
+	{
+		var a_ = this.Pneumococcal_Conjugate_Vaccine();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization PneumococcalVaccination)
+		{
+			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var q_ = context.Operators.LateBoundProperty<CqlDateTime>(PneumococcalVaccination?.Occurrence, "value");
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = CQMCommon_2_0_000.ToDateInterval(r_);
+			var t_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, s_, "day");
+
+			return t_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		CqlDate f_(Immunization PneumococcalVaccination)
+		{
+			var u_ = context.Operators.LateBoundProperty<CqlDateTime>(PneumococcalVaccination?.Occurrence, "value");
+			var v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
+			var w_ = CQMCommon_2_0_000.ToDateInterval(v_);
+			var x_ = context.Operators.Start(w_);
+			var y_ = context.Operators.ConvertDateToDateTime(x_);
+			var z_ = context.Operators.DateFrom(y_);
+
+			return z_;
+		};
+		var g_ = context.Operators.SelectOrNull<Immunization, CqlDate>(e_, f_);
+		var h_ = this.Pneumococcal_Conjugate_Vaccine_Administered();
+		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		bool? k_(Procedure PneumococcalProcedure)
+		{
+			var aa_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var ab_ = FHIRHelpers_4_3_000.ToValue(PneumococcalProcedure?.Performed);
+			var ac_ = QICoreCommon_2_0_000.ToInterval(ab_);
+			var ad_ = CQMCommon_2_0_000.ToDateInterval(ac_);
+			var ae_ = context.Operators.IntervalIncludesInterval<CqlDate>(aa_, ad_, "day");
+
+			return ae_;
+		};
+		var l_ = context.Operators.WhereOrNull<Procedure>(j_, k_);
+		CqlDate m_(Procedure PneumococcalProcedure)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(PneumococcalProcedure?.Performed);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
+			var ai_ = context.Operators.Start(ah_);
+			var aj_ = context.Operators.ConvertDateToDateTime(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+
+			return ak_;
+		};
+		var n_ = context.Operators.SelectOrNull<Procedure, CqlDate>(l_, m_);
+		var o_ = context.Operators.ListUnion<CqlDate>(g_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("Pneumococcal Conjugate Immunizations or Procedures")]
+	public IEnumerable<CqlDate> Pneumococcal_Conjugate_Immunizations_or_Procedures() => 
+		__Pneumococcal_Conjugate_Immunizations_or_Procedures.Value;
+
+	private IEnumerable<CqlDate> Four_Pneumococcal_Conjugate_Vaccinations_Value()
+	{
+		var a_ = this.Pneumococcal_Conjugate_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> b_(CqlDate _PneumococcalVaccination1)
+		{
+			var o_ = this.Pneumococcal_Conjugate_Immunizations_or_Procedures();
+
+			return o_;
+		};
+		Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh c_(CqlDate _PneumococcalVaccination1, CqlDate _PneumococcalVaccination2)
+		{
+			var p_ = new Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh
+			{
+				PneumococcalVaccination1 = _PneumococcalVaccination1,
+				PneumococcalVaccination2 = _PneumococcalVaccination2,
+			};
+
+			return p_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<CqlDate, CqlDate, Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh _PneumococcalVaccination1PneumococcalVaccination2)
+		{
+			var q_ = this.Pneumococcal_Conjugate_Immunizations_or_Procedures();
+
+			return q_;
+		};
+		Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh f_(Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh PneumococcalVaccination1PneumococcalVaccination2, CqlDate _PneumococcalVaccination3)
+		{
+			var r_ = new Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh
+			{
+				PneumococcalVaccination1 = PneumococcalVaccination1PneumococcalVaccination2.PneumococcalVaccination1,
+				PneumococcalVaccination2 = PneumococcalVaccination1PneumococcalVaccination2.PneumococcalVaccination2,
+				PneumococcalVaccination3 = _PneumococcalVaccination3,
+			};
+
+			return r_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh, CqlDate, Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh>(d_, e_, f_);
+		IEnumerable<CqlDate> h_(Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh _PneumococcalVaccination1PneumococcalVaccination2PneumococcalVaccination3)
+		{
+			var s_ = this.Pneumococcal_Conjugate_Immunizations_or_Procedures();
+
+			return s_;
+		};
+		Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh i_(Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh PneumococcalVaccination1PneumococcalVaccination2PneumococcalVaccination3, CqlDate _PneumococcalVaccination4)
+		{
+			var t_ = new Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh
+			{
+				PneumococcalVaccination1 = PneumococcalVaccination1PneumococcalVaccination2PneumococcalVaccination3.PneumococcalVaccination1,
+				PneumococcalVaccination2 = PneumococcalVaccination1PneumococcalVaccination2PneumococcalVaccination3.PneumococcalVaccination2,
+				PneumococcalVaccination3 = PneumococcalVaccination1PneumococcalVaccination2PneumococcalVaccination3.PneumococcalVaccination3,
+				PneumococcalVaccination4 = _PneumococcalVaccination4,
+			};
+
+			return t_;
+		};
+		var j_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh, CqlDate, Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh>(g_, h_, i_);
+		bool? k_(Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh tuple_bvcgrhsdcrlnscbmjukidnajh)
+		{
+			var u_ = context.Operators.Quantity(1m, "day");
+			var v_ = context.Operators.Add(tuple_bvcgrhsdcrlnscbmjukidnajh.PneumococcalVaccination1, u_);
+			var w_ = context.Operators.SameOrAfter(tuple_bvcgrhsdcrlnscbmjukidnajh.PneumococcalVaccination2, v_, "day");
+			var y_ = context.Operators.Add(tuple_bvcgrhsdcrlnscbmjukidnajh.PneumococcalVaccination2, u_);
+			var z_ = context.Operators.SameOrAfter(tuple_bvcgrhsdcrlnscbmjukidnajh.PneumococcalVaccination3, y_, "day");
+			var aa_ = context.Operators.And(w_, z_);
+			var ac_ = context.Operators.Add(tuple_bvcgrhsdcrlnscbmjukidnajh.PneumococcalVaccination3, u_);
+			var ad_ = context.Operators.SameOrAfter(tuple_bvcgrhsdcrlnscbmjukidnajh.PneumococcalVaccination4, ac_, "day");
+			var ae_ = context.Operators.And(aa_, ad_);
+
+			return ae_;
+		};
+		var l_ = context.Operators.WhereOrNull<Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh>(j_, k_);
+		CqlDate m_(Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh tuple_bvcgrhsdcrlnscbmjukidnajh) => 
+			tuple_bvcgrhsdcrlnscbmjukidnajh.PneumococcalVaccination1;
+		var n_ = context.Operators.SelectOrNull<Tuples.Tuple_BVCGRhSDCRLNScbMJUKidNAJh, CqlDate>(l_, m_);
+
+		return n_;
+	}
+
+    [CqlDeclaration("Four Pneumococcal Conjugate Vaccinations")]
+	public IEnumerable<CqlDate> Four_Pneumococcal_Conjugate_Vaccinations() => 
+		__Four_Pneumococcal_Conjugate_Vaccinations.Value;
+
+	private IEnumerable<Condition> Pneumococcal_Conjugate_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		var d_ = Status_1_6_000.Active_Condition(c_);
+		bool? e_(Condition PneumococcalReaction)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(PneumococcalReaction);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Pneumococcal Conjugate Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> Pneumococcal_Conjugate_Numerator_Inclusion_Conditions() => 
+		__Pneumococcal_Conjugate_Numerator_Inclusion_Conditions.Value;
+
+	private IEnumerable<object> One_Hepatitis_A_Vaccinations_Value()
+	{
+		var a_ = this.Hepatitis_A_Vaccine();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization HepatitisAVaccination)
+		{
+			var l_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			var m_ = context.Operators.LateBoundProperty<CqlDateTime>(HepatitisAVaccination?.Occurrence, "value");
+			var n_ = QICoreCommon_2_0_000.ToInterval((m_ as object));
+			var o_ = CQMCommon_2_0_000.ToDateInterval(n_);
+			var p_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, o_, null);
+
+			return p_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		var f_ = this.Hepatitis_A_Vaccine_Administered();
+		var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		var h_ = Status_1_6_000.Completed_Procedure(g_);
+		bool? i_(Procedure HepatitisAProcedure)
+		{
+			var q_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			var r_ = FHIRHelpers_4_3_000.ToValue(HepatitisAProcedure?.Performed);
+			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(q_, t_, null);
+
+			return u_;
+		};
+		var j_ = context.Operators.WhereOrNull<Procedure>(h_, i_);
+		var k_ = context.Operators.ListUnion<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
+
+		return k_;
+	}
+
+    [CqlDeclaration("One Hepatitis A Vaccinations")]
+	public IEnumerable<object> One_Hepatitis_A_Vaccinations() => 
+		__One_Hepatitis_A_Vaccinations.Value;
+
+	private IEnumerable<Condition> Hepatitis_A_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Hepatitis_A();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_();
+		var d_ = context.Operators.ToList<CqlCode>(c_);
+		var e_ = context.Operators.RetrieveByCodes<Condition>(d_, null);
+		var f_ = context.Operators.ListUnion<Condition>(b_, e_);
+		var g_ = Status_1_6_000.Active_Condition(f_);
+		bool? h_(Condition HepatitisADiagnosis)
+		{
+			var j_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HepatitisADiagnosis);
+			var k_ = context.Operators.Start(j_);
+			var l_ = context.Operators.DateFrom(k_);
+			var m_ = this.First_Two_Years();
+			var n_ = context.Operators.ElementInInterval<CqlDate>(l_, m_, "day");
+
+			return n_;
+		};
+		var i_ = context.Operators.WhereOrNull<Condition>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Hepatitis A Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> Hepatitis_A_Numerator_Inclusion_Conditions() => 
+		__Hepatitis_A_Numerator_Inclusion_Conditions.Value;
+
+	private IEnumerable<CqlDate> Rotavirus_2_Dose_Immunizations_or_Procedures_Value()
+	{
+		var a_ = this.rotavirus__live__monovalent_vaccine();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Immunization>(b_, null);
+		var d_ = Status_1_6_000.Completed_Immunization(c_);
+		bool? e_(Immunization TwoDoseRotavirusVaccine)
+		{
+			var q_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var r_ = context.Operators.LateBoundProperty<CqlDateTime>(TwoDoseRotavirusVaccine?.Occurrence, "value");
+			var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(q_, t_, "day");
+
+			return u_;
+		};
+		var f_ = context.Operators.WhereOrNull<Immunization>(d_, e_);
+		CqlDate g_(Immunization TwoDoseRotavirusVaccine)
+		{
+			var v_ = context.Operators.LateBoundProperty<CqlDateTime>(TwoDoseRotavirusVaccine?.Occurrence, "value");
+			var w_ = QICoreCommon_2_0_000.ToInterval((v_ as object));
+			var x_ = CQMCommon_2_0_000.ToDateInterval(w_);
+			var y_ = context.Operators.Start(x_);
+			var z_ = context.Operators.ConvertDateToDateTime(y_);
+			var aa_ = context.Operators.DateFrom(z_);
+
+			return aa_;
+		};
+		var h_ = context.Operators.SelectOrNull<Immunization, CqlDate>(f_, g_);
+		var i_ = this.Rotavirus_Vaccine__2_dose_schedule__Administered();
+		var j_ = context.Operators.RetrieveByValueSet<Procedure>(i_, null);
+		var k_ = Status_1_6_000.Completed_Procedure(j_);
+		bool? l_(Procedure TwoDoseRotavirusProcedure)
+		{
+			var ab_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var ac_ = FHIRHelpers_4_3_000.ToValue(TwoDoseRotavirusProcedure?.Performed);
+			var ad_ = QICoreCommon_2_0_000.ToInterval(ac_);
+			var ae_ = CQMCommon_2_0_000.ToDateInterval(ad_);
+			var af_ = context.Operators.IntervalIncludesInterval<CqlDate>(ab_, ae_, "day");
+
+			return af_;
+		};
+		var m_ = context.Operators.WhereOrNull<Procedure>(k_, l_);
+		CqlDate n_(Procedure TwoDoseRotavirusProcedure)
+		{
+			var ag_ = FHIRHelpers_4_3_000.ToValue(TwoDoseRotavirusProcedure?.Performed);
+			var ah_ = QICoreCommon_2_0_000.ToInterval(ag_);
+			var ai_ = CQMCommon_2_0_000.ToDateInterval(ah_);
+			var aj_ = context.Operators.Start(ai_);
+			var ak_ = context.Operators.ConvertDateToDateTime(aj_);
+			var al_ = context.Operators.DateFrom(ak_);
+
+			return al_;
+		};
+		var o_ = context.Operators.SelectOrNull<Procedure, CqlDate>(m_, n_);
+		var p_ = context.Operators.ListUnion<CqlDate>(h_, o_);
+
+		return p_;
+	}
+
+    [CqlDeclaration("Rotavirus 2 Dose Immunizations or Procedures")]
+	public IEnumerable<CqlDate> Rotavirus_2_Dose_Immunizations_or_Procedures() => 
+		__Rotavirus_2_Dose_Immunizations_or_Procedures.Value;
+
+	private IEnumerable<CqlDate> Rotavirus_3_Dose_Immunizations_or_Procedures_Value()
+	{
+		var a_ = this.Rotavirus_Vaccine__3_dose_schedule_();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization ThreeDoseRotavirusVaccine)
+		{
+			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var q_ = context.Operators.LateBoundProperty<CqlDateTime>(ThreeDoseRotavirusVaccine?.Occurrence, "value");
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = CQMCommon_2_0_000.ToDateInterval(r_);
+			var t_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, s_, "day");
+
+			return t_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		CqlDate f_(Immunization ThreeDoseRotavirusVaccine)
+		{
+			var u_ = context.Operators.LateBoundProperty<CqlDateTime>(ThreeDoseRotavirusVaccine?.Occurrence, "value");
+			var v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
+			var w_ = CQMCommon_2_0_000.ToDateInterval(v_);
+			var x_ = context.Operators.Start(w_);
+			var y_ = context.Operators.ConvertDateToDateTime(x_);
+			var z_ = context.Operators.DateFrom(y_);
+
+			return z_;
+		};
+		var g_ = context.Operators.SelectOrNull<Immunization, CqlDate>(e_, f_);
+		var h_ = this.Rotavirus_Vaccine__3_dose_schedule__Administered();
+		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		bool? k_(Procedure ThreeDoseRotavirusAdministered)
+		{
+			var aa_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var ab_ = FHIRHelpers_4_3_000.ToValue(ThreeDoseRotavirusAdministered?.Performed);
+			var ac_ = QICoreCommon_2_0_000.ToInterval(ab_);
+			var ad_ = CQMCommon_2_0_000.ToDateInterval(ac_);
+			var ae_ = context.Operators.IntervalIncludesInterval<CqlDate>(aa_, ad_, "day");
+
+			return ae_;
+		};
+		var l_ = context.Operators.WhereOrNull<Procedure>(j_, k_);
+		CqlDate m_(Procedure ThreeDoseRotavirusAdministered)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(ThreeDoseRotavirusAdministered?.Performed);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
+			var ai_ = context.Operators.Start(ah_);
+			var aj_ = context.Operators.ConvertDateToDateTime(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+
+			return ak_;
+		};
+		var n_ = context.Operators.SelectOrNull<Procedure, CqlDate>(l_, m_);
+		var o_ = context.Operators.ListUnion<CqlDate>(g_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("Rotavirus 3 Dose Immunizations or Procedures")]
+	public IEnumerable<CqlDate> Rotavirus_3_Dose_Immunizations_or_Procedures() => 
+		__Rotavirus_3_Dose_Immunizations_or_Procedures.Value;
+
+	private IEnumerable<CqlDate> Rotavirus_2_or_3_Dose_Immunizations_Value()
+	{
+		var a_ = this.Rotavirus_2_Dose_Immunizations_or_Procedures();
+		var b_ = this.Rotavirus_3_Dose_Immunizations_or_Procedures();
+		var c_ = context.Operators.ListUnion<CqlDate>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Rotavirus 2 or 3 Dose Immunizations")]
+	public IEnumerable<CqlDate> Rotavirus_2_or_3_Dose_Immunizations() => 
+		__Rotavirus_2_or_3_Dose_Immunizations.Value;
+
+	private IEnumerable<CqlDate> All_Rotavirus_Vaccinations_Value()
+	{
+		var a_ = this.Rotavirus_2_or_3_Dose_Immunizations();
+		IEnumerable<CqlDate> c_(CqlDate AllRotavirusDoses1)
+		{
+			var f_ = this.Rotavirus_2_or_3_Dose_Immunizations();
+			bool? g_(CqlDate AllRotavirusDoses2)
+			{
+				var k_ = context.Operators.Quantity(1m, "day");
+				var l_ = context.Operators.Subtract(AllRotavirusDoses2, k_);
+				var m_ = context.Operators.Interval(l_, AllRotavirusDoses2, false, false);
+				var n_ = context.Operators.ElementInInterval<CqlDate>(AllRotavirusDoses1, m_, null);
+
+				return n_;
+			};
+			var h_ = context.Operators.WhereOrNull<CqlDate>(f_, g_);
+			CqlDate i_(CqlDate AllRotavirusDoses2) => 
+				AllRotavirusDoses1;
+			var j_ = context.Operators.SelectOrNull<CqlDate, CqlDate>(h_, i_);
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<CqlDate, CqlDate>(a_, c_);
+		var e_ = context.Operators.ListExcept<CqlDate>(a_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("All Rotavirus Vaccinations")]
+	public IEnumerable<CqlDate> All_Rotavirus_Vaccinations() => 
+		__All_Rotavirus_Vaccinations.Value;
+
+	private bool? Has_Appropriate_Number_of_Rotavirus_Immunizations_Value()
+	{
+		var a_ = this.All_Rotavirus_Vaccinations();
+		bool? b_(CqlDate RotavirusImmunization)
+		{
+			var e_ = this.Rotavirus_3_Dose_Immunizations_or_Procedures();
+			var f_ = context.Operators.CountOrNull<CqlDate>(e_);
+			var g_ = context.Operators.Greater(f_, (int?)0);
+			var h_ = this.All_Rotavirus_Vaccinations();
+			CqlDate i_(CqlDate RotavirusVaccinations) => 
+				RotavirusVaccinations;
+			var j_ = context.Operators.SelectOrNull<CqlDate, CqlDate>(h_, i_);
+			var k_ = context.Operators.ListDistinct<CqlDate>(j_);
+			var l_ = context.Operators.CountOrNull<CqlDate>(k_);
+			var m_ = context.Operators.GreaterOrEqual(l_, (int?)3);
+			var n_ = context.Operators.And(g_, m_);
+			var p_ = context.Operators.CountOrNull<CqlDate>(e_);
+			var q_ = context.Operators.Greater(p_, (int?)0);
+			var r_ = context.Operators.IsFalse(q_);
+			var u_ = context.Operators.SelectOrNull<CqlDate, CqlDate>(h_, i_);
+			var v_ = context.Operators.ListDistinct<CqlDate>(u_);
+			var w_ = context.Operators.CountOrNull<CqlDate>(v_);
+			var x_ = context.Operators.GreaterOrEqual(w_, (int?)2);
+			var y_ = context.Operators.And(r_, x_);
+			var z_ = context.Operators.Or(n_, y_);
+
+			return z_;
+		};
+		var c_ = context.Operators.WhereOrNull<CqlDate>(a_, b_);
+		var d_ = context.Operators.ExistsInList<CqlDate>(c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Has Appropriate Number of Rotavirus Immunizations")]
+	public bool? Has_Appropriate_Number_of_Rotavirus_Immunizations() => 
+		__Has_Appropriate_Number_of_Rotavirus_Immunizations.Value;
+
+	private IEnumerable<Condition> Rotavirus_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Anaphylaxis_due_to_rotavirus_vaccine__disorder_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		var d_ = Status_1_6_000.Active_Condition(c_);
+		bool? e_(Condition RotavirusConditions)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(RotavirusConditions);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Rotavirus Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> Rotavirus_Numerator_Inclusion_Conditions() => 
+		__Rotavirus_Numerator_Inclusion_Conditions.Value;
+
+	private CqlInterval<CqlDate> Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
+		var c_ = context.Operators.ConvertDateToDateTime(b_);
+		var d_ = context.Operators.DateFrom(c_);
+		var e_ = context.Operators.Quantity(180m, "days");
+		var f_ = context.Operators.Add(d_, e_);
+		var g_ = this.Date_of_Second_Birthday();
+		var h_ = context.Operators.Interval(f_, g_, true, true);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Vaccine Administration Interval - 180 Days up to 2 Years Old")]
+	public CqlInterval<CqlDate> Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old() => 
+		__Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old.Value;
+
+	private IEnumerable<CqlDate> Influenza_Immunizations_or_Procedures_Value()
+	{
+		var a_ = this.Child_Influenza_Immunization_Administered();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization InfluenzaVaccine)
+		{
+			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			var q_ = context.Operators.LateBoundProperty<CqlDateTime>(InfluenzaVaccine?.Occurrence, "value");
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = CQMCommon_2_0_000.ToDateInterval(r_);
+			var t_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, s_, "day");
+
+			return t_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		CqlDate f_(Immunization InfluenzaVaccine)
+		{
+			var u_ = context.Operators.LateBoundProperty<CqlDateTime>(InfluenzaVaccine?.Occurrence, "value");
+			var v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
+			var w_ = CQMCommon_2_0_000.ToDateInterval(v_);
+			var x_ = context.Operators.Start(w_);
+			var y_ = context.Operators.ConvertDateToDateTime(x_);
+			var z_ = context.Operators.DateFrom(y_);
+
+			return z_;
+		};
+		var g_ = context.Operators.SelectOrNull<Immunization, CqlDate>(e_, f_);
+		var h_ = this.Child_Influenza_Vaccine_Administered();
+		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		bool? k_(Procedure InfluenzaAdministration)
+		{
+			var aa_ = this.Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old();
+			var ab_ = context.Operators.ConvertDateToDateTime(aa_?.low);
+			var ad_ = context.Operators.ConvertDateToDateTime(aa_?.high);
+			var ag_ = context.Operators.Interval(ab_, ad_, aa_?.lowClosed, aa_?.highClosed);
+			var ah_ = FHIRHelpers_4_3_000.ToValue(InfluenzaAdministration?.Performed);
+			var ai_ = QICoreCommon_2_0_000.ToInterval(ah_);
+			var aj_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ag_, ai_, "day");
+
+			return aj_;
+		};
+		var l_ = context.Operators.WhereOrNull<Procedure>(j_, k_);
+		CqlDate m_(Procedure InfluenzaAdministration)
+		{
+			var ak_ = FHIRHelpers_4_3_000.ToValue(InfluenzaAdministration?.Performed);
+			var al_ = QICoreCommon_2_0_000.ToInterval(ak_);
+			var am_ = CQMCommon_2_0_000.ToDateInterval(al_);
+			var an_ = context.Operators.Start(am_);
+			var ao_ = context.Operators.ConvertDateToDateTime(an_);
+			var ap_ = context.Operators.DateFrom(ao_);
+
+			return ap_;
+		};
+		var n_ = context.Operators.SelectOrNull<Procedure, CqlDate>(l_, m_);
+		var o_ = context.Operators.ListUnion<CqlDate>(g_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("Influenza Immunizations or Procedures")]
+	public IEnumerable<CqlDate> Influenza_Immunizations_or_Procedures() => 
+		__Influenza_Immunizations_or_Procedures.Value;
+
+	private IEnumerable<CqlDate> Two_Influenza_Vaccinations_Value()
+	{
+		var a_ = this.Influenza_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> b_(CqlDate _FluVaccination1)
+		{
+			var i_ = this.Influenza_Immunizations_or_Procedures();
+
+			return i_;
+		};
+		Tuples.Tuple_ESUAOONTBOMCFNSgVCeZOQUbj c_(CqlDate _FluVaccination1, CqlDate _FluVaccination2)
+		{
+			var j_ = new Tuples.Tuple_ESUAOONTBOMCFNSgVCeZOQUbj
+			{
+				FluVaccination1 = _FluVaccination1,
+				FluVaccination2 = _FluVaccination2,
+			};
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<CqlDate, CqlDate, Tuples.Tuple_ESUAOONTBOMCFNSgVCeZOQUbj>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_ESUAOONTBOMCFNSgVCeZOQUbj tuple_esuaoontbomcfnsgvcezoqubj)
+		{
+			var k_ = context.Operators.Quantity(1m, "day");
+			var l_ = context.Operators.Add(tuple_esuaoontbomcfnsgvcezoqubj.FluVaccination1, k_);
+			var m_ = context.Operators.SameOrAfter(tuple_esuaoontbomcfnsgvcezoqubj.FluVaccination2, l_, "day");
+
+			return m_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_ESUAOONTBOMCFNSgVCeZOQUbj>(d_, e_);
+		CqlDate g_(Tuples.Tuple_ESUAOONTBOMCFNSgVCeZOQUbj tuple_esuaoontbomcfnsgvcezoqubj) => 
+			tuple_esuaoontbomcfnsgvcezoqubj.FluVaccination1;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_ESUAOONTBOMCFNSgVCeZOQUbj, CqlDate>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Two Influenza Vaccinations")]
+	public IEnumerable<CqlDate> Two_Influenza_Vaccinations() => 
+		__Two_Influenza_Vaccinations.Value;
+
+	private IEnumerable<CqlDate> LAIV_Vaccinations_Value()
+	{
+		var a_ = this.Influenza_Virus_LAIV_Immunization();
+		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		bool? d_(Immunization LAIVVaccine)
+		{
+			var p_ = this.Date_of_Second_Birthday();
+			var r_ = context.Operators.Interval(p_, p_, true, true);
+			var s_ = context.Operators.LateBoundProperty<CqlDateTime>(LAIVVaccine?.Occurrence, "value");
+			var t_ = QICoreCommon_2_0_000.ToInterval((s_ as object));
+			var u_ = CQMCommon_2_0_000.ToDateInterval(t_);
+			var v_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, u_, "day");
+
+			return v_;
+		};
+		var e_ = context.Operators.WhereOrNull<Immunization>(c_, d_);
+		CqlDate f_(Immunization LAIVVaccine)
+		{
+			var w_ = context.Operators.LateBoundProperty<CqlDateTime>(LAIVVaccine?.Occurrence, "value");
+			var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+			var y_ = CQMCommon_2_0_000.ToDateInterval(x_);
+			var z_ = context.Operators.Start(y_);
+			var aa_ = context.Operators.ConvertDateToDateTime(z_);
+			var ab_ = context.Operators.DateFrom(aa_);
+
+			return ab_;
+		};
+		var g_ = context.Operators.SelectOrNull<Immunization, CqlDate>(e_, f_);
+		var h_ = this.Influenza_Virus_LAIV_Procedure();
+		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		bool? k_(Procedure InfluenzaAdministration)
+		{
+			var ac_ = this.Date_of_Second_Birthday();
+			var ae_ = context.Operators.Interval(ac_, ac_, true, true);
+			var af_ = FHIRHelpers_4_3_000.ToValue(InfluenzaAdministration?.Performed);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
+			var ai_ = context.Operators.IntervalIncludesInterval<CqlDate>(ae_, ah_, "day");
+
+			return ai_;
+		};
+		var l_ = context.Operators.WhereOrNull<Procedure>(j_, k_);
+		CqlDate m_(Procedure InfluenzaAdministration)
+		{
+			var aj_ = FHIRHelpers_4_3_000.ToValue(InfluenzaAdministration?.Performed);
+			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			var al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
+			var am_ = context.Operators.Start(al_);
+			var an_ = context.Operators.ConvertDateToDateTime(am_);
+			var ao_ = context.Operators.DateFrom(an_);
+
+			return ao_;
+		};
+		var n_ = context.Operators.SelectOrNull<Procedure, CqlDate>(l_, m_);
+		var o_ = context.Operators.ListUnion<CqlDate>(g_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("LAIV Vaccinations")]
+	public IEnumerable<CqlDate> LAIV_Vaccinations() => 
+		__LAIV_Vaccinations.Value;
+
+	private bool? Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination_Value()
+	{
+		var a_ = this.LAIV_Vaccinations();
+		var b_ = context.Operators.ExistsInList<CqlDate>(a_);
+		var c_ = this.Influenza_Immunizations_or_Procedures();
+		var d_ = context.Operators.ExistsInList<CqlDate>(c_);
+		var e_ = context.Operators.And(b_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Two Influenza Vaccinations Including One LAIV Vaccination")]
+	public bool? Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination() => 
+		__Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination.Value;
+
+	private IEnumerable<Condition> Influenza_Numerator_Inclusion_Conditions_Value()
+	{
+		var a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		var d_ = Status_1_6_000.Active_Condition(c_);
+		bool? e_(Condition InfluenzaConditions)
+		{
+			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(InfluenzaConditions);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = this.First_Two_Years();
+			var k_ = context.Operators.ElementInInterval<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Influenza Numerator Inclusion Conditions")]
+	public IEnumerable<Condition> Influenza_Numerator_Inclusion_Conditions() => 
+		__Influenza_Numerator_Inclusion_Conditions.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Four_DTaP_Vaccinations();
+		var b_ = context.Operators.ExistsInList<CqlDate>(a_);
+		var c_ = this.DTaP_Numerator_Inclusion_Conditions();
+		var d_ = context.Operators.ExistsInList<Condition>(c_);
+		var e_ = context.Operators.Or(b_, d_);
+		var f_ = this.Three_Polio_Vaccinations();
+		var g_ = context.Operators.ExistsInList<CqlDate>(f_);
+		var h_ = this.Polio_Numerator_Inclusion_Conditions();
+		var i_ = context.Operators.ExistsInList<Condition>(h_);
+		var j_ = context.Operators.Or(g_, i_);
+		var k_ = context.Operators.And(e_, j_);
+		var l_ = this.One_MMR_Vaccination();
+		var m_ = context.Operators.ExistsInList<object>(l_);
+		var n_ = this.MMR_Numerator_Inclusion_Conditions();
+		var o_ = context.Operators.ExistsInList<Condition>(n_);
+		var p_ = context.Operators.Or(m_, o_);
+		var q_ = this.Measles_Indicators();
+		var r_ = context.Operators.ExistsInList<Condition>(q_);
+		var s_ = this.Mumps_Indicators();
+		var t_ = context.Operators.ExistsInList<Condition>(s_);
+		var u_ = context.Operators.And(r_, t_);
+		var v_ = this.Rubella_Indicators();
+		var w_ = context.Operators.ExistsInList<Condition>(v_);
+		var x_ = context.Operators.And(u_, w_);
+		var y_ = context.Operators.Or(p_, x_);
+		var z_ = context.Operators.And(k_, y_);
+		var aa_ = this.Has_Appropriate_Number_of_Hib_Immunizations();
+		var ab_ = this.Hib_Numerator_Inclusion_Conditions();
+		var ac_ = context.Operators.ExistsInList<Condition>(ab_);
+		var ad_ = context.Operators.Or(aa_, ac_);
+		var ae_ = context.Operators.And(z_, ad_);
+		var af_ = this.Three_Hepatitis_B_Vaccinations();
+		var ag_ = context.Operators.ExistsInList<CqlDate>(af_);
+		var ah_ = this.Meets_HepB_Vaccination_Requirement();
+		var ai_ = context.Operators.ExistsInList<CqlDate>(ah_);
+		var aj_ = this.Hepatitis_B_Numerator_Inclusion_Conditions();
+		var ak_ = context.Operators.ExistsInList<Condition>(aj_);
+		var al_ = context.Operators.Or(ai_, ak_);
+		var am_ = context.Operators.Or(ag_, al_);
+		var an_ = context.Operators.And(ae_, am_);
+		var ao_ = this.One_Chicken_Pox_Vaccination();
+		var ap_ = context.Operators.ExistsInList<object>(ao_);
+		var aq_ = this.Varicella_Zoster_Numerator_Inclusion_Conditions();
+		var ar_ = context.Operators.ExistsInList<Condition>(aq_);
+		var as_ = context.Operators.Or(ap_, ar_);
+		var at_ = context.Operators.And(an_, as_);
+		var au_ = this.Four_Pneumococcal_Conjugate_Vaccinations();
+		var av_ = context.Operators.ExistsInList<CqlDate>(au_);
+		var aw_ = this.Pneumococcal_Conjugate_Numerator_Inclusion_Conditions();
+		var ax_ = context.Operators.ExistsInList<Condition>(aw_);
+		var ay_ = context.Operators.Or(av_, ax_);
+		var az_ = context.Operators.And(at_, ay_);
+		var ba_ = this.One_Hepatitis_A_Vaccinations();
+		var bb_ = context.Operators.ExistsInList<object>(ba_);
+		var bc_ = this.Hepatitis_A_Numerator_Inclusion_Conditions();
+		var bd_ = context.Operators.ExistsInList<Condition>(bc_);
+		var be_ = context.Operators.Or(bb_, bd_);
+		var bf_ = context.Operators.And(az_, be_);
+		var bg_ = this.Has_Appropriate_Number_of_Rotavirus_Immunizations();
+		var bh_ = this.Rotavirus_Numerator_Inclusion_Conditions();
+		var bi_ = context.Operators.ExistsInList<Condition>(bh_);
+		var bj_ = context.Operators.Or(bg_, bi_);
+		var bk_ = context.Operators.And(bf_, bj_);
+		var bl_ = this.Two_Influenza_Vaccinations();
+		var bm_ = context.Operators.ExistsInList<CqlDate>(bl_);
+		var bn_ = this.Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination();
+		var bo_ = context.Operators.Or(bm_, bn_);
+		var bp_ = this.Influenza_Numerator_Inclusion_Conditions();
+		var bq_ = context.Operators.ExistsInList<Condition>(bp_);
+		var br_ = context.Operators.Or(bo_, bq_);
+		var bs_ = context.Operators.And(bk_, br_);
+
+		return bs_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
+++ b/Demo/Measures-cms/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
@@ -1,0 +1,355 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("ChildrenWhoHaveDentalDecayOrCavitiesFHIR", "0.0.001")]
+public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Clinical_Oral_Evaluation;
+    internal Lazy<CqlValueSet> __Dental_Caries;
+    internal Lazy<CqlValueSet> __Discharged_to_Health_Care_Facility_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Discharged_to_Home_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Hospice_care_ambulatory;
+    internal Lazy<CqlCode> __Discharge_to_healthcare_facility_for_hospice_care__procedure_;
+    internal Lazy<CqlCode> __Discharge_to_home_for_hospice_care__procedure_;
+    internal Lazy<CqlCode> __Hospice_care__Minimum_Data_Set_;
+    internal Lazy<CqlCode> __Yes__qualifier_value_;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+
+        __Clinical_Oral_Evaluation = new Lazy<CqlValueSet>(this.Clinical_Oral_Evaluation_Value);
+        __Dental_Caries = new Lazy<CqlValueSet>(this.Dental_Caries_Value);
+        __Discharged_to_Health_Care_Facility_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Health_Care_Facility_for_Hospice_Care_Value);
+        __Discharged_to_Home_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Home_for_Hospice_Care_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Hospice_care_ambulatory = new Lazy<CqlValueSet>(this.Hospice_care_ambulatory_Value);
+        __Discharge_to_healthcare_facility_for_hospice_care__procedure_ = new Lazy<CqlCode>(this.Discharge_to_healthcare_facility_for_hospice_care__procedure__Value);
+        __Discharge_to_home_for_hospice_care__procedure_ = new Lazy<CqlCode>(this.Discharge_to_home_for_hospice_care__procedure__Value);
+        __Hospice_care__Minimum_Data_Set_ = new Lazy<CqlCode>(this.Hospice_care__Minimum_Data_Set__Value);
+        __Yes__qualifier_value_ = new Lazy<CqlCode>(this.Yes__qualifier_value__Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", null);
+
+    [CqlDeclaration("Clinical Oral Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
+	public CqlValueSet Clinical_Oral_Evaluation() => 
+		__Clinical_Oral_Evaluation.Value;
+
+	private CqlValueSet Dental_Caries_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004", null);
+
+    [CqlDeclaration("Dental Caries")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004")]
+	public CqlValueSet Dental_Caries() => 
+		__Dental_Caries.Value;
+
+	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+
+    [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
+	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
+		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
+
+	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+
+    [CqlDeclaration("Discharged to Home for Hospice Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
+	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
+		__Discharged_to_Home_for_Hospice_Care.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Hospice_care_ambulatory_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+
+    [CqlDeclaration("Hospice care ambulatory")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
+	public CqlValueSet Hospice_care_ambulatory() => 
+		__Hospice_care_ambulatory.Value;
+
+	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
+		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
+	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
+		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
+
+	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
+		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Discharge to home for hospice care (procedure)")]
+	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
+		__Discharge_to_home_for_hospice_care__procedure_.Value;
+
+	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
+		new CqlCode("45755-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Hospice care [Minimum Data Set]")]
+	public CqlCode Hospice_care__Minimum_Data_Set_() => 
+		__Hospice_care__Minimum_Data_Set_.Value;
+
+	private CqlCode Yes__qualifier_value__Value() => 
+		new CqlCode("373066001", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Yes (qualifier value)")]
+	public CqlCode Yes__qualifier_value_() => 
+		__Yes__qualifier_value_.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("45755-6", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
+			new CqlCode("428361000124107", "http://snomed.info/sct", null, null),
+			new CqlCode("373066001", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value()
+	{
+		var a_ = this.Clinical_Oral_Evaluation();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = Status_1_6_000.isEncounterPerformed(b_);
+		bool? d_(Encounter ValidEncounter)
+		{
+			var f_ = this.Measurement_Period();
+			var g_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, g_, "day");
+
+			return h_;
+		};
+		var e_ = context.Operators.WhereOrNull<Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)1, (int?)20, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var i_ = this.Qualifying_Encounters();
+		var j_ = context.Operators.ExistsInList<Encounter>(i_);
+		var k_ = context.Operators.And(h_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Dental_Caries();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition DentalCaries)
+		{
+			var f_ = QICoreCommon_2_0_000.prevalenceInterval(DentalCaries);
+			var g_ = this.Measurement_Period();
+			var h_ = context.Operators.Overlaps(f_, g_, null);
+
+			return h_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
@@ -1,0 +1,988 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("ChlamydiaScreeninginWomenFHIR", "0.1.000")]
+public class ChlamydiaScreeninginWomenFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Chlamydia_Screening;
+    internal Lazy<CqlValueSet> __Complications_of_Pregnancy__Childbirth_and_the_Puerperium;
+    internal Lazy<CqlValueSet> __Contraceptive_Medications;
+    internal Lazy<CqlValueSet> __Diagnoses_Used_to_Indicate_Sexual_Activity;
+    internal Lazy<CqlValueSet> __Diagnostic_Studies_During_Pregnancy;
+    internal Lazy<CqlValueSet> __HIV;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Isotretinoin;
+    internal Lazy<CqlValueSet> __Lab_Tests_During_Pregnancy;
+    internal Lazy<CqlValueSet> __Lab_Tests_for_Sexually_Transmitted_Infections;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Pap_Test;
+    internal Lazy<CqlValueSet> __Pregnancy_Test;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care__Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Procedures_Used_to_Indicate_Sexual_Activity;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __XRay_Study;
+    internal Lazy<CqlCode> __Female;
+    internal Lazy<CqlCode> __Have_you_ever_had_vaginal_intercourse__PhenX_;
+    internal Lazy<CqlCode> __Yes__qualifier_value_;
+    internal Lazy<CqlCode[]> __AdministrativeGender;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<bool?> __Has_Assessments_Identifying_Sexual_Activity;
+    internal Lazy<bool?> __Has_Diagnoses_Identifying_Sexual_Activity;
+    internal Lazy<bool?> __Has_Active_Contraceptive_Medications;
+    internal Lazy<bool?> __Has_Ordered_Contraceptive_Medications;
+    internal Lazy<bool?> __Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy;
+    internal Lazy<bool?> __Has_Laboratory_Tests_Identifying_Sexual_Activity;
+    internal Lazy<bool?> __Has_Diagnostic_Studies_Identifying_Sexual_Activity;
+    internal Lazy<bool?> __Has_Procedures_Identifying_Sexual_Activity;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Has_Pregnancy_Test_Exclusion;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Stratification_1;
+    internal Lazy<bool?> __Stratification_2;
+
+    #endregion
+    public ChlamydiaScreeninginWomenFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        CumulativeMedicationDuration_4_0_000 = new CumulativeMedicationDuration_4_0_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+
+        __Chlamydia_Screening = new Lazy<CqlValueSet>(this.Chlamydia_Screening_Value);
+        __Complications_of_Pregnancy__Childbirth_and_the_Puerperium = new Lazy<CqlValueSet>(this.Complications_of_Pregnancy__Childbirth_and_the_Puerperium_Value);
+        __Contraceptive_Medications = new Lazy<CqlValueSet>(this.Contraceptive_Medications_Value);
+        __Diagnoses_Used_to_Indicate_Sexual_Activity = new Lazy<CqlValueSet>(this.Diagnoses_Used_to_Indicate_Sexual_Activity_Value);
+        __Diagnostic_Studies_During_Pregnancy = new Lazy<CqlValueSet>(this.Diagnostic_Studies_During_Pregnancy_Value);
+        __HIV = new Lazy<CqlValueSet>(this.HIV_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Isotretinoin = new Lazy<CqlValueSet>(this.Isotretinoin_Value);
+        __Lab_Tests_During_Pregnancy = new Lazy<CqlValueSet>(this.Lab_Tests_During_Pregnancy_Value);
+        __Lab_Tests_for_Sexually_Transmitted_Infections = new Lazy<CqlValueSet>(this.Lab_Tests_for_Sexually_Transmitted_Infections_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Pap_Test = new Lazy<CqlValueSet>(this.Pap_Test_Value);
+        __Pregnancy_Test = new Lazy<CqlValueSet>(this.Pregnancy_Test_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value);
+        __Preventive_Care__Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Established_Office_Visit__0_to_17_Value);
+        __Procedures_Used_to_Indicate_Sexual_Activity = new Lazy<CqlValueSet>(this.Procedures_Used_to_Indicate_Sexual_Activity_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __XRay_Study = new Lazy<CqlValueSet>(this.XRay_Study_Value);
+        __Female = new Lazy<CqlCode>(this.Female_Value);
+        __Have_you_ever_had_vaginal_intercourse__PhenX_ = new Lazy<CqlCode>(this.Have_you_ever_had_vaginal_intercourse__PhenX__Value);
+        __Yes__qualifier_value_ = new Lazy<CqlCode>(this.Yes__qualifier_value__Value);
+        __AdministrativeGender = new Lazy<CqlCode[]>(this.AdministrativeGender_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value);
+        __Has_Assessments_Identifying_Sexual_Activity = new Lazy<bool?>(this.Has_Assessments_Identifying_Sexual_Activity_Value);
+        __Has_Diagnoses_Identifying_Sexual_Activity = new Lazy<bool?>(this.Has_Diagnoses_Identifying_Sexual_Activity_Value);
+        __Has_Active_Contraceptive_Medications = new Lazy<bool?>(this.Has_Active_Contraceptive_Medications_Value);
+        __Has_Ordered_Contraceptive_Medications = new Lazy<bool?>(this.Has_Ordered_Contraceptive_Medications_Value);
+        __Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy = new Lazy<bool?>(this.Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy_Value);
+        __Has_Laboratory_Tests_Identifying_Sexual_Activity = new Lazy<bool?>(this.Has_Laboratory_Tests_Identifying_Sexual_Activity_Value);
+        __Has_Diagnostic_Studies_Identifying_Sexual_Activity = new Lazy<bool?>(this.Has_Diagnostic_Studies_Identifying_Sexual_Activity_Value);
+        __Has_Procedures_Identifying_Sexual_Activity = new Lazy<bool?>(this.Has_Procedures_Identifying_Sexual_Activity_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Has_Pregnancy_Test_Exclusion = new Lazy<bool?>(this.Has_Pregnancy_Test_Exclusion_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __Stratification_1 = new Lazy<bool?>(this.Stratification_1_Value);
+        __Stratification_2 = new Lazy<bool?>(this.Stratification_2_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public CumulativeMedicationDuration_4_0_000 CumulativeMedicationDuration_4_0_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Chlamydia_Screening_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052", null);
+
+    [CqlDeclaration("Chlamydia Screening")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052")]
+	public CqlValueSet Chlamydia_Screening() => 
+		__Chlamydia_Screening.Value;
+
+	private CqlValueSet Complications_of_Pregnancy__Childbirth_and_the_Puerperium_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012", null);
+
+    [CqlDeclaration("Complications of Pregnancy, Childbirth and the Puerperium")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012")]
+	public CqlValueSet Complications_of_Pregnancy__Childbirth_and_the_Puerperium() => 
+		__Complications_of_Pregnancy__Childbirth_and_the_Puerperium.Value;
+
+	private CqlValueSet Contraceptive_Medications_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080", null);
+
+    [CqlDeclaration("Contraceptive Medications")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080")]
+	public CqlValueSet Contraceptive_Medications() => 
+		__Contraceptive_Medications.Value;
+
+	private CqlValueSet Diagnoses_Used_to_Indicate_Sexual_Activity_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018", null);
+
+    [CqlDeclaration("Diagnoses Used to Indicate Sexual Activity")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018")]
+	public CqlValueSet Diagnoses_Used_to_Indicate_Sexual_Activity() => 
+		__Diagnoses_Used_to_Indicate_Sexual_Activity.Value;
+
+	private CqlValueSet Diagnostic_Studies_During_Pregnancy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008", null);
+
+    [CqlDeclaration("Diagnostic Studies During Pregnancy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008")]
+	public CqlValueSet Diagnostic_Studies_During_Pregnancy() => 
+		__Diagnostic_Studies_During_Pregnancy.Value;
+
+	private CqlValueSet HIV_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+
+    [CqlDeclaration("HIV")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
+	public CqlValueSet HIV() => 
+		__HIV.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Isotretinoin_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143", null);
+
+    [CqlDeclaration("Isotretinoin")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143")]
+	public CqlValueSet Isotretinoin() => 
+		__Isotretinoin.Value;
+
+	private CqlValueSet Lab_Tests_During_Pregnancy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007", null);
+
+    [CqlDeclaration("Lab Tests During Pregnancy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007")]
+	public CqlValueSet Lab_Tests_During_Pregnancy() => 
+		__Lab_Tests_During_Pregnancy.Value;
+
+	private CqlValueSet Lab_Tests_for_Sexually_Transmitted_Infections_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051", null);
+
+    [CqlDeclaration("Lab Tests for Sexually Transmitted Infections")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051")]
+	public CqlValueSet Lab_Tests_for_Sexually_Transmitted_Infections() => 
+		__Lab_Tests_for_Sexually_Transmitted_Infections.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Pap_Test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", null);
+
+    [CqlDeclaration("Pap Test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
+	public CqlValueSet Pap_Test() => 
+		__Pap_Test.Value;
+
+	private CqlValueSet Pregnancy_Test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011", null);
+
+    [CqlDeclaration("Pregnancy Test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011")]
+	public CqlValueSet Pregnancy_Test() => 
+		__Pregnancy_Test.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+
+    [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
+	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+
+    [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
+	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
+		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Procedures_Used_to_Indicate_Sexual_Activity_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017", null);
+
+    [CqlDeclaration("Procedures Used to Indicate Sexual Activity")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017")]
+	public CqlValueSet Procedures_Used_to_Indicate_Sexual_Activity() => 
+		__Procedures_Used_to_Indicate_Sexual_Activity.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlValueSet XRay_Study_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034", null);
+
+    [CqlDeclaration("XRay Study")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034")]
+	public CqlValueSet XRay_Study() => 
+		__XRay_Study.Value;
+
+	private CqlCode Female_Value() => 
+		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null);
+
+    [CqlDeclaration("Female")]
+	public CqlCode Female() => 
+		__Female.Value;
+
+	private CqlCode Have_you_ever_had_vaginal_intercourse__PhenX__Value() => 
+		new CqlCode("64728-9", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Have you ever had vaginal intercourse [PhenX]")]
+	public CqlCode Have_you_ever_had_vaginal_intercourse__PhenX_() => 
+		__Have_you_ever_had_vaginal_intercourse__PhenX_.Value;
+
+	private CqlCode Yes__qualifier_value__Value() => 
+		new CqlCode("373066001", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Yes (qualifier value)")]
+	public CqlCode Yes__qualifier_value_() => 
+		__Yes__qualifier_value_.Value;
+
+	private CqlCode[] AdministrativeGender_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("AdministrativeGender")]
+	public CqlCode[] AdministrativeGender() => 
+		__AdministrativeGender.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("64728-9", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("373066001", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("ChlamydiaScreeninginWomenFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Home_Healthcare_Services();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Telephone_Visits();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = this.Online_Assessments();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
+		var x_ = Status_1_6_000.Finished_Encounter(w_);
+		bool? y_(Encounter ValidEncounters)
+		{
+			var aa_ = this.Measurement_Period();
+			var ab_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounters?.Period);
+			var ac_ = QICoreCommon_2_0_000.ToInterval((ab_ as object));
+			var ad_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aa_, ac_, "day");
+
+			return ad_;
+		};
+		var z_ = context.Operators.WhereOrNull<Encounter>(x_, y_);
+
+		return z_;
+	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters.Value;
+
+	private bool? Has_Assessments_Identifying_Sexual_Activity_Value()
+	{
+		var a_ = this.Have_you_ever_had_vaginal_intercourse__PhenX_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		bool? e_(Observation SexualActivityAssessment)
+		{
+			var h_ = FHIRHelpers_4_3_000.ToValue(SexualActivityAssessment?.Value);
+			var i_ = this.Yes__qualifier_value_();
+			var j_ = context.Operators.ConvertCodeToConcept(i_);
+			var k_ = context.Operators.Equivalent((h_ as CqlConcept), j_);
+			var l_ = FHIRHelpers_4_3_000.ToValue(SexualActivityAssessment?.Effective);
+			var m_ = QICoreCommon_2_0_000.ToInterval(l_);
+			CqlInterval<CqlDateTime> n_()
+			{
+				if ((context.Operators.End(this.Measurement_Period()) is null))
+				{
+					return null;
+				}
+				else
+				{
+					var q_ = this.Measurement_Period();
+					var r_ = context.Operators.End(q_);
+					var t_ = context.Operators.End(q_);
+					var u_ = context.Operators.Interval(r_, t_, true, true);
+
+					return u_;
+				};
+			};
+			var o_ = context.Operators.IntervalSameOrBefore(m_, n_(), null);
+			var p_ = context.Operators.And(k_, o_);
+
+			return p_;
+		};
+		var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+		var g_ = context.Operators.ExistsInList<Observation>(f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Has Assessments Identifying Sexual Activity")]
+	public bool? Has_Assessments_Identifying_Sexual_Activity() => 
+		__Has_Assessments_Identifying_Sexual_Activity.Value;
+
+	private bool? Has_Diagnoses_Identifying_Sexual_Activity_Value()
+	{
+		var a_ = this.Diagnoses_Used_to_Indicate_Sexual_Activity();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = this.HIV();
+		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		var e_ = context.Operators.ListUnion<Condition>(b_, d_);
+		var f_ = this.Complications_of_Pregnancy__Childbirth_and_the_Puerperium();
+		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		var h_ = context.Operators.ListUnion<Condition>(e_, g_);
+		bool? i_(Condition SexualActivityDiagnosis)
+		{
+			var l_ = QICoreCommon_2_0_000.ToPrevalenceInterval(SexualActivityDiagnosis);
+			var m_ = this.Measurement_Period();
+			var n_ = context.Operators.Overlaps(l_, m_, null);
+
+			return n_;
+		};
+		var j_ = context.Operators.WhereOrNull<Condition>(h_, i_);
+		var k_ = context.Operators.ExistsInList<Condition>(j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Has Diagnoses Identifying Sexual Activity")]
+	public bool? Has_Diagnoses_Identifying_Sexual_Activity() => 
+		__Has_Diagnoses_Identifying_Sexual_Activity.Value;
+
+	private bool? Has_Active_Contraceptive_Medications_Value()
+	{
+		var a_ = this.Contraceptive_Medications();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = Status_1_6_000.Active_Medication(e_);
+		bool? g_(MedicationRequest ActiveContraceptives)
+		{
+			var j_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ActiveContraceptives);
+			var k_ = context.Operators.ConvertDateToDateTime(j_?.low);
+			var m_ = context.Operators.ConvertDateToDateTime(j_?.high);
+			var p_ = context.Operators.Interval(k_, m_, j_?.lowClosed, j_?.highClosed);
+			var q_ = this.Measurement_Period();
+			var r_ = context.Operators.Overlaps(p_, q_, null);
+
+			return r_;
+		};
+		var h_ = context.Operators.WhereOrNull<MedicationRequest>(f_, g_);
+		var i_ = context.Operators.ExistsInList<MedicationRequest>(h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Has Active Contraceptive Medications")]
+	public bool? Has_Active_Contraceptive_Medications() => 
+		__Has_Active_Contraceptive_Medications.Value;
+
+	private bool? Has_Ordered_Contraceptive_Medications_Value()
+	{
+		var a_ = this.Contraceptive_Medications();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
+		bool? g_(MedicationRequest OrderedContraceptives)
+		{
+			var j_ = this.Measurement_Period();
+			var k_ = context.Operators.Convert<CqlDateTime>(OrderedContraceptives?.AuthoredOnElement);
+			var l_ = QICoreCommon_2_0_000.ToInterval((k_ as object));
+			var m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, "day");
+
+			return m_;
+		};
+		var h_ = context.Operators.WhereOrNull<MedicationRequest>(f_, g_);
+		var i_ = context.Operators.ExistsInList<MedicationRequest>(h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Has Ordered Contraceptive Medications")]
+	public bool? Has_Ordered_Contraceptive_Medications() => 
+		__Has_Ordered_Contraceptive_Medications.Value;
+
+	private bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy_Value()
+	{
+		var a_ = this.Pap_Test();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var c_ = this.Lab_Tests_During_Pregnancy();
+		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
+		var e_ = context.Operators.ListUnion<ServiceRequest>(b_, d_);
+		var f_ = this.Lab_Tests_for_Sexually_Transmitted_Infections();
+		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		var h_ = context.Operators.ListUnion<ServiceRequest>(e_, g_);
+		var i_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(h_);
+		bool? j_(ServiceRequest LabOrders)
+		{
+			var m_ = this.Measurement_Period();
+			var n_ = context.Operators.Convert<CqlDateTime>(LabOrders?.AuthoredOnElement);
+			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
+
+			return p_;
+		};
+		var k_ = context.Operators.WhereOrNull<ServiceRequest>(i_, j_);
+		var l_ = context.Operators.ExistsInList<ServiceRequest>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Laboratory Tests Identifying Sexual Activity But Not Pregnancy")]
+	public bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy() => 
+		__Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy.Value;
+
+	private bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_Value()
+	{
+		var a_ = this.Pregnancy_Test();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
+		bool? d_(ServiceRequest PregnancyTest)
+		{
+			var i_ = this.Measurement_Period();
+			var j_ = context.Operators.Convert<CqlDateTime>(PregnancyTest?.AuthoredOnElement);
+			var k_ = QICoreCommon_2_0_000.ToInterval((j_ as object));
+			var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, k_, "day");
+
+			return l_;
+		};
+		var e_ = context.Operators.WhereOrNull<ServiceRequest>(c_, d_);
+		var f_ = context.Operators.ExistsInList<ServiceRequest>(e_);
+		var g_ = this.Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy();
+		var h_ = context.Operators.Or(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Has Laboratory Tests Identifying Sexual Activity")]
+	public bool? Has_Laboratory_Tests_Identifying_Sexual_Activity() => 
+		__Has_Laboratory_Tests_Identifying_Sexual_Activity.Value;
+
+	private bool? Has_Diagnostic_Studies_Identifying_Sexual_Activity_Value()
+	{
+		var a_ = this.Diagnostic_Studies_During_Pregnancy();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
+		bool? d_(ServiceRequest SexualActivityDiagnostics)
+		{
+			var g_ = this.Measurement_Period();
+			var h_ = context.Operators.Convert<CqlDateTime>(SexualActivityDiagnostics?.AuthoredOnElement);
+			var i_ = QICoreCommon_2_0_000.ToInterval((h_ as object));
+			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, "day");
+
+			return j_;
+		};
+		var e_ = context.Operators.WhereOrNull<ServiceRequest>(c_, d_);
+		var f_ = context.Operators.ExistsInList<ServiceRequest>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Diagnostic Studies Identifying Sexual Activity")]
+	public bool? Has_Diagnostic_Studies_Identifying_Sexual_Activity() => 
+		__Has_Diagnostic_Studies_Identifying_Sexual_Activity.Value;
+
+	private bool? Has_Procedures_Identifying_Sexual_Activity_Value()
+	{
+		var a_ = this.Procedures_Used_to_Indicate_Sexual_Activity();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		bool? d_(Procedure ProceduresForSexualActivity)
+		{
+			var g_ = this.Measurement_Period();
+			var h_ = FHIRHelpers_4_3_000.ToValue(ProceduresForSexualActivity?.Performed);
+			var i_ = QICoreCommon_2_0_000.ToInterval(h_);
+			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, "day");
+
+			return j_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Procedure>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Procedures Identifying Sexual Activity")]
+	public bool? Has_Procedures_Identifying_Sexual_Activity() => 
+		__Has_Procedures_Identifying_Sexual_Activity.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)16, (int?)24, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var j_ = context.Operators.EnumEqualsString(a_?.GenderElement?.Value, "female");
+		var k_ = context.Operators.And(h_, j_);
+		var l_ = this.Qualifying_Encounters();
+		var m_ = context.Operators.ExistsInList<Encounter>(l_);
+		var n_ = context.Operators.And(k_, m_);
+		var o_ = this.Has_Assessments_Identifying_Sexual_Activity();
+		var p_ = this.Has_Diagnoses_Identifying_Sexual_Activity();
+		var q_ = context.Operators.Or(o_, p_);
+		var r_ = this.Has_Active_Contraceptive_Medications();
+		var s_ = context.Operators.Or(q_, r_);
+		var t_ = this.Has_Ordered_Contraceptive_Medications();
+		var u_ = context.Operators.Or(s_, t_);
+		var v_ = this.Has_Laboratory_Tests_Identifying_Sexual_Activity();
+		var w_ = context.Operators.Or(u_, v_);
+		var x_ = this.Has_Diagnostic_Studies_Identifying_Sexual_Activity();
+		var y_ = context.Operators.Or(w_, x_);
+		var z_ = this.Has_Procedures_Identifying_Sexual_Activity();
+		var aa_ = context.Operators.Or(y_, z_);
+		var ab_ = context.Operators.And(n_, aa_);
+
+		return ab_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Has_Pregnancy_Test_Exclusion_Value()
+	{
+		var a_ = this.Pregnancy_Test();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
+		IEnumerable<ServiceRequest> d_(ServiceRequest PregnancyTest)
+		{
+			var m_ = this.XRay_Study();
+			var n_ = context.Operators.RetrieveByValueSet<ServiceRequest>(m_, null);
+			var o_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(n_);
+			bool? p_(ServiceRequest XrayOrder)
+			{
+				var t_ = context.Operators.Convert<CqlDateTime>(XrayOrder?.AuthoredOnElement);
+				var u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
+				var v_ = context.Operators.Start(u_);
+				var w_ = context.Operators.Convert<CqlDateTime>(PregnancyTest?.AuthoredOnElement);
+				var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+				var y_ = context.Operators.End(x_);
+				var aa_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+				var ab_ = context.Operators.End(aa_);
+				var ac_ = context.Operators.Quantity(6m, "days");
+				var ad_ = context.Operators.Add(ab_, ac_);
+				var ae_ = context.Operators.Interval(y_, ad_, true, true);
+				var af_ = context.Operators.ElementInInterval<CqlDateTime>(v_, ae_, "day");
+				var ah_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+				var ai_ = context.Operators.End(ah_);
+				var aj_ = context.Operators.Not((bool?)(ai_ is null));
+				var ak_ = context.Operators.And(af_, aj_);
+				var al_ = this.Measurement_Period();
+				var an_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+				var ao_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(al_, an_, null);
+				var ap_ = context.Operators.And(ak_, ao_);
+
+				return ap_;
+			};
+			var q_ = context.Operators.WhereOrNull<ServiceRequest>(o_, p_);
+			ServiceRequest r_(ServiceRequest XrayOrder) => 
+				PregnancyTest;
+			var s_ = context.Operators.SelectOrNull<ServiceRequest, ServiceRequest>(q_, r_);
+
+			return s_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<ServiceRequest, ServiceRequest>(c_, d_);
+		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var h_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(g_);
+		IEnumerable<ServiceRequest> i_(ServiceRequest PregnancyTestOrder)
+		{
+			var aq_ = this.Isotretinoin();
+			var ar_ = context.Operators.RetrieveByValueSet<MedicationRequest>(aq_, null);
+			var at_ = context.Operators.RetrieveByValueSet<MedicationRequest>(aq_, null);
+			var au_ = context.Operators.ListUnion<MedicationRequest>(ar_, at_);
+			var av_ = Status_1_6_000.Active_or_Completed_Medication_Request(au_);
+			bool? aw_(MedicationRequest AccutaneOrder)
+			{
+				var ba_ = context.Operators.Convert<CqlDateTime>(AccutaneOrder?.AuthoredOnElement);
+				var bb_ = QICoreCommon_2_0_000.ToInterval((ba_ as object));
+				var bc_ = context.Operators.Start(bb_);
+				var bd_ = context.Operators.Convert<CqlDateTime>(PregnancyTestOrder?.AuthoredOnElement);
+				var be_ = QICoreCommon_2_0_000.ToInterval((bd_ as object));
+				var bf_ = context.Operators.End(be_);
+				var bh_ = QICoreCommon_2_0_000.ToInterval((bd_ as object));
+				var bi_ = context.Operators.End(bh_);
+				var bj_ = context.Operators.Quantity(6m, "days");
+				var bk_ = context.Operators.Add(bi_, bj_);
+				var bl_ = context.Operators.Interval(bf_, bk_, true, true);
+				var bm_ = context.Operators.ElementInInterval<CqlDateTime>(bc_, bl_, "day");
+				var bo_ = QICoreCommon_2_0_000.ToInterval((bd_ as object));
+				var bp_ = context.Operators.End(bo_);
+				var bq_ = context.Operators.Not((bool?)(bp_ is null));
+				var br_ = context.Operators.And(bm_, bq_);
+				var bs_ = this.Measurement_Period();
+				var bu_ = QICoreCommon_2_0_000.ToInterval((bd_ as object));
+				var bv_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bs_, bu_, null);
+				var bw_ = context.Operators.And(br_, bv_);
+
+				return bw_;
+			};
+			var ax_ = context.Operators.WhereOrNull<MedicationRequest>(av_, aw_);
+			ServiceRequest ay_(MedicationRequest AccutaneOrder) => 
+				PregnancyTestOrder;
+			var az_ = context.Operators.SelectOrNull<MedicationRequest, ServiceRequest>(ax_, ay_);
+
+			return az_;
+		};
+		var j_ = context.Operators.SelectManyOrNull<ServiceRequest, ServiceRequest>(h_, i_);
+		var k_ = context.Operators.ListUnion<ServiceRequest>(e_, j_);
+		var l_ = context.Operators.ExistsInList<ServiceRequest>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Pregnancy Test Exclusion")]
+	public bool? Has_Pregnancy_Test_Exclusion() => 
+		__Has_Pregnancy_Test_Exclusion.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = this.Has_Pregnancy_Test_Exclusion();
+		var c_ = this.Has_Assessments_Identifying_Sexual_Activity();
+		var d_ = context.Operators.Not(c_);
+		var e_ = context.Operators.And(b_, d_);
+		var f_ = this.Has_Diagnoses_Identifying_Sexual_Activity();
+		var g_ = context.Operators.Not(f_);
+		var h_ = context.Operators.And(e_, g_);
+		var i_ = this.Has_Active_Contraceptive_Medications();
+		var j_ = context.Operators.Not(i_);
+		var k_ = context.Operators.And(h_, j_);
+		var l_ = this.Has_Ordered_Contraceptive_Medications();
+		var m_ = context.Operators.Not(l_);
+		var n_ = context.Operators.And(k_, m_);
+		var o_ = this.Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy();
+		var p_ = context.Operators.Not(o_);
+		var q_ = context.Operators.And(n_, p_);
+		var r_ = this.Has_Diagnostic_Studies_Identifying_Sexual_Activity();
+		var s_ = context.Operators.Not(r_);
+		var t_ = context.Operators.And(q_, s_);
+		var u_ = this.Has_Procedures_Identifying_Sexual_Activity();
+		var v_ = context.Operators.Not(u_);
+		var w_ = context.Operators.And(t_, v_);
+		var x_ = context.Operators.Or(a_, w_);
+
+		return x_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Chlamydia_Screening();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.Final_Lab_Observation(b_);
+		bool? d_(Observation ChlamydiaTest)
+		{
+			object g_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(ChlamydiaTest?.Effective) is CqlDateTime)
+				{
+					var n_ = FHIRHelpers_4_3_000.ToValue(ChlamydiaTest?.Effective);
+
+					return ((n_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(ChlamydiaTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var o_ = FHIRHelpers_4_3_000.ToValue(ChlamydiaTest?.Effective);
+
+					return ((o_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(ChlamydiaTest?.Effective) is CqlDateTime)
+				{
+					var p_ = FHIRHelpers_4_3_000.ToValue(ChlamydiaTest?.Effective);
+
+					return ((p_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var h_ = QICoreCommon_2_0_000.Latest(g_());
+			var i_ = this.Measurement_Period();
+			var j_ = context.Operators.ElementInInterval<CqlDateTime>(h_, i_, "day");
+			var k_ = FHIRHelpers_4_3_000.ToValue(ChlamydiaTest?.Value);
+			var l_ = context.Operators.Not((bool?)(k_ is null));
+			var m_ = context.Operators.And(j_, l_);
+
+			return m_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Observation>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private bool? Stratification_1_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)16, (int?)20, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Stratification 1")]
+	public bool? Stratification_1() => 
+		__Stratification_1.Value;
+
+	private bool? Stratification_2_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)21, (int?)24, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Stratification 2")]
+	public bool? Stratification_2() => 
+		__Stratification_2.Value;
+
+}

--- a/Demo/Measures-cms/ColonCancerScreeningFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/ColonCancerScreeningFHIR-0.1.000.g.cs
@@ -1,0 +1,588 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("ColonCancerScreeningFHIR", "0.1.000")]
+public class ColonCancerScreeningFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Colonoscopy;
+    internal Lazy<CqlValueSet> __CT_Colonography;
+    internal Lazy<CqlValueSet> __Fecal_Occult_Blood_Test__FOBT_;
+    internal Lazy<CqlValueSet> __sDNA_FIT_Test;
+    internal Lazy<CqlValueSet> __Flexible_Sigmoidoscopy;
+    internal Lazy<CqlValueSet> __Malignant_Neoplasm_of_Colon;
+    internal Lazy<CqlValueSet> __Total_Colectomy;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Condition>> __Malignant_Neoplasm;
+    internal Lazy<IEnumerable<Procedure>> __Total_Colectomy_Performed;
+    internal Lazy<bool?> __Denominator_Exclusion;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Occult_Blood_Test_Performed;
+    internal Lazy<IEnumerable<Observation>> __Stool_DNA_with_FIT_Test_Performed;
+    internal Lazy<IEnumerable<Procedure>> __Flexible_Sigmoidoscopy_Performed;
+    internal Lazy<IEnumerable<Observation>> __CT_Colonography_Performed;
+    internal Lazy<IEnumerable<Procedure>> __Colonoscopy_Performed;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Stratification_1;
+    internal Lazy<bool?> __Stratification_2;
+
+    #endregion
+    public ColonCancerScreeningFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        PalliativeCare_1_9_000 = new PalliativeCare_1_9_000(context);
+        AdultOutpatientEncounters_4_8_000 = new AdultOutpatientEncounters_4_8_000(context);
+        AdvancedIllnessandFrailty_1_8_000 = new AdvancedIllnessandFrailty_1_8_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Colonoscopy = new Lazy<CqlValueSet>(this.Colonoscopy_Value);
+        __CT_Colonography = new Lazy<CqlValueSet>(this.CT_Colonography_Value);
+        __Fecal_Occult_Blood_Test__FOBT_ = new Lazy<CqlValueSet>(this.Fecal_Occult_Blood_Test__FOBT__Value);
+        __sDNA_FIT_Test = new Lazy<CqlValueSet>(this.sDNA_FIT_Test_Value);
+        __Flexible_Sigmoidoscopy = new Lazy<CqlValueSet>(this.Flexible_Sigmoidoscopy_Value);
+        __Malignant_Neoplasm_of_Colon = new Lazy<CqlValueSet>(this.Malignant_Neoplasm_of_Colon_Value);
+        __Total_Colectomy = new Lazy<CqlValueSet>(this.Total_Colectomy_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Malignant_Neoplasm = new Lazy<IEnumerable<Condition>>(this.Malignant_Neoplasm_Value);
+        __Total_Colectomy_Performed = new Lazy<IEnumerable<Procedure>>(this.Total_Colectomy_Performed_Value);
+        __Denominator_Exclusion = new Lazy<bool?>(this.Denominator_Exclusion_Value);
+        __Fecal_Occult_Blood_Test_Performed = new Lazy<IEnumerable<Observation>>(this.Fecal_Occult_Blood_Test_Performed_Value);
+        __Stool_DNA_with_FIT_Test_Performed = new Lazy<IEnumerable<Observation>>(this.Stool_DNA_with_FIT_Test_Performed_Value);
+        __Flexible_Sigmoidoscopy_Performed = new Lazy<IEnumerable<Procedure>>(this.Flexible_Sigmoidoscopy_Performed_Value);
+        __CT_Colonography_Performed = new Lazy<IEnumerable<Observation>>(this.CT_Colonography_Performed_Value);
+        __Colonoscopy_Performed = new Lazy<IEnumerable<Procedure>>(this.Colonoscopy_Performed_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __Stratification_1 = new Lazy<bool?>(this.Stratification_1_Value);
+        __Stratification_2 = new Lazy<bool?>(this.Stratification_2_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public PalliativeCare_1_9_000 PalliativeCare_1_9_000 { get; }
+    public AdultOutpatientEncounters_4_8_000 AdultOutpatientEncounters_4_8_000 { get; }
+    public AdvancedIllnessandFrailty_1_8_000 AdvancedIllnessandFrailty_1_8_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Colonoscopy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", null);
+
+    [CqlDeclaration("Colonoscopy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
+	public CqlValueSet Colonoscopy() => 
+		__Colonoscopy.Value;
+
+	private CqlValueSet CT_Colonography_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", null);
+
+    [CqlDeclaration("CT Colonography")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
+	public CqlValueSet CT_Colonography() => 
+		__CT_Colonography.Value;
+
+	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", null);
+
+    [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
+	public CqlValueSet Fecal_Occult_Blood_Test__FOBT_() => 
+		__Fecal_Occult_Blood_Test__FOBT_.Value;
+
+	private CqlValueSet sDNA_FIT_Test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", null);
+
+    [CqlDeclaration("sDNA FIT Test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
+	public CqlValueSet sDNA_FIT_Test() => 
+		__sDNA_FIT_Test.Value;
+
+	private CqlValueSet Flexible_Sigmoidoscopy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", null);
+
+    [CqlDeclaration("Flexible Sigmoidoscopy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
+	public CqlValueSet Flexible_Sigmoidoscopy() => 
+		__Flexible_Sigmoidoscopy.Value;
+
+	private CqlValueSet Malignant_Neoplasm_of_Colon_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", null);
+
+    [CqlDeclaration("Malignant Neoplasm of Colon")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
+	public CqlValueSet Malignant_Neoplasm_of_Colon() => 
+		__Malignant_Neoplasm_of_Colon.Value;
+
+	private CqlValueSet Total_Colectomy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", null);
+
+    [CqlDeclaration("Total Colectomy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
+	public CqlValueSet Total_Colectomy() => 
+		__Total_Colectomy.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("ColonCancerScreeningFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)46, (int?)75, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var i_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
+		var j_ = context.Operators.ExistsInList<Encounter>(i_);
+		var k_ = context.Operators.And(h_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Condition> Malignant_Neoplasm_Value()
+	{
+		var a_ = this.Malignant_Neoplasm_of_Colon();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition ColorectalCancer)
+		{
+			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(ColorectalCancer);
+			var g_ = context.Operators.Start(f_);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.End(h_);
+			var j_ = context.Operators.SameOrBefore(g_, i_, "day");
+
+			return j_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Malignant Neoplasm")]
+	public IEnumerable<Condition> Malignant_Neoplasm() => 
+		__Malignant_Neoplasm.Value;
+
+	private IEnumerable<Procedure> Total_Colectomy_Performed_Value()
+	{
+		var a_ = this.Total_Colectomy();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		bool? d_(Procedure Colectomy)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToValue(Colectomy?.Performed);
+			var g_ = QICoreCommon_2_0_000.ToInterval(f_);
+			var h_ = context.Operators.End(g_);
+			var i_ = this.Measurement_Period();
+			var j_ = context.Operators.End(i_);
+			var k_ = context.Operators.SameOrBefore(h_, j_, "day");
+
+			return k_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Total Colectomy Performed")]
+	public IEnumerable<Procedure> Total_Colectomy_Performed() => 
+		__Total_Colectomy_Performed.Value;
+
+	private bool? Denominator_Exclusion_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = this.Malignant_Neoplasm();
+		var c_ = context.Operators.ExistsInList<Condition>(b_);
+		var d_ = context.Operators.Or(a_, c_);
+		var e_ = this.Total_Colectomy_Performed();
+		var f_ = context.Operators.ExistsInList<Procedure>(e_);
+		var g_ = context.Operators.Or(d_, f_);
+		var h_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty();
+		var i_ = context.Operators.Or(g_, h_);
+		var j_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home();
+		var k_ = context.Operators.Or(i_, j_);
+		var l_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		var m_ = context.Operators.Or(k_, l_);
+
+		return m_;
+	}
+
+    [CqlDeclaration("Denominator Exclusion")]
+	public bool? Denominator_Exclusion() => 
+		__Denominator_Exclusion.Value;
+
+	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value()
+	{
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.Final_Lab_Observation(b_);
+		bool? d_(Observation FecalOccultResult)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToValue(FecalOccultResult?.Value);
+			var g_ = context.Operators.Not((bool?)(f_ is null));
+			object h_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(FecalOccultResult?.Effective) is CqlDateTime)
+				{
+					var m_ = FHIRHelpers_4_3_000.ToValue(FecalOccultResult?.Effective);
+
+					return ((m_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(FecalOccultResult?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var n_ = FHIRHelpers_4_3_000.ToValue(FecalOccultResult?.Effective);
+
+					return ((n_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(FecalOccultResult?.Effective) is CqlDateTime)
+				{
+					var o_ = FHIRHelpers_4_3_000.ToValue(FecalOccultResult?.Effective);
+
+					return ((o_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var i_ = QICoreCommon_2_0_000.Latest(h_());
+			var j_ = this.Measurement_Period();
+			var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, "day");
+			var l_ = context.Operators.And(g_, k_);
+
+			return l_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Fecal Occult Blood Test Performed")]
+	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed() => 
+		__Fecal_Occult_Blood_Test_Performed.Value;
+
+	private IEnumerable<Observation> Stool_DNA_with_FIT_Test_Performed_Value()
+	{
+		var a_ = this.sDNA_FIT_Test();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.Final_Lab_Observation(b_);
+		bool? d_(Observation sDNATest)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToValue(sDNATest?.Value);
+			var g_ = context.Operators.Not((bool?)(f_ is null));
+			object h_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(sDNATest?.Effective) is CqlDateTime)
+				{
+					var s_ = FHIRHelpers_4_3_000.ToValue(sDNATest?.Effective);
+
+					return ((s_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(sDNATest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var t_ = FHIRHelpers_4_3_000.ToValue(sDNATest?.Effective);
+
+					return ((t_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(sDNATest?.Effective) is CqlDateTime)
+				{
+					var u_ = FHIRHelpers_4_3_000.ToValue(sDNATest?.Effective);
+
+					return ((u_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var i_ = QICoreCommon_2_0_000.Latest(h_());
+			var j_ = this.Measurement_Period();
+			var k_ = context.Operators.Start(j_);
+			var l_ = context.Operators.Quantity(2m, "years");
+			var m_ = context.Operators.Subtract(k_, l_);
+			var o_ = context.Operators.End(j_);
+			var p_ = context.Operators.Interval(m_, o_, true, true);
+			var q_ = context.Operators.ElementInInterval<CqlDateTime>(i_, p_, "day");
+			var r_ = context.Operators.And(g_, q_);
+
+			return r_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Stool DNA with FIT Test Performed")]
+	public IEnumerable<Observation> Stool_DNA_with_FIT_Test_Performed() => 
+		__Stool_DNA_with_FIT_Test_Performed.Value;
+
+	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value()
+	{
+		var a_ = this.Flexible_Sigmoidoscopy();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		bool? d_(Procedure FlexibleSigmoidoscopy)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToValue(FlexibleSigmoidoscopy?.Performed);
+			var g_ = QICoreCommon_2_0_000.ToInterval(f_);
+			var h_ = context.Operators.End(g_);
+			var i_ = this.Measurement_Period();
+			var j_ = context.Operators.Start(i_);
+			var k_ = context.Operators.Quantity(4m, "years");
+			var l_ = context.Operators.Subtract(j_, k_);
+			var n_ = context.Operators.End(i_);
+			var o_ = context.Operators.Interval(l_, n_, true, true);
+			var p_ = context.Operators.ElementInInterval<CqlDateTime>(h_, o_, "day");
+
+			return p_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Flexible Sigmoidoscopy Performed")]
+	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed() => 
+		__Flexible_Sigmoidoscopy_Performed.Value;
+
+	private IEnumerable<Observation> CT_Colonography_Performed_Value()
+	{
+		var a_ = this.CT_Colonography();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.Final_Observation(b_);
+		bool? d_(Observation Colonography)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToValue(Colonography?.Effective);
+			var g_ = QICoreCommon_2_0_000.ToInterval(f_);
+			var h_ = context.Operators.End(g_);
+			var i_ = this.Measurement_Period();
+			var j_ = context.Operators.Start(i_);
+			var k_ = context.Operators.Quantity(4m, "years");
+			var l_ = context.Operators.Subtract(j_, k_);
+			var n_ = context.Operators.End(i_);
+			var o_ = context.Operators.Interval(l_, n_, true, true);
+			var p_ = context.Operators.ElementInInterval<CqlDateTime>(h_, o_, "day");
+
+			return p_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("CT Colonography Performed")]
+	public IEnumerable<Observation> CT_Colonography_Performed() => 
+		__CT_Colonography_Performed.Value;
+
+	private IEnumerable<Procedure> Colonoscopy_Performed_Value()
+	{
+		var a_ = this.Colonoscopy();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		bool? d_(Procedure Colonoscopy)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToValue(Colonoscopy?.Performed);
+			var g_ = QICoreCommon_2_0_000.ToInterval(f_);
+			var h_ = context.Operators.End(g_);
+			var i_ = this.Measurement_Period();
+			var j_ = context.Operators.Start(i_);
+			var k_ = context.Operators.Quantity(9m, "years");
+			var l_ = context.Operators.Subtract(j_, k_);
+			var n_ = context.Operators.End(i_);
+			var o_ = context.Operators.Interval(l_, n_, true, true);
+			var p_ = context.Operators.ElementInInterval<CqlDateTime>(h_, o_, "day");
+
+			return p_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Colonoscopy Performed")]
+	public IEnumerable<Procedure> Colonoscopy_Performed() => 
+		__Colonoscopy_Performed.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Fecal_Occult_Blood_Test_Performed();
+		var b_ = context.Operators.ExistsInList<Observation>(a_);
+		var c_ = this.Stool_DNA_with_FIT_Test_Performed();
+		var d_ = context.Operators.ExistsInList<Observation>(c_);
+		var e_ = context.Operators.Or(b_, d_);
+		var f_ = this.Flexible_Sigmoidoscopy_Performed();
+		var g_ = context.Operators.ExistsInList<Procedure>(f_);
+		var h_ = context.Operators.Or(e_, g_);
+		var i_ = this.CT_Colonography_Performed();
+		var j_ = context.Operators.ExistsInList<Observation>(i_);
+		var k_ = context.Operators.Or(h_, j_);
+		var l_ = this.Colonoscopy_Performed();
+		var m_ = context.Operators.ExistsInList<Procedure>(l_);
+		var n_ = context.Operators.Or(k_, m_);
+
+		return n_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private bool? Stratification_1_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)46, (int?)49, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Stratification 1")]
+	public bool? Stratification_1() => 
+		__Stratification_1.Value;
+
+	private bool? Stratification_2_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)50, (int?)75, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Stratification 2")]
+	public bool? Stratification_2() => 
+		__Stratification_2.Value;
+
+}

--- a/Demo/Measures-cms/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
@@ -1,0 +1,908 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("DRCommunicationWithPhysicianManagingDiabetesFHIR", "0.1.000")]
+public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Care_Services_in_Long_Term_Residential_Facility;
+    internal Lazy<CqlValueSet> __Diabetic_Retinopathy;
+    internal Lazy<CqlValueSet> __Level_of_Severity_of_Retinopathy_Findings;
+    internal Lazy<CqlValueSet> __Macular_Edema_Findings_Present;
+    internal Lazy<CqlValueSet> __Macular_Exam;
+    internal Lazy<CqlValueSet> __Medical_Reason;
+    internal Lazy<CqlValueSet> __Nursing_Facility_Visit;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Ophthalmological_Services;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Patient_Reason;
+    internal Lazy<CqlValueSet> __Macular_edema_absent__situation_;
+    internal Lazy<CqlCode> __Healthcare_professional__occupation_;
+    internal Lazy<CqlCode> __Medical_practitioner__occupation_;
+    internal Lazy<CqlCode> __Ophthalmologist__occupation_;
+    internal Lazy<CqlCode> __Optometrist__occupation_;
+    internal Lazy<CqlCode> __Physician__occupation_;
+    internal Lazy<CqlCode> __virtual;
+    internal Lazy<CqlCode> __AMB;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __ActCode;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter_During_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Diabetic_Retinopathy_Encounter;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<IEnumerable<Observation>> __Macular_Exam_Performed;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Communication>> __Level_of_Severity_of_Retinopathy_Findings_Communicated;
+    internal Lazy<IEnumerable<Communication>> __Macular_Edema_Absence_Communicated;
+    internal Lazy<IEnumerable<Communication>> __Macular_Edema_Presence_Communicated;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<IEnumerable<Communication>> __Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy;
+    internal Lazy<IEnumerable<Communication>> __Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema;
+    internal Lazy<IEnumerable<Communication>> __Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema;
+    internal Lazy<bool?> __Denominator_Exceptions;
+    internal Lazy<bool?> __Results_of_Dilated_Macular_or_Fundus_Exam_Communicated;
+
+    #endregion
+    public DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Care_Services_in_Long_Term_Residential_Facility = new Lazy<CqlValueSet>(this.Care_Services_in_Long_Term_Residential_Facility_Value);
+        __Diabetic_Retinopathy = new Lazy<CqlValueSet>(this.Diabetic_Retinopathy_Value);
+        __Level_of_Severity_of_Retinopathy_Findings = new Lazy<CqlValueSet>(this.Level_of_Severity_of_Retinopathy_Findings_Value);
+        __Macular_Edema_Findings_Present = new Lazy<CqlValueSet>(this.Macular_Edema_Findings_Present_Value);
+        __Macular_Exam = new Lazy<CqlValueSet>(this.Macular_Exam_Value);
+        __Medical_Reason = new Lazy<CqlValueSet>(this.Medical_Reason_Value);
+        __Nursing_Facility_Visit = new Lazy<CqlValueSet>(this.Nursing_Facility_Visit_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Ophthalmological_Services = new Lazy<CqlValueSet>(this.Ophthalmological_Services_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Patient_Reason = new Lazy<CqlValueSet>(this.Patient_Reason_Value);
+        __Macular_edema_absent__situation_ = new Lazy<CqlValueSet>(this.Macular_edema_absent__situation__Value);
+        __Healthcare_professional__occupation_ = new Lazy<CqlCode>(this.Healthcare_professional__occupation__Value);
+        __Medical_practitioner__occupation_ = new Lazy<CqlCode>(this.Medical_practitioner__occupation__Value);
+        __Ophthalmologist__occupation_ = new Lazy<CqlCode>(this.Ophthalmologist__occupation__Value);
+        __Optometrist__occupation_ = new Lazy<CqlCode>(this.Optometrist__occupation__Value);
+        __Physician__occupation_ = new Lazy<CqlCode>(this.Physician__occupation__Value);
+        __virtual = new Lazy<CqlCode>(this.@virtual_Value);
+        __AMB = new Lazy<CqlCode>(this.AMB_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __ActCode = new Lazy<CqlCode[]>(this.ActCode_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounter_During_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_During_Measurement_Period_Value);
+        __Diabetic_Retinopathy_Encounter = new Lazy<IEnumerable<Encounter>>(this.Diabetic_Retinopathy_Encounter_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Macular_Exam_Performed = new Lazy<IEnumerable<Observation>>(this.Macular_Exam_Performed_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Level_of_Severity_of_Retinopathy_Findings_Communicated = new Lazy<IEnumerable<Communication>>(this.Level_of_Severity_of_Retinopathy_Findings_Communicated_Value);
+        __Macular_Edema_Absence_Communicated = new Lazy<IEnumerable<Communication>>(this.Macular_Edema_Absence_Communicated_Value);
+        __Macular_Edema_Presence_Communicated = new Lazy<IEnumerable<Communication>>(this.Macular_Edema_Presence_Communicated_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy = new Lazy<IEnumerable<Communication>>(this.Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy_Value);
+        __Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema = new Lazy<IEnumerable<Communication>>(this.Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema_Value);
+        __Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema = new Lazy<IEnumerable<Communication>>(this.Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema_Value);
+        __Denominator_Exceptions = new Lazy<bool?>(this.Denominator_Exceptions_Value);
+        __Results_of_Dilated_Macular_or_Fundus_Exam_Communicated = new Lazy<bool?>(this.Results_of_Dilated_Macular_or_Fundus_Exam_Communicated_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+
+    [CqlDeclaration("Care Services in Long-Term Residential Facility")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
+	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
+		__Care_Services_in_Long_Term_Residential_Facility.Value;
+
+	private CqlValueSet Diabetic_Retinopathy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
+
+    [CqlDeclaration("Diabetic Retinopathy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
+	public CqlValueSet Diabetic_Retinopathy() => 
+		__Diabetic_Retinopathy.Value;
+
+	private CqlValueSet Level_of_Severity_of_Retinopathy_Findings_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", null);
+
+    [CqlDeclaration("Level of Severity of Retinopathy Findings")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283")]
+	public CqlValueSet Level_of_Severity_of_Retinopathy_Findings() => 
+		__Level_of_Severity_of_Retinopathy_Findings.Value;
+
+	private CqlValueSet Macular_Edema_Findings_Present_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", null);
+
+    [CqlDeclaration("Macular Edema Findings Present")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320")]
+	public CqlValueSet Macular_Edema_Findings_Present() => 
+		__Macular_Edema_Findings_Present.Value;
+
+	private CqlValueSet Macular_Exam_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", null);
+
+    [CqlDeclaration("Macular Exam")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251")]
+	public CqlValueSet Macular_Exam() => 
+		__Macular_Exam.Value;
+
+	private CqlValueSet Medical_Reason_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlDeclaration("Medical Reason")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
+	public CqlValueSet Medical_Reason() => 
+		__Medical_Reason.Value;
+
+	private CqlValueSet Nursing_Facility_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+
+    [CqlDeclaration("Nursing Facility Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
+	public CqlValueSet Nursing_Facility_Visit() => 
+		__Nursing_Facility_Visit.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Ophthalmological_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+
+    [CqlDeclaration("Ophthalmological Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
+	public CqlValueSet Ophthalmological_Services() => 
+		__Ophthalmological_Services.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Patient_Reason_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+
+    [CqlDeclaration("Patient Reason")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
+	public CqlValueSet Patient_Reason() => 
+		__Patient_Reason.Value;
+
+	private CqlValueSet Macular_edema_absent__situation__Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391", null);
+
+    [CqlDeclaration("Macular edema absent (situation)")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391")]
+	public CqlValueSet Macular_edema_absent__situation_() => 
+		__Macular_edema_absent__situation_.Value;
+
+	private CqlCode Healthcare_professional__occupation__Value() => 
+		new CqlCode("223366009", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Healthcare professional (occupation)")]
+	public CqlCode Healthcare_professional__occupation_() => 
+		__Healthcare_professional__occupation_.Value;
+
+	private CqlCode Medical_practitioner__occupation__Value() => 
+		new CqlCode("158965000", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Medical practitioner (occupation)")]
+	public CqlCode Medical_practitioner__occupation_() => 
+		__Medical_practitioner__occupation_.Value;
+
+	private CqlCode Ophthalmologist__occupation__Value() => 
+		new CqlCode("422234006", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Ophthalmologist (occupation)")]
+	public CqlCode Ophthalmologist__occupation_() => 
+		__Ophthalmologist__occupation_.Value;
+
+	private CqlCode Optometrist__occupation__Value() => 
+		new CqlCode("28229004", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Optometrist (occupation)")]
+	public CqlCode Optometrist__occupation_() => 
+		__Optometrist__occupation_.Value;
+
+	private CqlCode Physician__occupation__Value() => 
+		new CqlCode("309343006", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Physician (occupation)")]
+	public CqlCode Physician__occupation_() => 
+		__Physician__occupation_.Value;
+
+	private CqlCode @virtual_Value() => 
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+
+    [CqlDeclaration("virtual")]
+	public CqlCode @virtual() => 
+		__virtual.Value;
+
+	private CqlCode AMB_Value() => 
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+
+    [CqlDeclaration("AMB")]
+	public CqlCode AMB() => 
+		__AMB.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("223366009", "http://snomed.info/sct", null, null),
+			new CqlCode("158965000", "http://snomed.info/sct", null, null),
+			new CqlCode("422234006", "http://snomed.info/sct", null, null),
+			new CqlCode("28229004", "http://snomed.info/sct", null, null),
+			new CqlCode("309343006", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] ActCode_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ActCode")]
+	public CqlCode[] ActCode() => 
+		__ActCode.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Ophthalmological_Services();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Outpatient_Consultation();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Nursing_Facility_Visit();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = context.Operators.ListUnion<Encounter>(k_, m_);
+		bool? o_(Encounter QualifyingEncounter)
+		{
+			var q_ = this.Measurement_Period();
+			var r_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+			var s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, r_, null);
+			var t_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(QualifyingEncounter?.StatusElement?.Value);
+			var u_ = context.Operators.Equal(t_, "finished");
+			var v_ = context.Operators.And(s_, u_);
+			var w_ = FHIRHelpers_4_3_000.ToCode(QualifyingEncounter?.Class);
+			var x_ = this.@virtual();
+			var y_ = context.Operators.Equivalent(w_, x_);
+			var z_ = context.Operators.Not(y_);
+			var aa_ = context.Operators.And(v_, z_);
+
+			return aa_;
+		};
+		var p_ = context.Operators.WhereOrNull<Encounter>(n_, o_);
+
+		return p_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter During Measurement Period")]
+	public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period() => 
+		__Qualifying_Encounter_During_Measurement_Period.Value;
+
+	private IEnumerable<Encounter> Diabetic_Retinopathy_Encounter_Value()
+	{
+		var a_ = this.Qualifying_Encounter_During_Measurement_Period();
+		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
+		{
+			var d_ = this.Diabetic_Retinopathy();
+			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			bool? f_(Condition DiabeticRetinopathy)
+			{
+				var j_ = QICoreCommon_2_0_000.prevalenceInterval(DiabeticRetinopathy);
+				var k_ = FHIRHelpers_4_3_000.ToInterval(ValidQualifyingEncounter?.Period);
+				var l_ = context.Operators.Overlaps(j_, k_, null);
+				var m_ = QICoreCommon_2_0_000.isActive(DiabeticRetinopathy);
+				var n_ = context.Operators.And(l_, m_);
+				var o_ = FHIRHelpers_4_3_000.ToConcept(DiabeticRetinopathy?.VerificationStatus);
+				var p_ = QICoreCommon_2_0_000.unconfirmed();
+				var q_ = context.Operators.ConvertCodeToConcept(p_);
+				var r_ = context.Operators.Equivalent(o_, q_);
+				var t_ = QICoreCommon_2_0_000.refuted();
+				var u_ = context.Operators.ConvertCodeToConcept(t_);
+				var v_ = context.Operators.Equivalent(o_, u_);
+				var w_ = context.Operators.Or(r_, v_);
+				var y_ = QICoreCommon_2_0_000.entered_in_error();
+				var z_ = context.Operators.ConvertCodeToConcept(y_);
+				var aa_ = context.Operators.Equivalent(o_, z_);
+				var ab_ = context.Operators.Or(w_, aa_);
+				var ac_ = context.Operators.Not(ab_);
+				var ad_ = context.Operators.And(n_, ac_);
+
+				return ad_;
+			};
+			var g_ = context.Operators.WhereOrNull<Condition>(e_, f_);
+			Encounter h_(Condition DiabeticRetinopathy) => 
+				ValidQualifyingEncounter;
+			var i_ = context.Operators.SelectOrNull<Condition, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Diabetic Retinopathy Encounter")]
+	public IEnumerable<Encounter> Diabetic_Retinopathy_Encounter() => 
+		__Diabetic_Retinopathy_Encounter.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.GreaterOrEqual(f_, (int?)18);
+		var h_ = this.Diabetic_Retinopathy_Encounter();
+		var i_ = context.Operators.ExistsInList<Encounter>(h_);
+		var j_ = context.Operators.And(g_, i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Observation> Macular_Exam_Performed_Value()
+	{
+		var a_ = this.Macular_Exam();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_(Observation MacularExam)
+		{
+			var g_ = this.Diabetic_Retinopathy_Encounter();
+			bool? h_(Encounter EncounterDiabeticRetinopathy)
+			{
+				var l_ = FHIRHelpers_4_3_000.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var m_ = FHIRHelpers_4_3_000.ToValue(MacularExam?.Effective);
+				var n_ = QICoreCommon_2_0_000.toInterval(m_);
+				var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, null);
+
+				return o_;
+			};
+			var i_ = context.Operators.WhereOrNull<Encounter>(g_, h_);
+			Observation j_(Encounter EncounterDiabeticRetinopathy) => 
+				MacularExam;
+			var k_ = context.Operators.SelectOrNull<Encounter, Observation>(i_, j_);
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Observation, Observation>(b_, c_);
+		bool? e_(Observation MacularExam)
+		{
+			var p_ = FHIRHelpers_4_3_000.ToValue(MacularExam?.Value);
+			var q_ = context.Operators.Not((bool?)(p_ is null));
+			var r_ = context.Operators.Convert<Code<ObservationStatus>>(MacularExam?.StatusElement?.Value);
+			var s_ = context.Operators.Convert<string>(r_);
+			var t_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+				"preliminary",
+			};
+			var u_ = context.Operators.InList<string>(s_, (t_ as IEnumerable<string>));
+			var v_ = context.Operators.And(q_, u_);
+
+			return v_;
+		};
+		var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Macular Exam Performed")]
+	public IEnumerable<Observation> Macular_Exam_Performed() => 
+		__Macular_Exam_Performed.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+		var b_ = this.Macular_Exam_Performed();
+		var c_ = context.Operators.ExistsInList<Observation>(b_);
+		var d_ = context.Operators.And(a_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Communication> Level_of_Severity_of_Retinopathy_Findings_Communicated_Value()
+	{
+		var a_ = this.Level_of_Severity_of_Retinopathy_Findings();
+		var b_ = typeof(Communication).GetProperty("ReasonCode");
+		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		IEnumerable<Communication> d_(Communication LevelOfSeverityCommunicated)
+		{
+			var h_ = this.Diabetic_Retinopathy_Encounter();
+			bool? i_(Encounter EncounterDiabeticRetinopathy)
+			{
+				var m_ = context.Operators.Convert<CqlDateTime>(LevelOfSeverityCommunicated?.SentElement);
+				var n_ = FHIRHelpers_4_3_000.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var o_ = context.Operators.Start(n_);
+				var p_ = context.Operators.After(m_, o_, null);
+				var r_ = this.Measurement_Period();
+				var s_ = context.Operators.ElementInInterval<CqlDateTime>(m_, r_, "day");
+				var t_ = context.Operators.And(p_, s_);
+
+				return t_;
+			};
+			var j_ = context.Operators.WhereOrNull<Encounter>(h_, i_);
+			Communication k_(Encounter EncounterDiabeticRetinopathy) => 
+				LevelOfSeverityCommunicated;
+			var l_ = context.Operators.SelectOrNull<Encounter, Communication>(j_, k_);
+
+			return l_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<Communication, Communication>(c_, d_);
+		bool? f_(Communication LevelOfSeverityCommunicated)
+		{
+			var u_ = context.Operators.Convert<Code<EventStatus>>(LevelOfSeverityCommunicated?.StatusElement?.Value);
+			var v_ = context.Operators.Equal(u_, "completed");
+
+			return v_;
+		};
+		var g_ = context.Operators.WhereOrNull<Communication>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Level of Severity of Retinopathy Findings Communicated")]
+	public IEnumerable<Communication> Level_of_Severity_of_Retinopathy_Findings_Communicated() => 
+		__Level_of_Severity_of_Retinopathy_Findings_Communicated.Value;
+
+	private IEnumerable<Communication> Macular_Edema_Absence_Communicated_Value()
+	{
+		var a_ = this.Macular_edema_absent__situation_();
+		var b_ = typeof(Communication).GetProperty("ReasonCode");
+		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		IEnumerable<Communication> d_(Communication MacularEdemaAbsentCommunicated)
+		{
+			var h_ = this.Diabetic_Retinopathy_Encounter();
+			bool? i_(Encounter EncounterDiabeticRetinopathy)
+			{
+				var m_ = context.Operators.Convert<CqlDateTime>(MacularEdemaAbsentCommunicated?.SentElement);
+				var n_ = FHIRHelpers_4_3_000.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var o_ = context.Operators.Start(n_);
+				var p_ = context.Operators.After(m_, o_, null);
+				var r_ = this.Measurement_Period();
+				var s_ = context.Operators.ElementInInterval<CqlDateTime>(m_, r_, "day");
+				var t_ = context.Operators.And(p_, s_);
+
+				return t_;
+			};
+			var j_ = context.Operators.WhereOrNull<Encounter>(h_, i_);
+			Communication k_(Encounter EncounterDiabeticRetinopathy) => 
+				MacularEdemaAbsentCommunicated;
+			var l_ = context.Operators.SelectOrNull<Encounter, Communication>(j_, k_);
+
+			return l_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<Communication, Communication>(c_, d_);
+		bool? f_(Communication MacularEdemaAbsentCommunicated)
+		{
+			var u_ = context.Operators.Convert<Code<EventStatus>>(MacularEdemaAbsentCommunicated?.StatusElement?.Value);
+			var v_ = context.Operators.Equal(u_, "completed");
+
+			return v_;
+		};
+		var g_ = context.Operators.WhereOrNull<Communication>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Macular Edema Absence Communicated")]
+	public IEnumerable<Communication> Macular_Edema_Absence_Communicated() => 
+		__Macular_Edema_Absence_Communicated.Value;
+
+	private IEnumerable<Communication> Macular_Edema_Presence_Communicated_Value()
+	{
+		var a_ = this.Macular_Edema_Findings_Present();
+		var b_ = typeof(Communication).GetProperty("ReasonCode");
+		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		IEnumerable<Communication> d_(Communication MacularEdemaPresentCommunicated)
+		{
+			var h_ = this.Diabetic_Retinopathy_Encounter();
+			bool? i_(Encounter EncounterDiabeticRetinopathy)
+			{
+				var m_ = context.Operators.Convert<CqlDateTime>(MacularEdemaPresentCommunicated?.SentElement);
+				var n_ = FHIRHelpers_4_3_000.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var o_ = context.Operators.Start(n_);
+				var p_ = context.Operators.After(m_, o_, null);
+				var r_ = this.Measurement_Period();
+				var s_ = context.Operators.ElementInInterval<CqlDateTime>(m_, r_, "day");
+				var t_ = context.Operators.And(p_, s_);
+
+				return t_;
+			};
+			var j_ = context.Operators.WhereOrNull<Encounter>(h_, i_);
+			Communication k_(Encounter EncounterDiabeticRetinopathy) => 
+				MacularEdemaPresentCommunicated;
+			var l_ = context.Operators.SelectOrNull<Encounter, Communication>(j_, k_);
+
+			return l_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<Communication, Communication>(c_, d_);
+		bool? f_(Communication MacularEdemaPresentCommunicated)
+		{
+			var u_ = context.Operators.Convert<Code<EventStatus>>(MacularEdemaPresentCommunicated?.StatusElement?.Value);
+			var v_ = context.Operators.Equal(u_, "completed");
+
+			return v_;
+		};
+		var g_ = context.Operators.WhereOrNull<Communication>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Macular Edema Presence Communicated")]
+	public IEnumerable<Communication> Macular_Edema_Presence_Communicated() => 
+		__Macular_Edema_Presence_Communicated.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated();
+		var b_ = context.Operators.ExistsInList<Communication>(a_);
+		var c_ = this.Macular_Edema_Absence_Communicated();
+		var d_ = context.Operators.ExistsInList<Communication>(c_);
+		var e_ = this.Macular_Edema_Presence_Communicated();
+		var f_ = context.Operators.ExistsInList<Communication>(e_);
+		var g_ = context.Operators.Or(d_, f_);
+		var h_ = context.Operators.And(b_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy_Value()
+	{
+		var a_ = this.Level_of_Severity_of_Retinopathy_Findings();
+		var b_ = typeof(Communication).GetProperty("ReasonCode");
+		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		var f_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		var g_ = context.Operators.ListUnion<Communication>(c_, f_);
+		IEnumerable<Communication> h_(Communication LevelOfSeverityNotCommunicated)
+		{
+			var l_ = this.Diabetic_Retinopathy_Encounter();
+			bool? m_(Encounter EncounterDiabeticRetinopathy)
+			{
+				bool? q_(Extension @this)
+				{
+					var y_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+
+					return y_;
+				};
+				var r_ = context.Operators.WhereOrNull<Extension>(((LevelOfSeverityNotCommunicated is DomainResource)
+						? ((LevelOfSeverityNotCommunicated as DomainResource).Extension)
+						: null), q_);
+				DataType s_(Extension @this) => 
+					@this?.Value;
+				var t_ = context.Operators.SelectOrNull<Extension, DataType>(r_, s_);
+				var u_ = context.Operators.SingleOrNull<DataType>(t_);
+				var v_ = context.Operators.Convert<CqlDateTime>(u_);
+				var w_ = FHIRHelpers_4_3_000.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var x_ = context.Operators.ElementInInterval<CqlDateTime>(v_, w_, null);
+
+				return x_;
+			};
+			var n_ = context.Operators.WhereOrNull<Encounter>(l_, m_);
+			Communication o_(Encounter EncounterDiabeticRetinopathy) => 
+				LevelOfSeverityNotCommunicated;
+			var p_ = context.Operators.SelectOrNull<Encounter, Communication>(n_, o_);
+
+			return p_;
+		};
+		var i_ = context.Operators.SelectManyOrNull<Communication, Communication>(g_, h_);
+		bool? j_(Communication LevelOfSeverityNotCommunicated)
+		{
+			var z_ = FHIRHelpers_4_3_000.ToConcept(LevelOfSeverityNotCommunicated?.StatusReason);
+			var aa_ = this.Medical_Reason();
+			var ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+			var ad_ = this.Patient_Reason();
+			var ae_ = context.Operators.ConceptInValueSet(z_, ad_);
+			var af_ = context.Operators.Or(ab_, ae_);
+
+			return af_;
+		};
+		var k_ = context.Operators.WhereOrNull<Communication>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Medical or Patient Reason for Not Communicating Level of Severity of Retinopathy")]
+	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy() => 
+		__Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy.Value;
+
+	private IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema_Value()
+	{
+		var a_ = this.Macular_edema_absent__situation_();
+		var b_ = typeof(Communication).GetProperty("ReasonCode");
+		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		var f_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		var g_ = context.Operators.ListUnion<Communication>(c_, f_);
+		IEnumerable<Communication> h_(Communication MacularEdemaAbsentNotCommunicated)
+		{
+			var l_ = this.Diabetic_Retinopathy_Encounter();
+			bool? m_(Encounter EncounterDiabeticRetinopathy)
+			{
+				bool? q_(Extension @this)
+				{
+					var y_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+
+					return y_;
+				};
+				var r_ = context.Operators.WhereOrNull<Extension>(((MacularEdemaAbsentNotCommunicated is DomainResource)
+						? ((MacularEdemaAbsentNotCommunicated as DomainResource).Extension)
+						: null), q_);
+				DataType s_(Extension @this) => 
+					@this?.Value;
+				var t_ = context.Operators.SelectOrNull<Extension, DataType>(r_, s_);
+				var u_ = context.Operators.SingleOrNull<DataType>(t_);
+				var v_ = context.Operators.Convert<CqlDateTime>(u_);
+				var w_ = FHIRHelpers_4_3_000.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var x_ = context.Operators.ElementInInterval<CqlDateTime>(v_, w_, null);
+
+				return x_;
+			};
+			var n_ = context.Operators.WhereOrNull<Encounter>(l_, m_);
+			Communication o_(Encounter EncounterDiabeticRetinopathy) => 
+				MacularEdemaAbsentNotCommunicated;
+			var p_ = context.Operators.SelectOrNull<Encounter, Communication>(n_, o_);
+
+			return p_;
+		};
+		var i_ = context.Operators.SelectManyOrNull<Communication, Communication>(g_, h_);
+		bool? j_(Communication MacularEdemaAbsentNotCommunicated)
+		{
+			var z_ = FHIRHelpers_4_3_000.ToConcept(MacularEdemaAbsentNotCommunicated?.StatusReason);
+			var aa_ = this.Medical_Reason();
+			var ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+			var ad_ = this.Patient_Reason();
+			var ae_ = context.Operators.ConceptInValueSet(z_, ad_);
+			var af_ = context.Operators.Or(ab_, ae_);
+
+			return af_;
+		};
+		var k_ = context.Operators.WhereOrNull<Communication>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Medical or Patient Reason for Not Communicating Absence of Macular Edema")]
+	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema() => 
+		__Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema.Value;
+
+	private IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema_Value()
+	{
+		var a_ = this.Macular_Edema_Findings_Present();
+		var b_ = typeof(Communication).GetProperty("ReasonCode");
+		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		var f_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		var g_ = context.Operators.ListUnion<Communication>(c_, f_);
+		IEnumerable<Communication> h_(Communication MacularEdemaPresentNotCommunicated)
+		{
+			var l_ = this.Diabetic_Retinopathy_Encounter();
+			bool? m_(Encounter EncounterDiabeticRetinopathy)
+			{
+				bool? q_(Extension @this)
+				{
+					var y_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+
+					return y_;
+				};
+				var r_ = context.Operators.WhereOrNull<Extension>(((MacularEdemaPresentNotCommunicated is DomainResource)
+						? ((MacularEdemaPresentNotCommunicated as DomainResource).Extension)
+						: null), q_);
+				DataType s_(Extension @this) => 
+					@this?.Value;
+				var t_ = context.Operators.SelectOrNull<Extension, DataType>(r_, s_);
+				var u_ = context.Operators.SingleOrNull<DataType>(t_);
+				var v_ = context.Operators.Convert<CqlDateTime>(u_);
+				var w_ = FHIRHelpers_4_3_000.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var x_ = context.Operators.ElementInInterval<CqlDateTime>(v_, w_, null);
+
+				return x_;
+			};
+			var n_ = context.Operators.WhereOrNull<Encounter>(l_, m_);
+			Communication o_(Encounter EncounterDiabeticRetinopathy) => 
+				MacularEdemaPresentNotCommunicated;
+			var p_ = context.Operators.SelectOrNull<Encounter, Communication>(n_, o_);
+
+			return p_;
+		};
+		var i_ = context.Operators.SelectManyOrNull<Communication, Communication>(g_, h_);
+		bool? j_(Communication MacularEdemaPresentNotCommunicated)
+		{
+			var z_ = FHIRHelpers_4_3_000.ToConcept(MacularEdemaPresentNotCommunicated?.StatusReason);
+			var aa_ = this.Medical_Reason();
+			var ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+			var ad_ = this.Patient_Reason();
+			var ae_ = context.Operators.ConceptInValueSet(z_, ad_);
+			var af_ = context.Operators.Or(ab_, ae_);
+
+			return af_;
+		};
+		var k_ = context.Operators.WhereOrNull<Communication>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Medical or Patient Reason for Not Communicating Presence of Macular Edema")]
+	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema() => 
+		__Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema.Value;
+
+	private bool? Denominator_Exceptions_Value()
+	{
+		var a_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy();
+		var b_ = context.Operators.ExistsInList<Communication>(a_);
+		var c_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema();
+		var d_ = context.Operators.ExistsInList<Communication>(c_);
+		var e_ = context.Operators.Or(b_, d_);
+		var f_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema();
+		var g_ = context.Operators.ExistsInList<Communication>(f_);
+		var h_ = context.Operators.Or(e_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Denominator Exceptions")]
+	public bool? Denominator_Exceptions() => 
+		__Denominator_Exceptions.Value;
+
+	private bool? Results_of_Dilated_Macular_or_Fundus_Exam_Communicated_Value()
+	{
+		var a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated();
+		var b_ = context.Operators.ExistsInList<Communication>(a_);
+		var c_ = this.Macular_Edema_Absence_Communicated();
+		var d_ = context.Operators.ExistsInList<Communication>(c_);
+		var e_ = this.Macular_Edema_Presence_Communicated();
+		var f_ = context.Operators.ExistsInList<Communication>(e_);
+		var g_ = context.Operators.Or(d_, f_);
+		var h_ = context.Operators.And(b_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Results of Dilated Macular or Fundus Exam Communicated")]
+	public bool? Results_of_Dilated_Macular_or_Fundus_Exam_Communicated() => 
+		__Results_of_Dilated_Macular_or_Fundus_Exam_Communicated.Value;
+
+}

--- a/Demo/Measures-cms/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
@@ -1,0 +1,589 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("DementiaCognitiveAssessmentFHIR", "0.1.000")]
+public class DementiaCognitiveAssessmentFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Behavioral_Neuropsych_Assessment;
+    internal Lazy<CqlValueSet> __Care_Services_in_Long_Term_Residential_Facility;
+    internal Lazy<CqlValueSet> __Cognitive_Assessment;
+    internal Lazy<CqlValueSet> __Dementia_and_Mental_Degenerations;
+    internal Lazy<CqlValueSet> __Face_to_Face_Interaction;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Nursing_Facility_Visit;
+    internal Lazy<CqlValueSet> __Occupational_Therapy_Evaluation;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Patient_Provider_Interaction;
+    internal Lazy<CqlValueSet> __Patient_Reason;
+    internal Lazy<CqlValueSet> __Psych_Visit_Diagnostic_Evaluation;
+    internal Lazy<CqlValueSet> __Psych_Visit_Psychotherapy;
+    internal Lazy<CqlValueSet> __Standardized_Tools_Score_for_Assessment_of_Cognition;
+    internal Lazy<CqlCode[]> __ActCode;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_to_Assess_Cognition;
+    internal Lazy<IEnumerable<Encounter>> __Dementia_Encounter_During_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter_During_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Observation>> __Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<IEnumerable<Observation>> __Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods;
+    internal Lazy<bool?> __Denominator_Exceptions;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+
+    #endregion
+    public DementiaCognitiveAssessmentFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Behavioral_Neuropsych_Assessment = new Lazy<CqlValueSet>(this.Behavioral_Neuropsych_Assessment_Value);
+        __Care_Services_in_Long_Term_Residential_Facility = new Lazy<CqlValueSet>(this.Care_Services_in_Long_Term_Residential_Facility_Value);
+        __Cognitive_Assessment = new Lazy<CqlValueSet>(this.Cognitive_Assessment_Value);
+        __Dementia_and_Mental_Degenerations = new Lazy<CqlValueSet>(this.Dementia_and_Mental_Degenerations_Value);
+        __Face_to_Face_Interaction = new Lazy<CqlValueSet>(this.Face_to_Face_Interaction_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Nursing_Facility_Visit = new Lazy<CqlValueSet>(this.Nursing_Facility_Visit_Value);
+        __Occupational_Therapy_Evaluation = new Lazy<CqlValueSet>(this.Occupational_Therapy_Evaluation_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Patient_Provider_Interaction = new Lazy<CqlValueSet>(this.Patient_Provider_Interaction_Value);
+        __Patient_Reason = new Lazy<CqlValueSet>(this.Patient_Reason_Value);
+        __Psych_Visit_Diagnostic_Evaluation = new Lazy<CqlValueSet>(this.Psych_Visit_Diagnostic_Evaluation_Value);
+        __Psych_Visit_Psychotherapy = new Lazy<CqlValueSet>(this.Psych_Visit_Psychotherapy_Value);
+        __Standardized_Tools_Score_for_Assessment_of_Cognition = new Lazy<CqlValueSet>(this.Standardized_Tools_Score_for_Assessment_of_Cognition_Value);
+        __ActCode = new Lazy<CqlCode[]>(this.ActCode_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Encounter_to_Assess_Cognition = new Lazy<IEnumerable<Encounter>>(this.Encounter_to_Assess_Cognition_Value);
+        __Dementia_Encounter_During_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Dementia_Encounter_During_Measurement_Period_Value);
+        __Qualifying_Encounter_During_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_During_Measurement_Period_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods = new Lazy<IEnumerable<Observation>>(this.Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods = new Lazy<IEnumerable<Observation>>(this.Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value);
+        __Denominator_Exceptions = new Lazy<bool?>(this.Denominator_Exceptions_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Behavioral_Neuropsych_Assessment_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023", null);
+
+    [CqlDeclaration("Behavioral/Neuropsych Assessment")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023")]
+	public CqlValueSet Behavioral_Neuropsych_Assessment() => 
+		__Behavioral_Neuropsych_Assessment.Value;
+
+	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+
+    [CqlDeclaration("Care Services in Long Term Residential Facility")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
+	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
+		__Care_Services_in_Long_Term_Residential_Facility.Value;
+
+	private CqlValueSet Cognitive_Assessment_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332", null);
+
+    [CqlDeclaration("Cognitive Assessment")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332")]
+	public CqlValueSet Cognitive_Assessment() => 
+		__Cognitive_Assessment.Value;
+
+	private CqlValueSet Dementia_and_Mental_Degenerations_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005", null);
+
+    [CqlDeclaration("Dementia & Mental Degenerations")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005")]
+	public CqlValueSet Dementia_and_Mental_Degenerations() => 
+		__Dementia_and_Mental_Degenerations.Value;
+
+	private CqlValueSet Face_to_Face_Interaction_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+
+    [CqlDeclaration("Face-to-Face Interaction")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
+	public CqlValueSet Face_to_Face_Interaction() => 
+		__Face_to_Face_Interaction.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Nursing_Facility_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+
+    [CqlDeclaration("Nursing Facility Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
+	public CqlValueSet Nursing_Facility_Visit() => 
+		__Nursing_Facility_Visit.Value;
+
+	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", null);
+
+    [CqlDeclaration("Occupational Therapy Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
+	public CqlValueSet Occupational_Therapy_Evaluation() => 
+		__Occupational_Therapy_Evaluation.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Patient_Provider_Interaction_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", null);
+
+    [CqlDeclaration("Patient Provider Interaction")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012")]
+	public CqlValueSet Patient_Provider_Interaction() => 
+		__Patient_Provider_Interaction.Value;
+
+	private CqlValueSet Patient_Reason_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+
+    [CqlDeclaration("Patient Reason")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
+	public CqlValueSet Patient_Reason() => 
+		__Patient_Reason.Value;
+
+	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
+
+    [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
+	public CqlValueSet Psych_Visit_Diagnostic_Evaluation() => 
+		__Psych_Visit_Diagnostic_Evaluation.Value;
+
+	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
+
+    [CqlDeclaration("Psych Visit Psychotherapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
+	public CqlValueSet Psych_Visit_Psychotherapy() => 
+		__Psych_Visit_Psychotherapy.Value;
+
+	private CqlValueSet Standardized_Tools_Score_for_Assessment_of_Cognition_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006", null);
+
+    [CqlDeclaration("Standardized Tools Score for Assessment of Cognition")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006")]
+	public CqlValueSet Standardized_Tools_Score_for_Assessment_of_Cognition() => 
+		__Standardized_Tools_Score_for_Assessment_of_Cognition.Value;
+
+	private CqlCode[] ActCode_Value()
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
+    [CqlDeclaration("ActCode")]
+	public CqlCode[] ActCode() => 
+		__ActCode.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("DementiaCognitiveAssessmentFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Encounter_to_Assess_Cognition_Value()
+	{
+		var a_ = this.Psych_Visit_Diagnostic_Evaluation();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Nursing_Facility_Visit();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Home_Healthcare_Services();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Psych_Visit_Psychotherapy();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Behavioral_Neuropsych_Assessment();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Occupational_Therapy_Evaluation();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = this.Office_Visit();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
+		var x_ = this.Outpatient_Consultation();
+		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		var z_ = context.Operators.ListUnion<Encounter>(w_, y_);
+
+		return z_;
+	}
+
+    [CqlDeclaration("Encounter to Assess Cognition")]
+	public IEnumerable<Encounter> Encounter_to_Assess_Cognition() => 
+		__Encounter_to_Assess_Cognition.Value;
+
+	private IEnumerable<Encounter> Dementia_Encounter_During_Measurement_Period_Value()
+	{
+		var a_ = this.Encounter_to_Assess_Cognition();
+		IEnumerable<Encounter> b_(Encounter EncounterAssessCognition)
+		{
+			var d_ = this.Dementia_and_Mental_Degenerations();
+			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			bool? f_(Condition Dementia)
+			{
+				var j_ = this.Measurement_Period();
+				var k_ = FHIRHelpers_4_3_000.ToInterval(EncounterAssessCognition?.Period);
+				var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, k_, null);
+				var m_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
+				var o_ = context.Operators.Overlaps(m_, k_, "day");
+				var p_ = context.Operators.And(l_, o_);
+				var q_ = QICoreCommon_2_0_000.isActive(Dementia);
+				var r_ = context.Operators.And(p_, q_);
+				var s_ = FHIRHelpers_4_3_000.ToConcept(Dementia?.VerificationStatus);
+				var t_ = QICoreCommon_2_0_000.unconfirmed();
+				var u_ = context.Operators.ConvertCodeToConcept(t_);
+				var v_ = context.Operators.Equivalent(s_, u_);
+				var x_ = QICoreCommon_2_0_000.refuted();
+				var y_ = context.Operators.ConvertCodeToConcept(x_);
+				var z_ = context.Operators.Equivalent(s_, y_);
+				var aa_ = context.Operators.Or(v_, z_);
+				var ac_ = QICoreCommon_2_0_000.entered_in_error();
+				var ad_ = context.Operators.ConvertCodeToConcept(ac_);
+				var ae_ = context.Operators.Equivalent(s_, ad_);
+				var af_ = context.Operators.Or(aa_, ae_);
+				var ag_ = context.Operators.Not(af_);
+				var ah_ = context.Operators.And(r_, ag_);
+
+				return ah_;
+			};
+			var g_ = context.Operators.WhereOrNull<Condition>(e_, f_);
+			Encounter h_(Condition Dementia) => 
+				EncounterAssessCognition;
+			var i_ = context.Operators.SelectOrNull<Condition, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Dementia Encounter During Measurement Period")]
+	public IEnumerable<Encounter> Dementia_Encounter_During_Measurement_Period() => 
+		__Dementia_Encounter_During_Measurement_Period.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
+	{
+		var a_ = this.Encounter_to_Assess_Cognition();
+		var b_ = this.Patient_Provider_Interaction();
+		var c_ = context.Operators.RetrieveByValueSet<Encounter>(b_, null);
+		var d_ = context.Operators.ListUnion<Encounter>(a_, c_);
+		bool? e_(Encounter ValidEncounter)
+		{
+			var g_ = this.Measurement_Period();
+			var h_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, h_, null);
+			var j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ValidEncounter?.StatusElement?.Value);
+			var k_ = context.Operators.Equal(j_, "finished");
+			var l_ = context.Operators.And(i_, k_);
+
+			return l_;
+		};
+		var f_ = context.Operators.WhereOrNull<Encounter>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter During Measurement Period")]
+	public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period() => 
+		__Qualifying_Encounter_During_Measurement_Period.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Dementia_Encounter_During_Measurement_Period();
+		var b_ = context.Operators.ExistsInList<Encounter>(a_);
+		var c_ = this.Qualifying_Encounter_During_Measurement_Period();
+		var d_ = context.Operators.CountOrNull<Encounter>(c_);
+		var e_ = context.Operators.GreaterOrEqual(d_, (int?)2);
+		var f_ = context.Operators.And(b_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Observation> Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value()
+	{
+		var a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = this.Cognitive_Assessment();
+		var d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		var e_ = context.Operators.ListUnion<Observation>(b_, d_);
+		IEnumerable<Observation> f_(Observation CognitiveAssessment)
+		{
+			var j_ = this.Dementia_Encounter_During_Measurement_Period();
+			bool? k_(Encounter EncounterDementia)
+			{
+				var o_ = FHIRHelpers_4_3_000.ToValue(CognitiveAssessment?.Effective);
+				var p_ = QICoreCommon_2_0_000.toInterval(o_);
+				var q_ = context.Operators.Start(p_);
+				var r_ = FHIRHelpers_4_3_000.ToInterval(EncounterDementia?.Period);
+				var s_ = context.Operators.End(r_);
+				var t_ = context.Operators.Quantity(12m, "months");
+				var u_ = context.Operators.Subtract(s_, t_);
+				var w_ = context.Operators.End(r_);
+				var x_ = context.Operators.Interval(u_, w_, true, true);
+				var y_ = context.Operators.ElementInInterval<CqlDateTime>(q_, x_, "day");
+				var aa_ = context.Operators.End(r_);
+				var ab_ = context.Operators.Not((bool?)(aa_ is null));
+				var ac_ = context.Operators.And(y_, ab_);
+
+				return ac_;
+			};
+			var l_ = context.Operators.WhereOrNull<Encounter>(j_, k_);
+			Observation m_(Encounter EncounterDementia) => 
+				CognitiveAssessment;
+			var n_ = context.Operators.SelectOrNull<Encounter, Observation>(l_, m_);
+
+			return n_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<Observation, Observation>(e_, f_);
+		bool? h_(Observation CognitiveAssessment)
+		{
+			var ad_ = FHIRHelpers_4_3_000.ToValue(CognitiveAssessment?.Value);
+			var ae_ = context.Operators.Not((bool?)(ad_ is null));
+			var af_ = context.Operators.Convert<Code<ObservationStatus>>(CognitiveAssessment?.StatusElement?.Value);
+			var ag_ = context.Operators.Convert<string>(af_);
+			var ah_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+				"preliminary",
+			};
+			var ai_ = context.Operators.InList<string>(ag_, (ah_ as IEnumerable<string>));
+			var aj_ = context.Operators.And(ae_, ai_);
+
+			return aj_;
+		};
+		var i_ = context.Operators.WhereOrNull<Observation>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Assessment of Cognition Using Standardized Tools or Alternate Methods")]
+	public IEnumerable<Observation> Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods() => 
+		__Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods();
+		var b_ = context.Operators.ExistsInList<Observation>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private IEnumerable<Observation> Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value()
+	{
+		var a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = this.Cognitive_Assessment();
+		var d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		var e_ = context.Operators.ListUnion<Observation>(b_, d_);
+		IEnumerable<Observation> f_(Observation NoCognitiveAssessment)
+		{
+			var j_ = this.Dementia_Encounter_During_Measurement_Period();
+			bool? k_(Encounter EncounterDementia)
+			{
+				var o_ = context.Operators.Convert<CqlDateTime>(NoCognitiveAssessment?.IssuedElement?.Value);
+				var p_ = FHIRHelpers_4_3_000.ToInterval(EncounterDementia?.Period);
+				var q_ = context.Operators.ElementInInterval<CqlDateTime>(o_, p_, null);
+
+				return q_;
+			};
+			var l_ = context.Operators.WhereOrNull<Encounter>(j_, k_);
+			Observation m_(Encounter EncounterDementia) => 
+				NoCognitiveAssessment;
+			var n_ = context.Operators.SelectOrNull<Encounter, Observation>(l_, m_);
+
+			return n_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<Observation, Observation>(e_, f_);
+		bool? h_(Observation NoCognitiveAssessment)
+		{
+			bool? r_(Extension @this)
+			{
+				var aa_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+				return aa_;
+			};
+			var s_ = context.Operators.WhereOrNull<Extension>(((NoCognitiveAssessment is DomainResource)
+					? ((NoCognitiveAssessment as DomainResource).Extension)
+					: null), r_);
+			DataType t_(Extension @this) => 
+				@this?.Value;
+			var u_ = context.Operators.SelectOrNull<Extension, DataType>(s_, t_);
+			var v_ = context.Operators.SingleOrNull<DataType>(u_);
+			var w_ = context.Operators.Convert<CodeableConcept>(v_);
+			var x_ = FHIRHelpers_4_3_000.ToConcept(w_);
+			var y_ = this.Patient_Reason();
+			var z_ = context.Operators.ConceptInValueSet(x_, y_);
+
+			return z_;
+		};
+		var i_ = context.Operators.WhereOrNull<Observation>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Patient Reason for Not Performing Assessment of Cognition Using Standardized Tools or Alternate Methods")]
+	public IEnumerable<Observation> Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods() => 
+		__Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods.Value;
+
+	private bool? Denominator_Exceptions_Value()
+	{
+		var a_ = this.Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods();
+		var b_ = context.Operators.ExistsInList<Observation>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Denominator Exceptions")]
+	public bool? Denominator_Exceptions() => 
+		__Denominator_Exceptions.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+}

--- a/Demo/Measures-cms/DiabetesEyeExamFHIR-0.0.001.g.cs
+++ b/Demo/Measures-cms/DiabetesEyeExamFHIR-0.0.001.g.cs
@@ -1,0 +1,484 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("DiabetesEyeExamFHIR", "0.0.001")]
+public class DiabetesEyeExamFHIR_0_0_001
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Diabetes;
+    internal Lazy<CqlValueSet> __Diabetic_Retinopathy;
+    internal Lazy<CqlValueSet> __Discharged_to_Health_Care_Facility_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Discharged_to_Home_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Hospice_Care_Ambulatory;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Ophthalmological_Services;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Retinal_or_Dilated_Eye_Exam;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Diabetic_Retinopathy_Overlapping_Measurement_Period;
+    internal Lazy<IEnumerable<Observation>> __Retinal_Exam_in_Measurement_Period;
+    internal Lazy<IEnumerable<Observation>> __Retinal_Exam_in_Measurement_Period_or_Year_Prior;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public DiabetesEyeExamFHIR_0_0_001(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        PalliativeCare_1_9_000 = new PalliativeCare_1_9_000(context);
+        AdvancedIllnessandFrailty_1_8_000 = new AdvancedIllnessandFrailty_1_8_000(context);
+
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value);
+        __Diabetes = new Lazy<CqlValueSet>(this.Diabetes_Value);
+        __Diabetic_Retinopathy = new Lazy<CqlValueSet>(this.Diabetic_Retinopathy_Value);
+        __Discharged_to_Health_Care_Facility_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Health_Care_Facility_for_Hospice_Care_Value);
+        __Discharged_to_Home_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Home_for_Hospice_Care_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Hospice_Care_Ambulatory = new Lazy<CqlValueSet>(this.Hospice_Care_Ambulatory_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Ophthalmological_Services = new Lazy<CqlValueSet>(this.Ophthalmological_Services_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Retinal_or_Dilated_Eye_Exam = new Lazy<CqlValueSet>(this.Retinal_or_Dilated_Eye_Exam_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Diabetic_Retinopathy_Overlapping_Measurement_Period = new Lazy<bool?>(this.Diabetic_Retinopathy_Overlapping_Measurement_Period_Value);
+        __Retinal_Exam_in_Measurement_Period = new Lazy<IEnumerable<Observation>>(this.Retinal_Exam_in_Measurement_Period_Value);
+        __Retinal_Exam_in_Measurement_Period_or_Year_Prior = new Lazy<IEnumerable<Observation>>(this.Retinal_Exam_in_Measurement_Period_or_Year_Prior_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public PalliativeCare_1_9_000 PalliativeCare_1_9_000 { get; }
+    public AdvancedIllnessandFrailty_1_8_000 AdvancedIllnessandFrailty_1_8_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Annual_Wellness_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+
+    [CqlDeclaration("Annual Wellness Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit.Value;
+
+	private CqlValueSet Diabetes_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+
+    [CqlDeclaration("Diabetes")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
+	public CqlValueSet Diabetes() => 
+		__Diabetes.Value;
+
+	private CqlValueSet Diabetic_Retinopathy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
+
+    [CqlDeclaration("Diabetic Retinopathy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
+	public CqlValueSet Diabetic_Retinopathy() => 
+		__Diabetic_Retinopathy.Value;
+
+	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+
+    [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
+	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
+		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
+
+	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+
+    [CqlDeclaration("Discharged to Home for Hospice Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
+	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
+		__Discharged_to_Home_for_Hospice_Care.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+
+    [CqlDeclaration("Hospice Care Ambulatory")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
+	public CqlValueSet Hospice_Care_Ambulatory() => 
+		__Hospice_Care_Ambulatory.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Ophthalmological_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+
+    [CqlDeclaration("Ophthalmological Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
+	public CqlValueSet Ophthalmological_Services() => 
+		__Ophthalmological_Services.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Retinal_or_Dilated_Eye_Exam_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088", null);
+
+    [CqlDeclaration("Retinal or Dilated Eye Exam")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088")]
+	public CqlValueSet Retinal_or_Dilated_Eye_Exam() => 
+		__Retinal_or_Dilated_Eye_Exam.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("DiabetesEyeExamFHIR-0.0.001", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Annual_Wellness_Visit();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Home_Healthcare_Services();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Ophthalmological_Services();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Telephone_Visits();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = context.Operators.ListUnion<Encounter>(q_, s_);
+		var u_ = Status_1_6_000.isEncounterPerformed(t_);
+		bool? v_(Encounter ValidEncounters)
+		{
+			var x_ = this.Measurement_Period();
+			var y_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounters?.Period);
+			var z_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, y_, "day");
+
+			return z_;
+		};
+		var w_ = context.Operators.WhereOrNull<Encounter>(u_, v_);
+
+		return w_;
+	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)18, (int?)75, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var i_ = this.Qualifying_Encounters();
+		var j_ = context.Operators.ExistsInList<Encounter>(i_);
+		var k_ = context.Operators.And(h_, j_);
+		var l_ = this.Diabetes();
+		var m_ = context.Operators.RetrieveByValueSet<Condition>(l_, null);
+		bool? n_(Condition Diabetes)
+		{
+			var r_ = QICoreCommon_2_0_000.prevalenceInterval(Diabetes);
+			var s_ = this.Measurement_Period();
+			var t_ = context.Operators.Overlaps(r_, s_, null);
+
+			return t_;
+		};
+		var o_ = context.Operators.WhereOrNull<Condition>(m_, n_);
+		var p_ = context.Operators.ExistsInList<Condition>(o_);
+		var q_ = context.Operators.And(k_, p_);
+
+		return q_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home();
+		var e_ = context.Operators.Or(c_, d_);
+		var f_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		var g_ = context.Operators.Or(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private bool? Diabetic_Retinopathy_Overlapping_Measurement_Period_Value()
+	{
+		var a_ = this.Diabetic_Retinopathy();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition Retinopathy)
+		{
+			var f_ = QICoreCommon_2_0_000.prevalenceInterval(Retinopathy);
+			var g_ = this.Measurement_Period();
+			var h_ = context.Operators.Overlaps(f_, g_, null);
+
+			return h_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Diabetic Retinopathy Overlapping Measurement Period")]
+	public bool? Diabetic_Retinopathy_Overlapping_Measurement_Period() => 
+		__Diabetic_Retinopathy_Overlapping_Measurement_Period.Value;
+
+	private IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_Value()
+	{
+		var a_ = this.Retinal_or_Dilated_Eye_Exam();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		bool? d_(Observation RetinalExam)
+		{
+			var f_ = this.Measurement_Period();
+			var g_ = FHIRHelpers_4_3_000.ToValue(RetinalExam?.Effective);
+			var h_ = QICoreCommon_2_0_000.toInterval(g_);
+			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
+
+			return i_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Retinal Exam in Measurement Period")]
+	public IEnumerable<Observation> Retinal_Exam_in_Measurement_Period() => 
+		__Retinal_Exam_in_Measurement_Period.Value;
+
+	private IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_or_Year_Prior_Value()
+	{
+		var a_ = this.Retinal_or_Dilated_Eye_Exam();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		bool? d_(Observation RetinalExam)
+		{
+			var f_ = this.Measurement_Period();
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.Quantity(1m, "year");
+			var i_ = context.Operators.Subtract(g_, h_);
+			var k_ = context.Operators.End(f_);
+			var l_ = context.Operators.Interval(i_, k_, true, true);
+			var m_ = FHIRHelpers_4_3_000.ToValue(RetinalExam?.Effective);
+			var n_ = QICoreCommon_2_0_000.toInterval(m_);
+			var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, "day");
+
+			return o_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Retinal Exam in Measurement Period or Year Prior")]
+	public IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_or_Year_Prior() => 
+		__Retinal_Exam_in_Measurement_Period_or_Year_Prior.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Diabetic_Retinopathy_Overlapping_Measurement_Period();
+		var b_ = this.Retinal_Exam_in_Measurement_Period();
+		var c_ = context.Operators.ExistsInList<Observation>(b_);
+		var d_ = context.Operators.And(a_, c_);
+		var f_ = context.Operators.Not(a_);
+		var g_ = this.Retinal_Exam_in_Measurement_Period_or_Year_Prior();
+		var h_ = context.Operators.ExistsInList<Observation>(g_);
+		var i_ = context.Operators.And(f_, h_);
+		var j_ = context.Operators.Or(d_, i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
@@ -1,0 +1,385 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR", "0.1.000")]
+public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Diabetes;
+    internal Lazy<CqlValueSet> __HbA1c_Laboratory_Test;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<Observation> __Most_Recent_HbA1c;
+    internal Lazy<bool?> __Has_Most_Recent_HbA1c_Without_Result;
+    internal Lazy<bool?> __Has_Most_Recent_Elevated_HbA1c;
+    internal Lazy<bool?> __Has_No_Record_Of_HbA1c;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        CumulativeMedicationDuration_4_0_000 = new CumulativeMedicationDuration_4_0_000(context);
+        AdultOutpatientEncounters_4_8_000 = new AdultOutpatientEncounters_4_8_000(context);
+        AdvancedIllnessandFrailty_1_8_000 = new AdvancedIllnessandFrailty_1_8_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        PalliativeCare_1_9_000 = new PalliativeCare_1_9_000(context);
+
+        __Diabetes = new Lazy<CqlValueSet>(this.Diabetes_Value);
+        __HbA1c_Laboratory_Test = new Lazy<CqlValueSet>(this.HbA1c_Laboratory_Test_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Most_Recent_HbA1c = new Lazy<Observation>(this.Most_Recent_HbA1c_Value);
+        __Has_Most_Recent_HbA1c_Without_Result = new Lazy<bool?>(this.Has_Most_Recent_HbA1c_Without_Result_Value);
+        __Has_Most_Recent_Elevated_HbA1c = new Lazy<bool?>(this.Has_Most_Recent_Elevated_HbA1c_Value);
+        __Has_No_Record_Of_HbA1c = new Lazy<bool?>(this.Has_No_Record_Of_HbA1c_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public CumulativeMedicationDuration_4_0_000 CumulativeMedicationDuration_4_0_000 { get; }
+    public AdultOutpatientEncounters_4_8_000 AdultOutpatientEncounters_4_8_000 { get; }
+    public AdvancedIllnessandFrailty_1_8_000 AdvancedIllnessandFrailty_1_8_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public PalliativeCare_1_9_000 PalliativeCare_1_9_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Diabetes_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+
+    [CqlDeclaration("Diabetes")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
+	public CqlValueSet Diabetes() => 
+		__Diabetes.Value;
+
+	private CqlValueSet HbA1c_Laboratory_Test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", null);
+
+    [CqlDeclaration("HbA1c Laboratory Test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013")]
+	public CqlValueSet HbA1c_Laboratory_Test() => 
+		__HbA1c_Laboratory_Test.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)18, (int?)75, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var i_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
+		var j_ = context.Operators.ExistsInList<Encounter>(i_);
+		var k_ = context.Operators.And(h_, j_);
+		var l_ = this.Diabetes();
+		var m_ = context.Operators.RetrieveByValueSet<Condition>(l_, null);
+		bool? n_(Condition Diabetes)
+		{
+			var r_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
+			var s_ = this.Measurement_Period();
+			var t_ = context.Operators.Overlaps(r_, s_, null);
+
+			return t_;
+		};
+		var o_ = context.Operators.WhereOrNull<Condition>(m_, n_);
+		var p_ = context.Operators.ExistsInList<Condition>(o_);
+		var q_ = context.Operators.And(k_, p_);
+
+		return q_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home();
+		var e_ = context.Operators.Or(c_, d_);
+		var f_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		var g_ = context.Operators.Or(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private Observation Most_Recent_HbA1c_Value()
+	{
+		var a_ = this.HbA1c_Laboratory_Test();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
+		bool? d_(Observation RecentHbA1c)
+		{
+			object i_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(RecentHbA1c?.Effective) is CqlDateTime)
+				{
+					var m_ = FHIRHelpers_4_3_000.ToValue(RecentHbA1c?.Effective);
+
+					return ((m_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(RecentHbA1c?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var n_ = FHIRHelpers_4_3_000.ToValue(RecentHbA1c?.Effective);
+
+					return ((n_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(RecentHbA1c?.Effective) is CqlDateTime)
+				{
+					var o_ = FHIRHelpers_4_3_000.ToValue(RecentHbA1c?.Effective);
+
+					return ((o_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var j_ = QICoreCommon_2_0_000.Latest(i_());
+			var k_ = this.Measurement_Period();
+			var l_ = context.Operators.ElementInInterval<CqlDateTime>(j_, k_, "day");
+
+			return l_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		object f_(Observation @this)
+		{
+			var p_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var q_ = QICoreCommon_2_0_000.ToInterval(p_);
+			var r_ = context.Operators.Start(q_);
+
+			return r_;
+		};
+		var g_ = context.Operators.ListSortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		var h_ = context.Operators.LastOfList<Observation>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Most Recent HbA1c")]
+	public Observation Most_Recent_HbA1c() => 
+		__Most_Recent_HbA1c.Value;
+
+	private bool? Has_Most_Recent_HbA1c_Without_Result_Value()
+	{
+		var a_ = this.Most_Recent_HbA1c();
+		var b_ = context.Operators.Not((bool?)(a_ is null));
+		var d_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
+		var e_ = context.Operators.And(b_, (bool?)(d_ is null));
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Most Recent HbA1c Without Result")]
+	public bool? Has_Most_Recent_HbA1c_Without_Result() => 
+		__Has_Most_Recent_HbA1c_Without_Result.Value;
+
+	private bool? Has_Most_Recent_Elevated_HbA1c_Value()
+	{
+		var a_ = this.Most_Recent_HbA1c();
+		var b_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
+		var c_ = context.Operators.Quantity(9m, "%");
+		var d_ = context.Operators.Greater((b_ as CqlQuantity), c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Has Most Recent Elevated HbA1c")]
+	public bool? Has_Most_Recent_Elevated_HbA1c() => 
+		__Has_Most_Recent_Elevated_HbA1c.Value;
+
+	private bool? Has_No_Record_Of_HbA1c_Value()
+	{
+		var a_ = this.HbA1c_Laboratory_Test();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
+		bool? d_(Observation NoHbA1c)
+		{
+			object h_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(NoHbA1c?.Effective) is CqlDateTime)
+				{
+					var l_ = FHIRHelpers_4_3_000.ToValue(NoHbA1c?.Effective);
+
+					return ((l_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(NoHbA1c?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var m_ = FHIRHelpers_4_3_000.ToValue(NoHbA1c?.Effective);
+
+					return ((m_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(NoHbA1c?.Effective) is CqlDateTime)
+				{
+					var n_ = FHIRHelpers_4_3_000.ToValue(NoHbA1c?.Effective);
+
+					return ((n_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var i_ = QICoreCommon_2_0_000.Latest(h_());
+			var j_ = this.Measurement_Period();
+			var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, "day");
+
+			return k_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Observation>(e_);
+		var g_ = context.Operators.Not(f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Has No Record Of HbA1c")]
+	public bool? Has_No_Record_Of_HbA1c() => 
+		__Has_No_Record_Of_HbA1c.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Has_Most_Recent_HbA1c_Without_Result();
+		var b_ = this.Has_Most_Recent_Elevated_HbA1c();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = this.Has_No_Record_Of_HbA1c();
+		var e_ = context.Operators.Or(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+}

--- a/Demo/Measures-cms/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
+++ b/Demo/Measures-cms/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
@@ -1,0 +1,510 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("DischargedonAntithromboticTherapyFHIR", "0.9.000")]
+public class DischargedonAntithromboticTherapyFHIR_0_9_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Antithrombotic_Therapy_for_Ischemic_Stroke;
+    internal Lazy<CqlValueSet> __Medical_Reason_For_Not_Providing_Treatment;
+    internal Lazy<CqlValueSet> __Patient_Refusal;
+    internal Lazy<CqlValueSet> __Pharmacological_Contraindications_For_Antithrombotic_Therapy;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<IEnumerable<MedicationRequest>> __Antithrombotic_Therapy_at_Discharge;
+    internal Lazy<IEnumerable<MedicationRequest>> __Reason_for_Not_Giving_Antithrombotic_at_Discharge;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge;
+    internal Lazy<IEnumerable<MedicationRequest>> __Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exceptions;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public DischargedonAntithromboticTherapyFHIR_0_9_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        TJCOverall_8_11_000 = new TJCOverall_8_11_000(context);
+
+        __Antithrombotic_Therapy_for_Ischemic_Stroke = new Lazy<CqlValueSet>(this.Antithrombotic_Therapy_for_Ischemic_Stroke_Value);
+        __Medical_Reason_For_Not_Providing_Treatment = new Lazy<CqlValueSet>(this.Medical_Reason_For_Not_Providing_Treatment_Value);
+        __Patient_Refusal = new Lazy<CqlValueSet>(this.Patient_Refusal_Value);
+        __Pharmacological_Contraindications_For_Antithrombotic_Therapy = new Lazy<CqlValueSet>(this.Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke_Value);
+        __Denominator_Exclusions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exclusions_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+        __Antithrombotic_Therapy_at_Discharge = new Lazy<IEnumerable<MedicationRequest>>(this.Antithrombotic_Therapy_at_Discharge_Value);
+        __Reason_for_Not_Giving_Antithrombotic_at_Discharge = new Lazy<IEnumerable<MedicationRequest>>(this.Reason_for_Not_Giving_Antithrombotic_at_Discharge_Value);
+        __Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge_Value);
+        __Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge = new Lazy<IEnumerable<MedicationRequest>>(this.Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value);
+        __Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value);
+        __Denominator_Exceptions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exceptions_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public TJCOverall_8_11_000 TJCOverall_8_11_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Antithrombotic_Therapy_for_Ischemic_Stroke_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62", null);
+
+    [CqlDeclaration("Antithrombotic Therapy for Ischemic Stroke")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62")]
+	public CqlValueSet Antithrombotic_Therapy_for_Ischemic_Stroke() => 
+		__Antithrombotic_Therapy_for_Ischemic_Stroke.Value;
+
+	private CqlValueSet Medical_Reason_For_Not_Providing_Treatment_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", null);
+
+    [CqlDeclaration("Medical Reason For Not Providing Treatment")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
+	public CqlValueSet Medical_Reason_For_Not_Providing_Treatment() => 
+		__Medical_Reason_For_Not_Providing_Treatment.Value;
+
+	private CqlValueSet Patient_Refusal_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", null);
+
+    [CqlDeclaration("Patient Refusal")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
+	public CqlValueSet Patient_Refusal() => 
+		__Patient_Refusal.Value;
+
+	private CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", null);
+
+    [CqlDeclaration("Pharmacological Contraindications For Antithrombotic Therapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52")]
+	public CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy() => 
+		__Pharmacological_Contraindications_For_Antithrombotic_Therapy.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("DischargedonAntithromboticTherapyFHIR-0.9.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = TJCOverall_8_11_000.Encounter_with_Principal_Diagnosis_and_Age();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke_Value()
+	{
+		var a_ = this.Denominator();
+		IEnumerable<Encounter> b_(Encounter Encounter)
+		{
+			var d_ = TJCOverall_8_11_000.Intervention_Comfort_Measures();
+			bool? e_(object ComfortMeasure)
+			{
+				var i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				var k_ = QICoreCommon_2_0_000.toInterval(j_);
+				var l_ = context.Operators.Start(k_);
+				var m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+				var n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
+				var o_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
+				var p_ = context.Operators.ElementInInterval<CqlDateTime>((l_ ?? n_), o_, null);
+
+				return p_;
+			};
+			var f_ = context.Operators.WhereOrNull<object>(d_, e_);
+			Encounter g_(object ComfortMeasure) => 
+				Encounter;
+			var h_ = context.Operators.SelectOrNull<object, Encounter>(f_, g_);
+
+			return h_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Comfort Measures during Hospitalization for Patients with Documented Ischemic Stroke")]
+	public IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke() => 
+		__Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke.Value;
+
+	private IEnumerable<Encounter> Denominator_Exclusions_Value()
+	{
+		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounters_with_Discharge_Disposition();
+		var b_ = this.Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public IEnumerable<Encounter> Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
+		{
+			var d_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
+			var e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			var h_ = context.Operators.ListUnion<MedicationRequest>(e_, g_);
+			bool? i_(MedicationRequest DischargeAntithrombotic)
+			{
+				var m_ = context.Operators.Convert<CqlDateTime>(DischargeAntithrombotic?.AuthoredOnElement);
+				var n_ = FHIRHelpers_4_3_000.ToInterval(IschemicStrokeEncounter?.Period);
+				var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, null);
+
+				return o_;
+			};
+			var j_ = context.Operators.WhereOrNull<MedicationRequest>(h_, i_);
+			Encounter k_(MedicationRequest DischargeAntithrombotic) => 
+				IschemicStrokeEncounter;
+			var l_ = context.Operators.SelectOrNull<MedicationRequest, Encounter>(j_, k_);
+
+			return l_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+	private IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge_Value()
+	{
+		var a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		bool? f_(MedicationRequest Antithrombotic)
+		{
+			var h_ = QICoreCommon_2_0_000.isCommunity(Antithrombotic);
+			var i_ = QICoreCommon_2_0_000.isDischarge(Antithrombotic);
+			var j_ = context.Operators.Or(h_, i_);
+			var k_ = context.Operators.Convert<string>(Antithrombotic?.StatusElement?.Value);
+			var l_ = new string[]
+			{
+				"active",
+				"completed",
+			};
+			var m_ = context.Operators.InList<string>(k_, (l_ as IEnumerable<string>));
+			var n_ = context.Operators.And(j_, m_);
+			var o_ = context.Operators.Convert<string>(Antithrombotic?.IntentElement?.Value);
+			var p_ = new string[]
+			{
+				"order",
+				"original-order",
+				"reflex-order",
+				"filler-order",
+				"instance-order",
+			};
+			var q_ = context.Operators.InList<string>(o_, (p_ as IEnumerable<string>));
+			var r_ = context.Operators.And(n_, q_);
+			var s_ = context.Operators.IsTrue(Antithrombotic?.DoNotPerformElement?.Value);
+			var t_ = context.Operators.Not(s_);
+			var u_ = context.Operators.And(r_, t_);
+
+			return u_;
+		};
+		var g_ = context.Operators.WhereOrNull<MedicationRequest>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Antithrombotic Therapy at Discharge")]
+	public IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge() => 
+		__Antithrombotic_Therapy_at_Discharge.Value;
+
+	private IEnumerable<MedicationRequest> Reason_for_Not_Giving_Antithrombotic_at_Discharge_Value()
+	{
+		var a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		bool? f_(MedicationRequest NoAntithromboticDischarge)
+		{
+			CqlConcept h_(CodeableConcept @this)
+			{
+				var y_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return y_;
+			};
+			var i_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(NoAntithromboticDischarge?.ReasonCode, h_);
+			var j_ = this.Medical_Reason_For_Not_Providing_Treatment();
+			var k_ = context.Operators.ConceptsInValueSet(i_, j_);
+			CqlConcept l_(CodeableConcept @this)
+			{
+				var z_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return z_;
+			};
+			var m_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(NoAntithromboticDischarge?.ReasonCode, l_);
+			var n_ = this.Patient_Refusal();
+			var o_ = context.Operators.ConceptsInValueSet(m_, n_);
+			var p_ = context.Operators.Or(k_, o_);
+			var q_ = QICoreCommon_2_0_000.isCommunity(NoAntithromboticDischarge);
+			var r_ = QICoreCommon_2_0_000.isDischarge(NoAntithromboticDischarge);
+			var s_ = context.Operators.Or(q_, r_);
+			var t_ = context.Operators.And(p_, s_);
+			var u_ = context.Operators.Convert<string>(NoAntithromboticDischarge?.IntentElement?.Value);
+			var v_ = new string[]
+			{
+				"order",
+				"original-order",
+				"reflex-order",
+				"filler-order",
+				"instance-order",
+			};
+			var w_ = context.Operators.InList<string>(u_, (v_ as IEnumerable<string>));
+			var x_ = context.Operators.And(t_, w_);
+
+			return x_;
+		};
+		var g_ = context.Operators.WhereOrNull<MedicationRequest>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Reason for Not Giving Antithrombotic at Discharge")]
+	public IEnumerable<MedicationRequest> Reason_for_Not_Giving_Antithrombotic_at_Discharge() => 
+		__Reason_for_Not_Giving_Antithrombotic_at_Discharge.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge_Value()
+	{
+		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
+		{
+			var d_ = this.Reason_for_Not_Giving_Antithrombotic_at_Discharge();
+			bool? e_(MedicationRequest NoDischargeAntithrombotic)
+			{
+				var i_ = context.Operators.Convert<CqlDateTime>(NoDischargeAntithrombotic?.AuthoredOnElement);
+				var j_ = FHIRHelpers_4_3_000.ToInterval(IschemicStrokeEncounter?.Period);
+				var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, null);
+
+				return k_;
+			};
+			var f_ = context.Operators.WhereOrNull<MedicationRequest>(d_, e_);
+			Encounter g_(MedicationRequest NoDischargeAntithrombotic) => 
+				IschemicStrokeEncounter;
+			var h_ = context.Operators.SelectOrNull<MedicationRequest, Encounter>(f_, g_);
+
+			return h_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Documented Reason for No Antithrombotic At Discharge")]
+	public IEnumerable<Encounter> Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge() => 
+		__Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge.Value;
+
+	private IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value()
+	{
+		var a_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		bool? f_(MedicationRequest Pharmacological)
+		{
+			var h_ = QICoreCommon_2_0_000.isCommunity(Pharmacological);
+			var i_ = QICoreCommon_2_0_000.isDischarge(Pharmacological);
+			var j_ = context.Operators.Or(h_, i_);
+			var k_ = context.Operators.Convert<string>(Pharmacological?.StatusElement?.Value);
+			var l_ = new string[]
+			{
+				"active",
+				"completed",
+			};
+			var m_ = context.Operators.InList<string>(k_, (l_ as IEnumerable<string>));
+			var n_ = context.Operators.And(j_, m_);
+			var o_ = context.Operators.Convert<string>(Pharmacological?.IntentElement?.Value);
+			var p_ = new string[]
+			{
+				"order",
+				"original-order",
+				"reflex-order",
+				"filler-order",
+				"instance-order",
+			};
+			var q_ = context.Operators.InList<string>(o_, (p_ as IEnumerable<string>));
+			var r_ = context.Operators.And(n_, q_);
+			var s_ = context.Operators.IsTrue(Pharmacological?.DoNotPerformElement?.Value);
+			var t_ = context.Operators.Not(s_);
+			var u_ = context.Operators.And(r_, t_);
+
+			return u_;
+		};
+		var g_ = context.Operators.WhereOrNull<MedicationRequest>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Pharmacological Contraindications for Antithrombotic Therapy at Discharge")]
+	public IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge() => 
+		__Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value()
+	{
+		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
+		{
+			var d_ = this.Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge();
+			bool? e_(MedicationRequest DischargePharmacological)
+			{
+				var i_ = context.Operators.Convert<CqlDateTime>(DischargePharmacological?.AuthoredOnElement);
+				var j_ = FHIRHelpers_4_3_000.ToInterval(IschemicStrokeEncounter?.Period);
+				var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, null);
+
+				return k_;
+			};
+			var f_ = context.Operators.WhereOrNull<MedicationRequest>(d_, e_);
+			Encounter g_(MedicationRequest DischargePharmacological) => 
+				IschemicStrokeEncounter;
+			var h_ = context.Operators.SelectOrNull<MedicationRequest, Encounter>(f_, g_);
+
+			return h_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Pharmacological Contraindications for Antithrombotic Therapy at Discharge")]
+	public IEnumerable<Encounter> Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge() => 
+		__Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge.Value;
+
+	private IEnumerable<Encounter> Denominator_Exceptions_Value()
+	{
+		var a_ = this.Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge();
+		var b_ = this.Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Denominator Exceptions")]
+	public IEnumerable<Encounter> Denominator_Exceptions() => 
+		__Denominator_Exceptions.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
@@ -1,0 +1,431 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("FallsScreeningForFutureFallRiskFHIR", "0.1.000")]
+public class FallsScreeningForFutureFallRiskFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Audiology_Visit;
+    internal Lazy<CqlValueSet> __Care_Services_in_Long_Term_Residential_Facility;
+    internal Lazy<CqlValueSet> __Discharge_Services_Nursing_Facility;
+    internal Lazy<CqlValueSet> __Falls_Screening;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Nursing_Facility_Visit;
+    internal Lazy<CqlValueSet> __Occupational_Therapy_Evaluation;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Ophthalmological_Services;
+    internal Lazy<CqlValueSet> __Physical_Therapy_Evaluation;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Individual_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public FallsScreeningForFutureFallRiskFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value);
+        __Audiology_Visit = new Lazy<CqlValueSet>(this.Audiology_Visit_Value);
+        __Care_Services_in_Long_Term_Residential_Facility = new Lazy<CqlValueSet>(this.Care_Services_in_Long_Term_Residential_Facility_Value);
+        __Discharge_Services_Nursing_Facility = new Lazy<CqlValueSet>(this.Discharge_Services_Nursing_Facility_Value);
+        __Falls_Screening = new Lazy<CqlValueSet>(this.Falls_Screening_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Nursing_Facility_Visit = new Lazy<CqlValueSet>(this.Nursing_Facility_Visit_Value);
+        __Occupational_Therapy_Evaluation = new Lazy<CqlValueSet>(this.Occupational_Therapy_Evaluation_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Ophthalmological_Services = new Lazy<CqlValueSet>(this.Ophthalmological_Services_Value);
+        __Physical_Therapy_Evaluation = new Lazy<CqlValueSet>(this.Physical_Therapy_Evaluation_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Individual_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Individual_Counseling_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Annual_Wellness_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+
+    [CqlDeclaration("Annual Wellness Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit.Value;
+
+	private CqlValueSet Audiology_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066", null);
+
+    [CqlDeclaration("Audiology Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066")]
+	public CqlValueSet Audiology_Visit() => 
+		__Audiology_Visit.Value;
+
+	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+
+    [CqlDeclaration("Care Services in Long Term Residential Facility")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
+	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
+		__Care_Services_in_Long_Term_Residential_Facility.Value;
+
+	private CqlValueSet Discharge_Services_Nursing_Facility_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", null);
+
+    [CqlDeclaration("Discharge Services Nursing Facility")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013")]
+	public CqlValueSet Discharge_Services_Nursing_Facility() => 
+		__Discharge_Services_Nursing_Facility.Value;
+
+	private CqlValueSet Falls_Screening_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028", null);
+
+    [CqlDeclaration("Falls Screening")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028")]
+	public CqlValueSet Falls_Screening() => 
+		__Falls_Screening.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Nursing_Facility_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+
+    [CqlDeclaration("Nursing Facility Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
+	public CqlValueSet Nursing_Facility_Visit() => 
+		__Nursing_Facility_Visit.Value;
+
+	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", null);
+
+    [CqlDeclaration("Occupational Therapy Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
+	public CqlValueSet Occupational_Therapy_Evaluation() => 
+		__Occupational_Therapy_Evaluation.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Ophthalmological_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+
+    [CqlDeclaration("Ophthalmological Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
+	public CqlValueSet Ophthalmological_Services() => 
+		__Ophthalmological_Services.Value;
+
+	private CqlValueSet Physical_Therapy_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", null);
+
+    [CqlDeclaration("Physical Therapy Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022")]
+	public CqlValueSet Physical_Therapy_Evaluation() => 
+		__Physical_Therapy_Evaluation.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+
+    [CqlDeclaration("Preventive Care Services Individual Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
+	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
+		__Preventive_Care_Services_Individual_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("FallsScreeningForFutureFallRiskFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Annual_Wellness_Visit();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Home_Healthcare_Services();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Ophthalmological_Services();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Preventive_Care_Services_Individual_Counseling();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = this.Discharge_Services_Nursing_Facility();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
+		var x_ = this.Nursing_Facility_Visit();
+		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		var z_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		var ab_ = context.Operators.ListUnion<Encounter>(y_, aa_);
+		var ac_ = context.Operators.ListUnion<Encounter>(w_, ab_);
+		var ad_ = this.Audiology_Visit();
+		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		var af_ = this.Telephone_Visits();
+		var ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		var ah_ = context.Operators.ListUnion<Encounter>(ae_, ag_);
+		var ai_ = context.Operators.ListUnion<Encounter>(ac_, ah_);
+		var aj_ = this.Online_Assessments();
+		var ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, null);
+		var al_ = this.Physical_Therapy_Evaluation();
+		var am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		var an_ = context.Operators.ListUnion<Encounter>(ak_, am_);
+		var ao_ = context.Operators.ListUnion<Encounter>(ai_, an_);
+		var ap_ = this.Occupational_Therapy_Evaluation();
+		var aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, null);
+		var ar_ = context.Operators.ListUnion<Encounter>(ao_, aq_);
+		var as_ = Status_1_6_000.Finished_Encounter(ar_);
+		bool? at_(Encounter ValidEncounter)
+		{
+			var av_ = this.Measurement_Period();
+			var aw_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var ax_ = QICoreCommon_2_0_000.ToInterval((aw_ as object));
+			var ay_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(av_, ax_, "day");
+
+			return ay_;
+		};
+		var au_ = context.Operators.WhereOrNull<Encounter>(as_, at_);
+
+		return au_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter")]
+	public IEnumerable<Encounter> Qualifying_Encounter() => 
+		__Qualifying_Encounter.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.GreaterOrEqual(f_, (int?)65);
+		var h_ = this.Qualifying_Encounter();
+		var i_ = context.Operators.ExistsInList<Encounter>(h_);
+		var j_ = context.Operators.And(g_, i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Falls_Screening();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		bool? d_(Observation FallsScreening)
+		{
+			var g_ = this.Measurement_Period();
+			var h_ = FHIRHelpers_4_3_000.ToValue(FallsScreening?.Effective);
+			var i_ = QICoreCommon_2_0_000.ToInterval(h_);
+			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, "day");
+
+			return j_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Observation>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+}

--- a/Demo/Measures-cms/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
@@ -1,0 +1,1528 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR", "0.1.000")]
+public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Ambulatory;
+    internal Lazy<CqlValueSet> __Atomoxetine;
+    internal Lazy<CqlValueSet> __Behavioral_Health_Follow_up_Visit;
+    internal Lazy<CqlValueSet> __Clonidine;
+    internal Lazy<CqlValueSet> __Dexmethylphenidate;
+    internal Lazy<CqlValueSet> __Dextroamphetamine;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Guanfacine;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Initial_Hospital_Observation_Care;
+    internal Lazy<CqlValueSet> __Lisdexamfetamine;
+    internal Lazy<CqlValueSet> __Mental_Behavioral_and_Neurodevelopmental_Disorders;
+    internal Lazy<CqlValueSet> __Methylphenidate;
+    internal Lazy<CqlValueSet> __Narcolepsy;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Group_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Individual_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care__Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Psych_Visit_Diagnostic_Evaluation;
+    internal Lazy<CqlValueSet> __Psych_Visit_Psychotherapy;
+    internal Lazy<CqlValueSet> __Psychotherapy_and_Pharmacologic_Management;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlCode> ___24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule;
+    internal Lazy<CqlCode> __methamphetamine_hydrochloride_5_MG_Oral_Tablet;
+    internal Lazy<CqlCode[]> __RXNORM;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<CqlDateTime> __March_1_of_Year_Prior_to_Measurement_Period;
+    internal Lazy<CqlDateTime> __Last_Calendar_Day_of_February_of_Measurement_Period;
+    internal Lazy<CqlInterval<CqlDateTime>> __Intake_Period;
+    internal Lazy<IEnumerable<Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE>> __ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication;
+    internal Lazy<CqlDate> __First_ADHD_Medication_Prescribed_During_Intake_Period;
+    internal Lazy<CqlDate> __IPSD;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Stay_with_Qualifying_Diagnosis;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase;
+    internal Lazy<bool?> __Initial_Population_1;
+    internal Lazy<bool?> __Denominator_1;
+    internal Lazy<IEnumerable<Condition>> __Narcolepsy_Exclusion;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Numerator_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_During_Initiation_Phase;
+    internal Lazy<bool?> __Numerator_1;
+    internal Lazy<IEnumerable<CqlInterval<CqlDate>>> __ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase;
+    internal Lazy<int?> __ADHD_Cumulative_Medication_Duration;
+    internal Lazy<bool?> __Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase;
+    internal Lazy<bool?> __Initial_Population_2;
+    internal Lazy<bool?> __Denominator_2;
+    internal Lazy<IEnumerable<CqlDate>> __Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase;
+    internal Lazy<bool?> __Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase;
+    internal Lazy<IEnumerable<CqlDate>> __Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase;
+    internal Lazy<bool?> __Numerator_2;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        CumulativeMedicationDuration_4_0_000 = new CumulativeMedicationDuration_4_0_000(context);
+
+        __Ambulatory = new Lazy<CqlValueSet>(this.Ambulatory_Value);
+        __Atomoxetine = new Lazy<CqlValueSet>(this.Atomoxetine_Value);
+        __Behavioral_Health_Follow_up_Visit = new Lazy<CqlValueSet>(this.Behavioral_Health_Follow_up_Visit_Value);
+        __Clonidine = new Lazy<CqlValueSet>(this.Clonidine_Value);
+        __Dexmethylphenidate = new Lazy<CqlValueSet>(this.Dexmethylphenidate_Value);
+        __Dextroamphetamine = new Lazy<CqlValueSet>(this.Dextroamphetamine_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Guanfacine = new Lazy<CqlValueSet>(this.Guanfacine_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Initial_Hospital_Observation_Care = new Lazy<CqlValueSet>(this.Initial_Hospital_Observation_Care_Value);
+        __Lisdexamfetamine = new Lazy<CqlValueSet>(this.Lisdexamfetamine_Value);
+        __Mental_Behavioral_and_Neurodevelopmental_Disorders = new Lazy<CqlValueSet>(this.Mental_Behavioral_and_Neurodevelopmental_Disorders_Value);
+        __Methylphenidate = new Lazy<CqlValueSet>(this.Methylphenidate_Value);
+        __Narcolepsy = new Lazy<CqlValueSet>(this.Narcolepsy_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Preventive_Care_Services_Group_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Group_Counseling_Value);
+        __Preventive_Care_Services_Individual_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Individual_Counseling_Value);
+        __Preventive_Care_Services__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value);
+        __Preventive_Care__Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Established_Office_Visit__0_to_17_Value);
+        __Psych_Visit_Diagnostic_Evaluation = new Lazy<CqlValueSet>(this.Psych_Visit_Diagnostic_Evaluation_Value);
+        __Psych_Visit_Psychotherapy = new Lazy<CqlValueSet>(this.Psych_Visit_Psychotherapy_Value);
+        __Psychotherapy_and_Pharmacologic_Management = new Lazy<CqlValueSet>(this.Psychotherapy_and_Pharmacologic_Management_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        ___24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule = new Lazy<CqlCode>(this._24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule_Value);
+        __methamphetamine_hydrochloride_5_MG_Oral_Tablet = new Lazy<CqlCode>(this.methamphetamine_hydrochloride_5_MG_Oral_Tablet_Value);
+        __RXNORM = new Lazy<CqlCode[]>(this.RXNORM_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __March_1_of_Year_Prior_to_Measurement_Period = new Lazy<CqlDateTime>(this.March_1_of_Year_Prior_to_Measurement_Period_Value);
+        __Last_Calendar_Day_of_February_of_Measurement_Period = new Lazy<CqlDateTime>(this.Last_Calendar_Day_of_February_of_Measurement_Period_Value);
+        __Intake_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Intake_Period_Value);
+        __ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication = new Lazy<IEnumerable<Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE>>(this.ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication_Value);
+        __First_ADHD_Medication_Prescribed_During_Intake_Period = new Lazy<CqlDate>(this.First_ADHD_Medication_Prescribed_During_Intake_Period_Value);
+        __IPSD = new Lazy<CqlDate>(this.IPSD_Value);
+        __Qualifying_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_Value);
+        __Inpatient_Stay_with_Qualifying_Diagnosis = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Stay_with_Qualifying_Diagnosis_Value);
+        __Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase_Value);
+        __Initial_Population_1 = new Lazy<bool?>(this.Initial_Population_1_Value);
+        __Denominator_1 = new Lazy<bool?>(this.Denominator_1_Value);
+        __Narcolepsy_Exclusion = new Lazy<IEnumerable<Condition>>(this.Narcolepsy_Exclusion_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Qualifying_Numerator_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Numerator_Encounter_Value);
+        __Encounter_During_Initiation_Phase = new Lazy<IEnumerable<Encounter>>(this.Encounter_During_Initiation_Phase_Value);
+        __Numerator_1 = new Lazy<bool?>(this.Numerator_1_Value);
+        __ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase = new Lazy<IEnumerable<CqlInterval<CqlDate>>>(this.ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase_Value);
+        __ADHD_Cumulative_Medication_Duration = new Lazy<int?>(this.ADHD_Cumulative_Medication_Duration_Value);
+        __Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days = new Lazy<bool?>(this.Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days_Value);
+        __Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase_Value);
+        __Initial_Population_2 = new Lazy<bool?>(this.Initial_Population_2_Value);
+        __Denominator_2 = new Lazy<bool?>(this.Denominator_2_Value);
+        __Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase = new Lazy<IEnumerable<CqlDate>>(this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value);
+        __Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase = new Lazy<bool?>(this.Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value);
+        __Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase = new Lazy<IEnumerable<CqlDate>>(this.Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value);
+        __Numerator_2 = new Lazy<bool?>(this.Numerator_2_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public CumulativeMedicationDuration_4_0_000 CumulativeMedicationDuration_4_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Ambulatory_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003", null);
+
+    [CqlDeclaration("Ambulatory")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003")]
+	public CqlValueSet Ambulatory() => 
+		__Ambulatory.Value;
+
+	private CqlValueSet Atomoxetine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170", null);
+
+    [CqlDeclaration("Atomoxetine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170")]
+	public CqlValueSet Atomoxetine() => 
+		__Atomoxetine.Value;
+
+	private CqlValueSet Behavioral_Health_Follow_up_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054", null);
+
+    [CqlDeclaration("Behavioral Health Follow up Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054")]
+	public CqlValueSet Behavioral_Health_Follow_up_Visit() => 
+		__Behavioral_Health_Follow_up_Visit.Value;
+
+	private CqlValueSet Clonidine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171", null);
+
+    [CqlDeclaration("Clonidine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171")]
+	public CqlValueSet Clonidine() => 
+		__Clonidine.Value;
+
+	private CqlValueSet Dexmethylphenidate_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172", null);
+
+    [CqlDeclaration("Dexmethylphenidate")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172")]
+	public CqlValueSet Dexmethylphenidate() => 
+		__Dexmethylphenidate.Value;
+
+	private CqlValueSet Dextroamphetamine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173", null);
+
+    [CqlDeclaration("Dextroamphetamine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173")]
+	public CqlValueSet Dextroamphetamine() => 
+		__Dextroamphetamine.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Guanfacine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252", null);
+
+    [CqlDeclaration("Guanfacine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252")]
+	public CqlValueSet Guanfacine() => 
+		__Guanfacine.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", null);
+
+    [CqlDeclaration("Initial Hospital Observation Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
+	public CqlValueSet Initial_Hospital_Observation_Care() => 
+		__Initial_Hospital_Observation_Care.Value;
+
+	private CqlValueSet Lisdexamfetamine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174", null);
+
+    [CqlDeclaration("Lisdexamfetamine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174")]
+	public CqlValueSet Lisdexamfetamine() => 
+		__Lisdexamfetamine.Value;
+
+	private CqlValueSet Mental_Behavioral_and_Neurodevelopmental_Disorders_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203", null);
+
+    [CqlDeclaration("Mental Behavioral and Neurodevelopmental Disorders")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203")]
+	public CqlValueSet Mental_Behavioral_and_Neurodevelopmental_Disorders() => 
+		__Mental_Behavioral_and_Neurodevelopmental_Disorders.Value;
+
+	private CqlValueSet Methylphenidate_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176", null);
+
+    [CqlDeclaration("Methylphenidate")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176")]
+	public CqlValueSet Methylphenidate() => 
+		__Methylphenidate.Value;
+
+	private CqlValueSet Narcolepsy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011", null);
+
+    [CqlDeclaration("Narcolepsy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011")]
+	public CqlValueSet Narcolepsy() => 
+		__Narcolepsy.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+
+    [CqlDeclaration("Preventive Care Services Group Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
+	public CqlValueSet Preventive_Care_Services_Group_Counseling() => 
+		__Preventive_Care_Services_Group_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+
+    [CqlDeclaration("Preventive Care Services Individual Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
+	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
+		__Preventive_Care_Services_Individual_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+
+    [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
+	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+
+    [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
+	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
+		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
+
+    [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
+	public CqlValueSet Psych_Visit_Diagnostic_Evaluation() => 
+		__Psych_Visit_Diagnostic_Evaluation.Value;
+
+	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
+
+    [CqlDeclaration("Psych Visit Psychotherapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
+	public CqlValueSet Psych_Visit_Psychotherapy() => 
+		__Psych_Visit_Psychotherapy.Value;
+
+	private CqlValueSet Psychotherapy_and_Pharmacologic_Management_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055", null);
+
+    [CqlDeclaration("Psychotherapy and Pharmacologic Management")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055")]
+	public CqlValueSet Psychotherapy_and_Pharmacologic_Management() => 
+		__Psychotherapy_and_Pharmacologic_Management.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlCode _24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule_Value() => 
+		new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("24 HR dexmethylphenidate hydrochloride 40 MG Extended Release Oral Capsule")]
+	public CqlCode _24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule() => 
+		___24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule.Value;
+
+	private CqlCode methamphetamine_hydrochloride_5_MG_Oral_Tablet_Value() => 
+		new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("methamphetamine hydrochloride 5 MG Oral Tablet")]
+	public CqlCode methamphetamine_hydrochloride_5_MG_Oral_Tablet() => 
+		__methamphetamine_hydrochloride_5_MG_Oral_Tablet.Value;
+
+	private CqlCode[] RXNORM_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("RXNORM")]
+	public CqlCode[] RXNORM() => 
+		__RXNORM.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private CqlDateTime March_1_of_Year_Prior_to_Measurement_Period_Value()
+	{
+		var a_ = this.Measurement_Period();
+		var b_ = context.Operators.Start(a_);
+		var c_ = context.Operators.ComponentFrom(b_, "year");
+		var d_ = context.Operators.Subtract(c_, (int?)1);
+		var e_ = context.Operators.ConvertIntegerToDecimal((int?)0);
+		var f_ = context.Operators.DateTime(d_, (int?)3, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("March 1 of Year Prior to Measurement Period")]
+	public CqlDateTime March_1_of_Year_Prior_to_Measurement_Period() => 
+		__March_1_of_Year_Prior_to_Measurement_Period.Value;
+
+	private CqlDateTime Last_Calendar_Day_of_February_of_Measurement_Period_Value()
+	{
+		var a_ = this.Measurement_Period();
+		var b_ = context.Operators.Start(a_);
+		var c_ = context.Operators.ComponentFrom(b_, "year");
+		var d_ = context.Operators.ConvertIntegerToDecimal((int?)0);
+		var e_ = context.Operators.DateTime(c_, (int?)3, (int?)1, (int?)23, (int?)59, (int?)59, (int?)0, d_);
+		var f_ = context.Operators.Quantity(1m, "day");
+		var g_ = context.Operators.Subtract(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Last Calendar Day of February of Measurement Period")]
+	public CqlDateTime Last_Calendar_Day_of_February_of_Measurement_Period() => 
+		__Last_Calendar_Day_of_February_of_Measurement_Period.Value;
+
+	private CqlInterval<CqlDateTime> Intake_Period_Value()
+	{
+		var a_ = this.March_1_of_Year_Prior_to_Measurement_Period();
+		var b_ = this.Last_Calendar_Day_of_February_of_Measurement_Period();
+		var c_ = context.Operators.Interval(a_, b_, true, true);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Intake Period")]
+	public CqlInterval<CqlDateTime> Intake_Period() => 
+		__Intake_Period.Value;
+
+	private IEnumerable<Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE> ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication_Value()
+	{
+		var a_ = this.Atomoxetine();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = this.Clonidine();
+		var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		var j_ = context.Operators.ListUnion<MedicationRequest>(g_, i_);
+		var k_ = context.Operators.ListUnion<MedicationRequest>(e_, j_);
+		var l_ = this.Dexmethylphenidate();
+		var m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		var o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		var p_ = context.Operators.ListUnion<MedicationRequest>(m_, o_);
+		var q_ = context.Operators.ListUnion<MedicationRequest>(k_, p_);
+		var r_ = this.Dextroamphetamine();
+		var s_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		var u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		var v_ = context.Operators.ListUnion<MedicationRequest>(s_, u_);
+		var w_ = context.Operators.ListUnion<MedicationRequest>(q_, v_);
+		var x_ = this.Lisdexamfetamine();
+		var y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		var aa_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		var ab_ = context.Operators.ListUnion<MedicationRequest>(y_, aa_);
+		var ac_ = context.Operators.ListUnion<MedicationRequest>(w_, ab_);
+		var ad_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
+		var ae_ = context.Operators.ToList<CqlCode>(ad_);
+		var af_ = context.Operators.RetrieveByCodes<MedicationRequest>(ae_, null);
+		var ah_ = context.Operators.ToList<CqlCode>(ad_);
+		var ai_ = context.Operators.RetrieveByCodes<MedicationRequest>(ah_, null);
+		var aj_ = context.Operators.ListUnion<MedicationRequest>(af_, ai_);
+		var ak_ = context.Operators.ListUnion<MedicationRequest>(ac_, aj_);
+		var al_ = this.Methylphenidate();
+		var am_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		var ao_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		var ap_ = context.Operators.ListUnion<MedicationRequest>(am_, ao_);
+		var aq_ = context.Operators.ListUnion<MedicationRequest>(ak_, ap_);
+		var ar_ = this.Guanfacine();
+		var as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		var au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		var av_ = context.Operators.ListUnion<MedicationRequest>(as_, au_);
+		var aw_ = context.Operators.ListUnion<MedicationRequest>(aq_, av_);
+		bool? ax_(MedicationRequest ADHDMedications)
+		{
+			var df_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ADHDMedications);
+			var dg_ = context.Operators.Start(df_);
+			var dh_ = context.Operators.ConvertDateToDateTime(dg_);
+			var di_ = this.Intake_Period();
+			var dj_ = context.Operators.ElementInInterval<CqlDateTime>(dh_, di_, null);
+
+			return dj_;
+		};
+		var ay_ = context.Operators.WhereOrNull<MedicationRequest>(aw_, ax_);
+		var ba_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var bc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var bd_ = context.Operators.ListUnion<MedicationRequest>(ba_, bc_);
+		var bf_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		var bh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		var bi_ = context.Operators.ListUnion<MedicationRequest>(bf_, bh_);
+		var bj_ = context.Operators.ListUnion<MedicationRequest>(bd_, bi_);
+		var bl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		var bn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		var bo_ = context.Operators.ListUnion<MedicationRequest>(bl_, bn_);
+		var bp_ = context.Operators.ListUnion<MedicationRequest>(bj_, bo_);
+		var br_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		var bt_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		var bu_ = context.Operators.ListUnion<MedicationRequest>(br_, bt_);
+		var bv_ = context.Operators.ListUnion<MedicationRequest>(bp_, bu_);
+		var bx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		var bz_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		var ca_ = context.Operators.ListUnion<MedicationRequest>(bx_, bz_);
+		var cb_ = context.Operators.ListUnion<MedicationRequest>(bv_, ca_);
+		var cd_ = context.Operators.ToList<CqlCode>(ad_);
+		var ce_ = context.Operators.RetrieveByCodes<MedicationRequest>(cd_, null);
+		var cg_ = context.Operators.ToList<CqlCode>(ad_);
+		var ch_ = context.Operators.RetrieveByCodes<MedicationRequest>(cg_, null);
+		var ci_ = context.Operators.ListUnion<MedicationRequest>(ce_, ch_);
+		var cj_ = context.Operators.ListUnion<MedicationRequest>(cb_, ci_);
+		var cl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		var cn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		var co_ = context.Operators.ListUnion<MedicationRequest>(cl_, cn_);
+		var cp_ = context.Operators.ListUnion<MedicationRequest>(cj_, co_);
+		var cr_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		var ct_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		var cu_ = context.Operators.ListUnion<MedicationRequest>(cr_, ct_);
+		var cv_ = context.Operators.ListUnion<MedicationRequest>(cp_, cu_);
+		bool? cw_(MedicationRequest ADHDMedications)
+		{
+			var dk_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ADHDMedications);
+			var dl_ = context.Operators.Start(dk_);
+			var dm_ = context.Operators.ConvertDateToDateTime(dl_);
+			var dn_ = this.Intake_Period();
+			var do_ = context.Operators.ElementInInterval<CqlDateTime>(dm_, dn_, null);
+
+			return do_;
+		};
+		var cx_ = context.Operators.WhereOrNull<MedicationRequest>(cv_, cw_);
+		IEnumerable<MedicationRequest> cy_(MedicationRequest ADHDMedicationOrder)
+		{
+			var dp_ = this.Atomoxetine();
+			var dq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, null);
+			var ds_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, null);
+			var dt_ = context.Operators.ListUnion<MedicationRequest>(dq_, ds_);
+			var du_ = this.Clonidine();
+			var dv_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, null);
+			var dx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, null);
+			var dy_ = context.Operators.ListUnion<MedicationRequest>(dv_, dx_);
+			var dz_ = context.Operators.ListUnion<MedicationRequest>(dt_, dy_);
+			var ea_ = this.Dexmethylphenidate();
+			var eb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, null);
+			var ed_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, null);
+			var ee_ = context.Operators.ListUnion<MedicationRequest>(eb_, ed_);
+			var ef_ = context.Operators.ListUnion<MedicationRequest>(dz_, ee_);
+			var eg_ = this.Dextroamphetamine();
+			var eh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, null);
+			var ej_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, null);
+			var ek_ = context.Operators.ListUnion<MedicationRequest>(eh_, ej_);
+			var el_ = context.Operators.ListUnion<MedicationRequest>(ef_, ek_);
+			var em_ = this.Lisdexamfetamine();
+			var en_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, null);
+			var ep_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, null);
+			var eq_ = context.Operators.ListUnion<MedicationRequest>(en_, ep_);
+			var er_ = context.Operators.ListUnion<MedicationRequest>(el_, eq_);
+			var es_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
+			var et_ = context.Operators.ToList<CqlCode>(es_);
+			var eu_ = context.Operators.RetrieveByCodes<MedicationRequest>(et_, null);
+			var ew_ = context.Operators.ToList<CqlCode>(es_);
+			var ex_ = context.Operators.RetrieveByCodes<MedicationRequest>(ew_, null);
+			var ey_ = context.Operators.ListUnion<MedicationRequest>(eu_, ex_);
+			var ez_ = context.Operators.ListUnion<MedicationRequest>(er_, ey_);
+			var fa_ = this.Methylphenidate();
+			var fb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, null);
+			var fd_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, null);
+			var fe_ = context.Operators.ListUnion<MedicationRequest>(fb_, fd_);
+			var ff_ = context.Operators.ListUnion<MedicationRequest>(ez_, fe_);
+			var fg_ = this.Guanfacine();
+			var fh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, null);
+			var fj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, null);
+			var fk_ = context.Operators.ListUnion<MedicationRequest>(fh_, fj_);
+			var fl_ = context.Operators.ListUnion<MedicationRequest>(ff_, fk_);
+			bool? fm_(MedicationRequest ActiveADHDMedication)
+			{
+				var fq_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ActiveADHDMedication);
+				var fr_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ADHDMedicationOrder);
+				var fs_ = context.Operators.Start(fr_);
+				var ft_ = context.Operators.ConvertDateToDateTime(fs_);
+				var fu_ = context.Operators.DateFrom(ft_);
+				var fv_ = context.Operators.Quantity(120m, "days");
+				var fw_ = context.Operators.Subtract(fu_, fv_);
+				var fy_ = context.Operators.Start(fr_);
+				var fz_ = context.Operators.ConvertDateToDateTime(fy_);
+				var ga_ = context.Operators.DateFrom(fz_);
+				var gb_ = context.Operators.Interval(fw_, ga_, true, false);
+				var gc_ = context.Operators.Overlaps(fq_, gb_, null);
+
+				return gc_;
+			};
+			var fn_ = context.Operators.WhereOrNull<MedicationRequest>(fl_, fm_);
+			MedicationRequest fo_(MedicationRequest ActiveADHDMedication) => 
+				ADHDMedicationOrder;
+			var fp_ = context.Operators.SelectOrNull<MedicationRequest, MedicationRequest>(fn_, fo_);
+
+			return fp_;
+		};
+		var cz_ = context.Operators.SelectManyOrNull<MedicationRequest, MedicationRequest>(cx_, cy_);
+		var da_ = context.Operators.ListExcept<MedicationRequest>(ay_, cz_);
+		Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE db_(MedicationRequest QualifyingMed)
+		{
+			var gd_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(QualifyingMed);
+			var ge_ = context.Operators.Start(gd_);
+			var gf_ = new Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE
+			{
+				startDate = ge_,
+			};
+
+			return gf_;
+		};
+		var dc_ = context.Operators.SelectOrNull<MedicationRequest, Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE>(da_, db_);
+		object dd_(Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE @this) => 
+			@this?.startDate;
+		var de_ = context.Operators.ListSortBy<Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE>(dc_, dd_, System.ComponentModel.ListSortDirection.Ascending);
+
+		return de_;
+	}
+
+    [CqlDeclaration("ADHD Medication Prescribed During Intake Period and Not Previously on ADHD Medication")]
+	public IEnumerable<Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE> ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication() => 
+		__ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication.Value;
+
+	private CqlDate First_ADHD_Medication_Prescribed_During_Intake_Period_Value()
+	{
+		var a_ = this.ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication();
+		bool? b_(Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE @this)
+		{
+			var g_ = context.Operators.Not((bool?)(@this?.startDate is null));
+
+			return g_;
+		};
+		var c_ = context.Operators.WhereOrNull<Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE>(a_, b_);
+		CqlDate d_(Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE @this) => 
+			@this?.startDate;
+		var e_ = context.Operators.SelectOrNull<Tuples.Tuple_GgbdNTdhNeafRfiEMSgeHDMdE, CqlDate>(c_, d_);
+		var f_ = context.Operators.FirstOfList<CqlDate>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("First ADHD Medication Prescribed During Intake Period")]
+	public CqlDate First_ADHD_Medication_Prescribed_During_Intake_Period() => 
+		__First_ADHD_Medication_Prescribed_During_Intake_Period.Value;
+
+	private CqlDate IPSD_Value()
+	{
+		var a_ = this.First_ADHD_Medication_Prescribed_During_Intake_Period();
+
+		return a_;
+	}
+
+    [CqlDeclaration("IPSD")]
+	public CqlDate IPSD() => 
+		__IPSD.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Home_Healthcare_Services();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		bool? l_(Encounter ValidEncounters)
+		{
+			var n_ = this.IPSD();
+			var o_ = context.Operators.Quantity(6m, "months");
+			var p_ = context.Operators.Subtract(n_, o_);
+			var r_ = context.Operators.Interval(p_, n_, true, true);
+			var s_ = context.Operators.ConvertDateToDateTime(r_?.low);
+			var v_ = context.Operators.Subtract(n_, o_);
+			var x_ = context.Operators.Interval(v_, n_, true, true);
+			var y_ = context.Operators.ConvertDateToDateTime(x_?.high);
+			var ab_ = context.Operators.Subtract(n_, o_);
+			var ad_ = context.Operators.Interval(ab_, n_, true, true);
+			var ag_ = context.Operators.Subtract(n_, o_);
+			var ai_ = context.Operators.Interval(ag_, n_, true, true);
+			var aj_ = context.Operators.Interval(s_, y_, ad_?.lowClosed, ai_?.highClosed);
+			var ak_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounters?.Period);
+			var al_ = QICoreCommon_2_0_000.ToInterval((ak_ as object));
+			var am_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aj_, al_, "day");
+
+			return am_;
+		};
+		var m_ = context.Operators.WhereOrNull<Encounter>(k_, l_);
+
+		return m_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter")]
+	public IEnumerable<Encounter> Qualifying_Encounter() => 
+		__Qualifying_Encounter.Value;
+
+    [CqlDeclaration("PrincipalDiagnosis")]
+	public IEnumerable<Condition> PrincipalDiagnosis(Encounter Encounter)
+	{
+		bool? a_(Encounter.DiagnosisComponent D)
+		{
+			var e_ = context.Operators.Equal(D?.RankElement?.Value, (int?)1);
+
+			return e_;
+		};
+		var b_ = context.Operators.WhereOrNull<Encounter.DiagnosisComponent>((Encounter?.Diagnosis as IEnumerable<Encounter.DiagnosisComponent>), a_);
+		Condition c_(Encounter.DiagnosisComponent PD)
+		{
+			var f_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? g_(Condition C)
+			{
+				var j_ = QICoreCommon_2_0_000.getId(PD?.Condition?.ReferenceElement?.Value);
+				var k_ = context.Operators.Equal(C?.IdElement?.Value, j_);
+
+				return k_;
+			};
+			var h_ = context.Operators.WhereOrNull<Condition>(f_, g_);
+			var i_ = context.Operators.SingleOrNull<Condition>(h_);
+
+			return i_;
+		};
+		var d_ = context.Operators.SelectOrNull<Encounter.DiagnosisComponent, Condition>(b_, c_);
+
+		return d_;
+	}
+
+	private IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_Value()
+	{
+		var a_ = this.Encounter_Inpatient();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter InpatientStay)
+		{
+			var e_ = this.PrincipalDiagnosis(InpatientStay);
+			bool? f_(Condition EncounterDiagnosis)
+			{
+				var i_ = FHIRHelpers_4_3_000.ToConcept(EncounterDiagnosis?.Code);
+				var j_ = this.Mental_Behavioral_and_Neurodevelopmental_Disorders();
+				var k_ = context.Operators.ConceptInValueSet(i_, j_);
+
+				return k_;
+			};
+			var g_ = context.Operators.WhereOrNull<Condition>(e_, f_);
+			var h_ = context.Operators.ExistsInList<Condition>(g_);
+
+			return h_;
+		};
+		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Inpatient Stay with Qualifying Diagnosis")]
+	public IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis() => 
+		__Inpatient_Stay_with_Qualifying_Diagnosis.Value;
+
+	private IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase_Value()
+	{
+		var a_ = this.Inpatient_Stay_with_Qualifying_Diagnosis();
+		bool? b_(Encounter InpatientStay)
+		{
+			var d_ = FHIRHelpers_4_3_000.ToInterval(InpatientStay?.Period);
+			var e_ = CQMCommon_2_0_000.ToDateInterval(d_);
+			var f_ = context.Operators.Start(e_);
+			var g_ = this.IPSD();
+			var i_ = context.Operators.Quantity(30m, "days");
+			var j_ = context.Operators.Add(g_, i_);
+			var k_ = context.Operators.Interval(g_, j_, false, true);
+			var l_ = context.Operators.ElementInInterval<CqlDate>(f_, k_, "day");
+			var n_ = context.Operators.Not((bool?)(g_ is null));
+			var o_ = context.Operators.And(l_, n_);
+
+			return o_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Inpatient Stay with Qualifying Diagnosis During Initiation Phase")]
+	public IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase() => 
+		__Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase.Value;
+
+	private bool? Initial_Population_1_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Intake_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.GreaterOrEqual(f_, (int?)6);
+		var i_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var k_ = context.Operators.End(c_);
+		var l_ = context.Operators.DateFrom(k_);
+		var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+		var n_ = context.Operators.LessOrEqual(m_, (int?)12);
+		var o_ = context.Operators.And(g_, n_);
+		var p_ = this.Qualifying_Encounter();
+		var q_ = context.Operators.ExistsInList<Encounter>(p_);
+		var r_ = context.Operators.And(o_, q_);
+		var s_ = this.First_ADHD_Medication_Prescribed_During_Intake_Period();
+		var t_ = context.Operators.Not((bool?)(s_ is null));
+		var u_ = context.Operators.And(r_, t_);
+		var v_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase();
+		var w_ = context.Operators.ExistsInList<Encounter>(v_);
+		var x_ = context.Operators.Not(w_);
+		var y_ = context.Operators.And(u_, x_);
+
+		return y_;
+	}
+
+    [CqlDeclaration("Initial Population 1")]
+	public bool? Initial_Population_1() => 
+		__Initial_Population_1.Value;
+
+	private bool? Denominator_1_Value()
+	{
+		var a_ = this.Initial_Population_1();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator 1")]
+	public bool? Denominator_1() => 
+		__Denominator_1.Value;
+
+	private IEnumerable<Condition> Narcolepsy_Exclusion_Value()
+	{
+		var a_ = this.Narcolepsy();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition Narcolepsy)
+		{
+			var e_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Narcolepsy);
+			var f_ = context.Operators.Start(e_);
+			var g_ = this.Measurement_Period();
+			var h_ = context.Operators.End(g_);
+			var i_ = context.Operators.SameOrBefore(f_, h_, null);
+
+			return i_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Narcolepsy Exclusion")]
+	public IEnumerable<Condition> Narcolepsy_Exclusion() => 
+		__Narcolepsy_Exclusion.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = this.Narcolepsy_Exclusion();
+		var c_ = context.Operators.ExistsInList<Condition>(b_);
+		var d_ = context.Operators.Or(a_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<Encounter> Qualifying_Numerator_Encounter_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Initial_Hospital_Observation_Care();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care_Services_Group_Counseling();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Behavioral_Health_Follow_up_Visit();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Preventive_Care_Services_Individual_Counseling();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Psychotherapy_and_Pharmacologic_Management();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		bool? p_(Encounter PsychPharmManagement)
+		{
+			bool? ao_(Encounter.LocationComponent Location)
+			{
+				var ar_ = CQMCommon_2_0_000.GetLocation(Location?.Location);
+				CqlConcept as_(CodeableConcept @this)
+				{
+					var aw_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+					return aw_;
+				};
+				var at_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(ar_?.Type, as_);
+				var au_ = this.Ambulatory();
+				var av_ = context.Operators.ConceptsInValueSet(at_, au_);
+
+				return av_;
+			};
+			var ap_ = context.Operators.WhereOrNull<Encounter.LocationComponent>((PsychPharmManagement?.Location as IEnumerable<Encounter.LocationComponent>), ao_);
+			var aq_ = context.Operators.ExistsInList<Encounter.LocationComponent>(ap_);
+
+			return aq_;
+		};
+		var q_ = context.Operators.WhereOrNull<Encounter>(o_, p_);
+		var r_ = context.Operators.ListUnion<Encounter>(m_, q_);
+		var s_ = context.Operators.ListUnion<Encounter>(k_, r_);
+		var t_ = this.Outpatient_Consultation();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = this.Home_Healthcare_Services();
+		var w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
+		var x_ = context.Operators.ListUnion<Encounter>(u_, w_);
+		var y_ = context.Operators.ListUnion<Encounter>(s_, x_);
+		var z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		var ab_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, null);
+		var ad_ = context.Operators.ListUnion<Encounter>(aa_, ac_);
+		var ae_ = context.Operators.ListUnion<Encounter>(y_, ad_);
+		var af_ = this.Psych_Visit_Diagnostic_Evaluation();
+		var ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		var ah_ = this.Psych_Visit_Psychotherapy();
+		var ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, null);
+		var aj_ = context.Operators.ListUnion<Encounter>(ag_, ai_);
+		var ak_ = context.Operators.ListUnion<Encounter>(ae_, aj_);
+		var al_ = this.Telephone_Visits();
+		var am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		var an_ = context.Operators.ListUnion<Encounter>(ak_, am_);
+
+		return an_;
+	}
+
+    [CqlDeclaration("Qualifying Numerator Encounter")]
+	public IEnumerable<Encounter> Qualifying_Numerator_Encounter() => 
+		__Qualifying_Numerator_Encounter.Value;
+
+	private IEnumerable<Encounter> Encounter_During_Initiation_Phase_Value()
+	{
+		var a_ = this.Qualifying_Numerator_Encounter();
+		bool? b_(Encounter ValidNumeratorEncounter)
+		{
+			var d_ = FHIRHelpers_4_3_000.ToInterval(ValidNumeratorEncounter?.Period);
+			var e_ = CQMCommon_2_0_000.ToDateInterval(d_);
+			var f_ = context.Operators.Start(e_);
+			var g_ = this.IPSD();
+			var i_ = context.Operators.Quantity(30m, "days");
+			var j_ = context.Operators.Add(g_, i_);
+			var k_ = context.Operators.Interval(g_, j_, false, true);
+			var l_ = context.Operators.ElementInInterval<CqlDate>(f_, k_, "day");
+			var n_ = context.Operators.Not((bool?)(g_ is null));
+			var o_ = context.Operators.And(l_, n_);
+
+			return o_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter During Initiation Phase")]
+	public IEnumerable<Encounter> Encounter_During_Initiation_Phase() => 
+		__Encounter_During_Initiation_Phase.Value;
+
+	private bool? Numerator_1_Value()
+	{
+		var a_ = this.Encounter_During_Initiation_Phase();
+		var b_ = context.Operators.ExistsInList<Encounter>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Numerator 1")]
+	public bool? Numerator_1() => 
+		__Numerator_1.Value;
+
+	private IEnumerable<CqlInterval<CqlDate>> ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase_Value()
+	{
+		var a_ = this.Atomoxetine();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS f_(MedicationRequest AtomoxetineMed)
+		{
+			var dt_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(AtomoxetineMed);
+			var dv_ = context.Operators.Start(dt_);
+			var dw_ = new Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS
+			{
+				period = dt_,
+				periodStart = dv_,
+			};
+
+			return dw_;
+		};
+		var g_ = context.Operators.SelectOrNull<MedicationRequest, Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(e_, f_);
+		object h_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this) => 
+			@this?.periodStart;
+		var i_ = context.Operators.ListSortBy<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(g_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		bool? j_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this)
+		{
+			var dx_ = context.Operators.Not((bool?)(@this?.period is null));
+
+			return dx_;
+		};
+		var k_ = context.Operators.WhereOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(i_, j_);
+		CqlInterval<CqlDate> l_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this) => 
+			@this?.period;
+		var m_ = context.Operators.SelectOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS, CqlInterval<CqlDate>>(k_, l_);
+		var n_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(m_);
+		var o_ = this.Clonidine();
+		var p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, null);
+		var r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, null);
+		var s_ = context.Operators.ListUnion<MedicationRequest>(p_, r_);
+		Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS t_(MedicationRequest ClonidineMed)
+		{
+			var dy_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ClonidineMed);
+			var ea_ = context.Operators.Start(dy_);
+			var eb_ = new Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS
+			{
+				period = dy_,
+				periodStart = ea_,
+			};
+
+			return eb_;
+		};
+		var u_ = context.Operators.SelectOrNull<MedicationRequest, Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(s_, t_);
+		var w_ = context.Operators.ListSortBy<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(u_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		bool? x_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this)
+		{
+			var ec_ = context.Operators.Not((bool?)(@this?.period is null));
+
+			return ec_;
+		};
+		var y_ = context.Operators.WhereOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(w_, x_);
+		var aa_ = context.Operators.SelectOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS, CqlInterval<CqlDate>>(y_, l_);
+		var ab_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(aa_);
+		var ac_ = context.Operators.ListUnion<CqlInterval<CqlDate>>(n_, ab_);
+		var ad_ = this.Dexmethylphenidate();
+		var ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, null);
+		var ag_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, null);
+		var ah_ = context.Operators.ListUnion<MedicationRequest>(ae_, ag_);
+		Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS ai_(MedicationRequest DexmethylphenidateMed)
+		{
+			var ed_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(DexmethylphenidateMed);
+			var ef_ = context.Operators.Start(ed_);
+			var eg_ = new Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS
+			{
+				period = ed_,
+				periodStart = ef_,
+			};
+
+			return eg_;
+		};
+		var aj_ = context.Operators.SelectOrNull<MedicationRequest, Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(ah_, ai_);
+		var al_ = context.Operators.ListSortBy<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(aj_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		bool? am_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this)
+		{
+			var eh_ = context.Operators.Not((bool?)(@this?.period is null));
+
+			return eh_;
+		};
+		var an_ = context.Operators.WhereOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(al_, am_);
+		var ap_ = context.Operators.SelectOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS, CqlInterval<CqlDate>>(an_, l_);
+		var aq_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(ap_);
+		var ar_ = this.Dextroamphetamine();
+		var as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		var au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		var av_ = context.Operators.ListUnion<MedicationRequest>(as_, au_);
+		Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS aw_(MedicationRequest DextroamphetamineMed)
+		{
+			var ei_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(DextroamphetamineMed);
+			var ek_ = context.Operators.Start(ei_);
+			var el_ = new Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS
+			{
+				period = ei_,
+				periodStart = ek_,
+			};
+
+			return el_;
+		};
+		var ax_ = context.Operators.SelectOrNull<MedicationRequest, Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(av_, aw_);
+		var az_ = context.Operators.ListSortBy<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(ax_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		bool? ba_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this)
+		{
+			var em_ = context.Operators.Not((bool?)(@this?.period is null));
+
+			return em_;
+		};
+		var bb_ = context.Operators.WhereOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(az_, ba_);
+		var bd_ = context.Operators.SelectOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS, CqlInterval<CqlDate>>(bb_, l_);
+		var be_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(bd_);
+		var bf_ = context.Operators.ListUnion<CqlInterval<CqlDate>>(aq_, be_);
+		var bg_ = context.Operators.ListUnion<CqlInterval<CqlDate>>(ac_, bf_);
+		var bh_ = this.Lisdexamfetamine();
+		var bi_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, null);
+		var bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, null);
+		var bl_ = context.Operators.ListUnion<MedicationRequest>(bi_, bk_);
+		Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS bm_(MedicationRequest LisdexamfetamineMed)
+		{
+			var en_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(LisdexamfetamineMed);
+			var ep_ = context.Operators.Start(en_);
+			var eq_ = new Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS
+			{
+				period = en_,
+				periodStart = ep_,
+			};
+
+			return eq_;
+		};
+		var bn_ = context.Operators.SelectOrNull<MedicationRequest, Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(bl_, bm_);
+		var bp_ = context.Operators.ListSortBy<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(bn_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		bool? bq_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this)
+		{
+			var er_ = context.Operators.Not((bool?)(@this?.period is null));
+
+			return er_;
+		};
+		var br_ = context.Operators.WhereOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(bp_, bq_);
+		var bt_ = context.Operators.SelectOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS, CqlInterval<CqlDate>>(br_, l_);
+		var bu_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(bt_);
+		var bv_ = this.Methylphenidate();
+		var bw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, null);
+		var by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, null);
+		var bz_ = context.Operators.ListUnion<MedicationRequest>(bw_, by_);
+		Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS ca_(MedicationRequest MethylphenidateMed)
+		{
+			var es_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(MethylphenidateMed);
+			var eu_ = context.Operators.Start(es_);
+			var ev_ = new Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS
+			{
+				period = es_,
+				periodStart = eu_,
+			};
+
+			return ev_;
+		};
+		var cb_ = context.Operators.SelectOrNull<MedicationRequest, Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(bz_, ca_);
+		var cd_ = context.Operators.ListSortBy<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(cb_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		bool? ce_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this)
+		{
+			var ew_ = context.Operators.Not((bool?)(@this?.period is null));
+
+			return ew_;
+		};
+		var cf_ = context.Operators.WhereOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(cd_, ce_);
+		var ch_ = context.Operators.SelectOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS, CqlInterval<CqlDate>>(cf_, l_);
+		var ci_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(ch_);
+		var cj_ = context.Operators.ListUnion<CqlInterval<CqlDate>>(bu_, ci_);
+		var ck_ = context.Operators.ListUnion<CqlInterval<CqlDate>>(bg_, cj_);
+		var cl_ = this.Guanfacine();
+		var cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		var co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		var cp_ = context.Operators.ListUnion<MedicationRequest>(cm_, co_);
+		Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS cq_(MedicationRequest GuanfacineMed)
+		{
+			var ex_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(GuanfacineMed);
+			var ez_ = context.Operators.Start(ex_);
+			var fa_ = new Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS
+			{
+				period = ex_,
+				periodStart = ez_,
+			};
+
+			return fa_;
+		};
+		var cr_ = context.Operators.SelectOrNull<MedicationRequest, Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(cp_, cq_);
+		var ct_ = context.Operators.ListSortBy<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(cr_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		bool? cu_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this)
+		{
+			var fb_ = context.Operators.Not((bool?)(@this?.period is null));
+
+			return fb_;
+		};
+		var cv_ = context.Operators.WhereOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(ct_, cu_);
+		var cx_ = context.Operators.SelectOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS, CqlInterval<CqlDate>>(cv_, l_);
+		var cy_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(cx_);
+		var cz_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
+		var da_ = context.Operators.ToList<CqlCode>(cz_);
+		var db_ = context.Operators.RetrieveByCodes<MedicationRequest>(da_, null);
+		var dd_ = context.Operators.ToList<CqlCode>(cz_);
+		var de_ = context.Operators.RetrieveByCodes<MedicationRequest>(dd_, null);
+		var df_ = context.Operators.ListUnion<MedicationRequest>(db_, de_);
+		Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS dg_(MedicationRequest MethamphetamineMed)
+		{
+			var fc_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(MethamphetamineMed);
+			var fe_ = context.Operators.Start(fc_);
+			var ff_ = new Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS
+			{
+				period = fc_,
+				periodStart = fe_,
+			};
+
+			return ff_;
+		};
+		var dh_ = context.Operators.SelectOrNull<MedicationRequest, Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(df_, dg_);
+		var dj_ = context.Operators.ListSortBy<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(dh_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		bool? dk_(Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS @this)
+		{
+			var fg_ = context.Operators.Not((bool?)(@this?.period is null));
+
+			return fg_;
+		};
+		var dl_ = context.Operators.WhereOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS>(dj_, dk_);
+		var dn_ = context.Operators.SelectOrNull<Tuples.Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS, CqlInterval<CqlDate>>(dl_, l_);
+		var do_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(dn_);
+		var dp_ = context.Operators.ListUnion<CqlInterval<CqlDate>>(cy_, do_);
+		var dq_ = context.Operators.ListUnion<CqlInterval<CqlDate>>(ck_, dp_);
+		CqlInterval<CqlDate> dr_(CqlInterval<CqlDate> ADHDMedication)
+		{
+			var fh_ = this.IPSD();
+			var fj_ = context.Operators.Quantity(300m, "days");
+			var fk_ = context.Operators.Add(fh_, fj_);
+			var fl_ = context.Operators.Interval(fh_, fk_, true, true);
+			var fm_ = context.Operators.IntervalIntersectsInterval<CqlDate>(ADHDMedication, fl_);
+
+			return fm_;
+		};
+		var ds_ = context.Operators.SelectOrNull<CqlInterval<CqlDate>, CqlInterval<CqlDate>>(dq_, dr_);
+
+		return ds_;
+	}
+
+    [CqlDeclaration("ADHD Medications Taken on IPSD or During Continuation and Maintenance Phase")]
+	public IEnumerable<CqlInterval<CqlDate>> ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase() => 
+		__ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase.Value;
+
+	private int? ADHD_Cumulative_Medication_Duration_Value()
+	{
+		var a_ = this.ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase();
+		var b_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("ADHD Cumulative Medication Duration")]
+	public int? ADHD_Cumulative_Medication_Duration() => 
+		__ADHD_Cumulative_Medication_Duration.Value;
+
+	private bool? Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days_Value()
+	{
+		var a_ = this.ADHD_Cumulative_Medication_Duration();
+		var b_ = context.Operators.GreaterOrEqual(a_, (int?)210);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Has ADHD Cumulative Medication Duration Greater Than or Equal to 210 Days")]
+	public bool? Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days() => 
+		__Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days.Value;
+
+	private IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase_Value()
+	{
+		var a_ = this.Inpatient_Stay_with_Qualifying_Diagnosis();
+		bool? b_(Encounter InpatientStay)
+		{
+			var d_ = FHIRHelpers_4_3_000.ToInterval(InpatientStay?.Period);
+			var e_ = CQMCommon_2_0_000.ToDateInterval(d_);
+			var f_ = context.Operators.Start(e_);
+			var g_ = this.IPSD();
+			var i_ = context.Operators.Quantity(300m, "days");
+			var j_ = context.Operators.Add(g_, i_);
+			var k_ = context.Operators.Interval(g_, j_, false, true);
+			var l_ = context.Operators.ElementInInterval<CqlDate>(f_, k_, "day");
+			var n_ = context.Operators.Not((bool?)(g_ is null));
+			var o_ = context.Operators.And(l_, n_);
+
+			return o_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Inpatient Stay with Qualifying Diagnosis During Continuation and Maintenance Phase")]
+	public IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase() => 
+		__Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase.Value;
+
+	private bool? Initial_Population_2_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Intake_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.GreaterOrEqual(f_, (int?)6);
+		var i_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var k_ = context.Operators.End(c_);
+		var l_ = context.Operators.DateFrom(k_);
+		var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+		var n_ = context.Operators.LessOrEqual(m_, (int?)12);
+		var o_ = context.Operators.And(g_, n_);
+		var p_ = this.Qualifying_Encounter();
+		var q_ = context.Operators.ExistsInList<Encounter>(p_);
+		var r_ = context.Operators.And(o_, q_);
+		var s_ = this.First_ADHD_Medication_Prescribed_During_Intake_Period();
+		var t_ = context.Operators.Not((bool?)(s_ is null));
+		var u_ = context.Operators.And(r_, t_);
+		var v_ = this.Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days();
+		var w_ = context.Operators.And(u_, v_);
+		var x_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase();
+		var y_ = context.Operators.ExistsInList<Encounter>(x_);
+		var z_ = context.Operators.Not(y_);
+		var aa_ = context.Operators.And(w_, z_);
+
+		return aa_;
+	}
+
+    [CqlDeclaration("Initial Population 2")]
+	public bool? Initial_Population_2() => 
+		__Initial_Population_2.Value;
+
+	private bool? Denominator_2_Value()
+	{
+		var a_ = this.Initial_Population_2();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator 2")]
+	public bool? Denominator_2() => 
+		__Denominator_2.Value;
+
+	private IEnumerable<CqlDate> Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value()
+	{
+		var a_ = this.Qualifying_Numerator_Encounter();
+		bool? b_(Encounter ValidNumeratorEncounter)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToInterval(ValidNumeratorEncounter?.Period);
+			var g_ = CQMCommon_2_0_000.ToDateInterval(f_);
+			var h_ = context.Operators.Start(g_);
+			var i_ = this.IPSD();
+			var j_ = context.Operators.Quantity(31m, "days");
+			var k_ = context.Operators.Add(i_, j_);
+			var m_ = context.Operators.Quantity(300m, "days");
+			var n_ = context.Operators.Add(i_, m_);
+			var o_ = context.Operators.Interval(k_, n_, true, true);
+			var p_ = context.Operators.ElementInInterval<CqlDate>(h_, o_, "day");
+
+			return p_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		CqlDate d_(Encounter ValidNumeratorEncounter)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(ValidNumeratorEncounter?.Period);
+			var r_ = context.Operators.Start(q_);
+			var s_ = context.Operators.DateFrom(r_);
+
+			return s_;
+		};
+		var e_ = context.Operators.SelectOrNull<Encounter, CqlDate>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Encounter 31 to 300 Days into Continuation and Maintenance Phase")]
+	public IEnumerable<CqlDate> Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase() => 
+		__Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase.Value;
+
+	private bool? Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value()
+	{
+		var a_ = this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
+		var b_ = context.Operators.CountOrNull<CqlDate>(a_);
+		var c_ = context.Operators.GreaterOrEqual(b_, (int?)2);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Two or More Encounters 31 to 300 Days into Continuation and Maintenance Phase")]
+	public bool? Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase() => 
+		__Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase.Value;
+
+	private IEnumerable<CqlDate> Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value()
+	{
+		var a_ = this.Online_Assessments();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter OnlineAssessment)
+		{
+			var g_ = FHIRHelpers_4_3_000.ToInterval(OnlineAssessment?.Period);
+			var h_ = CQMCommon_2_0_000.ToDateInterval(g_);
+			var i_ = context.Operators.Start(h_);
+			var j_ = this.IPSD();
+			var k_ = context.Operators.Quantity(31m, "days");
+			var l_ = context.Operators.Add(j_, k_);
+			var n_ = context.Operators.Quantity(300m, "days");
+			var o_ = context.Operators.Add(j_, n_);
+			var p_ = context.Operators.Interval(l_, o_, true, true);
+			var q_ = context.Operators.ElementInInterval<CqlDate>(i_, p_, "day");
+
+			return q_;
+		};
+		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
+		CqlDate e_(Encounter OnlineAssessment)
+		{
+			var r_ = FHIRHelpers_4_3_000.ToInterval(OnlineAssessment?.Period);
+			var s_ = context.Operators.Start(r_);
+			var t_ = context.Operators.DateFrom(s_);
+
+			return t_;
+		};
+		var f_ = context.Operators.SelectOrNull<Encounter, CqlDate>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Online Assessment 31 to 300 Days into Continuation and Maintenance Phase")]
+	public IEnumerable<CqlDate> Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase() => 
+		__Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase.Value;
+
+	private bool? Numerator_2_Value()
+	{
+		var a_ = this.Encounter_During_Initiation_Phase();
+		var b_ = context.Operators.ExistsInList<Encounter>(a_);
+		var c_ = this.Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
+		var d_ = this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
+		IEnumerable<CqlDate> e_(CqlDate Encounter1)
+		{
+			var j_ = this.Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
+			bool? k_(CqlDate Encounter2)
+			{
+				var o_ = context.Operators.Not((bool?)(Encounter1 is null));
+				var p_ = context.Operators.Not((bool?)(Encounter2 is null));
+				var q_ = context.Operators.And(o_, p_);
+				var r_ = context.Operators.Equivalent(Encounter1, Encounter2);
+				var s_ = context.Operators.Not(r_);
+				var t_ = context.Operators.And(q_, s_);
+
+				return t_;
+			};
+			var l_ = context.Operators.WhereOrNull<CqlDate>(j_, k_);
+			CqlDate m_(CqlDate Encounter2) => 
+				Encounter1;
+			var n_ = context.Operators.SelectOrNull<CqlDate, CqlDate>(l_, m_);
+
+			return n_;
+		};
+		var f_ = context.Operators.SelectManyOrNull<CqlDate, CqlDate>(d_, e_);
+		var g_ = context.Operators.ExistsInList<CqlDate>(f_);
+		var h_ = context.Operators.Or(c_, g_);
+		var i_ = context.Operators.And(b_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Numerator 2")]
+	public bool? Numerator_2() => 
+		__Numerator_2.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
+++ b/Demo/Measures-cms/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
@@ -1,0 +1,1940 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("FunctionalStatusAssessmentforTotalHipReplacementFHIR", "0.0.008")]
+public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Ethnicity;
+    internal Lazy<CqlValueSet> __Lower_Body_Fractures_Excluding_Ankle_and_Foot;
+    internal Lazy<CqlValueSet> __Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs;
+    internal Lazy<CqlValueSet> __Mechanical_Complications_Excluding_Upper_Body;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __ONC_Administrative_Sex;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Partial_Arthroplasty_of_Hip;
+    internal Lazy<CqlValueSet> __Payer;
+    internal Lazy<CqlValueSet> __Primary_THA_Procedure;
+    internal Lazy<CqlValueSet> __Race;
+    internal Lazy<CqlValueSet> __Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlCode> __Activities_of_daily_living_score__HOOS_;
+    internal Lazy<CqlCode> __Dead__finding_;
+    internal Lazy<CqlCode> __Discharge_to_healthcare_facility_for_hospice_care__procedure_;
+    internal Lazy<CqlCode> __Discharge_to_home_for_hospice_care__procedure_;
+    internal Lazy<CqlCode> __Hospice_care__Minimum_Data_Set_;
+    internal Lazy<CqlCode> __Pain_score__HOOS_;
+    internal Lazy<CqlCode> __Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure;
+    internal Lazy<CqlCode> __PROMIS_10_Global_Mental_Health__GMH__score_T_score;
+    internal Lazy<CqlCode> __PROMIS_10_Global_Physical_Health__GPH__score_T_score;
+    internal Lazy<CqlCode> __Quality_of_life_score__HOOS_;
+    internal Lazy<CqlCode> __Severe_cognitive_impairment__finding_;
+    internal Lazy<CqlCode> __Sport_recreation_score__HOOS_;
+    internal Lazy<CqlCode> __survey;
+    internal Lazy<CqlCode> __Symptoms_score__HOOS_;
+    internal Lazy<CqlCode> __Total_interval_score__HOOSJR_;
+    internal Lazy<CqlCode> __VR_12_Mental_component_summary__MCS__score___oblique_method_T_score;
+    internal Lazy<CqlCode> __VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score;
+    internal Lazy<CqlCode> __VR_12_Physical_component_summary__PCS__score___oblique_method_T_score;
+    internal Lazy<CqlCode> __VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score;
+    internal Lazy<CqlCode> __Yes__qualifier_value_;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlCode[]> __ConditionCategoryCodes;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __ObservationCategoryCodes;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<CqlDateTime> __November_1_Year_Prior_to_the_Measurement_Period;
+    internal Lazy<bool?> __Has_Qualifying_Encounter;
+    internal Lazy<CqlDateTime> __November_1_Two_Years_Prior_to_the_Measurement_Period;
+    internal Lazy<CqlDateTime> __October_31_Year_Prior_to_the_Measurement_Period;
+    internal Lazy<IEnumerable<Procedure>> __Total_Hip_Arthroplasty_Procedure;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Has_Severe_Cognitive_Impairment;
+    internal Lazy<bool?> __Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures;
+    internal Lazy<bool?> __Has_Partial_Hip_Arthroplasty_Procedure;
+    internal Lazy<bool?> __Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure;
+    internal Lazy<bool?> __Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs;
+    internal Lazy<bool?> __Has_Mechanical_Complication;
+    internal Lazy<bool?> __Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed;
+    internal Lazy<bool?> __Death_Within_300_Days_of_the_THA_Procedure;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<CqlDate>> __Date_HOOS_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_HOOSJr_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_PROMIS10_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_VR12_Oblique_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_VR12_Orthogonal_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Ethnicity = new Lazy<CqlValueSet>(this.Ethnicity_Value);
+        __Lower_Body_Fractures_Excluding_Ankle_and_Foot = new Lazy<CqlValueSet>(this.Lower_Body_Fractures_Excluding_Ankle_and_Foot_Value);
+        __Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs = new Lazy<CqlValueSet>(this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs_Value);
+        __Mechanical_Complications_Excluding_Upper_Body = new Lazy<CqlValueSet>(this.Mechanical_Complications_Excluding_Upper_Body_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __ONC_Administrative_Sex = new Lazy<CqlValueSet>(this.ONC_Administrative_Sex_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Partial_Arthroplasty_of_Hip = new Lazy<CqlValueSet>(this.Partial_Arthroplasty_of_Hip_Value);
+        __Payer = new Lazy<CqlValueSet>(this.Payer_Value);
+        __Primary_THA_Procedure = new Lazy<CqlValueSet>(this.Primary_THA_Procedure_Value);
+        __Race = new Lazy<CqlValueSet>(this.Race_Value);
+        __Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine = new Lazy<CqlValueSet>(this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Activities_of_daily_living_score__HOOS_ = new Lazy<CqlCode>(this.Activities_of_daily_living_score__HOOS__Value);
+        __Dead__finding_ = new Lazy<CqlCode>(this.Dead__finding__Value);
+        __Discharge_to_healthcare_facility_for_hospice_care__procedure_ = new Lazy<CqlCode>(this.Discharge_to_healthcare_facility_for_hospice_care__procedure__Value);
+        __Discharge_to_home_for_hospice_care__procedure_ = new Lazy<CqlCode>(this.Discharge_to_home_for_hospice_care__procedure__Value);
+        __Hospice_care__Minimum_Data_Set_ = new Lazy<CqlCode>(this.Hospice_care__Minimum_Data_Set__Value);
+        __Pain_score__HOOS_ = new Lazy<CqlCode>(this.Pain_score__HOOS__Value);
+        __Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure = new Lazy<CqlCode>(this.Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value);
+        __PROMIS_10_Global_Mental_Health__GMH__score_T_score = new Lazy<CqlCode>(this.PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value);
+        __PROMIS_10_Global_Physical_Health__GPH__score_T_score = new Lazy<CqlCode>(this.PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value);
+        __Quality_of_life_score__HOOS_ = new Lazy<CqlCode>(this.Quality_of_life_score__HOOS__Value);
+        __Severe_cognitive_impairment__finding_ = new Lazy<CqlCode>(this.Severe_cognitive_impairment__finding__Value);
+        __Sport_recreation_score__HOOS_ = new Lazy<CqlCode>(this.Sport_recreation_score__HOOS__Value);
+        __survey = new Lazy<CqlCode>(this.survey_Value);
+        __Symptoms_score__HOOS_ = new Lazy<CqlCode>(this.Symptoms_score__HOOS__Value);
+        __Total_interval_score__HOOSJR_ = new Lazy<CqlCode>(this.Total_interval_score__HOOSJR__Value);
+        __VR_12_Mental_component_summary__MCS__score___oblique_method_T_score = new Lazy<CqlCode>(this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value);
+        __VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score = new Lazy<CqlCode>(this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value);
+        __VR_12_Physical_component_summary__PCS__score___oblique_method_T_score = new Lazy<CqlCode>(this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value);
+        __VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score = new Lazy<CqlCode>(this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value);
+        __Yes__qualifier_value_ = new Lazy<CqlCode>(this.Yes__qualifier_value__Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __ConditionCategoryCodes = new Lazy<CqlCode[]>(this.ConditionCategoryCodes_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __ObservationCategoryCodes = new Lazy<CqlCode[]>(this.ObservationCategoryCodes_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __November_1_Year_Prior_to_the_Measurement_Period = new Lazy<CqlDateTime>(this.November_1_Year_Prior_to_the_Measurement_Period_Value);
+        __Has_Qualifying_Encounter = new Lazy<bool?>(this.Has_Qualifying_Encounter_Value);
+        __November_1_Two_Years_Prior_to_the_Measurement_Period = new Lazy<CqlDateTime>(this.November_1_Two_Years_Prior_to_the_Measurement_Period_Value);
+        __October_31_Year_Prior_to_the_Measurement_Period = new Lazy<CqlDateTime>(this.October_31_Year_Prior_to_the_Measurement_Period_Value);
+        __Total_Hip_Arthroplasty_Procedure = new Lazy<IEnumerable<Procedure>>(this.Total_Hip_Arthroplasty_Procedure_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Has_Severe_Cognitive_Impairment = new Lazy<bool?>(this.Has_Severe_Cognitive_Impairment_Value);
+        __Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures = new Lazy<bool?>(this.Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures_Value);
+        __Has_Partial_Hip_Arthroplasty_Procedure = new Lazy<bool?>(this.Has_Partial_Hip_Arthroplasty_Procedure_Value);
+        __Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure = new Lazy<bool?>(this.Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Value);
+        __Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs = new Lazy<bool?>(this.Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Value);
+        __Has_Mechanical_Complication = new Lazy<bool?>(this.Has_Mechanical_Complication_Value);
+        __Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed = new Lazy<bool?>(this.Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Value);
+        __Death_Within_300_Days_of_the_THA_Procedure = new Lazy<bool?>(this.Death_Within_300_Days_of_the_THA_Procedure_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Date_HOOS_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_HOOS_Total_Assessment_Completed_Value);
+        __Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments = new Lazy<bool?>(this.Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments_Value);
+        __Date_HOOSJr_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_HOOSJr_Total_Assessment_Completed_Value);
+        __Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments = new Lazy<bool?>(this.Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments_Value);
+        __Date_PROMIS10_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_PROMIS10_Total_Assessment_Completed_Value);
+        __Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments = new Lazy<bool?>(this.Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments_Value);
+        __Date_VR12_Oblique_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_VR12_Oblique_Total_Assessment_Completed_Value);
+        __Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments = new Lazy<bool?>(this.Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments_Value);
+        __Date_VR12_Orthogonal_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_VR12_Orthogonal_Total_Assessment_Completed_Value);
+        __Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments = new Lazy<bool?>(this.Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Ethnicity_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+
+    [CqlDeclaration("Ethnicity")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
+	public CqlValueSet Ethnicity() => 
+		__Ethnicity.Value;
+
+	private CqlValueSet Lower_Body_Fractures_Excluding_Ankle_and_Foot_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178", null);
+
+    [CqlDeclaration("Lower Body Fractures Excluding Ankle and Foot")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178")]
+	public CqlValueSet Lower_Body_Fractures_Excluding_Ankle_and_Foot() => 
+		__Lower_Body_Fractures_Excluding_Ankle_and_Foot.Value;
+
+	private CqlValueSet Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180", null);
+
+    [CqlDeclaration("Malignant Neoplasms of Lower and Unspecified Limbs")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180")]
+	public CqlValueSet Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs() => 
+		__Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs.Value;
+
+	private CqlValueSet Mechanical_Complications_Excluding_Upper_Body_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182", null);
+
+    [CqlDeclaration("Mechanical Complications Excluding Upper Body")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182")]
+	public CqlValueSet Mechanical_Complications_Excluding_Upper_Body() => 
+		__Mechanical_Complications_Excluding_Upper_Body.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet ONC_Administrative_Sex_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+
+    [CqlDeclaration("ONC Administrative Sex")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
+	public CqlValueSet ONC_Administrative_Sex() => 
+		__ONC_Administrative_Sex.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Partial_Arthroplasty_of_Hip_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184", null);
+
+    [CqlDeclaration("Partial Arthroplasty of Hip")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184")]
+	public CqlValueSet Partial_Arthroplasty_of_Hip() => 
+		__Partial_Arthroplasty_of_Hip.Value;
+
+	private CqlValueSet Payer_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+
+    [CqlDeclaration("Payer")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
+	public CqlValueSet Payer() => 
+		__Payer.Value;
+
+	private CqlValueSet Primary_THA_Procedure_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006", null);
+
+    [CqlDeclaration("Primary THA Procedure")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006")]
+	public CqlValueSet Primary_THA_Procedure() => 
+		__Primary_THA_Procedure.Value;
+
+	private CqlValueSet Race_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+
+    [CqlDeclaration("Race")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
+	public CqlValueSet Race() => 
+		__Race.Value;
+
+	private CqlValueSet Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189", null);
+
+    [CqlDeclaration("Removal, Revision and Supplement Procedures of the Lower Body and Spine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189")]
+	public CqlValueSet Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine() => 
+		__Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlCode Activities_of_daily_living_score__HOOS__Value() => 
+		new CqlCode("72095-3", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Activities of daily living score [HOOS]")]
+	public CqlCode Activities_of_daily_living_score__HOOS_() => 
+		__Activities_of_daily_living_score__HOOS_.Value;
+
+	private CqlCode Dead__finding__Value() => 
+		new CqlCode("419099009", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Dead (finding)")]
+	public CqlCode Dead__finding_() => 
+		__Dead__finding_.Value;
+
+	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
+		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
+	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
+		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
+
+	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
+		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Discharge to home for hospice care (procedure)")]
+	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
+		__Discharge_to_home_for_hospice_care__procedure_.Value;
+
+	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
+		new CqlCode("45755-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Hospice care [Minimum Data Set]")]
+	public CqlCode Hospice_care__Minimum_Data_Set_() => 
+		__Hospice_care__Minimum_Data_Set_.Value;
+
+	private CqlCode Pain_score__HOOS__Value() => 
+		new CqlCode("72097-9", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Pain score [HOOS]")]
+	public CqlCode Pain_score__HOOS_() => 
+		__Pain_score__HOOS_.Value;
+
+	private CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value() => 
+		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Postoperative follow-up visit, normally included in the surgical package, to indicate that an evaluation and management service was performed during a postoperative period for a reason(s) related to the original procedure")]
+	public CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure() => 
+		__Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure.Value;
+
+	private CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value() => 
+		new CqlCode("71969-0", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-10 Global Mental Health (GMH) score T-score")]
+	public CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score() => 
+		__PROMIS_10_Global_Mental_Health__GMH__score_T_score.Value;
+
+	private CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value() => 
+		new CqlCode("71971-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-10 Global Physical Health (GPH) score T-score")]
+	public CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score() => 
+		__PROMIS_10_Global_Physical_Health__GPH__score_T_score.Value;
+
+	private CqlCode Quality_of_life_score__HOOS__Value() => 
+		new CqlCode("72093-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Quality of life score [HOOS]")]
+	public CqlCode Quality_of_life_score__HOOS_() => 
+		__Quality_of_life_score__HOOS_.Value;
+
+	private CqlCode Severe_cognitive_impairment__finding__Value() => 
+		new CqlCode("702956004", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Severe cognitive impairment (finding)")]
+	public CqlCode Severe_cognitive_impairment__finding_() => 
+		__Severe_cognitive_impairment__finding_.Value;
+
+	private CqlCode Sport_recreation_score__HOOS__Value() => 
+		new CqlCode("72094-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Sport-recreation score [HOOS]")]
+	public CqlCode Sport_recreation_score__HOOS_() => 
+		__Sport_recreation_score__HOOS_.Value;
+
+	private CqlCode survey_Value() => 
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", null, null);
+
+    [CqlDeclaration("survey")]
+	public CqlCode survey() => 
+		__survey.Value;
+
+	private CqlCode Symptoms_score__HOOS__Value() => 
+		new CqlCode("72096-1", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Symptoms score [HOOS]")]
+	public CqlCode Symptoms_score__HOOS_() => 
+		__Symptoms_score__HOOS_.Value;
+
+	private CqlCode Total_interval_score__HOOSJR__Value() => 
+		new CqlCode("82323-7", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Total interval score [HOOSJR]")]
+	public CqlCode Total_interval_score__HOOSJR_() => 
+		__Total_interval_score__HOOSJR_.Value;
+
+	private CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
+		new CqlCode("72026-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-12 Mental component summary (MCS) score - oblique method T-score")]
+	public CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score() => 
+		__VR_12_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
+
+	private CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
+		new CqlCode("72028-4", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-12 Mental component summary (MCS) score - orthogonal method T-score")]
+	public CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
+		__VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
+
+	private CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
+		new CqlCode("72025-0", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-12 Physical component summary (PCS) score - oblique method T-score")]
+	public CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score() => 
+		__VR_12_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
+
+	private CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
+		new CqlCode("72027-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-12 Physical component summary (PCS) score - orthogonal method T-score")]
+	public CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
+		__VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
+
+	private CqlCode Yes__qualifier_value__Value() => 
+		new CqlCode("373066001", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Yes (qualifier value)")]
+	public CqlCode Yes__qualifier_value_() => 
+		__Yes__qualifier_value_.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("72095-3", "http://loinc.org", null, null),
+			new CqlCode("45755-6", "http://loinc.org", null, null),
+			new CqlCode("72097-9", "http://loinc.org", null, null),
+			new CqlCode("71969-0", "http://loinc.org", null, null),
+			new CqlCode("71971-6", "http://loinc.org", null, null),
+			new CqlCode("72093-8", "http://loinc.org", null, null),
+			new CqlCode("72094-6", "http://loinc.org", null, null),
+			new CqlCode("72096-1", "http://loinc.org", null, null),
+			new CqlCode("82323-7", "http://loinc.org", null, null),
+			new CqlCode("72026-8", "http://loinc.org", null, null),
+			new CqlCode("72028-4", "http://loinc.org", null, null),
+			new CqlCode("72025-0", "http://loinc.org", null, null),
+			new CqlCode("72027-6", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlCode[] ConditionCategoryCodes_Value()
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
+    [CqlDeclaration("ConditionCategoryCodes")]
+	public CqlCode[] ConditionCategoryCodes() => 
+		__ConditionCategoryCodes.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("419099009", "http://snomed.info/sct", null, null),
+			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
+			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
+			new CqlCode("702956004", "http://snomed.info/sct", null, null),
+			new CqlCode("373066001", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] ObservationCategoryCodes_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ObservationCategoryCodes")]
+	public CqlCode[] ObservationCategoryCodes() => 
+		__ObservationCategoryCodes.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private CqlDateTime November_1_Year_Prior_to_the_Measurement_Period_Value()
+	{
+		var a_ = this.Measurement_Period();
+		var b_ = context.Operators.Start(a_);
+		var c_ = context.Operators.ComponentFrom(b_, "year");
+		var d_ = context.Operators.Subtract(c_, (int?)1);
+		var e_ = context.Operators.ConvertIntegerToDecimal((int?)0);
+		var f_ = context.Operators.DateTime(d_, (int?)11, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("November 1 Year Prior to the Measurement Period")]
+	public CqlDateTime November_1_Year_Prior_to_the_Measurement_Period() => 
+		__November_1_Year_Prior_to_the_Measurement_Period.Value;
+
+	private bool? Has_Qualifying_Encounter_Value()
+	{
+		var a_ = this.Outpatient_Consultation();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Office_Visit();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		bool? g_(Encounter E)
+		{
+			CqlConcept t_(CodeableConcept @this)
+			{
+				var y_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return y_;
+			};
+			var u_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, t_);
+			bool? v_(CqlConcept T)
+			{
+				var z_ = this.Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure();
+				var aa_ = context.Operators.ConvertCodeToConcept(z_);
+				var ab_ = context.Operators.Equivalent(T, aa_);
+
+				return ab_;
+			};
+			var w_ = context.Operators.WhereOrNull<CqlConcept>(u_, v_);
+			var x_ = context.Operators.ExistsInList<CqlConcept>(w_);
+
+			return x_;
+		};
+		var h_ = context.Operators.WhereOrNull<Encounter>(f_, g_);
+		var i_ = this.Telephone_Visits();
+		var j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
+		var k_ = context.Operators.ListUnion<Encounter>(h_, j_);
+		var l_ = context.Operators.ListUnion<Encounter>(e_, k_);
+		var m_ = this.Online_Assessments();
+		var n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		var o_ = context.Operators.ListUnion<Encounter>(l_, n_);
+		var p_ = Status_1_6_000.isEncounterPerformed(o_);
+		bool? q_(Encounter ValidEncounters)
+		{
+			var ac_ = this.November_1_Year_Prior_to_the_Measurement_Period();
+			var ad_ = this.Measurement_Period();
+			var ae_ = context.Operators.End(ad_);
+			var af_ = context.Operators.Interval(ac_, ae_, true, true);
+			var ag_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounters?.Period);
+			var ah_ = QICoreCommon_2_0_000.toInterval((ag_ as object));
+			var ai_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ah_, "day");
+
+			return ai_;
+		};
+		var r_ = context.Operators.WhereOrNull<Encounter>(p_, q_);
+		var s_ = context.Operators.ExistsInList<Encounter>(r_);
+
+		return s_;
+	}
+
+    [CqlDeclaration("Has Qualifying Encounter")]
+	public bool? Has_Qualifying_Encounter() => 
+		__Has_Qualifying_Encounter.Value;
+
+	private CqlDateTime November_1_Two_Years_Prior_to_the_Measurement_Period_Value()
+	{
+		var a_ = this.Measurement_Period();
+		var b_ = context.Operators.Start(a_);
+		var c_ = context.Operators.ComponentFrom(b_, "year");
+		var d_ = context.Operators.Subtract(c_, (int?)2);
+		var e_ = context.Operators.ConvertIntegerToDecimal((int?)0);
+		var f_ = context.Operators.DateTime(d_, (int?)11, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("November 1 Two Years Prior to the Measurement Period")]
+	public CqlDateTime November_1_Two_Years_Prior_to_the_Measurement_Period() => 
+		__November_1_Two_Years_Prior_to_the_Measurement_Period.Value;
+
+	private CqlDateTime October_31_Year_Prior_to_the_Measurement_Period_Value()
+	{
+		var a_ = this.Measurement_Period();
+		var b_ = context.Operators.Start(a_);
+		var c_ = context.Operators.ComponentFrom(b_, "year");
+		var d_ = context.Operators.Subtract(c_, (int?)1);
+		var e_ = context.Operators.ConvertIntegerToDecimal((int?)0);
+		var f_ = context.Operators.DateTime(d_, (int?)10, (int?)31, (int?)23, (int?)59, (int?)59, (int?)0, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("October 31 Year Prior to the Measurement Period")]
+	public CqlDateTime October_31_Year_Prior_to_the_Measurement_Period() => 
+		__October_31_Year_Prior_to_the_Measurement_Period.Value;
+
+	private IEnumerable<Procedure> Total_Hip_Arthroplasty_Procedure_Value()
+	{
+		var a_ = this.Primary_THA_Procedure();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.isProcedurePerformed(b_);
+		bool? d_(Procedure THAProcedure)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+			var g_ = QICoreCommon_2_0_000.toInterval(f_);
+			var h_ = context.Operators.Start(g_);
+			var i_ = this.November_1_Two_Years_Prior_to_the_Measurement_Period();
+			var j_ = this.October_31_Year_Prior_to_the_Measurement_Period();
+			var k_ = context.Operators.Interval(i_, j_, true, true);
+			var l_ = context.Operators.ElementInInterval<CqlDateTime>(h_, k_, "day");
+
+			return l_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Total Hip Arthroplasty Procedure")]
+	public IEnumerable<Procedure> Total_Hip_Arthroplasty_Procedure() => 
+		__Total_Hip_Arthroplasty_Procedure.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Has_Qualifying_Encounter();
+		var b_ = this.Total_Hip_Arthroplasty_Procedure();
+		var c_ = context.Operators.ExistsInList<Procedure>(b_);
+		var d_ = context.Operators.And(a_, c_);
+		var e_ = this.Patient();
+		var f_ = context.Operators.Convert<CqlDate>(e_?.BirthDateElement?.Value);
+		var g_ = this.Measurement_Period();
+		var h_ = context.Operators.Start(g_);
+		var i_ = context.Operators.DateFrom(h_);
+		var j_ = context.Operators.CalculateAgeAt(f_, i_, "year");
+		var k_ = context.Operators.GreaterOrEqual(j_, (int?)19);
+		var l_ = context.Operators.And(d_, k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Has_Severe_Cognitive_Impairment_Value()
+	{
+		var a_ = this.Severe_cognitive_impairment__finding_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		bool? d_(Condition Dementia)
+		{
+			var g_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Overlaps(g_, h_, null);
+
+			return i_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Condition>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Severe Cognitive Impairment")]
+	public bool? Has_Severe_Cognitive_Impairment() => 
+		__Has_Severe_Cognitive_Impairment.Value;
+
+	private bool? Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures_Value()
+	{
+		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> b_(Procedure THAProcedure)
+		{
+			var e_ = this.Lower_Body_Fractures_Excluding_Ankle_and_Foot();
+			var f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
+			bool? g_(Condition LowerBodyFracture)
+			{
+				var k_ = QICoreCommon_2_0_000.prevalenceInterval(LowerBodyFracture);
+				var l_ = context.Operators.Start(k_);
+				var m_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+				var n_ = QICoreCommon_2_0_000.toInterval(m_);
+				var o_ = context.Operators.Start(n_);
+				var p_ = context.Operators.Quantity(24m, "hours");
+				var q_ = context.Operators.Subtract(o_, p_);
+				var s_ = QICoreCommon_2_0_000.toInterval(m_);
+				var t_ = context.Operators.Start(s_);
+				var u_ = context.Operators.Interval(q_, t_, true, true);
+				var v_ = context.Operators.ElementInInterval<CqlDateTime>(l_, u_, null);
+				var x_ = QICoreCommon_2_0_000.toInterval(m_);
+				var y_ = context.Operators.Start(x_);
+				var z_ = context.Operators.Not((bool?)(y_ is null));
+				var aa_ = context.Operators.And(v_, z_);
+
+				return aa_;
+			};
+			var h_ = context.Operators.WhereOrNull<Condition>(f_, g_);
+			Procedure i_(Condition LowerBodyFracture) => 
+				THAProcedure;
+			var j_ = context.Operators.SelectOrNull<Condition, Procedure>(h_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(a_, b_);
+		var d_ = context.Operators.ExistsInList<Procedure>(c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Has Total Hip Arthroplasty with 1 or More Lower Body Fractures")]
+	public bool? Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures() => 
+		__Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures.Value;
+
+	private bool? Has_Partial_Hip_Arthroplasty_Procedure_Value()
+	{
+		var a_ = this.Partial_Arthroplasty_of_Hip();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.isProcedurePerformed(b_);
+		IEnumerable<Procedure> d_(Procedure PartialTHAProcedure)
+		{
+			var g_ = this.Total_Hip_Arthroplasty_Procedure();
+			bool? h_(Procedure THAProcedure)
+			{
+				var l_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+				var m_ = QICoreCommon_2_0_000.toInterval(l_);
+				var n_ = FHIRHelpers_4_3_000.ToValue(PartialTHAProcedure?.Performed);
+				var o_ = QICoreCommon_2_0_000.toInterval(n_);
+				var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
+
+				return p_;
+			};
+			var i_ = context.Operators.WhereOrNull<Procedure>(g_, h_);
+			Procedure j_(Procedure THAProcedure) => 
+				PartialTHAProcedure;
+			var k_ = context.Operators.SelectOrNull<Procedure, Procedure>(i_, j_);
+
+			return k_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Procedure>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Partial Hip Arthroplasty Procedure")]
+	public bool? Has_Partial_Hip_Arthroplasty_Procedure() => 
+		__Has_Partial_Hip_Arthroplasty_Procedure.Value;
+
+	private bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Value()
+	{
+		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> b_(Procedure THAProcedure)
+		{
+			var e_ = this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine();
+			var f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
+			var g_ = Status_1_6_000.isProcedurePerformed(f_);
+			bool? h_(Procedure RevisionTHAProcedure)
+			{
+				var l_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+				var m_ = QICoreCommon_2_0_000.toInterval(l_);
+				var n_ = FHIRHelpers_4_3_000.ToValue(RevisionTHAProcedure?.Performed);
+				var o_ = QICoreCommon_2_0_000.toInterval(n_);
+				var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
+
+				return p_;
+			};
+			var i_ = context.Operators.WhereOrNull<Procedure>(g_, h_);
+			Procedure j_(Procedure RevisionTHAProcedure) => 
+				THAProcedure;
+			var k_ = context.Operators.SelectOrNull<Procedure, Procedure>(i_, j_);
+
+			return k_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(a_, b_);
+		var d_ = context.Operators.ExistsInList<Procedure>(c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Has Revision Hip Arthroplasty Procedure or Implanted Device or Prosthesis Removal Procedure")]
+	public bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure() => 
+		__Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure.Value;
+
+	private bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Value()
+	{
+		var a_ = this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_(Condition MalignantNeoplasm)
+		{
+			var f_ = this.Total_Hip_Arthroplasty_Procedure();
+			bool? g_(Procedure THAProcedure)
+			{
+				var k_ = QICoreCommon_2_0_000.prevalenceInterval(MalignantNeoplasm);
+				var l_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+				var m_ = QICoreCommon_2_0_000.toInterval(l_);
+				var n_ = context.Operators.Overlaps(k_, m_, null);
+
+				return n_;
+			};
+			var h_ = context.Operators.WhereOrNull<Procedure>(f_, g_);
+			Condition i_(Procedure THAProcedure) => 
+				MalignantNeoplasm;
+			var j_ = context.Operators.SelectOrNull<Procedure, Condition>(h_, i_);
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Condition, Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Malignant Neoplasm of Lower and Unspecified Limbs")]
+	public bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs() => 
+		__Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs.Value;
+
+	private bool? Has_Mechanical_Complication_Value()
+	{
+		var a_ = this.Mechanical_Complications_Excluding_Upper_Body();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_(Condition MechanicalComplications)
+		{
+			var f_ = this.Total_Hip_Arthroplasty_Procedure();
+			bool? g_(Procedure THAProcedure)
+			{
+				var k_ = QICoreCommon_2_0_000.prevalenceInterval(MechanicalComplications);
+				var l_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+				var m_ = QICoreCommon_2_0_000.toInterval(l_);
+				var n_ = context.Operators.Overlaps(k_, m_, null);
+
+				return n_;
+			};
+			var h_ = context.Operators.WhereOrNull<Procedure>(f_, g_);
+			Condition i_(Procedure THAProcedure) => 
+				MechanicalComplications;
+			var j_ = context.Operators.SelectOrNull<Procedure, Condition>(h_, i_);
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Condition, Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Mechanical Complication")]
+	public bool? Has_Mechanical_Complication() => 
+		__Has_Mechanical_Complication.Value;
+
+	private bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Value()
+	{
+		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> b_(Procedure THAProcedure)
+		{
+			var e_ = this.Primary_THA_Procedure();
+			var f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
+			var g_ = Status_1_6_000.isProcedurePerformed(f_);
+			bool? h_(Procedure ElectiveTHAProcedure)
+			{
+				var l_ = context.Operators.Equivalent(THAProcedure?.IdElement?.Value, ElectiveTHAProcedure?.IdElement?.Value);
+				var m_ = context.Operators.Not(l_);
+				var n_ = FHIRHelpers_4_3_000.ToValue(ElectiveTHAProcedure?.Performed);
+				var o_ = QICoreCommon_2_0_000.toInterval(n_);
+				var p_ = context.Operators.Start(o_);
+				var q_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+				var r_ = QICoreCommon_2_0_000.toInterval(q_);
+				var s_ = context.Operators.Start(r_);
+				var t_ = context.Operators.Quantity(1m, "year");
+				var u_ = context.Operators.Subtract(s_, t_);
+				var w_ = QICoreCommon_2_0_000.toInterval(q_);
+				var x_ = context.Operators.Start(w_);
+				var z_ = context.Operators.Add(x_, t_);
+				var aa_ = context.Operators.Interval(u_, z_, true, true);
+				var ab_ = context.Operators.ElementInInterval<CqlDateTime>(p_, aa_, "day");
+				var ac_ = context.Operators.And(m_, ab_);
+
+				return ac_;
+			};
+			var i_ = context.Operators.WhereOrNull<Procedure>(g_, h_);
+			Procedure j_(Procedure ElectiveTHAProcedure) => 
+				THAProcedure;
+			var k_ = context.Operators.SelectOrNull<Procedure, Procedure>(i_, j_);
+
+			return k_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(a_, b_);
+		var d_ = context.Operators.ExistsInList<Procedure>(c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Has More Than One Elective Primary Total Hip Arthroplasty Performed")]
+	public bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed() => 
+		__Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed.Value;
+
+	private bool? Death_Within_300_Days_of_the_THA_Procedure_Value()
+	{
+		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		bool? b_(Procedure THAProcedure)
+		{
+			var e_ = this.Patient();
+			var f_ = FHIRHelpers_4_3_000.ToValue(e_?.Deceased);
+			var g_ = context.Operators.DateFrom((f_ as CqlDateTime));
+			var h_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+			var i_ = QICoreCommon_2_0_000.toInterval(h_);
+			var j_ = context.Operators.Start(i_);
+			var k_ = context.Operators.DateFrom(j_);
+			var m_ = QICoreCommon_2_0_000.toInterval(h_);
+			var n_ = context.Operators.Start(m_);
+			var o_ = context.Operators.DateFrom(n_);
+			var p_ = context.Operators.Quantity(300m, "days");
+			var q_ = context.Operators.Add(o_, p_);
+			var r_ = context.Operators.Interval(k_, q_, true, true);
+			var s_ = context.Operators.ElementInInterval<CqlDate>(g_, r_, "day");
+
+			return s_;
+		};
+		var c_ = context.Operators.WhereOrNull<Procedure>(a_, b_);
+		var d_ = context.Operators.ExistsInList<Procedure>(c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Death Within 300 Days of the THA Procedure")]
+	public bool? Death_Within_300_Days_of_the_THA_Procedure() => 
+		__Death_Within_300_Days_of_the_THA_Procedure.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = this.Has_Severe_Cognitive_Impairment();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = this.Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures();
+		var e_ = context.Operators.Or(c_, d_);
+		var f_ = this.Has_Partial_Hip_Arthroplasty_Procedure();
+		var g_ = context.Operators.Or(e_, f_);
+		var h_ = this.Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure();
+		var i_ = context.Operators.Or(g_, h_);
+		var j_ = this.Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs();
+		var k_ = context.Operators.Or(i_, j_);
+		var l_ = this.Has_Mechanical_Complication();
+		var m_ = context.Operators.Or(k_, l_);
+		var n_ = this.Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed();
+		var o_ = context.Operators.Or(m_, n_);
+		var p_ = this.Death_Within_300_Days_of_the_THA_Procedure();
+		var q_ = context.Operators.Or(o_, p_);
+
+		return q_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<CqlDate> Date_HOOS_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.Quality_of_life_score__HOOS_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.isAssessmentPerformed(c_);
+		IEnumerable<Observation> e_(Observation _HOOSLifeQuality)
+		{
+			var u_ = this.Sport_recreation_score__HOOS_();
+			var v_ = context.Operators.ToList<CqlCode>(u_);
+			var w_ = context.Operators.RetrieveByCodes<Observation>(v_, null);
+			var x_ = Status_1_6_000.isAssessmentPerformed(w_);
+
+			return x_;
+		};
+		Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf f_(Observation _HOOSLifeQuality, Observation _HOOSSport)
+		{
+			var y_ = new Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf
+			{
+				HOOSLifeQuality = _HOOSLifeQuality,
+				HOOSSport = _HOOSSport,
+			};
+
+			return y_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf>(d_, e_, f_);
+		IEnumerable<Observation> h_(Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf _HOOSLifeQualityHOOSSport)
+		{
+			var z_ = this.Activities_of_daily_living_score__HOOS_();
+			var aa_ = context.Operators.ToList<CqlCode>(z_);
+			var ab_ = context.Operators.RetrieveByCodes<Observation>(aa_, null);
+			var ac_ = Status_1_6_000.isAssessmentPerformed(ab_);
+
+			return ac_;
+		};
+		Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf i_(Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf HOOSLifeQualityHOOSSport, Observation _HOOSActivityScore)
+		{
+			var ad_ = new Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf
+			{
+				HOOSLifeQuality = HOOSLifeQualityHOOSSport.HOOSLifeQuality,
+				HOOSSport = HOOSLifeQualityHOOSSport.HOOSSport,
+				HOOSActivityScore = _HOOSActivityScore,
+			};
+
+			return ad_;
+		};
+		var j_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf, Observation, Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf>(g_, h_, i_);
+		IEnumerable<Observation> k_(Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf _HOOSLifeQualityHOOSSportHOOSActivityScore)
+		{
+			var ae_ = this.Symptoms_score__HOOS_();
+			var af_ = context.Operators.ToList<CqlCode>(ae_);
+			var ag_ = context.Operators.RetrieveByCodes<Observation>(af_, null);
+			var ah_ = Status_1_6_000.isAssessmentPerformed(ag_);
+
+			return ah_;
+		};
+		Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf l_(Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf HOOSLifeQualityHOOSSportHOOSActivityScore, Observation _HOOSSymptoms)
+		{
+			var ai_ = new Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf
+			{
+				HOOSLifeQuality = HOOSLifeQualityHOOSSportHOOSActivityScore.HOOSLifeQuality,
+				HOOSSport = HOOSLifeQualityHOOSSportHOOSActivityScore.HOOSSport,
+				HOOSActivityScore = HOOSLifeQualityHOOSSportHOOSActivityScore.HOOSActivityScore,
+				HOOSSymptoms = _HOOSSymptoms,
+			};
+
+			return ai_;
+		};
+		var m_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf, Observation, Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf>(j_, k_, l_);
+		IEnumerable<Observation> n_(Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf _HOOSLifeQualityHOOSSportHOOSActivityScoreHOOSSymptoms)
+		{
+			var aj_ = this.Pain_score__HOOS_();
+			var ak_ = context.Operators.ToList<CqlCode>(aj_);
+			var al_ = context.Operators.RetrieveByCodes<Observation>(ak_, null);
+			var am_ = Status_1_6_000.isAssessmentPerformed(al_);
+
+			return am_;
+		};
+		Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf o_(Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf HOOSLifeQualityHOOSSportHOOSActivityScoreHOOSSymptoms, Observation _HOOSPain)
+		{
+			var an_ = new Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf
+			{
+				HOOSLifeQuality = HOOSLifeQualityHOOSSportHOOSActivityScoreHOOSSymptoms.HOOSLifeQuality,
+				HOOSSport = HOOSLifeQualityHOOSSportHOOSActivityScoreHOOSSymptoms.HOOSSport,
+				HOOSActivityScore = HOOSLifeQualityHOOSSportHOOSActivityScoreHOOSSymptoms.HOOSActivityScore,
+				HOOSSymptoms = HOOSLifeQualityHOOSSportHOOSActivityScoreHOOSSymptoms.HOOSSymptoms,
+				HOOSPain = _HOOSPain,
+			};
+
+			return an_;
+		};
+		var p_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf, Observation, Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf>(m_, n_, o_);
+		bool? q_(Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf tuple_epubufihdvtjzfyvthglfueuf)
+		{
+			var ao_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSLifeQuality?.Effective);
+			var ap_ = QICoreCommon_2_0_000.toInterval(ao_);
+			var aq_ = context.Operators.Start(ap_);
+			var ar_ = context.Operators.DateFrom(aq_);
+			var as_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSSport?.Effective);
+			var at_ = QICoreCommon_2_0_000.toInterval(as_);
+			var au_ = context.Operators.Start(at_);
+			var av_ = context.Operators.DateFrom(au_);
+			var aw_ = context.Operators.SameAs(ar_, av_, "day");
+			var ax_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSSport?.Value);
+			var ay_ = context.Operators.Not((bool?)(ax_ is null));
+			var az_ = context.Operators.And(aw_, ay_);
+			var bb_ = QICoreCommon_2_0_000.toInterval(ao_);
+			var bc_ = context.Operators.Start(bb_);
+			var bd_ = context.Operators.DateFrom(bc_);
+			var be_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSActivityScore?.Effective);
+			var bf_ = QICoreCommon_2_0_000.toInterval(be_);
+			var bg_ = context.Operators.Start(bf_);
+			var bh_ = context.Operators.DateFrom(bg_);
+			var bi_ = context.Operators.SameAs(bd_, bh_, "day");
+			var bj_ = context.Operators.And(az_, bi_);
+			var bk_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSActivityScore?.Value);
+			var bl_ = context.Operators.Not((bool?)(bk_ is null));
+			var bm_ = context.Operators.And(bj_, bl_);
+			var bo_ = QICoreCommon_2_0_000.toInterval(ao_);
+			var bp_ = context.Operators.Start(bo_);
+			var bq_ = context.Operators.DateFrom(bp_);
+			var br_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSSymptoms?.Effective);
+			var bs_ = QICoreCommon_2_0_000.toInterval(br_);
+			var bt_ = context.Operators.Start(bs_);
+			var bu_ = context.Operators.DateFrom(bt_);
+			var bv_ = context.Operators.SameAs(bq_, bu_, "day");
+			var bw_ = context.Operators.And(bm_, bv_);
+			var bx_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSSymptoms?.Value);
+			var by_ = context.Operators.Not((bool?)(bx_ is null));
+			var bz_ = context.Operators.And(bw_, by_);
+			var cb_ = QICoreCommon_2_0_000.toInterval(ao_);
+			var cc_ = context.Operators.Start(cb_);
+			var cd_ = context.Operators.DateFrom(cc_);
+			var ce_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSPain?.Effective);
+			var cf_ = QICoreCommon_2_0_000.toInterval(ce_);
+			var cg_ = context.Operators.Start(cf_);
+			var ch_ = context.Operators.DateFrom(cg_);
+			var ci_ = context.Operators.SameAs(cd_, ch_, "day");
+			var cj_ = context.Operators.And(bz_, ci_);
+			var ck_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSPain?.Value);
+			var cl_ = context.Operators.Not((bool?)(ck_ is null));
+			var cm_ = context.Operators.And(cj_, cl_);
+			var cn_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSLifeQuality?.Value);
+			var co_ = context.Operators.Not((bool?)(cn_ is null));
+			var cp_ = context.Operators.And(cm_, co_);
+
+			return cp_;
+		};
+		var r_ = context.Operators.WhereOrNull<Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf>(p_, q_);
+		CqlDate s_(Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf tuple_epubufihdvtjzfyvthglfueuf)
+		{
+			var cq_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSLifeQuality?.Effective);
+			var cr_ = QICoreCommon_2_0_000.toInterval(cq_);
+			var cs_ = context.Operators.Start(cr_);
+			var ct_ = context.Operators.DateFrom(cs_);
+			var cu_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSSport?.Effective);
+			var cv_ = QICoreCommon_2_0_000.toInterval(cu_);
+			var cw_ = context.Operators.Start(cv_);
+			var cx_ = context.Operators.DateFrom(cw_);
+			var cy_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSActivityScore?.Effective);
+			var cz_ = QICoreCommon_2_0_000.toInterval(cy_);
+			var da_ = context.Operators.Start(cz_);
+			var db_ = context.Operators.DateFrom(da_);
+			var dc_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSSymptoms?.Effective);
+			var dd_ = QICoreCommon_2_0_000.toInterval(dc_);
+			var de_ = context.Operators.Start(dd_);
+			var df_ = context.Operators.DateFrom(de_);
+			var dg_ = FHIRHelpers_4_3_000.ToValue(tuple_epubufihdvtjzfyvthglfueuf.HOOSPain?.Effective);
+			var dh_ = QICoreCommon_2_0_000.toInterval(dg_);
+			var di_ = context.Operators.Start(dh_);
+			var dj_ = context.Operators.DateFrom(di_);
+			var dk_ = new CqlDate[]
+			{
+				ct_,
+				cx_,
+				db_,
+				df_,
+				dj_,
+			};
+			var dl_ = context.Operators.MaxOrNull<CqlDate>((dk_ as IEnumerable<CqlDate>));
+
+			return dl_;
+		};
+		var t_ = context.Operators.SelectOrNull<Tuples.Tuple_EPUbUfihDVTJZfYVTHGLFUeUf, CqlDate>(r_, s_);
+
+		return t_;
+	}
+
+    [CqlDeclaration("Date HOOS Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_HOOS_Total_Assessment_Completed() => 
+		__Date_HOOS_Total_Assessment_Completed.Value;
+
+	private bool? Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments_Value()
+	{
+		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
+		{
+			var i_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+			var j_ = QICoreCommon_2_0_000.toInterval(i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectOrNull<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var k_ = this.Date_HOOS_Total_Assessment_Completed();
+			bool? l_(CqlDate InitialHipAssessmentHOOS)
+			{
+				var p_ = context.Operators.Start(TotalHip);
+				var q_ = context.Operators.Quantity(90m, "days");
+				var r_ = context.Operators.Add(InitialHipAssessmentHOOS, q_);
+				var s_ = context.Operators.Interval(InitialHipAssessmentHOOS, r_, true, true);
+				var t_ = context.Operators.ConvertDateToDateTime(s_?.low);
+				var v_ = context.Operators.Add(InitialHipAssessmentHOOS, q_);
+				var w_ = context.Operators.Interval(InitialHipAssessmentHOOS, v_, true, true);
+				var x_ = context.Operators.ConvertDateToDateTime(w_?.high);
+				var z_ = context.Operators.Add(InitialHipAssessmentHOOS, q_);
+				var aa_ = context.Operators.Interval(InitialHipAssessmentHOOS, z_, true, true);
+				var ac_ = context.Operators.Add(InitialHipAssessmentHOOS, q_);
+				var ad_ = context.Operators.Interval(InitialHipAssessmentHOOS, ac_, true, true);
+				var ae_ = context.Operators.Interval(t_, x_, aa_?.lowClosed, ad_?.highClosed);
+				var af_ = context.Operators.ElementInInterval<CqlDateTime>(p_, ae_, "day");
+				var ag_ = context.Operators.Not((bool?)(InitialHipAssessmentHOOS is null));
+				var ah_ = context.Operators.And(af_, ag_);
+
+				return ah_;
+			};
+			var m_ = context.Operators.WhereOrNull<CqlDate>(k_, l_);
+			CqlInterval<CqlDateTime> n_(CqlDate InitialHipAssessmentHOOS) => 
+				TotalHip;
+			var o_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(m_, n_);
+
+			return o_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var ai_ = this.Date_HOOS_Total_Assessment_Completed();
+			bool? aj_(CqlDate FollowUpHipAssessmentHOOS)
+			{
+				var an_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentHOOS);
+				var ao_ = context.Operators.DateFrom(an_);
+				var ap_ = context.Operators.End(TotalHip);
+				var aq_ = context.Operators.DateFrom(ap_);
+				var ar_ = context.Operators.Quantity(300m, "days");
+				var as_ = context.Operators.Add(aq_, ar_);
+				var au_ = context.Operators.DateFrom(ap_);
+				var av_ = context.Operators.Quantity(425m, "days");
+				var aw_ = context.Operators.Add(au_, av_);
+				var ax_ = context.Operators.Interval(as_, aw_, true, true);
+				var ay_ = context.Operators.ElementInInterval<CqlDate>(ao_, ax_, "day");
+
+				return ay_;
+			};
+			var ak_ = context.Operators.WhereOrNull<CqlDate>(ai_, aj_);
+			CqlInterval<CqlDateTime> al_(CqlDate FollowUpHipAssessmentHOOS) => 
+				TotalHip;
+			var am_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(ak_, al_);
+
+			return am_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		var h_ = context.Operators.ExistsInList<CqlInterval<CqlDateTime>>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Has THA with Initial and Follow Up HOOS Assessments")]
+	public bool? Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments() => 
+		__Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_HOOSJr_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.Total_interval_score__HOOSJR_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		bool? d_(Observation HOOSJr)
+		{
+			var h_ = FHIRHelpers_4_3_000.ToValue(HOOSJr?.Value);
+			var i_ = context.Operators.Not((bool?)(h_ is null));
+
+			return i_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		CqlDate f_(Observation DocumentedHOOSJr)
+		{
+			var j_ = FHIRHelpers_4_3_000.ToValue(DocumentedHOOSJr?.Effective);
+			var k_ = QICoreCommon_2_0_000.toInterval(j_);
+			var l_ = context.Operators.Start(k_);
+			var m_ = context.Operators.DateFrom(l_);
+
+			return m_;
+		};
+		var g_ = context.Operators.SelectOrNull<Observation, CqlDate>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Date HOOSJr Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_HOOSJr_Total_Assessment_Completed() => 
+		__Date_HOOSJr_Total_Assessment_Completed.Value;
+
+	private bool? Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments_Value()
+	{
+		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
+		{
+			var i_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+			var j_ = QICoreCommon_2_0_000.toInterval(i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectOrNull<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var k_ = this.Date_HOOSJr_Total_Assessment_Completed();
+			bool? l_(CqlDate InitialHipAssessment)
+			{
+				var p_ = context.Operators.Start(TotalHip);
+				var q_ = context.Operators.Quantity(90m, "days");
+				var r_ = context.Operators.Add(InitialHipAssessment, q_);
+				var s_ = context.Operators.Interval(InitialHipAssessment, r_, true, true);
+				var t_ = context.Operators.ConvertDateToDateTime(s_?.low);
+				var v_ = context.Operators.Add(InitialHipAssessment, q_);
+				var w_ = context.Operators.Interval(InitialHipAssessment, v_, true, true);
+				var x_ = context.Operators.ConvertDateToDateTime(w_?.high);
+				var z_ = context.Operators.Add(InitialHipAssessment, q_);
+				var aa_ = context.Operators.Interval(InitialHipAssessment, z_, true, true);
+				var ac_ = context.Operators.Add(InitialHipAssessment, q_);
+				var ad_ = context.Operators.Interval(InitialHipAssessment, ac_, true, true);
+				var ae_ = context.Operators.Interval(t_, x_, aa_?.lowClosed, ad_?.highClosed);
+				var af_ = context.Operators.ElementInInterval<CqlDateTime>(p_, ae_, "day");
+				var ag_ = context.Operators.Not((bool?)(InitialHipAssessment is null));
+				var ah_ = context.Operators.And(af_, ag_);
+
+				return ah_;
+			};
+			var m_ = context.Operators.WhereOrNull<CqlDate>(k_, l_);
+			CqlInterval<CqlDateTime> n_(CqlDate InitialHipAssessment) => 
+				TotalHip;
+			var o_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(m_, n_);
+
+			return o_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var ai_ = this.Date_HOOSJr_Total_Assessment_Completed();
+			bool? aj_(CqlDate FollowUpHipAssessment)
+			{
+				var an_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessment);
+				var ao_ = context.Operators.DateFrom(an_);
+				var ap_ = context.Operators.End(TotalHip);
+				var aq_ = context.Operators.DateFrom(ap_);
+				var ar_ = context.Operators.Quantity(300m, "days");
+				var as_ = context.Operators.Add(aq_, ar_);
+				var au_ = context.Operators.DateFrom(ap_);
+				var av_ = context.Operators.Quantity(425m, "days");
+				var aw_ = context.Operators.Add(au_, av_);
+				var ax_ = context.Operators.Interval(as_, aw_, true, true);
+				var ay_ = context.Operators.ElementInInterval<CqlDate>(ao_, ax_, "day");
+
+				return ay_;
+			};
+			var ak_ = context.Operators.WhereOrNull<CqlDate>(ai_, aj_);
+			CqlInterval<CqlDateTime> al_(CqlDate FollowUpHipAssessment) => 
+				TotalHip;
+			var am_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(ak_, al_);
+
+			return am_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		var h_ = context.Operators.ExistsInList<CqlInterval<CqlDateTime>>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Has THA with Initial and Follow Up HOOSJr Assessments")]
+	public bool? Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments() => 
+		__Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_PROMIS10_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_(Observation _PROMIS10MentalScore)
+		{
+			var k_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
+			var l_ = context.Operators.ToList<CqlCode>(k_);
+			var m_ = context.Operators.RetrieveByCodes<Observation>(l_, null);
+
+			return m_;
+		};
+		Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM e_(Observation _PROMIS10MentalScore, Observation _PROMIS10PhysicalScore)
+		{
+			var n_ = new Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM
+			{
+				PROMIS10MentalScore = _PROMIS10MentalScore,
+				PROMIS10PhysicalScore = _PROMIS10PhysicalScore,
+			};
+
+			return n_;
+		};
+		var f_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM>(c_, d_, e_);
+		bool? g_(Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM tuple_csqnxjbdujcrvlsgajqoisbpm)
+		{
+			var o_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10MentalScore?.Effective);
+			var p_ = QICoreCommon_2_0_000.toInterval(o_);
+			var q_ = context.Operators.Start(p_);
+			var r_ = context.Operators.DateFrom(q_);
+			var s_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10PhysicalScore?.Effective);
+			var t_ = QICoreCommon_2_0_000.toInterval(s_);
+			var u_ = context.Operators.Start(t_);
+			var v_ = context.Operators.DateFrom(u_);
+			var w_ = context.Operators.SameAs(r_, v_, "day");
+			var x_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10PhysicalScore?.Value);
+			var y_ = context.Operators.Not((bool?)(x_ is null));
+			var z_ = context.Operators.And(w_, y_);
+			var aa_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10MentalScore?.Value);
+			var ab_ = context.Operators.Not((bool?)(aa_ is null));
+			var ac_ = context.Operators.And(z_, ab_);
+
+			return ac_;
+		};
+		var h_ = context.Operators.WhereOrNull<Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM>(f_, g_);
+		CqlDate i_(Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM tuple_csqnxjbdujcrvlsgajqoisbpm)
+		{
+			var ad_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10MentalScore?.Effective);
+			var ae_ = QICoreCommon_2_0_000.toInterval(ad_);
+			var af_ = context.Operators.Start(ae_);
+			var ag_ = context.Operators.DateFrom(af_);
+			var ah_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10PhysicalScore?.Effective);
+			var ai_ = QICoreCommon_2_0_000.toInterval(ah_);
+			var aj_ = context.Operators.Start(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+			var al_ = new CqlDate[]
+			{
+				ag_,
+				ak_,
+			};
+			var am_ = context.Operators.MaxOrNull<CqlDate>((al_ as IEnumerable<CqlDate>));
+
+			return am_;
+		};
+		var j_ = context.Operators.SelectOrNull<Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM, CqlDate>(h_, i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Date PROMIS10 Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_PROMIS10_Total_Assessment_Completed() => 
+		__Date_PROMIS10_Total_Assessment_Completed.Value;
+
+	private bool? Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments_Value()
+	{
+		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
+		{
+			var i_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+			var j_ = QICoreCommon_2_0_000.toInterval(i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectOrNull<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var k_ = this.Date_PROMIS10_Total_Assessment_Completed();
+			bool? l_(CqlDate InitialHipAssessmentPROMIS10)
+			{
+				var p_ = context.Operators.Start(TotalHip);
+				var q_ = context.Operators.Quantity(90m, "days");
+				var r_ = context.Operators.Add(InitialHipAssessmentPROMIS10, q_);
+				var s_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, r_, true, true);
+				var t_ = context.Operators.ConvertDateToDateTime(s_?.low);
+				var v_ = context.Operators.Add(InitialHipAssessmentPROMIS10, q_);
+				var w_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, v_, true, true);
+				var x_ = context.Operators.ConvertDateToDateTime(w_?.high);
+				var z_ = context.Operators.Add(InitialHipAssessmentPROMIS10, q_);
+				var aa_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, z_, true, true);
+				var ac_ = context.Operators.Add(InitialHipAssessmentPROMIS10, q_);
+				var ad_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ac_, true, true);
+				var ae_ = context.Operators.Interval(t_, x_, aa_?.lowClosed, ad_?.highClosed);
+				var af_ = context.Operators.ElementInInterval<CqlDateTime>(p_, ae_, "day");
+				var ag_ = context.Operators.Not((bool?)(InitialHipAssessmentPROMIS10 is null));
+				var ah_ = context.Operators.And(af_, ag_);
+
+				return ah_;
+			};
+			var m_ = context.Operators.WhereOrNull<CqlDate>(k_, l_);
+			CqlInterval<CqlDateTime> n_(CqlDate InitialHipAssessmentPROMIS10) => 
+				TotalHip;
+			var o_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(m_, n_);
+
+			return o_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var ai_ = this.Date_PROMIS10_Total_Assessment_Completed();
+			bool? aj_(CqlDate FollowUpHipAssessmentPROMIS10)
+			{
+				var an_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentPROMIS10);
+				var ao_ = context.Operators.DateFrom(an_);
+				var ap_ = context.Operators.End(TotalHip);
+				var aq_ = context.Operators.DateFrom(ap_);
+				var ar_ = context.Operators.Quantity(300m, "days");
+				var as_ = context.Operators.Add(aq_, ar_);
+				var au_ = context.Operators.DateFrom(ap_);
+				var av_ = context.Operators.Quantity(425m, "days");
+				var aw_ = context.Operators.Add(au_, av_);
+				var ax_ = context.Operators.Interval(as_, aw_, true, true);
+				var ay_ = context.Operators.ElementInInterval<CqlDate>(ao_, ax_, "day");
+
+				return ay_;
+			};
+			var ak_ = context.Operators.WhereOrNull<CqlDate>(ai_, aj_);
+			CqlInterval<CqlDateTime> al_(CqlDate FollowUpHipAssessmentPROMIS10) => 
+				TotalHip;
+			var am_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(ak_, al_);
+
+			return am_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		var h_ = context.Operators.ExistsInList<CqlInterval<CqlDateTime>>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Has THA with Initial and Follow Up PROMIS10 Assessments")]
+	public bool? Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments() => 
+		__Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_VR12_Oblique_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_(Observation _VR12MentalAssessment)
+		{
+			var k_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
+			var l_ = context.Operators.ToList<CqlCode>(k_);
+			var m_ = context.Operators.RetrieveByCodes<Observation>(l_, null);
+
+			return m_;
+		};
+		Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ e_(Observation _VR12MentalAssessment, Observation _VR12PhysicalAssessment)
+		{
+			var n_ = new Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ
+			{
+				VR12MentalAssessment = _VR12MentalAssessment,
+				VR12PhysicalAssessment = _VR12PhysicalAssessment,
+			};
+
+			return n_;
+		};
+		var f_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ>(c_, d_, e_);
+		bool? g_(Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ tuple_awlefjmgfwigjkoeokkqfqij)
+		{
+			var o_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Effective);
+			var p_ = QICoreCommon_2_0_000.toInterval(o_);
+			var q_ = context.Operators.Start(p_);
+			var r_ = context.Operators.DateFrom(q_);
+			var s_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Effective);
+			var t_ = QICoreCommon_2_0_000.toInterval(s_);
+			var u_ = context.Operators.Start(t_);
+			var v_ = context.Operators.DateFrom(u_);
+			var w_ = context.Operators.SameAs(r_, v_, "day");
+			var x_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Value);
+			var y_ = context.Operators.Not((bool?)(x_ is null));
+			var z_ = context.Operators.And(w_, y_);
+			var aa_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Value);
+			var ab_ = context.Operators.Not((bool?)(aa_ is null));
+			var ac_ = context.Operators.And(z_, ab_);
+
+			return ac_;
+		};
+		var h_ = context.Operators.WhereOrNull<Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ>(f_, g_);
+		CqlDate i_(Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ tuple_awlefjmgfwigjkoeokkqfqij)
+		{
+			var ad_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Effective);
+			var ae_ = QICoreCommon_2_0_000.toInterval(ad_);
+			var af_ = context.Operators.Start(ae_);
+			var ag_ = context.Operators.DateFrom(af_);
+			var ah_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Effective);
+			var ai_ = QICoreCommon_2_0_000.toInterval(ah_);
+			var aj_ = context.Operators.Start(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+			var al_ = new CqlDate[]
+			{
+				ag_,
+				ak_,
+			};
+			var am_ = context.Operators.MaxOrNull<CqlDate>((al_ as IEnumerable<CqlDate>));
+
+			return am_;
+		};
+		var j_ = context.Operators.SelectOrNull<Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ, CqlDate>(h_, i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Date VR12 Oblique Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_VR12_Oblique_Total_Assessment_Completed() => 
+		__Date_VR12_Oblique_Total_Assessment_Completed.Value;
+
+	private bool? Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments_Value()
+	{
+		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
+		{
+			var i_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+			var j_ = QICoreCommon_2_0_000.toInterval(i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectOrNull<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var k_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
+			bool? l_(CqlDate InitialHipAssessmentOblique)
+			{
+				var p_ = context.Operators.Start(TotalHip);
+				var q_ = context.Operators.Quantity(90m, "days");
+				var r_ = context.Operators.Add(InitialHipAssessmentOblique, q_);
+				var s_ = context.Operators.Interval(InitialHipAssessmentOblique, r_, true, true);
+				var t_ = context.Operators.ConvertDateToDateTime(s_?.low);
+				var v_ = context.Operators.Add(InitialHipAssessmentOblique, q_);
+				var w_ = context.Operators.Interval(InitialHipAssessmentOblique, v_, true, true);
+				var x_ = context.Operators.ConvertDateToDateTime(w_?.high);
+				var z_ = context.Operators.Add(InitialHipAssessmentOblique, q_);
+				var aa_ = context.Operators.Interval(InitialHipAssessmentOblique, z_, true, true);
+				var ac_ = context.Operators.Add(InitialHipAssessmentOblique, q_);
+				var ad_ = context.Operators.Interval(InitialHipAssessmentOblique, ac_, true, true);
+				var ae_ = context.Operators.Interval(t_, x_, aa_?.lowClosed, ad_?.highClosed);
+				var af_ = context.Operators.ElementInInterval<CqlDateTime>(p_, ae_, "day");
+				var ag_ = context.Operators.Not((bool?)(InitialHipAssessmentOblique is null));
+				var ah_ = context.Operators.And(af_, ag_);
+
+				return ah_;
+			};
+			var m_ = context.Operators.WhereOrNull<CqlDate>(k_, l_);
+			CqlInterval<CqlDateTime> n_(CqlDate InitialHipAssessmentOblique) => 
+				TotalHip;
+			var o_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(m_, n_);
+
+			return o_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var ai_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
+			bool? aj_(CqlDate FollowUpHipAssessmentOblique)
+			{
+				var an_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOblique);
+				var ao_ = context.Operators.DateFrom(an_);
+				var ap_ = context.Operators.End(TotalHip);
+				var aq_ = context.Operators.DateFrom(ap_);
+				var ar_ = context.Operators.Quantity(300m, "days");
+				var as_ = context.Operators.Add(aq_, ar_);
+				var au_ = context.Operators.DateFrom(ap_);
+				var av_ = context.Operators.Quantity(425m, "days");
+				var aw_ = context.Operators.Add(au_, av_);
+				var ax_ = context.Operators.Interval(as_, aw_, true, true);
+				var ay_ = context.Operators.ElementInInterval<CqlDate>(ao_, ax_, "day");
+
+				return ay_;
+			};
+			var ak_ = context.Operators.WhereOrNull<CqlDate>(ai_, aj_);
+			CqlInterval<CqlDateTime> al_(CqlDate FollowUpHipAssessmentOblique) => 
+				TotalHip;
+			var am_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(ak_, al_);
+
+			return am_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		var h_ = context.Operators.ExistsInList<CqlInterval<CqlDateTime>>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Has THA with Initial and Follow Up VR12 Oblique Assessments")]
+	public bool? Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments() => 
+		__Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_VR12_Orthogonal_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_(Observation _VR12MentalAssessment)
+		{
+			var k_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
+			var l_ = context.Operators.ToList<CqlCode>(k_);
+			var m_ = context.Operators.RetrieveByCodes<Observation>(l_, null);
+
+			return m_;
+		};
+		Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ e_(Observation _VR12MentalAssessment, Observation _VR12PhysicalAssessment)
+		{
+			var n_ = new Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ
+			{
+				VR12MentalAssessment = _VR12MentalAssessment,
+				VR12PhysicalAssessment = _VR12PhysicalAssessment,
+			};
+
+			return n_;
+		};
+		var f_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ>(c_, d_, e_);
+		bool? g_(Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ tuple_awlefjmgfwigjkoeokkqfqij)
+		{
+			var o_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Effective);
+			var p_ = QICoreCommon_2_0_000.toInterval(o_);
+			var q_ = context.Operators.Start(p_);
+			var r_ = context.Operators.DateFrom(q_);
+			var s_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Effective);
+			var t_ = QICoreCommon_2_0_000.toInterval(s_);
+			var u_ = context.Operators.Start(t_);
+			var v_ = context.Operators.DateFrom(u_);
+			var w_ = context.Operators.SameAs(r_, v_, "day");
+			var x_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Value);
+			var y_ = context.Operators.Not((bool?)(x_ is null));
+			var z_ = context.Operators.And(w_, y_);
+			var aa_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Value);
+			var ab_ = context.Operators.Not((bool?)(aa_ is null));
+			var ac_ = context.Operators.And(z_, ab_);
+
+			return ac_;
+		};
+		var h_ = context.Operators.WhereOrNull<Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ>(f_, g_);
+		CqlDate i_(Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ tuple_awlefjmgfwigjkoeokkqfqij)
+		{
+			var ad_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Effective);
+			var ae_ = QICoreCommon_2_0_000.toInterval(ad_);
+			var af_ = context.Operators.Start(ae_);
+			var ag_ = context.Operators.DateFrom(af_);
+			var ah_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Effective);
+			var ai_ = QICoreCommon_2_0_000.toInterval(ah_);
+			var aj_ = context.Operators.Start(ai_);
+			var ak_ = context.Operators.DateFrom(aj_);
+			var al_ = new CqlDate[]
+			{
+				ag_,
+				ak_,
+			};
+			var am_ = context.Operators.MaxOrNull<CqlDate>((al_ as IEnumerable<CqlDate>));
+
+			return am_;
+		};
+		var j_ = context.Operators.SelectOrNull<Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ, CqlDate>(h_, i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Date VR12 Orthogonal Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_VR12_Orthogonal_Total_Assessment_Completed() => 
+		__Date_VR12_Orthogonal_Total_Assessment_Completed.Value;
+
+	private bool? Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments_Value()
+	{
+		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
+		{
+			var i_ = FHIRHelpers_4_3_000.ToValue(THAProcedure?.Performed);
+			var j_ = QICoreCommon_2_0_000.toInterval(i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectOrNull<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var k_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
+			bool? l_(CqlDate InitialHipAssessmentOrthogonal)
+			{
+				var p_ = context.Operators.Start(TotalHip);
+				var q_ = context.Operators.Quantity(90m, "days");
+				var r_ = context.Operators.Add(InitialHipAssessmentOrthogonal, q_);
+				var s_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, r_, true, true);
+				var t_ = context.Operators.ConvertDateToDateTime(s_?.low);
+				var v_ = context.Operators.Add(InitialHipAssessmentOrthogonal, q_);
+				var w_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, v_, true, true);
+				var x_ = context.Operators.ConvertDateToDateTime(w_?.high);
+				var z_ = context.Operators.Add(InitialHipAssessmentOrthogonal, q_);
+				var aa_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, z_, true, true);
+				var ac_ = context.Operators.Add(InitialHipAssessmentOrthogonal, q_);
+				var ad_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ac_, true, true);
+				var ae_ = context.Operators.Interval(t_, x_, aa_?.lowClosed, ad_?.highClosed);
+				var af_ = context.Operators.ElementInInterval<CqlDateTime>(p_, ae_, "day");
+				var ag_ = context.Operators.Not((bool?)(InitialHipAssessmentOrthogonal is null));
+				var ah_ = context.Operators.And(af_, ag_);
+
+				return ah_;
+			};
+			var m_ = context.Operators.WhereOrNull<CqlDate>(k_, l_);
+			CqlInterval<CqlDateTime> n_(CqlDate InitialHipAssessmentOrthogonal) => 
+				TotalHip;
+			var o_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(m_, n_);
+
+			return o_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
+		{
+			var ai_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
+			bool? aj_(CqlDate FollowUpHipAssessmentOrthogonal)
+			{
+				var an_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOrthogonal);
+				var ao_ = context.Operators.DateFrom(an_);
+				var ap_ = context.Operators.End(TotalHip);
+				var aq_ = context.Operators.DateFrom(ap_);
+				var ar_ = context.Operators.Quantity(300m, "days");
+				var as_ = context.Operators.Add(aq_, ar_);
+				var au_ = context.Operators.DateFrom(ap_);
+				var av_ = context.Operators.Quantity(425m, "days");
+				var aw_ = context.Operators.Add(au_, av_);
+				var ax_ = context.Operators.Interval(as_, aw_, true, true);
+				var ay_ = context.Operators.ElementInInterval<CqlDate>(ao_, ax_, "day");
+
+				return ay_;
+			};
+			var ak_ = context.Operators.WhereOrNull<CqlDate>(ai_, aj_);
+			CqlInterval<CqlDateTime> al_(CqlDate FollowUpHipAssessmentOrthogonal) => 
+				TotalHip;
+			var am_ = context.Operators.SelectOrNull<CqlDate, CqlInterval<CqlDateTime>>(ak_, al_);
+
+			return am_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		var h_ = context.Operators.ExistsInList<CqlInterval<CqlDateTime>>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Has THA with Initial and Follow Up VR12 Orthogonal Assessments")]
+	public bool? Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments() => 
+		__Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments();
+		var b_ = this.Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = this.Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments();
+		var e_ = context.Operators.Or(c_, d_);
+		var f_ = this.Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments();
+		var g_ = context.Operators.Or(e_, f_);
+		var h_ = this.Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments();
+		var i_ = context.Operators.Or(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+}

--- a/Demo/Measures-cms/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
@@ -1,0 +1,2675 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("FunctionalStatusAssessmentsforHeartFailureFHIR", "0.1.000")]
+public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Heart_Failure;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlCode> __Emotional_score__MLHFQ_;
+    internal Lazy<CqlCode> __Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_;
+    internal Lazy<CqlCode> __Overall_summary_score__KCCQ_12_;
+    internal Lazy<CqlCode> __Overall_summary_score__KCCQ_;
+    internal Lazy<CqlCode> __Physical_limitation_score__KCCQ_;
+    internal Lazy<CqlCode> __Physical_score__MLHFQ_;
+    internal Lazy<CqlCode> __PROMIS_10_Global_Mental_Health__GMH__score_T_score;
+    internal Lazy<CqlCode> __PROMIS_10_Global_Physical_Health__GPH__score_T_score;
+    internal Lazy<CqlCode> __PROMIS_29_Anxiety_score_T_score;
+    internal Lazy<CqlCode> __PROMIS_29_Depression_score_T_score;
+    internal Lazy<CqlCode> __PROMIS_29_Fatigue_score_T_score;
+    internal Lazy<CqlCode> __PROMIS_29_Pain_interference_score_T_score;
+    internal Lazy<CqlCode> __PROMIS_29_Physical_function_score_T_score;
+    internal Lazy<CqlCode> __PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score;
+    internal Lazy<CqlCode> __PROMIS_29_Sleep_disturbance_score_T_score;
+    internal Lazy<CqlCode> __Quality_of_life_score__KCCQ_;
+    internal Lazy<CqlCode> __Self_efficacy_score__KCCQ_;
+    internal Lazy<CqlCode> __Severe_cognitive_impairment__finding_;
+    internal Lazy<CqlCode> __Social_limitation_score__KCCQ_;
+    internal Lazy<CqlCode> __Symptom_stability_score__KCCQ_;
+    internal Lazy<CqlCode> __Total_score__MLHFQ_;
+    internal Lazy<CqlCode> __Total_symptom_score__KCCQ_;
+    internal Lazy<CqlCode> __VR_12_Mental_component_summary__MCS__score___oblique_method_T_score;
+    internal Lazy<CqlCode> __VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score;
+    internal Lazy<CqlCode> __VR_12_Physical_component_summary__PCS__score___oblique_method_T_score;
+    internal Lazy<CqlCode> __VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score;
+    internal Lazy<CqlCode> __VR_36_Mental_component_summary__MCS__score___oblique_method_T_score;
+    internal Lazy<CqlCode> __VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score;
+    internal Lazy<CqlCode> __VR_36_Physical_component_summary__PCS__score___oblique_method_T_score;
+    internal Lazy<CqlCode> __VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<IEnumerable<Encounter>> __Two_Outpatient_Encounters_during_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<CqlDate>> __Date_PROMIS10_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_PROMIS29_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_VR12_Oblique_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_VR12_Orthogonal_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_VR36_Oblique_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_VR36_Orthogonal_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_MLHFQ_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_KCCQ12_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_KCCQ_Domain_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments;
+    internal Lazy<IEnumerable<CqlDate>> __Date_KCCQ_Total_Assessment_Completed;
+    internal Lazy<bool?> __Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Heart_Failure = new Lazy<CqlValueSet>(this.Heart_Failure_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Emotional_score__MLHFQ_ = new Lazy<CqlCode>(this.Emotional_score__MLHFQ__Value);
+        __Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_ = new Lazy<CqlCode>(this.Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12__Value);
+        __Overall_summary_score__KCCQ_12_ = new Lazy<CqlCode>(this.Overall_summary_score__KCCQ_12__Value);
+        __Overall_summary_score__KCCQ_ = new Lazy<CqlCode>(this.Overall_summary_score__KCCQ__Value);
+        __Physical_limitation_score__KCCQ_ = new Lazy<CqlCode>(this.Physical_limitation_score__KCCQ__Value);
+        __Physical_score__MLHFQ_ = new Lazy<CqlCode>(this.Physical_score__MLHFQ__Value);
+        __PROMIS_10_Global_Mental_Health__GMH__score_T_score = new Lazy<CqlCode>(this.PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value);
+        __PROMIS_10_Global_Physical_Health__GPH__score_T_score = new Lazy<CqlCode>(this.PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value);
+        __PROMIS_29_Anxiety_score_T_score = new Lazy<CqlCode>(this.PROMIS_29_Anxiety_score_T_score_Value);
+        __PROMIS_29_Depression_score_T_score = new Lazy<CqlCode>(this.PROMIS_29_Depression_score_T_score_Value);
+        __PROMIS_29_Fatigue_score_T_score = new Lazy<CqlCode>(this.PROMIS_29_Fatigue_score_T_score_Value);
+        __PROMIS_29_Pain_interference_score_T_score = new Lazy<CqlCode>(this.PROMIS_29_Pain_interference_score_T_score_Value);
+        __PROMIS_29_Physical_function_score_T_score = new Lazy<CqlCode>(this.PROMIS_29_Physical_function_score_T_score_Value);
+        __PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score = new Lazy<CqlCode>(this.PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score_Value);
+        __PROMIS_29_Sleep_disturbance_score_T_score = new Lazy<CqlCode>(this.PROMIS_29_Sleep_disturbance_score_T_score_Value);
+        __Quality_of_life_score__KCCQ_ = new Lazy<CqlCode>(this.Quality_of_life_score__KCCQ__Value);
+        __Self_efficacy_score__KCCQ_ = new Lazy<CqlCode>(this.Self_efficacy_score__KCCQ__Value);
+        __Severe_cognitive_impairment__finding_ = new Lazy<CqlCode>(this.Severe_cognitive_impairment__finding__Value);
+        __Social_limitation_score__KCCQ_ = new Lazy<CqlCode>(this.Social_limitation_score__KCCQ__Value);
+        __Symptom_stability_score__KCCQ_ = new Lazy<CqlCode>(this.Symptom_stability_score__KCCQ__Value);
+        __Total_score__MLHFQ_ = new Lazy<CqlCode>(this.Total_score__MLHFQ__Value);
+        __Total_symptom_score__KCCQ_ = new Lazy<CqlCode>(this.Total_symptom_score__KCCQ__Value);
+        __VR_12_Mental_component_summary__MCS__score___oblique_method_T_score = new Lazy<CqlCode>(this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value);
+        __VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score = new Lazy<CqlCode>(this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value);
+        __VR_12_Physical_component_summary__PCS__score___oblique_method_T_score = new Lazy<CqlCode>(this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value);
+        __VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score = new Lazy<CqlCode>(this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value);
+        __VR_36_Mental_component_summary__MCS__score___oblique_method_T_score = new Lazy<CqlCode>(this.VR_36_Mental_component_summary__MCS__score___oblique_method_T_score_Value);
+        __VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score = new Lazy<CqlCode>(this.VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value);
+        __VR_36_Physical_component_summary__PCS__score___oblique_method_T_score = new Lazy<CqlCode>(this.VR_36_Physical_component_summary__PCS__score___oblique_method_T_score_Value);
+        __VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score = new Lazy<CqlCode>(this.VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value);
+        __Two_Outpatient_Encounters_during_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Two_Outpatient_Encounters_during_Measurement_Period_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Date_PROMIS10_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_PROMIS10_Total_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments_Value);
+        __Date_PROMIS29_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_PROMIS29_Total_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments_Value);
+        __Date_VR12_Oblique_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_VR12_Oblique_Total_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments_Value);
+        __Date_VR12_Orthogonal_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_VR12_Orthogonal_Total_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments_Value);
+        __Date_VR36_Oblique_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_VR36_Oblique_Total_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments_Value);
+        __Date_VR36_Orthogonal_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_VR36_Orthogonal_Total_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments_Value);
+        __Date_MLHFQ_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_MLHFQ_Total_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments_Value);
+        __Date_KCCQ12_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_KCCQ12_Total_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments_Value);
+        __Date_KCCQ_Domain_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_KCCQ_Domain_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments_Value);
+        __Date_KCCQ_Total_Assessment_Completed = new Lazy<IEnumerable<CqlDate>>(this.Date_KCCQ_Total_Assessment_Completed_Value);
+        __Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments = new Lazy<bool?>(this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Heart_Failure_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", null);
+
+    [CqlDeclaration("Heart Failure")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376")]
+	public CqlValueSet Heart_Failure() => 
+		__Heart_Failure.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlCode Emotional_score__MLHFQ__Value() => 
+		new CqlCode("85609-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Emotional score [MLHFQ]")]
+	public CqlCode Emotional_score__MLHFQ_() => 
+		__Emotional_score__MLHFQ_.Value;
+
+	private CqlCode Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12__Value() => 
+		new CqlCode("86923-0", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Kansas City Cardiomyopathy Questionnaire - 12 item [KCCQ-12]")]
+	public CqlCode Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_() => 
+		__Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_.Value;
+
+	private CqlCode Overall_summary_score__KCCQ_12__Value() => 
+		new CqlCode("86924-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Overall summary score [KCCQ-12]")]
+	public CqlCode Overall_summary_score__KCCQ_12_() => 
+		__Overall_summary_score__KCCQ_12_.Value;
+
+	private CqlCode Overall_summary_score__KCCQ__Value() => 
+		new CqlCode("71940-1", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Overall summary score [KCCQ]")]
+	public CqlCode Overall_summary_score__KCCQ_() => 
+		__Overall_summary_score__KCCQ_.Value;
+
+	private CqlCode Physical_limitation_score__KCCQ__Value() => 
+		new CqlCode("72195-1", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Physical limitation score [KCCQ]")]
+	public CqlCode Physical_limitation_score__KCCQ_() => 
+		__Physical_limitation_score__KCCQ_.Value;
+
+	private CqlCode Physical_score__MLHFQ__Value() => 
+		new CqlCode("85618-7", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Physical score [MLHFQ]")]
+	public CqlCode Physical_score__MLHFQ_() => 
+		__Physical_score__MLHFQ_.Value;
+
+	private CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value() => 
+		new CqlCode("71969-0", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-10 Global Mental Health (GMH) score T-score")]
+	public CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score() => 
+		__PROMIS_10_Global_Mental_Health__GMH__score_T_score.Value;
+
+	private CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value() => 
+		new CqlCode("71971-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-10 Global Physical Health (GPH) score T-score")]
+	public CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score() => 
+		__PROMIS_10_Global_Physical_Health__GPH__score_T_score.Value;
+
+	private CqlCode PROMIS_29_Anxiety_score_T_score_Value() => 
+		new CqlCode("71967-4", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-29 Anxiety score T-score")]
+	public CqlCode PROMIS_29_Anxiety_score_T_score() => 
+		__PROMIS_29_Anxiety_score_T_score.Value;
+
+	private CqlCode PROMIS_29_Depression_score_T_score_Value() => 
+		new CqlCode("71965-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-29 Depression score T-score")]
+	public CqlCode PROMIS_29_Depression_score_T_score() => 
+		__PROMIS_29_Depression_score_T_score.Value;
+
+	private CqlCode PROMIS_29_Fatigue_score_T_score_Value() => 
+		new CqlCode("71963-3", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-29 Fatigue score T-score")]
+	public CqlCode PROMIS_29_Fatigue_score_T_score() => 
+		__PROMIS_29_Fatigue_score_T_score.Value;
+
+	private CqlCode PROMIS_29_Pain_interference_score_T_score_Value() => 
+		new CqlCode("71961-7", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-29 Pain interference score T-score")]
+	public CqlCode PROMIS_29_Pain_interference_score_T_score() => 
+		__PROMIS_29_Pain_interference_score_T_score.Value;
+
+	private CqlCode PROMIS_29_Physical_function_score_T_score_Value() => 
+		new CqlCode("71959-1", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-29 Physical function score T-score")]
+	public CqlCode PROMIS_29_Physical_function_score_T_score() => 
+		__PROMIS_29_Physical_function_score_T_score.Value;
+
+	private CqlCode PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score_Value() => 
+		new CqlCode("71957-5", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-29 Satisfaction with participation in social roles score T-score")]
+	public CqlCode PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score() => 
+		__PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score.Value;
+
+	private CqlCode PROMIS_29_Sleep_disturbance_score_T_score_Value() => 
+		new CqlCode("71955-9", "http://loinc.org", null, null);
+
+    [CqlDeclaration("PROMIS-29 Sleep disturbance score T-score")]
+	public CqlCode PROMIS_29_Sleep_disturbance_score_T_score() => 
+		__PROMIS_29_Sleep_disturbance_score_T_score.Value;
+
+	private CqlCode Quality_of_life_score__KCCQ__Value() => 
+		new CqlCode("72189-4", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Quality of life score [KCCQ]")]
+	public CqlCode Quality_of_life_score__KCCQ_() => 
+		__Quality_of_life_score__KCCQ_.Value;
+
+	private CqlCode Self_efficacy_score__KCCQ__Value() => 
+		new CqlCode("72190-2", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Self-efficacy score [KCCQ]")]
+	public CqlCode Self_efficacy_score__KCCQ_() => 
+		__Self_efficacy_score__KCCQ_.Value;
+
+	private CqlCode Severe_cognitive_impairment__finding__Value() => 
+		new CqlCode("702956004", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Severe cognitive impairment (finding)")]
+	public CqlCode Severe_cognitive_impairment__finding_() => 
+		__Severe_cognitive_impairment__finding_.Value;
+
+	private CqlCode Social_limitation_score__KCCQ__Value() => 
+		new CqlCode("72196-9", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Social limitation score [KCCQ]")]
+	public CqlCode Social_limitation_score__KCCQ_() => 
+		__Social_limitation_score__KCCQ_.Value;
+
+	private CqlCode Symptom_stability_score__KCCQ__Value() => 
+		new CqlCode("72194-4", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Symptom stability score [KCCQ]")]
+	public CqlCode Symptom_stability_score__KCCQ_() => 
+		__Symptom_stability_score__KCCQ_.Value;
+
+	private CqlCode Total_score__MLHFQ__Value() => 
+		new CqlCode("71938-5", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Total score [MLHFQ]")]
+	public CqlCode Total_score__MLHFQ_() => 
+		__Total_score__MLHFQ_.Value;
+
+	private CqlCode Total_symptom_score__KCCQ__Value() => 
+		new CqlCode("72191-0", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Total symptom score [KCCQ]")]
+	public CqlCode Total_symptom_score__KCCQ_() => 
+		__Total_symptom_score__KCCQ_.Value;
+
+	private CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
+		new CqlCode("72026-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-12 Mental component summary (MCS) score - oblique method T-score")]
+	public CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score() => 
+		__VR_12_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
+
+	private CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
+		new CqlCode("72028-4", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-12 Mental component summary (MCS) score - orthogonal method T-score")]
+	public CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
+		__VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
+
+	private CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
+		new CqlCode("72025-0", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-12 Physical component summary (PCS) score - oblique method T-score")]
+	public CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score() => 
+		__VR_12_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
+
+	private CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
+		new CqlCode("72027-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-12 Physical component summary (PCS) score - orthogonal method T-score")]
+	public CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
+		__VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
+
+	private CqlCode VR_36_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
+		new CqlCode("71990-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-36 Mental component summary (MCS) score - oblique method T-score")]
+	public CqlCode VR_36_Mental_component_summary__MCS__score___oblique_method_T_score() => 
+		__VR_36_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
+
+	private CqlCode VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
+		new CqlCode("72008-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-36 Mental component summary (MCS) score - orthogonal method T-score")]
+	public CqlCode VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
+		__VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
+
+	private CqlCode VR_36_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
+		new CqlCode("71989-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-36 Physical component summary (PCS) score - oblique method T-score")]
+	public CqlCode VR_36_Physical_component_summary__PCS__score___oblique_method_T_score() => 
+		__VR_36_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
+
+	private CqlCode VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
+		new CqlCode("72007-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("VR-36 Physical component summary (PCS) score - orthogonal method T-score")]
+	public CqlCode VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
+		__VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("85609-6", "http://loinc.org", null, null),
+			new CqlCode("86923-0", "http://loinc.org", null, null),
+			new CqlCode("86924-8", "http://loinc.org", null, null),
+			new CqlCode("71940-1", "http://loinc.org", null, null),
+			new CqlCode("72195-1", "http://loinc.org", null, null),
+			new CqlCode("85618-7", "http://loinc.org", null, null),
+			new CqlCode("71969-0", "http://loinc.org", null, null),
+			new CqlCode("71971-6", "http://loinc.org", null, null),
+			new CqlCode("71967-4", "http://loinc.org", null, null),
+			new CqlCode("71965-8", "http://loinc.org", null, null),
+			new CqlCode("71963-3", "http://loinc.org", null, null),
+			new CqlCode("71961-7", "http://loinc.org", null, null),
+			new CqlCode("71959-1", "http://loinc.org", null, null),
+			new CqlCode("71957-5", "http://loinc.org", null, null),
+			new CqlCode("71955-9", "http://loinc.org", null, null),
+			new CqlCode("72189-4", "http://loinc.org", null, null),
+			new CqlCode("72190-2", "http://loinc.org", null, null),
+			new CqlCode("72196-9", "http://loinc.org", null, null),
+			new CqlCode("72194-4", "http://loinc.org", null, null),
+			new CqlCode("71938-5", "http://loinc.org", null, null),
+			new CqlCode("72191-0", "http://loinc.org", null, null),
+			new CqlCode("72026-8", "http://loinc.org", null, null),
+			new CqlCode("72028-4", "http://loinc.org", null, null),
+			new CqlCode("72025-0", "http://loinc.org", null, null),
+			new CqlCode("72027-6", "http://loinc.org", null, null),
+			new CqlCode("71990-6", "http://loinc.org", null, null),
+			new CqlCode("72008-6", "http://loinc.org", null, null),
+			new CqlCode("71989-8", "http://loinc.org", null, null),
+			new CqlCode("72007-8", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("702956004", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Telephone_Visits();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Online_Assessments();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = context.Operators.ListUnion<Encounter>(e_, g_);
+		var i_ = Status_1_6_000.Finished_Encounter(h_);
+		bool? j_(Encounter ValidEncounter)
+		{
+			var l_ = this.Measurement_Period();
+			var m_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var n_ = QICoreCommon_2_0_000.ToInterval((m_ as object));
+			var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, "day");
+
+			return o_;
+		};
+		var k_ = context.Operators.WhereOrNull<Encounter>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters.Value;
+
+	private IEnumerable<Encounter> Two_Outpatient_Encounters_during_Measurement_Period_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<Encounter> b_(Encounter _OfficeVisit1)
+		{
+			var i_ = this.Qualifying_Encounters();
+
+			return i_;
+		};
+		Tuples.Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe c_(Encounter _OfficeVisit1, Encounter _OfficeVisit2)
+		{
+			var j_ = new Tuples.Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe
+			{
+				OfficeVisit1 = _OfficeVisit1,
+				OfficeVisit2 = _OfficeVisit2,
+			};
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Encounter, Tuples.Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe tuple_fgyjhhbrrztdgeekjqjiibgue)
+		{
+			var k_ = FHIRHelpers_4_3_000.ToInterval(tuple_fgyjhhbrrztdgeekjqjiibgue.OfficeVisit2?.Period);
+			var l_ = QICoreCommon_2_0_000.ToInterval((k_ as object));
+			var m_ = context.Operators.Start(l_);
+			var n_ = FHIRHelpers_4_3_000.ToInterval(tuple_fgyjhhbrrztdgeekjqjiibgue.OfficeVisit1?.Period);
+			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			var p_ = context.Operators.End(o_);
+			var q_ = context.Operators.Quantity(1m, "day");
+			var r_ = context.Operators.Add(p_, q_);
+			var s_ = context.Operators.SameOrAfter(m_, r_, "day");
+
+			return s_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe>(d_, e_);
+		Encounter g_(Tuples.Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe tuple_fgyjhhbrrztdgeekjqjiibgue) => 
+			tuple_fgyjhhbrrztdgeekjqjiibgue.OfficeVisit1;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Two Outpatient Encounters during Measurement Period")]
+	public IEnumerable<Encounter> Two_Outpatient_Encounters_during_Measurement_Period() => 
+		__Two_Outpatient_Encounters_during_Measurement_Period.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.GreaterOrEqual(f_, (int?)18);
+		var h_ = this.Heart_Failure();
+		var i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
+		bool? j_(Condition HeartFailure)
+		{
+			var q_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HeartFailure);
+			var r_ = this.Measurement_Period();
+			var s_ = context.Operators.OverlapsBefore(q_, r_, null);
+
+			return s_;
+		};
+		var k_ = context.Operators.WhereOrNull<Condition>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Condition>(k_);
+		var m_ = context.Operators.And(g_, l_);
+		var n_ = this.Two_Outpatient_Encounters_during_Measurement_Period();
+		var o_ = context.Operators.ExistsInList<Encounter>(n_);
+		var p_ = context.Operators.And(m_, o_);
+
+		return p_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = this.Severe_cognitive_impairment__finding_();
+		var c_ = context.Operators.ToList<CqlCode>(b_);
+		var d_ = context.Operators.RetrieveByCodes<Condition>(c_, null);
+		bool? e_(Condition Dementia)
+		{
+			var i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Dementia);
+			var j_ = this.Measurement_Period();
+			var k_ = context.Operators.Overlaps(i_, j_, null);
+
+			return k_;
+		};
+		var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+		var g_ = context.Operators.ExistsInList<Condition>(f_);
+		var h_ = context.Operators.Or(a_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<CqlDate> Date_PROMIS10_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		IEnumerable<Observation> e_(Observation _PROMIS10MentalScore)
+		{
+			var l_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
+			var m_ = context.Operators.ToList<CqlCode>(l_);
+			var n_ = context.Operators.RetrieveByCodes<Observation>(m_, null);
+			var o_ = Status_1_6_000.Final_Survey_Observation(n_);
+
+			return o_;
+		};
+		Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM f_(Observation _PROMIS10MentalScore, Observation _PROMIS10PhysicalScore)
+		{
+			var p_ = new Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM
+			{
+				PROMIS10MentalScore = _PROMIS10MentalScore,
+				PROMIS10PhysicalScore = _PROMIS10PhysicalScore,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM tuple_csqnxjbdujcrvlsgajqoisbpm)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10MentalScore?.Effective);
+			var r_ = QICoreCommon_2_0_000.ToInterval(q_);
+			var s_ = context.Operators.Start(r_);
+			var t_ = context.Operators.DateFrom(s_);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10PhysicalScore?.Effective);
+			var v_ = QICoreCommon_2_0_000.ToInterval(u_);
+			var w_ = context.Operators.Start(v_);
+			var x_ = context.Operators.DateFrom(w_);
+			var y_ = context.Operators.SameAs(t_, x_, "day");
+			var z_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10MentalScore?.Value);
+			var aa_ = context.Operators.Not((bool?)(z_ is null));
+			var ab_ = context.Operators.And(y_, aa_);
+			var ac_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10PhysicalScore?.Value);
+			var ad_ = context.Operators.Not((bool?)(ac_ is null));
+			var ae_ = context.Operators.And(ab_, ad_);
+
+			return ae_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM>(g_, h_);
+		CqlDate j_(Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM tuple_csqnxjbdujcrvlsgajqoisbpm)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10MentalScore?.Effective);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = context.Operators.Start(ag_);
+			var ai_ = context.Operators.DateFrom(ah_);
+			var aj_ = FHIRHelpers_4_3_000.ToValue(tuple_csqnxjbdujcrvlsgajqoisbpm.PROMIS10PhysicalScore?.Effective);
+			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			var al_ = context.Operators.Start(ak_);
+			var am_ = context.Operators.DateFrom(al_);
+			var an_ = new CqlDate[]
+			{
+				ai_,
+				am_,
+			};
+			var ao_ = context.Operators.MaxOrNull<CqlDate>((an_ as IEnumerable<CqlDate>));
+
+			return ao_;
+		};
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_CSQNXjbdUJCRVLSGAJQOISbPM, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Date PROMIS10 Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_PROMIS10_Total_Assessment_Completed() => 
+		__Date_PROMIS10_Total_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_PROMIS10_Total_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK c_(Encounter _ValidEncounters, CqlDate _InitialPROMIS10Date)
+		{
+			var n_ = new Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialPROMIS10Date = _InitialPROMIS10Date,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK _ValidEncountersInitialPROMIS10Date)
+		{
+			var o_ = this.Date_PROMIS10_Total_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK f_(Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK ValidEncountersInitialPROMIS10Date, CqlDate _FollowupPROMIS10Date)
+		{
+			var p_ = new Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK
+			{
+				ValidEncounters = ValidEncountersInitialPROMIS10Date.ValidEncounters,
+				InitialPROMIS10Date = ValidEncountersInitialPROMIS10Date.InitialPROMIS10Date,
+				FollowupPROMIS10Date = _FollowupPROMIS10Date,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK, CqlDate, Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK tuple_bapoxcdqpiefffdprayqhjvmk)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_bapoxcdqpiefffdprayqhjvmk.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_bapoxcdqpiefffdprayqhjvmk.InitialPROMIS10Date);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_bapoxcdqpiefffdprayqhjvmk.FollowupPROMIS10Date);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK>(g_, h_);
+		Encounter j_(Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK tuple_bapoxcdqpiefffdprayqhjvmk) => 
+			tuple_bapoxcdqpiefffdprayqhjvmk.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_BaPOXCdQPieFFFdPRAYQHJVMK, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up PROMIS10 Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_PROMIS29_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.PROMIS_29_Sleep_disturbance_score_T_score();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		IEnumerable<Observation> e_(Observation _Promis29Sleep)
+		{
+			var aa_ = this.PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score();
+			var ab_ = context.Operators.ToList<CqlCode>(aa_);
+			var ac_ = context.Operators.RetrieveByCodes<Observation>(ab_, null);
+			var ad_ = Status_1_6_000.Final_Survey_Observation(ac_);
+
+			return ad_;
+		};
+		Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb f_(Observation _Promis29Sleep, Observation _Promis29SocialRoles)
+		{
+			var ae_ = new Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb
+			{
+				Promis29Sleep = _Promis29Sleep,
+				Promis29SocialRoles = _Promis29SocialRoles,
+			};
+
+			return ae_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb>(d_, e_, f_);
+		IEnumerable<Observation> h_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb _Promis29SleepPromis29SocialRoles)
+		{
+			var af_ = this.PROMIS_29_Physical_function_score_T_score();
+			var ag_ = context.Operators.ToList<CqlCode>(af_);
+			var ah_ = context.Operators.RetrieveByCodes<Observation>(ag_, null);
+			var ai_ = Status_1_6_000.Final_Survey_Observation(ah_);
+
+			return ai_;
+		};
+		Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb i_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb Promis29SleepPromis29SocialRoles, Observation _Promis29Physical)
+		{
+			var aj_ = new Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb
+			{
+				Promis29Sleep = Promis29SleepPromis29SocialRoles.Promis29Sleep,
+				Promis29SocialRoles = Promis29SleepPromis29SocialRoles.Promis29SocialRoles,
+				Promis29Physical = _Promis29Physical,
+			};
+
+			return aj_;
+		};
+		var j_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb, Observation, Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb>(g_, h_, i_);
+		IEnumerable<Observation> k_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb _Promis29SleepPromis29SocialRolesPromis29Physical)
+		{
+			var ak_ = this.PROMIS_29_Pain_interference_score_T_score();
+			var al_ = context.Operators.ToList<CqlCode>(ak_);
+			var am_ = context.Operators.RetrieveByCodes<Observation>(al_, null);
+			var an_ = Status_1_6_000.Final_Survey_Observation(am_);
+
+			return an_;
+		};
+		Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb l_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb Promis29SleepPromis29SocialRolesPromis29Physical, Observation _Promis29Pain)
+		{
+			var ao_ = new Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb
+			{
+				Promis29Sleep = Promis29SleepPromis29SocialRolesPromis29Physical.Promis29Sleep,
+				Promis29SocialRoles = Promis29SleepPromis29SocialRolesPromis29Physical.Promis29SocialRoles,
+				Promis29Physical = Promis29SleepPromis29SocialRolesPromis29Physical.Promis29Physical,
+				Promis29Pain = _Promis29Pain,
+			};
+
+			return ao_;
+		};
+		var m_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb, Observation, Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb>(j_, k_, l_);
+		IEnumerable<Observation> n_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb _Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29Pain)
+		{
+			var ap_ = this.PROMIS_29_Fatigue_score_T_score();
+			var aq_ = context.Operators.ToList<CqlCode>(ap_);
+			var ar_ = context.Operators.RetrieveByCodes<Observation>(aq_, null);
+			var as_ = Status_1_6_000.Final_Survey_Observation(ar_);
+
+			return as_;
+		};
+		Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb o_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29Pain, Observation _Promis29Fatigue)
+		{
+			var at_ = new Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb
+			{
+				Promis29Sleep = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29Pain.Promis29Sleep,
+				Promis29SocialRoles = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29Pain.Promis29SocialRoles,
+				Promis29Physical = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29Pain.Promis29Physical,
+				Promis29Pain = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29Pain.Promis29Pain,
+				Promis29Fatigue = _Promis29Fatigue,
+			};
+
+			return at_;
+		};
+		var p_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb, Observation, Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb>(m_, n_, o_);
+		IEnumerable<Observation> q_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb _Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29Fatigue)
+		{
+			var au_ = this.PROMIS_29_Depression_score_T_score();
+			var av_ = context.Operators.ToList<CqlCode>(au_);
+			var aw_ = context.Operators.RetrieveByCodes<Observation>(av_, null);
+			var ax_ = Status_1_6_000.Final_Survey_Observation(aw_);
+
+			return ax_;
+		};
+		Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb r_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29Fatigue, Observation _Promis29Depression)
+		{
+			var ay_ = new Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb
+			{
+				Promis29Sleep = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29Fatigue.Promis29Sleep,
+				Promis29SocialRoles = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29Fatigue.Promis29SocialRoles,
+				Promis29Physical = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29Fatigue.Promis29Physical,
+				Promis29Pain = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29Fatigue.Promis29Pain,
+				Promis29Fatigue = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29Fatigue.Promis29Fatigue,
+				Promis29Depression = _Promis29Depression,
+			};
+
+			return ay_;
+		};
+		var s_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb, Observation, Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb>(p_, q_, r_);
+		IEnumerable<Observation> t_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb _Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29FatiguePromis29Depression)
+		{
+			var az_ = this.PROMIS_29_Anxiety_score_T_score();
+			var ba_ = context.Operators.ToList<CqlCode>(az_);
+			var bb_ = context.Operators.RetrieveByCodes<Observation>(ba_, null);
+			var bc_ = Status_1_6_000.Final_Survey_Observation(bb_);
+
+			return bc_;
+		};
+		Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb u_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29FatiguePromis29Depression, Observation _Promis29Anxiety)
+		{
+			var bd_ = new Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb
+			{
+				Promis29Sleep = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29FatiguePromis29Depression.Promis29Sleep,
+				Promis29SocialRoles = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29FatiguePromis29Depression.Promis29SocialRoles,
+				Promis29Physical = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29FatiguePromis29Depression.Promis29Physical,
+				Promis29Pain = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29FatiguePromis29Depression.Promis29Pain,
+				Promis29Fatigue = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29FatiguePromis29Depression.Promis29Fatigue,
+				Promis29Depression = Promis29SleepPromis29SocialRolesPromis29PhysicalPromis29PainPromis29FatiguePromis29Depression.Promis29Depression,
+				Promis29Anxiety = _Promis29Anxiety,
+			};
+
+			return bd_;
+		};
+		var v_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb, Observation, Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb>(s_, t_, u_);
+		bool? w_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb tuple_itzjebebsegnifgclhjyijnb)
+		{
+			var be_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Sleep?.Effective);
+			var bf_ = QICoreCommon_2_0_000.ToInterval(be_);
+			var bg_ = context.Operators.Start(bf_);
+			var bh_ = context.Operators.DateFrom(bg_);
+			var bi_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29SocialRoles?.Effective);
+			var bj_ = QICoreCommon_2_0_000.ToInterval(bi_);
+			var bk_ = context.Operators.Start(bj_);
+			var bl_ = context.Operators.DateFrom(bk_);
+			var bm_ = context.Operators.SameAs(bh_, bl_, "day");
+			var bn_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29SocialRoles?.Value);
+			var bo_ = context.Operators.Not((bool?)(bn_ is null));
+			var bp_ = context.Operators.And(bm_, bo_);
+			var br_ = QICoreCommon_2_0_000.ToInterval(be_);
+			var bs_ = context.Operators.Start(br_);
+			var bt_ = context.Operators.DateFrom(bs_);
+			var bu_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Physical?.Effective);
+			var bv_ = QICoreCommon_2_0_000.ToInterval(bu_);
+			var bw_ = context.Operators.Start(bv_);
+			var bx_ = context.Operators.DateFrom(bw_);
+			var by_ = context.Operators.SameAs(bt_, bx_, "day");
+			var bz_ = context.Operators.And(bp_, by_);
+			var ca_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Physical?.Value);
+			var cb_ = context.Operators.Not((bool?)(ca_ is null));
+			var cc_ = context.Operators.And(bz_, cb_);
+			var ce_ = QICoreCommon_2_0_000.ToInterval(be_);
+			var cf_ = context.Operators.Start(ce_);
+			var cg_ = context.Operators.DateFrom(cf_);
+			var ch_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Pain?.Effective);
+			var ci_ = QICoreCommon_2_0_000.ToInterval(ch_);
+			var cj_ = context.Operators.Start(ci_);
+			var ck_ = context.Operators.DateFrom(cj_);
+			var cl_ = context.Operators.SameAs(cg_, ck_, "day");
+			var cm_ = context.Operators.And(cc_, cl_);
+			var cn_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Pain?.Value);
+			var co_ = context.Operators.Not((bool?)(cn_ is null));
+			var cp_ = context.Operators.And(cm_, co_);
+			var cr_ = QICoreCommon_2_0_000.ToInterval(be_);
+			var cs_ = context.Operators.Start(cr_);
+			var ct_ = context.Operators.DateFrom(cs_);
+			var cu_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Fatigue?.Effective);
+			var cv_ = QICoreCommon_2_0_000.ToInterval(cu_);
+			var cw_ = context.Operators.Start(cv_);
+			var cx_ = context.Operators.DateFrom(cw_);
+			var cy_ = context.Operators.SameAs(ct_, cx_, "day");
+			var cz_ = context.Operators.And(cp_, cy_);
+			var da_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Fatigue?.Value);
+			var db_ = context.Operators.Not((bool?)(da_ is null));
+			var dc_ = context.Operators.And(cz_, db_);
+			var de_ = QICoreCommon_2_0_000.ToInterval(be_);
+			var df_ = context.Operators.Start(de_);
+			var dg_ = context.Operators.DateFrom(df_);
+			var dh_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Depression?.Effective);
+			var di_ = QICoreCommon_2_0_000.ToInterval(dh_);
+			var dj_ = context.Operators.Start(di_);
+			var dk_ = context.Operators.DateFrom(dj_);
+			var dl_ = context.Operators.SameAs(dg_, dk_, "day");
+			var dm_ = context.Operators.And(dc_, dl_);
+			var dn_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Depression?.Value);
+			var do_ = context.Operators.Not((bool?)(dn_ is null));
+			var dp_ = context.Operators.And(dm_, do_);
+			var dr_ = QICoreCommon_2_0_000.ToInterval(be_);
+			var ds_ = context.Operators.Start(dr_);
+			var dt_ = context.Operators.DateFrom(ds_);
+			var du_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Anxiety?.Effective);
+			var dv_ = QICoreCommon_2_0_000.ToInterval(du_);
+			var dw_ = context.Operators.Start(dv_);
+			var dx_ = context.Operators.DateFrom(dw_);
+			var dy_ = context.Operators.SameAs(dt_, dx_, "day");
+			var dz_ = context.Operators.And(dp_, dy_);
+			var ea_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Anxiety?.Value);
+			var eb_ = context.Operators.Not((bool?)(ea_ is null));
+			var ec_ = context.Operators.And(dz_, eb_);
+			var ed_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Sleep?.Value);
+			var ee_ = context.Operators.Not((bool?)(ed_ is null));
+			var ef_ = context.Operators.And(ec_, ee_);
+
+			return ef_;
+		};
+		var x_ = context.Operators.WhereOrNull<Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb>(v_, w_);
+		CqlDate y_(Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb tuple_itzjebebsegnifgclhjyijnb)
+		{
+			var eg_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Sleep?.Effective);
+			var eh_ = QICoreCommon_2_0_000.ToInterval(eg_);
+			var ei_ = context.Operators.Start(eh_);
+			var ej_ = context.Operators.DateFrom(ei_);
+			var ek_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29SocialRoles?.Effective);
+			var el_ = QICoreCommon_2_0_000.ToInterval(ek_);
+			var em_ = context.Operators.Start(el_);
+			var en_ = context.Operators.DateFrom(em_);
+			var eo_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Physical?.Effective);
+			var ep_ = QICoreCommon_2_0_000.ToInterval(eo_);
+			var eq_ = context.Operators.Start(ep_);
+			var er_ = context.Operators.DateFrom(eq_);
+			var es_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Pain?.Effective);
+			var et_ = QICoreCommon_2_0_000.ToInterval(es_);
+			var eu_ = context.Operators.Start(et_);
+			var ev_ = context.Operators.DateFrom(eu_);
+			var ew_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Fatigue?.Effective);
+			var ex_ = QICoreCommon_2_0_000.ToInterval(ew_);
+			var ey_ = context.Operators.Start(ex_);
+			var ez_ = context.Operators.DateFrom(ey_);
+			var fa_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Depression?.Effective);
+			var fb_ = QICoreCommon_2_0_000.ToInterval(fa_);
+			var fc_ = context.Operators.Start(fb_);
+			var fd_ = context.Operators.DateFrom(fc_);
+			var fe_ = FHIRHelpers_4_3_000.ToValue(tuple_itzjebebsegnifgclhjyijnb.Promis29Anxiety?.Effective);
+			var ff_ = QICoreCommon_2_0_000.ToInterval(fe_);
+			var fg_ = context.Operators.Start(ff_);
+			var fh_ = context.Operators.DateFrom(fg_);
+			var fi_ = new CqlDate[]
+			{
+				ej_,
+				en_,
+				er_,
+				ev_,
+				ez_,
+				fd_,
+				fh_,
+			};
+			var fj_ = context.Operators.MaxOrNull<CqlDate>((fi_ as IEnumerable<CqlDate>));
+
+			return fj_;
+		};
+		var z_ = context.Operators.SelectOrNull<Tuples.Tuple_ITZjeBeBSEgNiFGcLhJYIJNb, CqlDate>(x_, y_);
+
+		return z_;
+	}
+
+    [CqlDeclaration("Date PROMIS29 Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_PROMIS29_Total_Assessment_Completed() => 
+		__Date_PROMIS29_Total_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_PROMIS29_Total_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba c_(Encounter _ValidEncounters, CqlDate _InitialPROMIS29Date)
+		{
+			var n_ = new Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialPROMIS29Date = _InitialPROMIS29Date,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba _ValidEncountersInitialPROMIS29Date)
+		{
+			var o_ = this.Date_PROMIS29_Total_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba f_(Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba ValidEncountersInitialPROMIS29Date, CqlDate _FollowupPROMIS29Date)
+		{
+			var p_ = new Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba
+			{
+				ValidEncounters = ValidEncountersInitialPROMIS29Date.ValidEncounters,
+				InitialPROMIS29Date = ValidEncountersInitialPROMIS29Date.InitialPROMIS29Date,
+				FollowupPROMIS29Date = _FollowupPROMIS29Date,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba, CqlDate, Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba tuple_dcgyafmugiitlmlbigqthxaba)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_dcgyafmugiitlmlbigqthxaba.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_dcgyafmugiitlmlbigqthxaba.InitialPROMIS29Date);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_dcgyafmugiitlmlbigqthxaba.FollowupPROMIS29Date);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba>(g_, h_);
+		Encounter j_(Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba tuple_dcgyafmugiitlmlbigqthxaba) => 
+			tuple_dcgyafmugiitlmlbigqthxaba.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_DcgYAFMUGiITLMLBigQTHXaba, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up PROMIS29 Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_VR12_Oblique_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		IEnumerable<Observation> e_(Observation _VR12MentalAssessment)
+		{
+			var l_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
+			var m_ = context.Operators.ToList<CqlCode>(l_);
+			var n_ = context.Operators.RetrieveByCodes<Observation>(m_, null);
+			var o_ = Status_1_6_000.Final_Survey_Observation(n_);
+
+			return o_;
+		};
+		Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ f_(Observation _VR12MentalAssessment, Observation _VR12PhysicalAssessment)
+		{
+			var p_ = new Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ
+			{
+				VR12MentalAssessment = _VR12MentalAssessment,
+				VR12PhysicalAssessment = _VR12PhysicalAssessment,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ tuple_awlefjmgfwigjkoeokkqfqij)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Effective);
+			var r_ = QICoreCommon_2_0_000.ToInterval(q_);
+			var s_ = context.Operators.Start(r_);
+			var t_ = context.Operators.DateFrom(s_);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Effective);
+			var v_ = QICoreCommon_2_0_000.ToInterval(u_);
+			var w_ = context.Operators.Start(v_);
+			var x_ = context.Operators.DateFrom(w_);
+			var y_ = context.Operators.SameAs(t_, x_, "day");
+			var z_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Value);
+			var aa_ = context.Operators.Not((bool?)(z_ is null));
+			var ab_ = context.Operators.And(y_, aa_);
+			var ac_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Value);
+			var ad_ = context.Operators.Not((bool?)(ac_ is null));
+			var ae_ = context.Operators.And(ab_, ad_);
+
+			return ae_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ>(g_, h_);
+		CqlDate j_(Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ tuple_awlefjmgfwigjkoeokkqfqij)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Effective);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = context.Operators.Start(ag_);
+			var ai_ = context.Operators.DateFrom(ah_);
+			var aj_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Effective);
+			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			var al_ = context.Operators.Start(ak_);
+			var am_ = context.Operators.DateFrom(al_);
+			var an_ = new CqlDate[]
+			{
+				ai_,
+				am_,
+			};
+			var ao_ = context.Operators.MaxOrNull<CqlDate>((an_ as IEnumerable<CqlDate>));
+
+			return ao_;
+		};
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Date VR12 Oblique Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_VR12_Oblique_Total_Assessment_Completed() => 
+		__Date_VR12_Oblique_Total_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU c_(Encounter _ValidEncounters, CqlDate _InitialVR12ObliqueDate)
+		{
+			var n_ = new Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialVR12ObliqueDate = _InitialVR12ObliqueDate,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU _ValidEncountersInitialVR12ObliqueDate)
+		{
+			var o_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU f_(Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU ValidEncountersInitialVR12ObliqueDate, CqlDate _FollowupVR12ObliqueDate)
+		{
+			var p_ = new Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU
+			{
+				ValidEncounters = ValidEncountersInitialVR12ObliqueDate.ValidEncounters,
+				InitialVR12ObliqueDate = ValidEncountersInitialVR12ObliqueDate.InitialVR12ObliqueDate,
+				FollowupVR12ObliqueDate = _FollowupVR12ObliqueDate,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU, CqlDate, Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU tuple_ehgfqcqtpmavgfjerngbdigou)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_ehgfqcqtpmavgfjerngbdigou.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_ehgfqcqtpmavgfjerngbdigou.InitialVR12ObliqueDate);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_ehgfqcqtpmavgfjerngbdigou.FollowupVR12ObliqueDate);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU>(g_, h_);
+		Encounter j_(Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU tuple_ehgfqcqtpmavgfjerngbdigou) => 
+			tuple_ehgfqcqtpmavgfjerngbdigou.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up VR12 Oblique Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_VR12_Orthogonal_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		IEnumerable<Observation> e_(Observation _VR12MentalAssessment)
+		{
+			var l_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
+			var m_ = context.Operators.ToList<CqlCode>(l_);
+			var n_ = context.Operators.RetrieveByCodes<Observation>(m_, null);
+			var o_ = Status_1_6_000.Final_Survey_Observation(n_);
+
+			return o_;
+		};
+		Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ f_(Observation _VR12MentalAssessment, Observation _VR12PhysicalAssessment)
+		{
+			var p_ = new Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ
+			{
+				VR12MentalAssessment = _VR12MentalAssessment,
+				VR12PhysicalAssessment = _VR12PhysicalAssessment,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ tuple_awlefjmgfwigjkoeokkqfqij)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Effective);
+			var r_ = QICoreCommon_2_0_000.ToInterval(q_);
+			var s_ = context.Operators.Start(r_);
+			var t_ = context.Operators.DateFrom(s_);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Effective);
+			var v_ = QICoreCommon_2_0_000.ToInterval(u_);
+			var w_ = context.Operators.Start(v_);
+			var x_ = context.Operators.DateFrom(w_);
+			var y_ = context.Operators.SameAs(t_, x_, "day");
+			var z_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Value);
+			var aa_ = context.Operators.Not((bool?)(z_ is null));
+			var ab_ = context.Operators.And(y_, aa_);
+			var ac_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Value);
+			var ad_ = context.Operators.Not((bool?)(ac_ is null));
+			var ae_ = context.Operators.And(ab_, ad_);
+
+			return ae_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ>(g_, h_);
+		CqlDate j_(Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ tuple_awlefjmgfwigjkoeokkqfqij)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12MentalAssessment?.Effective);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = context.Operators.Start(ag_);
+			var ai_ = context.Operators.DateFrom(ah_);
+			var aj_ = FHIRHelpers_4_3_000.ToValue(tuple_awlefjmgfwigjkoeokkqfqij.VR12PhysicalAssessment?.Effective);
+			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			var al_ = context.Operators.Start(ak_);
+			var am_ = context.Operators.DateFrom(al_);
+			var an_ = new CqlDate[]
+			{
+				ai_,
+				am_,
+			};
+			var ao_ = context.Operators.MaxOrNull<CqlDate>((an_ as IEnumerable<CqlDate>));
+
+			return ao_;
+		};
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Date VR12 Orthogonal Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_VR12_Orthogonal_Total_Assessment_Completed() => 
+		__Date_VR12_Orthogonal_Total_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ c_(Encounter _ValidEncounters, CqlDate _InitialVR12OrthogonalDate)
+		{
+			var n_ = new Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialVR12OrthogonalDate = _InitialVR12OrthogonalDate,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ _ValidEncountersInitialVR12OrthogonalDate)
+		{
+			var o_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ f_(Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ ValidEncountersInitialVR12OrthogonalDate, CqlDate _FollowupVR12OrthogonalDate)
+		{
+			var p_ = new Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ
+			{
+				ValidEncounters = ValidEncountersInitialVR12OrthogonalDate.ValidEncounters,
+				InitialVR12OrthogonalDate = ValidEncountersInitialVR12OrthogonalDate.InitialVR12OrthogonalDate,
+				FollowupVR12OrthogonalDate = _FollowupVR12OrthogonalDate,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ, CqlDate, Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ tuple_dathnxwghivrygrfgdxjyjkrz)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_dathnxwghivrygrfgdxjyjkrz.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_dathnxwghivrygrfgdxjyjkrz.InitialVR12OrthogonalDate);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_dathnxwghivrygrfgdxjyjkrz.FollowupVR12OrthogonalDate);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ>(g_, h_);
+		Encounter j_(Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ tuple_dathnxwghivrygrfgdxjyjkrz) => 
+			tuple_dathnxwghivrygrfgdxjyjkrz.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up VR12 Orthogonal Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_VR36_Oblique_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.VR_36_Mental_component_summary__MCS__score___oblique_method_T_score();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		IEnumerable<Observation> e_(Observation _VR36MentalAssessment)
+		{
+			var l_ = this.VR_36_Physical_component_summary__PCS__score___oblique_method_T_score();
+			var m_ = context.Operators.ToList<CqlCode>(l_);
+			var n_ = context.Operators.RetrieveByCodes<Observation>(m_, null);
+			var o_ = Status_1_6_000.Final_Survey_Observation(n_);
+
+			return o_;
+		};
+		Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh f_(Observation _VR36MentalAssessment, Observation _VR36PhysicalAssessment)
+		{
+			var p_ = new Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh
+			{
+				VR36MentalAssessment = _VR36MentalAssessment,
+				VR36PhysicalAssessment = _VR36PhysicalAssessment,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh tuple_ebsjtadmhbbibbkjaibebhcjh)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36MentalAssessment?.Effective);
+			var r_ = QICoreCommon_2_0_000.ToInterval(q_);
+			var s_ = context.Operators.Start(r_);
+			var t_ = context.Operators.DateFrom(s_);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36PhysicalAssessment?.Effective);
+			var v_ = QICoreCommon_2_0_000.ToInterval(u_);
+			var w_ = context.Operators.Start(v_);
+			var x_ = context.Operators.DateFrom(w_);
+			var y_ = context.Operators.SameAs(t_, x_, "day");
+			var z_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36MentalAssessment?.Value);
+			var aa_ = context.Operators.Not((bool?)(z_ is null));
+			var ab_ = context.Operators.And(y_, aa_);
+			var ac_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36PhysicalAssessment?.Value);
+			var ad_ = context.Operators.Not((bool?)(ac_ is null));
+			var ae_ = context.Operators.And(ab_, ad_);
+
+			return ae_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh>(g_, h_);
+		CqlDate j_(Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh tuple_ebsjtadmhbbibbkjaibebhcjh)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36MentalAssessment?.Effective);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = context.Operators.Start(ag_);
+			var ai_ = context.Operators.DateFrom(ah_);
+			var aj_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36PhysicalAssessment?.Effective);
+			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			var al_ = context.Operators.Start(ak_);
+			var am_ = context.Operators.DateFrom(al_);
+			var an_ = new CqlDate[]
+			{
+				ai_,
+				am_,
+			};
+			var ao_ = context.Operators.MaxOrNull<CqlDate>((an_ as IEnumerable<CqlDate>));
+
+			return ao_;
+		};
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Date VR36 Oblique Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_VR36_Oblique_Total_Assessment_Completed() => 
+		__Date_VR36_Oblique_Total_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_VR36_Oblique_Total_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi c_(Encounter _ValidEncounters, CqlDate _InitialVR36ObliqueDate)
+		{
+			var n_ = new Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialVR36ObliqueDate = _InitialVR36ObliqueDate,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi _ValidEncountersInitialVR36ObliqueDate)
+		{
+			var o_ = this.Date_VR36_Oblique_Total_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi f_(Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi ValidEncountersInitialVR36ObliqueDate, CqlDate _FollowupVR36ObliqueDate)
+		{
+			var p_ = new Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi
+			{
+				ValidEncounters = ValidEncountersInitialVR36ObliqueDate.ValidEncounters,
+				InitialVR36ObliqueDate = ValidEncountersInitialVR36ObliqueDate.InitialVR36ObliqueDate,
+				FollowupVR36ObliqueDate = _FollowupVR36ObliqueDate,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi, CqlDate, Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi tuple_hnuzsejfeiqxihxgudxliwidi)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_hnuzsejfeiqxihxgudxliwidi.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_hnuzsejfeiqxihxgudxliwidi.InitialVR36ObliqueDate);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_hnuzsejfeiqxihxgudxliwidi.FollowupVR36ObliqueDate);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi>(g_, h_);
+		Encounter j_(Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi tuple_hnuzsejfeiqxihxgudxliwidi) => 
+			tuple_hnuzsejfeiqxihxgudxliwidi.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_HNUZSEJfeiQXIhXGUDXLiWidi, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up VR36 Oblique Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_VR36_Orthogonal_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		IEnumerable<Observation> e_(Observation _VR36MentalAssessment)
+		{
+			var l_ = this.VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score();
+			var m_ = context.Operators.ToList<CqlCode>(l_);
+			var n_ = context.Operators.RetrieveByCodes<Observation>(m_, null);
+			var o_ = Status_1_6_000.Final_Survey_Observation(n_);
+
+			return o_;
+		};
+		Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh f_(Observation _VR36MentalAssessment, Observation _VR36PhysicalAssessment)
+		{
+			var p_ = new Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh
+			{
+				VR36MentalAssessment = _VR36MentalAssessment,
+				VR36PhysicalAssessment = _VR36PhysicalAssessment,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh tuple_ebsjtadmhbbibbkjaibebhcjh)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36MentalAssessment?.Effective);
+			var r_ = QICoreCommon_2_0_000.ToInterval(q_);
+			var s_ = context.Operators.Start(r_);
+			var t_ = context.Operators.DateFrom(s_);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36PhysicalAssessment?.Effective);
+			var v_ = QICoreCommon_2_0_000.ToInterval(u_);
+			var w_ = context.Operators.Start(v_);
+			var x_ = context.Operators.DateFrom(w_);
+			var y_ = context.Operators.SameAs(t_, x_, "day");
+			var z_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36MentalAssessment?.Value);
+			var aa_ = context.Operators.Not((bool?)(z_ is null));
+			var ab_ = context.Operators.And(y_, aa_);
+			var ac_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36PhysicalAssessment?.Value);
+			var ad_ = context.Operators.Not((bool?)(ac_ is null));
+			var ae_ = context.Operators.And(ab_, ad_);
+
+			return ae_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh>(g_, h_);
+		CqlDate j_(Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh tuple_ebsjtadmhbbibbkjaibebhcjh)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36MentalAssessment?.Effective);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = context.Operators.Start(ag_);
+			var ai_ = context.Operators.DateFrom(ah_);
+			var aj_ = FHIRHelpers_4_3_000.ToValue(tuple_ebsjtadmhbbibbkjaibebhcjh.VR36PhysicalAssessment?.Effective);
+			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			var al_ = context.Operators.Start(ak_);
+			var am_ = context.Operators.DateFrom(al_);
+			var an_ = new CqlDate[]
+			{
+				ai_,
+				am_,
+			};
+			var ao_ = context.Operators.MaxOrNull<CqlDate>((an_ as IEnumerable<CqlDate>));
+
+			return ao_;
+		};
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_EbSJTAdMHbBibBKjAIBeBhcjh, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Date VR36 Orthogonal Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_VR36_Orthogonal_Total_Assessment_Completed() => 
+		__Date_VR36_Orthogonal_Total_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_VR36_Orthogonal_Total_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi c_(Encounter _ValidEncounters, CqlDate _InitialVR36OrthogonalDate)
+		{
+			var n_ = new Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialVR36OrthogonalDate = _InitialVR36OrthogonalDate,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi _ValidEncountersInitialVR36OrthogonalDate)
+		{
+			var o_ = this.Date_VR36_Orthogonal_Total_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi f_(Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi ValidEncountersInitialVR36OrthogonalDate, CqlDate _FollowupVR36OrthogonalDate)
+		{
+			var p_ = new Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi
+			{
+				ValidEncounters = ValidEncountersInitialVR36OrthogonalDate.ValidEncounters,
+				InitialVR36OrthogonalDate = ValidEncountersInitialVR36OrthogonalDate.InitialVR36OrthogonalDate,
+				FollowupVR36OrthogonalDate = _FollowupVR36OrthogonalDate,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi, CqlDate, Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi tuple_fzfelixhkplafndgwdmescidi)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_fzfelixhkplafndgwdmescidi.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_fzfelixhkplafndgwdmescidi.InitialVR36OrthogonalDate);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_fzfelixhkplafndgwdmescidi.FollowupVR36OrthogonalDate);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi>(g_, h_);
+		Encounter j_(Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi tuple_fzfelixhkplafndgwdmescidi) => 
+			tuple_fzfelixhkplafndgwdmescidi.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_FZFeLiXHKPLAfNDgWDMeScIDi, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up VR36 Orthogonal Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_MLHFQ_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.Physical_score__MLHFQ_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		IEnumerable<Observation> e_(Observation _MLHFQPhysical)
+		{
+			var l_ = this.Emotional_score__MLHFQ_();
+			var m_ = context.Operators.ToList<CqlCode>(l_);
+			var n_ = context.Operators.RetrieveByCodes<Observation>(m_, null);
+			var o_ = Status_1_6_000.Final_Survey_Observation(n_);
+
+			return o_;
+		};
+		Tuples.Tuple_CBaKLCFRCUhXghPfCScgCAfHU f_(Observation _MLHFQPhysical, Observation _MLHFQEmotional)
+		{
+			var p_ = new Tuples.Tuple_CBaKLCFRCUhXghPfCScgCAfHU
+			{
+				MLHFQPhysical = _MLHFQPhysical,
+				MLHFQEmotional = _MLHFQEmotional,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_CBaKLCFRCUhXghPfCScgCAfHU>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_CBaKLCFRCUhXghPfCScgCAfHU tuple_cbaklcfrcuhxghpfcscgcafhu)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToValue(tuple_cbaklcfrcuhxghpfcscgcafhu.MLHFQPhysical?.Effective);
+			var r_ = QICoreCommon_2_0_000.ToInterval(q_);
+			var s_ = context.Operators.Start(r_);
+			var t_ = context.Operators.DateFrom(s_);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_cbaklcfrcuhxghpfcscgcafhu.MLHFQEmotional?.Effective);
+			var v_ = QICoreCommon_2_0_000.ToInterval(u_);
+			var w_ = context.Operators.Start(v_);
+			var x_ = context.Operators.DateFrom(w_);
+			var y_ = context.Operators.SameAs(t_, x_, "day");
+			var z_ = FHIRHelpers_4_3_000.ToValue(tuple_cbaklcfrcuhxghpfcscgcafhu.MLHFQPhysical?.Value);
+			var aa_ = context.Operators.Not((bool?)(z_ is null));
+			var ab_ = context.Operators.And(y_, aa_);
+			var ac_ = FHIRHelpers_4_3_000.ToValue(tuple_cbaklcfrcuhxghpfcscgcafhu.MLHFQEmotional?.Value);
+			var ad_ = context.Operators.Not((bool?)(ac_ is null));
+			var ae_ = context.Operators.And(ab_, ad_);
+
+			return ae_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_CBaKLCFRCUhXghPfCScgCAfHU>(g_, h_);
+		CqlDate j_(Tuples.Tuple_CBaKLCFRCUhXghPfCScgCAfHU tuple_cbaklcfrcuhxghpfcscgcafhu)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(tuple_cbaklcfrcuhxghpfcscgcafhu.MLHFQPhysical?.Effective);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = context.Operators.Start(ag_);
+			var ai_ = context.Operators.DateFrom(ah_);
+			var aj_ = FHIRHelpers_4_3_000.ToValue(tuple_cbaklcfrcuhxghpfcscgcafhu.MLHFQEmotional?.Effective);
+			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			var al_ = context.Operators.Start(ak_);
+			var am_ = context.Operators.DateFrom(al_);
+			var an_ = new CqlDate[]
+			{
+				ai_,
+				am_,
+			};
+			var ao_ = context.Operators.MaxOrNull<CqlDate>((an_ as IEnumerable<CqlDate>));
+
+			return ao_;
+		};
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_CBaKLCFRCUhXghPfCScgCAfHU, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Date MLHFQ Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_MLHFQ_Total_Assessment_Completed() => 
+		__Date_MLHFQ_Total_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_MLHFQ_Total_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi c_(Encounter _ValidEncounters, CqlDate _InitialMLHFQDate)
+		{
+			var n_ = new Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialMLHFQDate = _InitialMLHFQDate,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi _ValidEncountersInitialMLHFQDate)
+		{
+			var o_ = this.Date_MLHFQ_Total_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi f_(Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi ValidEncountersInitialMLHFQDate, CqlDate _FollowupMLHFQDate)
+		{
+			var p_ = new Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi
+			{
+				ValidEncounters = ValidEncountersInitialMLHFQDate.ValidEncounters,
+				InitialMLHFQDate = ValidEncountersInitialMLHFQDate.InitialMLHFQDate,
+				FollowupMLHFQDate = _FollowupMLHFQDate,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi, CqlDate, Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi tuple_dgnbkfgfrhawdzadfpzkifxli)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_dgnbkfgfrhawdzadfpzkifxli.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_dgnbkfgfrhawdzadfpzkifxli.InitialMLHFQDate);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_dgnbkfgfrhawdzadfpzkifxli.FollowupMLHFQDate);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi>(g_, h_);
+		Encounter j_(Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi tuple_dgnbkfgfrhawdzadfpzkifxli) => 
+			tuple_dgnbkfgfrhawdzadfpzkifxli.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_DgNBKfGfRHaWDZaDFPZKifXLi, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up MLHFQ Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_KCCQ12_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		IEnumerable<Observation> e_(Observation _KCCQ12Item)
+		{
+			var l_ = this.Overall_summary_score__KCCQ_12_();
+			var m_ = context.Operators.ToList<CqlCode>(l_);
+			var n_ = context.Operators.RetrieveByCodes<Observation>(m_, null);
+			var o_ = Status_1_6_000.Final_Survey_Observation(n_);
+
+			return o_;
+		};
+		Tuples.Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF f_(Observation _KCCQ12Item, Observation _KCCQ12Summary)
+		{
+			var p_ = new Tuples.Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF
+			{
+				KCCQ12Item = _KCCQ12Item,
+				KCCQ12Summary = _KCCQ12Summary,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF tuple_ffjnyamqhzaofymnskahaudlf)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToValue(tuple_ffjnyamqhzaofymnskahaudlf.KCCQ12Item?.Effective);
+			var r_ = QICoreCommon_2_0_000.ToInterval(q_);
+			var s_ = context.Operators.Start(r_);
+			var t_ = context.Operators.DateFrom(s_);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_ffjnyamqhzaofymnskahaudlf.KCCQ12Summary?.Effective);
+			var v_ = QICoreCommon_2_0_000.ToInterval(u_);
+			var w_ = context.Operators.Start(v_);
+			var x_ = context.Operators.DateFrom(w_);
+			var y_ = context.Operators.SameAs(t_, x_, "day");
+			var z_ = FHIRHelpers_4_3_000.ToValue(tuple_ffjnyamqhzaofymnskahaudlf.KCCQ12Item?.Value);
+			var aa_ = context.Operators.Not((bool?)(z_ is null));
+			var ab_ = context.Operators.And(y_, aa_);
+			var ac_ = FHIRHelpers_4_3_000.ToValue(tuple_ffjnyamqhzaofymnskahaudlf.KCCQ12Summary?.Value);
+			var ad_ = context.Operators.Not((bool?)(ac_ is null));
+			var ae_ = context.Operators.And(ab_, ad_);
+
+			return ae_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF>(g_, h_);
+		CqlDate j_(Tuples.Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF tuple_ffjnyamqhzaofymnskahaudlf)
+		{
+			var af_ = FHIRHelpers_4_3_000.ToValue(tuple_ffjnyamqhzaofymnskahaudlf.KCCQ12Item?.Effective);
+			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			var ah_ = context.Operators.Start(ag_);
+			var ai_ = context.Operators.DateFrom(ah_);
+			var aj_ = FHIRHelpers_4_3_000.ToValue(tuple_ffjnyamqhzaofymnskahaudlf.KCCQ12Summary?.Effective);
+			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			var al_ = context.Operators.Start(ak_);
+			var am_ = context.Operators.DateFrom(al_);
+			var an_ = new CqlDate[]
+			{
+				ai_,
+				am_,
+			};
+			var ao_ = context.Operators.MaxOrNull<CqlDate>((an_ as IEnumerable<CqlDate>));
+
+			return ao_;
+		};
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF, CqlDate>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Date KCCQ12 Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_KCCQ12_Total_Assessment_Completed() => 
+		__Date_KCCQ12_Total_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_KCCQ12_Total_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi c_(Encounter _ValidEncounters, CqlDate _InitialKCCQ12Date)
+		{
+			var n_ = new Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialKCCQ12Date = _InitialKCCQ12Date,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi _ValidEncountersInitialKCCQ12Date)
+		{
+			var o_ = this.Date_KCCQ12_Total_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi f_(Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi ValidEncountersInitialKCCQ12Date, CqlDate _FollowupKCCQ12Date)
+		{
+			var p_ = new Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi
+			{
+				ValidEncounters = ValidEncountersInitialKCCQ12Date.ValidEncounters,
+				InitialKCCQ12Date = ValidEncountersInitialKCCQ12Date.InitialKCCQ12Date,
+				FollowupKCCQ12Date = _FollowupKCCQ12Date,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi, CqlDate, Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi tuple_dnzcztnizuqfffijaydwagbfi)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_dnzcztnizuqfffijaydwagbfi.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_dnzcztnizuqfffijaydwagbfi.InitialKCCQ12Date);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_dnzcztnizuqfffijaydwagbfi.FollowupKCCQ12Date);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi>(g_, h_);
+		Encounter j_(Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi tuple_dnzcztnizuqfffijaydwagbfi) => 
+			tuple_dnzcztnizuqfffijaydwagbfi.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_DNZcZTNIZUQfFfijaYDWagbfi, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up KCCQ12 Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_KCCQ_Domain_Assessment_Completed_Value()
+	{
+		var a_ = this.Quality_of_life_score__KCCQ_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		IEnumerable<Observation> e_(Observation _KCCQLifeQuality)
+		{
+			var x_ = this.Symptom_stability_score__KCCQ_();
+			var y_ = context.Operators.ToList<CqlCode>(x_);
+			var z_ = context.Operators.RetrieveByCodes<Observation>(y_, null);
+			var aa_ = Status_1_6_000.Final_Survey_Observation(z_);
+
+			return aa_;
+		};
+		Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV f_(Observation _KCCQLifeQuality, Observation _KCCQSymptomStability)
+		{
+			var ab_ = new Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV
+			{
+				KCCQLifeQuality = _KCCQLifeQuality,
+				KCCQSymptomStability = _KCCQSymptomStability,
+			};
+
+			return ab_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Observation, Observation, Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV>(d_, e_, f_);
+		IEnumerable<Observation> h_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV _KCCQLifeQualityKCCQSymptomStability)
+		{
+			var ac_ = this.Self_efficacy_score__KCCQ_();
+			var ad_ = context.Operators.ToList<CqlCode>(ac_);
+			var ae_ = context.Operators.RetrieveByCodes<Observation>(ad_, null);
+			var af_ = Status_1_6_000.Final_Survey_Observation(ae_);
+
+			return af_;
+		};
+		Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV i_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV KCCQLifeQualityKCCQSymptomStability, Observation _KCCQSelfEfficacy)
+		{
+			var ag_ = new Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV
+			{
+				KCCQLifeQuality = KCCQLifeQualityKCCQSymptomStability.KCCQLifeQuality,
+				KCCQSymptomStability = KCCQLifeQualityKCCQSymptomStability.KCCQSymptomStability,
+				KCCQSelfEfficacy = _KCCQSelfEfficacy,
+			};
+
+			return ag_;
+		};
+		var j_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV, Observation, Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV>(g_, h_, i_);
+		IEnumerable<Observation> k_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV _KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacy)
+		{
+			var ah_ = this.Total_symptom_score__KCCQ_();
+			var ai_ = context.Operators.ToList<CqlCode>(ah_);
+			var aj_ = context.Operators.RetrieveByCodes<Observation>(ai_, null);
+			var ak_ = Status_1_6_000.Final_Survey_Observation(aj_);
+
+			return ak_;
+		};
+		Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV l_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacy, Observation _KCCQSymptoms)
+		{
+			var al_ = new Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV
+			{
+				KCCQLifeQuality = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacy.KCCQLifeQuality,
+				KCCQSymptomStability = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacy.KCCQSymptomStability,
+				KCCQSelfEfficacy = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacy.KCCQSelfEfficacy,
+				KCCQSymptoms = _KCCQSymptoms,
+			};
+
+			return al_;
+		};
+		var m_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV, Observation, Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV>(j_, k_, l_);
+		IEnumerable<Observation> n_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV _KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptoms)
+		{
+			var am_ = this.Physical_limitation_score__KCCQ_();
+			var an_ = context.Operators.ToList<CqlCode>(am_);
+			var ao_ = context.Operators.RetrieveByCodes<Observation>(an_, null);
+			var ap_ = Status_1_6_000.Final_Survey_Observation(ao_);
+
+			return ap_;
+		};
+		Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV o_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptoms, Observation _KCCQPhysicalLimits)
+		{
+			var aq_ = new Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV
+			{
+				KCCQLifeQuality = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptoms.KCCQLifeQuality,
+				KCCQSymptomStability = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptoms.KCCQSymptomStability,
+				KCCQSelfEfficacy = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptoms.KCCQSelfEfficacy,
+				KCCQSymptoms = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptoms.KCCQSymptoms,
+				KCCQPhysicalLimits = _KCCQPhysicalLimits,
+			};
+
+			return aq_;
+		};
+		var p_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV, Observation, Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV>(m_, n_, o_);
+		IEnumerable<Observation> q_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV _KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptomsKCCQPhysicalLimits)
+		{
+			var ar_ = this.Social_limitation_score__KCCQ_();
+			var as_ = context.Operators.ToList<CqlCode>(ar_);
+			var at_ = context.Operators.RetrieveByCodes<Observation>(as_, null);
+			var au_ = Status_1_6_000.Final_Survey_Observation(at_);
+
+			return au_;
+		};
+		Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV r_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptomsKCCQPhysicalLimits, Observation _KCCQSocialLimits)
+		{
+			var av_ = new Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV
+			{
+				KCCQLifeQuality = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptomsKCCQPhysicalLimits.KCCQLifeQuality,
+				KCCQSymptomStability = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptomsKCCQPhysicalLimits.KCCQSymptomStability,
+				KCCQSelfEfficacy = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptomsKCCQPhysicalLimits.KCCQSelfEfficacy,
+				KCCQSymptoms = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptomsKCCQPhysicalLimits.KCCQSymptoms,
+				KCCQPhysicalLimits = KCCQLifeQualityKCCQSymptomStabilityKCCQSelfEfficacyKCCQSymptomsKCCQPhysicalLimits.KCCQPhysicalLimits,
+				KCCQSocialLimits = _KCCQSocialLimits,
+			};
+
+			return av_;
+		};
+		var s_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV, Observation, Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV>(p_, q_, r_);
+		bool? t_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV tuple_bbipkfiyffdqclchpcxkdafmv)
+		{
+			var aw_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQLifeQuality?.Effective);
+			var ax_ = QICoreCommon_2_0_000.ToInterval(aw_);
+			var ay_ = context.Operators.Start(ax_);
+			var az_ = context.Operators.DateFrom(ay_);
+			var ba_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSymptomStability?.Effective);
+			var bb_ = QICoreCommon_2_0_000.ToInterval(ba_);
+			var bc_ = context.Operators.Start(bb_);
+			var bd_ = context.Operators.DateFrom(bc_);
+			var be_ = context.Operators.SameAs(az_, bd_, "day");
+			var bf_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSymptomStability?.Value);
+			var bg_ = context.Operators.Not((bool?)(bf_ is null));
+			var bh_ = context.Operators.And(be_, bg_);
+			var bj_ = QICoreCommon_2_0_000.ToInterval(aw_);
+			var bk_ = context.Operators.Start(bj_);
+			var bl_ = context.Operators.DateFrom(bk_);
+			var bm_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSelfEfficacy?.Effective);
+			var bn_ = QICoreCommon_2_0_000.ToInterval(bm_);
+			var bo_ = context.Operators.Start(bn_);
+			var bp_ = context.Operators.DateFrom(bo_);
+			var bq_ = context.Operators.SameAs(bl_, bp_, "day");
+			var br_ = context.Operators.And(bh_, bq_);
+			var bs_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSelfEfficacy?.Value);
+			var bt_ = context.Operators.Not((bool?)(bs_ is null));
+			var bu_ = context.Operators.And(br_, bt_);
+			var bw_ = QICoreCommon_2_0_000.ToInterval(aw_);
+			var bx_ = context.Operators.Start(bw_);
+			var by_ = context.Operators.DateFrom(bx_);
+			var bz_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSymptoms?.Effective);
+			var ca_ = QICoreCommon_2_0_000.ToInterval(bz_);
+			var cb_ = context.Operators.Start(ca_);
+			var cc_ = context.Operators.DateFrom(cb_);
+			var cd_ = context.Operators.SameAs(by_, cc_, "day");
+			var ce_ = context.Operators.And(bu_, cd_);
+			var cf_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSymptoms?.Value);
+			var cg_ = context.Operators.Not((bool?)(cf_ is null));
+			var ch_ = context.Operators.And(ce_, cg_);
+			var cj_ = QICoreCommon_2_0_000.ToInterval(aw_);
+			var ck_ = context.Operators.Start(cj_);
+			var cl_ = context.Operators.DateFrom(ck_);
+			var cm_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQPhysicalLimits?.Effective);
+			var cn_ = QICoreCommon_2_0_000.ToInterval(cm_);
+			var co_ = context.Operators.Start(cn_);
+			var cp_ = context.Operators.DateFrom(co_);
+			var cq_ = context.Operators.SameAs(cl_, cp_, "day");
+			var cr_ = context.Operators.And(ch_, cq_);
+			var cs_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQPhysicalLimits?.Value);
+			var ct_ = context.Operators.Not((bool?)(cs_ is null));
+			var cu_ = context.Operators.And(cr_, ct_);
+			var cw_ = QICoreCommon_2_0_000.ToInterval(aw_);
+			var cx_ = context.Operators.Start(cw_);
+			var cy_ = context.Operators.DateFrom(cx_);
+			var cz_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSocialLimits?.Effective);
+			var da_ = QICoreCommon_2_0_000.ToInterval(cz_);
+			var db_ = context.Operators.Start(da_);
+			var dc_ = context.Operators.DateFrom(db_);
+			var dd_ = context.Operators.SameAs(cy_, dc_, "day");
+			var de_ = context.Operators.And(cu_, dd_);
+			var df_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSocialLimits?.Value);
+			var dg_ = context.Operators.Not((bool?)(df_ is null));
+			var dh_ = context.Operators.And(de_, dg_);
+			var di_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQLifeQuality?.Value);
+			var dj_ = context.Operators.Not((bool?)(di_ is null));
+			var dk_ = context.Operators.And(dh_, dj_);
+
+			return dk_;
+		};
+		var u_ = context.Operators.WhereOrNull<Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV>(s_, t_);
+		CqlDate v_(Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV tuple_bbipkfiyffdqclchpcxkdafmv)
+		{
+			var dl_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQLifeQuality?.Effective);
+			var dm_ = QICoreCommon_2_0_000.ToInterval(dl_);
+			var dn_ = context.Operators.Start(dm_);
+			var do_ = context.Operators.DateFrom(dn_);
+			var dp_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSymptomStability?.Effective);
+			var dq_ = QICoreCommon_2_0_000.ToInterval(dp_);
+			var dr_ = context.Operators.Start(dq_);
+			var ds_ = context.Operators.DateFrom(dr_);
+			var dt_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSelfEfficacy?.Effective);
+			var du_ = QICoreCommon_2_0_000.ToInterval(dt_);
+			var dv_ = context.Operators.Start(du_);
+			var dw_ = context.Operators.DateFrom(dv_);
+			var dx_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSymptoms?.Effective);
+			var dy_ = QICoreCommon_2_0_000.ToInterval(dx_);
+			var dz_ = context.Operators.Start(dy_);
+			var ea_ = context.Operators.DateFrom(dz_);
+			var eb_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQPhysicalLimits?.Effective);
+			var ec_ = QICoreCommon_2_0_000.ToInterval(eb_);
+			var ed_ = context.Operators.Start(ec_);
+			var ee_ = context.Operators.DateFrom(ed_);
+			var ef_ = FHIRHelpers_4_3_000.ToValue(tuple_bbipkfiyffdqclchpcxkdafmv.KCCQSocialLimits?.Effective);
+			var eg_ = QICoreCommon_2_0_000.ToInterval(ef_);
+			var eh_ = context.Operators.Start(eg_);
+			var ei_ = context.Operators.DateFrom(eh_);
+			var ej_ = new CqlDate[]
+			{
+				do_,
+				ds_,
+				dw_,
+				ea_,
+				ee_,
+				ei_,
+			};
+			var ek_ = context.Operators.MaxOrNull<CqlDate>((ej_ as IEnumerable<CqlDate>));
+
+			return ek_;
+		};
+		var w_ = context.Operators.SelectOrNull<Tuples.Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV, CqlDate>(u_, v_);
+
+		return w_;
+	}
+
+    [CqlDeclaration("Date KCCQ Domain Assessment Completed")]
+	public IEnumerable<CqlDate> Date_KCCQ_Domain_Assessment_Completed() => 
+		__Date_KCCQ_Domain_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_KCCQ_Domain_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC c_(Encounter _ValidEncounters, CqlDate _InitialKCCQAssessmentDate)
+		{
+			var n_ = new Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialKCCQAssessmentDate = _InitialKCCQAssessmentDate,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC _ValidEncountersInitialKCCQAssessmentDate)
+		{
+			var o_ = this.Date_KCCQ_Domain_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC f_(Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC ValidEncountersInitialKCCQAssessmentDate, CqlDate _FollowupKCCQAssessmentDate)
+		{
+			var p_ = new Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC
+			{
+				ValidEncounters = ValidEncountersInitialKCCQAssessmentDate.ValidEncounters,
+				InitialKCCQAssessmentDate = ValidEncountersInitialKCCQAssessmentDate.InitialKCCQAssessmentDate,
+				FollowupKCCQAssessmentDate = _FollowupKCCQAssessmentDate,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC, CqlDate, Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC tuple_gechmkfhepfubfjyjevegqtrc)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_gechmkfhepfubfjyjevegqtrc.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_gechmkfhepfubfjyjevegqtrc.InitialKCCQAssessmentDate);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_gechmkfhepfubfjyjevegqtrc.FollowupKCCQAssessmentDate);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC>(g_, h_);
+		Encounter j_(Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC tuple_gechmkfhepfubfjyjevegqtrc) => 
+			tuple_gechmkfhepfubfjyjevegqtrc.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_GechMKfhePFUbfJYJeVegQTRC, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up KCCQ Domain Score Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments.Value;
+
+	private IEnumerable<CqlDate> Date_KCCQ_Total_Assessment_Completed_Value()
+	{
+		var a_ = this.Overall_summary_score__KCCQ_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		bool? e_(Observation KCCQSummaryScore)
+		{
+			var i_ = FHIRHelpers_4_3_000.ToValue(KCCQSummaryScore?.Value);
+			var j_ = context.Operators.Not((bool?)(i_ is null));
+
+			return j_;
+		};
+		var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+		CqlDate g_(Observation KCCQSummaryScore)
+		{
+			var k_ = FHIRHelpers_4_3_000.ToValue(KCCQSummaryScore?.Effective);
+			var l_ = QICoreCommon_2_0_000.ToInterval(k_);
+			var m_ = context.Operators.Start(l_);
+			var n_ = context.Operators.DateFrom(m_);
+			var o_ = new CqlDate[]
+			{
+				n_,
+			};
+			var p_ = context.Operators.MaxOrNull<CqlDate>((o_ as IEnumerable<CqlDate>));
+
+			return p_;
+		};
+		var h_ = context.Operators.SelectOrNull<Observation, CqlDate>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Date KCCQ Total Assessment Completed")]
+	public IEnumerable<CqlDate> Date_KCCQ_Total_Assessment_Completed() => 
+		__Date_KCCQ_Total_Assessment_Completed.Value;
+
+	private bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments_Value()
+	{
+		var a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_(Encounter _ValidEncounters)
+		{
+			var m_ = this.Date_KCCQ_Total_Assessment_Completed();
+
+			return m_;
+		};
+		Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf c_(Encounter _ValidEncounters, CqlDate _InitialKCCQTotalScore)
+		{
+			var n_ = new Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf
+			{
+				ValidEncounters = _ValidEncounters,
+				InitialKCCQTotalScore = _InitialKCCQTotalScore,
+			};
+
+			return n_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, CqlDate, Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf>(a_, b_, c_);
+		IEnumerable<CqlDate> e_(Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf _ValidEncountersInitialKCCQTotalScore)
+		{
+			var o_ = this.Date_KCCQ_Total_Assessment_Completed();
+
+			return o_;
+		};
+		Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf f_(Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf ValidEncountersInitialKCCQTotalScore, CqlDate _FollowupKCCQTotalScore)
+		{
+			var p_ = new Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf
+			{
+				ValidEncounters = ValidEncountersInitialKCCQTotalScore.ValidEncounters,
+				InitialKCCQTotalScore = ValidEncountersInitialKCCQTotalScore.InitialKCCQTotalScore,
+				FollowupKCCQTotalScore = _FollowupKCCQTotalScore,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf, CqlDate, Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf tuple_dsdkcfqmumbjegqcvveyhpydf)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToInterval(tuple_dsdkcfqmumbjegqcvveyhpydf.ValidEncounters?.Period);
+			var r_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var s_ = context.Operators.End(r_);
+			var t_ = this.Measurement_Period();
+			var u_ = context.Operators.End(t_);
+			var v_ = context.Operators.Quantity(180m, "days");
+			var w_ = context.Operators.Subtract(u_, v_);
+			var x_ = context.Operators.SameOrBefore(s_, w_, "day");
+			var y_ = context.Operators.ConvertDateToDateTime(tuple_dsdkcfqmumbjegqcvveyhpydf.InitialKCCQTotalScore);
+			var aa_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ab_ = context.Operators.End(aa_);
+			var ac_ = context.Operators.Quantity(14m, "days");
+			var ad_ = context.Operators.Subtract(ab_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var ag_ = context.Operators.End(af_);
+			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(y_, ah_, "day");
+			var ak_ = QICoreCommon_2_0_000.ToInterval((q_ as object));
+			var al_ = context.Operators.End(ak_);
+			var am_ = context.Operators.Not((bool?)(al_ is null));
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.And(x_, an_);
+			var ap_ = context.Operators.ConvertDateToDateTime(tuple_dsdkcfqmumbjegqcvveyhpydf.FollowupKCCQTotalScore);
+			var aq_ = context.Operators.DateFrom(ap_);
+			var as_ = context.Operators.DateFrom(y_);
+			var at_ = context.Operators.Quantity(30m, "days");
+			var au_ = context.Operators.Add(as_, at_);
+			var aw_ = context.Operators.DateFrom(y_);
+			var ay_ = context.Operators.Add(aw_, v_);
+			var az_ = context.Operators.Interval(au_, ay_, true, true);
+			var ba_ = context.Operators.ElementInInterval<CqlDate>(aq_, az_, "day");
+			var bb_ = context.Operators.And(ao_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf>(g_, h_);
+		Encounter j_(Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf tuple_dsdkcfqmumbjegqcvveyhpydf) => 
+			tuple_dsdkcfqmumbjegqcvveyhpydf.ValidEncounters;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_DSdKcfQMUMBjegQCVVeYhPYdf, Encounter>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Has Encounter with Initial and Follow Up KCCQ Total Score Assessments")]
+	public bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments() => 
+		__Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments();
+		var b_ = this.Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments();
+		var e_ = context.Operators.Or(c_, d_);
+		var f_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments();
+		var g_ = context.Operators.Or(e_, f_);
+		var h_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments();
+		var i_ = context.Operators.Or(g_, h_);
+		var j_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments();
+		var k_ = context.Operators.Or(i_, j_);
+		var l_ = this.Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments();
+		var m_ = context.Operators.Or(k_, l_);
+		var n_ = this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments();
+		var o_ = context.Operators.Or(m_, n_);
+		var p_ = this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments();
+		var q_ = context.Operators.Or(o_, p_);
+		var r_ = this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments();
+		var s_ = context.Operators.Or(q_, r_);
+
+		return s_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+}

--- a/Demo/Measures-cms/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
@@ -1,0 +1,1206 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("GlobalMalnutritionCompositeFHIR", "0.1.000")]
+public class GlobalMalnutritionCompositeFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Ethnicity;
+    internal Lazy<CqlValueSet> __Hospital_Dietitian_Referral;
+    internal Lazy<CqlValueSet> __Malnutrition_Diagnosis;
+    internal Lazy<CqlValueSet> __Malnutrition_Risk_Screening;
+    internal Lazy<CqlValueSet> __Malnutrition_Screening_At_Risk_Result;
+    internal Lazy<CqlValueSet> __Malnutrition_Screening_Not_At_Risk_Result;
+    internal Lazy<CqlValueSet> __Nutrition_Assessment;
+    internal Lazy<CqlValueSet> __Nutrition_Assessment_Status_Moderately_Malnourished;
+    internal Lazy<CqlValueSet> __Nutrition_Assessment_Status_Not_or_Mildly_Malnourished;
+    internal Lazy<CqlValueSet> __Nutrition_Assessment_Status_Severely_Malnourished;
+    internal Lazy<CqlValueSet> __Nutrition_Care_Plan;
+    internal Lazy<CqlValueSet> __ONC_Administrative_Sex;
+    internal Lazy<CqlValueSet> __Payer_Type;
+    internal Lazy<CqlValueSet> __Race;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __ICD10CM;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer_Type;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Measure_Population;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Hospital_Dietitian_Referral;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Malnutrition_Risk_Screening;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Malnutrition_Risk_Screening_at_Risk;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Nutrition_Assessment_and_Identified_Status;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Malnutrition_Diagnosis;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Nutrition_Care_Plan;
+
+    #endregion
+    public GlobalMalnutritionCompositeFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Ethnicity = new Lazy<CqlValueSet>(this.Ethnicity_Value);
+        __Hospital_Dietitian_Referral = new Lazy<CqlValueSet>(this.Hospital_Dietitian_Referral_Value);
+        __Malnutrition_Diagnosis = new Lazy<CqlValueSet>(this.Malnutrition_Diagnosis_Value);
+        __Malnutrition_Risk_Screening = new Lazy<CqlValueSet>(this.Malnutrition_Risk_Screening_Value);
+        __Malnutrition_Screening_At_Risk_Result = new Lazy<CqlValueSet>(this.Malnutrition_Screening_At_Risk_Result_Value);
+        __Malnutrition_Screening_Not_At_Risk_Result = new Lazy<CqlValueSet>(this.Malnutrition_Screening_Not_At_Risk_Result_Value);
+        __Nutrition_Assessment = new Lazy<CqlValueSet>(this.Nutrition_Assessment_Value);
+        __Nutrition_Assessment_Status_Moderately_Malnourished = new Lazy<CqlValueSet>(this.Nutrition_Assessment_Status_Moderately_Malnourished_Value);
+        __Nutrition_Assessment_Status_Not_or_Mildly_Malnourished = new Lazy<CqlValueSet>(this.Nutrition_Assessment_Status_Not_or_Mildly_Malnourished_Value);
+        __Nutrition_Assessment_Status_Severely_Malnourished = new Lazy<CqlValueSet>(this.Nutrition_Assessment_Status_Severely_Malnourished_Value);
+        __Nutrition_Care_Plan = new Lazy<CqlValueSet>(this.Nutrition_Care_Plan_Value);
+        __ONC_Administrative_Sex = new Lazy<CqlValueSet>(this.ONC_Administrative_Sex_Value);
+        __Payer_Type = new Lazy<CqlValueSet>(this.Payer_Type_Value);
+        __Race = new Lazy<CqlValueSet>(this.Race_Value);
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __ICD10CM = new Lazy<CqlCode[]>(this.ICD10CM_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer_Type = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Type_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Measure_Population = new Lazy<IEnumerable<Encounter>>(this.Measure_Population_Value);
+        __Encounter_with_Hospital_Dietitian_Referral = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Hospital_Dietitian_Referral_Value);
+        __Encounter_with_Malnutrition_Risk_Screening = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Malnutrition_Risk_Screening_Value);
+        __Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral_Value);
+        __Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk_Value);
+        __Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral_Value);
+        __Encounter_with_Malnutrition_Risk_Screening_at_Risk = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_Value);
+        __Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral_Value);
+        __Encounter_with_Nutrition_Assessment_and_Identified_Status = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Nutrition_Assessment_and_Identified_Status_Value);
+        __Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished_Value);
+        __Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished_Value);
+        __Encounter_with_Malnutrition_Diagnosis = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Malnutrition_Diagnosis_Value);
+        __Encounter_with_Nutrition_Care_Plan = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Nutrition_Care_Plan_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Ethnicity_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+
+    [CqlDeclaration("Ethnicity")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
+	public CqlValueSet Ethnicity() => 
+		__Ethnicity.Value;
+
+	private CqlValueSet Hospital_Dietitian_Referral_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91", null);
+
+    [CqlDeclaration("Hospital Dietitian Referral")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91")]
+	public CqlValueSet Hospital_Dietitian_Referral() => 
+		__Hospital_Dietitian_Referral.Value;
+
+	private CqlValueSet Malnutrition_Diagnosis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55", null);
+
+    [CqlDeclaration("Malnutrition Diagnosis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55")]
+	public CqlValueSet Malnutrition_Diagnosis() => 
+		__Malnutrition_Diagnosis.Value;
+
+	private CqlValueSet Malnutrition_Risk_Screening_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92", null);
+
+    [CqlDeclaration("Malnutrition Risk Screening")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92")]
+	public CqlValueSet Malnutrition_Risk_Screening() => 
+		__Malnutrition_Risk_Screening.Value;
+
+	private CqlValueSet Malnutrition_Screening_At_Risk_Result_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38", null);
+
+    [CqlDeclaration("Malnutrition Screening At Risk Result")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38")]
+	public CqlValueSet Malnutrition_Screening_At_Risk_Result() => 
+		__Malnutrition_Screening_At_Risk_Result.Value;
+
+	private CqlValueSet Malnutrition_Screening_Not_At_Risk_Result_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34", null);
+
+    [CqlDeclaration("Malnutrition Screening Not At Risk Result")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34")]
+	public CqlValueSet Malnutrition_Screening_Not_At_Risk_Result() => 
+		__Malnutrition_Screening_Not_At_Risk_Result.Value;
+
+	private CqlValueSet Nutrition_Assessment_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21", null);
+
+    [CqlDeclaration("Nutrition Assessment")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21")]
+	public CqlValueSet Nutrition_Assessment() => 
+		__Nutrition_Assessment.Value;
+
+	private CqlValueSet Nutrition_Assessment_Status_Moderately_Malnourished_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44", null);
+
+    [CqlDeclaration("Nutrition Assessment Status Moderately Malnourished")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44")]
+	public CqlValueSet Nutrition_Assessment_Status_Moderately_Malnourished() => 
+		__Nutrition_Assessment_Status_Moderately_Malnourished.Value;
+
+	private CqlValueSet Nutrition_Assessment_Status_Not_or_Mildly_Malnourished_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48", null);
+
+    [CqlDeclaration("Nutrition Assessment Status Not or Mildly Malnourished")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48")]
+	public CqlValueSet Nutrition_Assessment_Status_Not_or_Mildly_Malnourished() => 
+		__Nutrition_Assessment_Status_Not_or_Mildly_Malnourished.Value;
+
+	private CqlValueSet Nutrition_Assessment_Status_Severely_Malnourished_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42", null);
+
+    [CqlDeclaration("Nutrition Assessment Status Severely Malnourished")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42")]
+	public CqlValueSet Nutrition_Assessment_Status_Severely_Malnourished() => 
+		__Nutrition_Assessment_Status_Severely_Malnourished.Value;
+
+	private CqlValueSet Nutrition_Care_Plan_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93", null);
+
+    [CqlDeclaration("Nutrition Care Plan")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93")]
+	public CqlValueSet Nutrition_Care_Plan() => 
+		__Nutrition_Care_Plan.Value;
+
+	private CqlValueSet ONC_Administrative_Sex_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+
+    [CqlDeclaration("ONC Administrative Sex")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
+	public CqlValueSet ONC_Administrative_Sex() => 
+		__ONC_Administrative_Sex.Value;
+
+	private CqlValueSet Payer_Type_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+
+    [CqlDeclaration("Payer Type")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
+	public CqlValueSet Payer_Type() => 
+		__Payer_Type.Value;
+
+	private CqlValueSet Race_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+
+    [CqlDeclaration("Race")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
+	public CqlValueSet Race() => 
+		__Race.Value;
+
+	private CqlCode Birth_date_Value() => 
+		new CqlCode("21112-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("21112-8", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] ICD10CM_Value()
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
+    [CqlDeclaration("ICD10CM")]
+	public CqlCode[] ICD10CM() => 
+		__ICD10CM.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("GlobalMalnutritionCompositeFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Type_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer Type")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Type() => 
+		__SDE_Payer_Type.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_Value()
+	{
+		var a_ = this.Encounter_Inpatient();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter EncounterInpatient)
+		{
+			var e_ = FHIRHelpers_4_3_000.ToInterval(EncounterInpatient?.Period);
+			var f_ = context.Operators.End(e_);
+			var g_ = this.Measurement_Period();
+			var h_ = context.Operators.ElementInInterval<CqlDateTime>(f_, g_, "day");
+			var i_ = this.Patient();
+			var j_ = context.Operators.Convert<CqlDate>(i_?.BirthDateElement?.Value);
+			var l_ = context.Operators.Start(e_);
+			var m_ = context.Operators.DateFrom(l_);
+			var n_ = context.Operators.CalculateAgeAt(j_, m_, "year");
+			var o_ = context.Operators.GreaterOrEqual(n_, (int?)65);
+			var p_ = context.Operators.And(h_, o_);
+			var r_ = context.Operators.Start(e_);
+			var t_ = context.Operators.End(e_);
+			var u_ = context.Operators.DurationBetween(r_, t_, "hour");
+			var v_ = context.Operators.GreaterOrEqual(u_, (int?)24);
+			var w_ = context.Operators.And(p_, v_);
+			var x_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(EncounterInpatient?.StatusElement?.Value);
+			var y_ = context.Operators.Equal(x_, "finished");
+			var z_ = context.Operators.And(w_, y_);
+
+			return z_;
+		};
+		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter")]
+	public IEnumerable<Encounter> Qualifying_Encounter() => 
+		__Qualifying_Encounter.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Measure_Population_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Measure Population")]
+	public IEnumerable<Encounter> Measure_Population() => 
+		__Measure_Population.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Hospital_Dietitian_Referral_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Procedure> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Hospital_Dietitian_Referral();
+			var j_ = context.Operators.RetrieveByValueSet<Procedure>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_BdOfeUSQKMfBEYcULSQYBIjjC c_(Encounter _QualifyingEncounter, Procedure _HospitalDietitianReferral)
+		{
+			var k_ = new Tuples.Tuple_BdOfeUSQKMfBEYcULSQYBIjjC
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				HospitalDietitianReferral = _HospitalDietitianReferral,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Procedure, Tuples.Tuple_BdOfeUSQKMfBEYcULSQYBIjjC>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_BdOfeUSQKMfBEYcULSQYBIjjC tuple_bdofeusqkmfbeyculsqybijjc)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToConcept(tuple_bdofeusqkmfbeyculsqybijjc.HospitalDietitianReferral?.Code);
+			var m_ = this.Hospital_Dietitian_Referral();
+			var n_ = context.Operators.ConceptInValueSet((l_ as CqlConcept), m_);
+			var o_ = context.Operators.Convert<string>(tuple_bdofeusqkmfbeyculsqybijjc.HospitalDietitianReferral?.StatusElement?.Value);
+			var p_ = new string[]
+			{
+				"active",
+				"completed",
+				"in-progress",
+			};
+			var q_ = context.Operators.InList<string>(o_, (p_ as IEnumerable<string>));
+			var r_ = context.Operators.And(n_, q_);
+			var s_ = FHIRHelpers_4_3_000.ToValue(tuple_bdofeusqkmfbeyculsqybijjc.HospitalDietitianReferral?.Performed);
+			var t_ = QICoreCommon_2_0_000.earliest(s_);
+			var u_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_bdofeusqkmfbeyculsqybijjc.QualifyingEncounter);
+			var v_ = context.Operators.ElementInInterval<CqlDateTime>(t_, u_, null);
+			var w_ = context.Operators.And(r_, v_);
+
+			return w_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_BdOfeUSQKMfBEYcULSQYBIjjC>(d_, e_);
+		Encounter g_(Tuples.Tuple_BdOfeUSQKMfBEYcULSQYBIjjC tuple_bdofeusqkmfbeyculsqybijjc) => 
+			tuple_bdofeusqkmfbeyculsqybijjc.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_BdOfeUSQKMfBEYcULSQYBIjjC, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Hospital Dietitian Referral")]
+	public IEnumerable<Encounter> Encounter_with_Hospital_Dietitian_Referral() => 
+		__Encounter_with_Hospital_Dietitian_Referral.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Observation> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Malnutrition_Risk_Screening();
+			var j_ = context.Operators.RetrieveByValueSet<Observation>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS c_(Encounter _QualifyingEncounter, Observation _MalnutritionRiskScreening)
+		{
+			var k_ = new Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				MalnutritionRiskScreening = _MalnutritionRiskScreening,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Observation, Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS tuple_ffuejbaxzfeabrilhfreepdgs)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToConcept(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.Code);
+			var m_ = this.Malnutrition_Risk_Screening();
+			var n_ = context.Operators.ConceptInValueSet((l_ as CqlConcept), m_);
+			var o_ = context.Operators.Convert<Code<ObservationStatus>>(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.StatusElement?.Value);
+			var p_ = context.Operators.Convert<string>(o_);
+			var q_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var r_ = context.Operators.InList<string>(p_, (q_ as IEnumerable<string>));
+			var s_ = context.Operators.And(n_, r_);
+			var t_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_ffuejbaxzfeabrilhfreepdgs.QualifyingEncounter);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.Effective);
+			var v_ = QICoreCommon_2_0_000.toInterval(u_);
+			var w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
+			var x_ = context.Operators.And(s_, w_);
+			var y_ = FHIRHelpers_4_3_000.ToValue(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.Value);
+			var z_ = this.Malnutrition_Screening_Not_At_Risk_Result();
+			var aa_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), z_);
+			var ac_ = this.Malnutrition_Screening_At_Risk_Result();
+			var ad_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), ac_);
+			var ae_ = context.Operators.Or(aa_, ad_);
+			var af_ = context.Operators.And(x_, ae_);
+
+			return af_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS>(d_, e_);
+		Encounter g_(Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS tuple_ffuejbaxzfeabrilhfreepdgs) => 
+			tuple_ffuejbaxzfeabrilhfreepdgs.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Malnutrition Risk Screening")]
+	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening() => 
+		__Encounter_with_Malnutrition_Risk_Screening.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var f_ = this.Encounter_with_Malnutrition_Risk_Screening();
+			var g_ = context.Operators.ListContains<Encounter>(f_, QualifyingEncounter);
+			var h_ = this.Encounter_with_Hospital_Dietitian_Referral();
+			var i_ = context.Operators.ListContains<Encounter>(h_, QualifyingEncounter);
+			var j_ = context.Operators.Or(g_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter QualifyingEncounter) => 
+			QualifyingEncounter;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Encounter with Malnutrition Risk Screening or with Hospital Dietitian Referral")]
+	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral() => 
+		__Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Observation> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Malnutrition_Risk_Screening();
+			var j_ = context.Operators.RetrieveByValueSet<Observation>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS c_(Encounter _QualifyingEncounter, Observation _MalnutritionRiskScreening)
+		{
+			var k_ = new Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				MalnutritionRiskScreening = _MalnutritionRiskScreening,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Observation, Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS tuple_ffuejbaxzfeabrilhfreepdgs)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToConcept(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.Code);
+			var m_ = this.Malnutrition_Risk_Screening();
+			var n_ = context.Operators.ConceptInValueSet((l_ as CqlConcept), m_);
+			var o_ = context.Operators.Convert<Code<ObservationStatus>>(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.StatusElement?.Value);
+			var p_ = context.Operators.Convert<string>(o_);
+			var q_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var r_ = context.Operators.InList<string>(p_, (q_ as IEnumerable<string>));
+			var s_ = context.Operators.And(n_, r_);
+			var t_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_ffuejbaxzfeabrilhfreepdgs.QualifyingEncounter);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.Effective);
+			var v_ = QICoreCommon_2_0_000.toInterval(u_);
+			var w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
+			var x_ = context.Operators.And(s_, w_);
+			var y_ = FHIRHelpers_4_3_000.ToValue(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.Value);
+			var z_ = this.Malnutrition_Screening_Not_At_Risk_Result();
+			var aa_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), z_);
+			var ab_ = context.Operators.And(x_, aa_);
+
+			return ab_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS>(d_, e_);
+		Encounter g_(Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS tuple_ffuejbaxzfeabrilhfreepdgs) => 
+			tuple_ffuejbaxzfeabrilhfreepdgs.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Malnutrition Risk Screening Not at Risk")]
+	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk() => 
+		__Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var f_ = this.Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk();
+			var g_ = context.Operators.ListContains<Encounter>(f_, QualifyingEncounter);
+			var h_ = this.Encounter_with_Hospital_Dietitian_Referral();
+			var i_ = context.Operators.ExistsInList<Encounter>(h_);
+			var j_ = context.Operators.Not(i_);
+			var k_ = context.Operators.And(g_, j_);
+
+			return k_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter QualifyingEncounter) => 
+			QualifyingEncounter;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Encounter with Malnutrition Not at Risk Screening and without Hospital Dietitian Referral")]
+	public IEnumerable<Encounter> Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral() => 
+		__Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_at_Risk_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Observation> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Malnutrition_Risk_Screening();
+			var j_ = context.Operators.RetrieveByValueSet<Observation>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS c_(Encounter _QualifyingEncounter, Observation _MalnutritionRiskScreening)
+		{
+			var k_ = new Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				MalnutritionRiskScreening = _MalnutritionRiskScreening,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Observation, Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS tuple_ffuejbaxzfeabrilhfreepdgs)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToConcept(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.Code);
+			var m_ = this.Malnutrition_Risk_Screening();
+			var n_ = context.Operators.ConceptInValueSet((l_ as CqlConcept), m_);
+			var o_ = context.Operators.Convert<Code<ObservationStatus>>(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.StatusElement?.Value);
+			var p_ = context.Operators.Convert<string>(o_);
+			var q_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var r_ = context.Operators.InList<string>(p_, (q_ as IEnumerable<string>));
+			var s_ = context.Operators.And(n_, r_);
+			var t_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_ffuejbaxzfeabrilhfreepdgs.QualifyingEncounter);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.Effective);
+			var v_ = QICoreCommon_2_0_000.toInterval(u_);
+			var w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
+			var x_ = context.Operators.And(s_, w_);
+			var y_ = FHIRHelpers_4_3_000.ToValue(tuple_ffuejbaxzfeabrilhfreepdgs.MalnutritionRiskScreening?.Value);
+			var z_ = this.Malnutrition_Screening_At_Risk_Result();
+			var aa_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), z_);
+			var ab_ = context.Operators.And(x_, aa_);
+
+			return ab_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS>(d_, e_);
+		Encounter g_(Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS tuple_ffuejbaxzfeabrilhfreepdgs) => 
+			tuple_ffuejbaxzfeabrilhfreepdgs.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_FfUejBAXZfEABRILhFReePdGS, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Malnutrition Risk Screening at Risk")]
+	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_at_Risk() => 
+		__Encounter_with_Malnutrition_Risk_Screening_at_Risk.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var f_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk();
+			var g_ = context.Operators.ListContains<Encounter>(f_, QualifyingEncounter);
+			var h_ = this.Encounter_with_Hospital_Dietitian_Referral();
+			var i_ = context.Operators.ListContains<Encounter>(h_, QualifyingEncounter);
+			var j_ = context.Operators.Or(g_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		Encounter d_(Encounter QualifyingEncounter) => 
+			QualifyingEncounter;
+		var e_ = context.Operators.SelectOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Encounter with Malnutrition Risk Screening at Risk or with Hospital Dietitian Referral")]
+	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral() => 
+		__Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_and_Identified_Status_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Observation> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Nutrition_Assessment();
+			var j_ = context.Operators.RetrieveByValueSet<Observation>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh c_(Encounter _QualifyingEncounter, Observation _NutritionAssessment)
+		{
+			var k_ = new Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				NutritionAssessment = _NutritionAssessment,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Observation, Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh tuple_fnbckkyclgcbujddfesqqggfh)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToConcept(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.Code);
+			var m_ = this.Nutrition_Assessment();
+			var n_ = context.Operators.ConceptInValueSet((l_ as CqlConcept), m_);
+			var o_ = context.Operators.Convert<Code<ObservationStatus>>(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.StatusElement?.Value);
+			var p_ = context.Operators.Convert<string>(o_);
+			var q_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var r_ = context.Operators.InList<string>(p_, (q_ as IEnumerable<string>));
+			var s_ = context.Operators.And(n_, r_);
+			var t_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_fnbckkyclgcbujddfesqqggfh.QualifyingEncounter);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.Effective);
+			var v_ = QICoreCommon_2_0_000.toInterval(u_);
+			var w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
+			var x_ = context.Operators.And(s_, w_);
+			var y_ = FHIRHelpers_4_3_000.ToValue(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.Value);
+			var z_ = this.Nutrition_Assessment_Status_Moderately_Malnourished();
+			var aa_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), z_);
+			var ac_ = this.Nutrition_Assessment_Status_Not_or_Mildly_Malnourished();
+			var ad_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), ac_);
+			var ae_ = context.Operators.Or(aa_, ad_);
+			var ag_ = this.Nutrition_Assessment_Status_Severely_Malnourished();
+			var ah_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), ag_);
+			var ai_ = context.Operators.Or(ae_, ah_);
+			var aj_ = context.Operators.And(x_, ai_);
+
+			return aj_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh>(d_, e_);
+		Encounter g_(Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh tuple_fnbckkyclgcbujddfesqqggfh) => 
+			tuple_fnbckkyclgcbujddfesqqggfh.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Nutrition Assessment and Identified Status")]
+	public IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_and_Identified_Status() => 
+		__Encounter_with_Nutrition_Assessment_and_Identified_Status.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Observation> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Nutrition_Assessment();
+			var j_ = context.Operators.RetrieveByValueSet<Observation>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh c_(Encounter _QualifyingEncounter, Observation _NutritionAssessment)
+		{
+			var k_ = new Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				NutritionAssessment = _NutritionAssessment,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Observation, Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh tuple_fnbckkyclgcbujddfesqqggfh)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToConcept(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.Code);
+			var m_ = this.Nutrition_Assessment();
+			var n_ = context.Operators.ConceptInValueSet((l_ as CqlConcept), m_);
+			var o_ = context.Operators.Convert<Code<ObservationStatus>>(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.StatusElement?.Value);
+			var p_ = context.Operators.Convert<string>(o_);
+			var q_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var r_ = context.Operators.InList<string>(p_, (q_ as IEnumerable<string>));
+			var s_ = context.Operators.And(n_, r_);
+			var t_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_fnbckkyclgcbujddfesqqggfh.QualifyingEncounter);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.Effective);
+			var v_ = QICoreCommon_2_0_000.toInterval(u_);
+			var w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
+			var x_ = context.Operators.And(s_, w_);
+			var y_ = FHIRHelpers_4_3_000.ToValue(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.Value);
+			var z_ = this.Nutrition_Assessment_Status_Moderately_Malnourished();
+			var aa_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), z_);
+			var ac_ = this.Nutrition_Assessment_Status_Severely_Malnourished();
+			var ad_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), ac_);
+			var ae_ = context.Operators.Or(aa_, ad_);
+			var af_ = context.Operators.And(x_, ae_);
+
+			return af_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh>(d_, e_);
+		Encounter g_(Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh tuple_fnbckkyclgcbujddfesqqggfh) => 
+			tuple_fnbckkyclgcbujddfesqqggfh.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Nutrition Assessment Status Moderately Or Severely Malnourished")]
+	public IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished() => 
+		__Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Observation> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Nutrition_Assessment();
+			var j_ = context.Operators.RetrieveByValueSet<Observation>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh c_(Encounter _QualifyingEncounter, Observation _NutritionAssessment)
+		{
+			var k_ = new Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				NutritionAssessment = _NutritionAssessment,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Observation, Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh tuple_fnbckkyclgcbujddfesqqggfh)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToConcept(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.Code);
+			var m_ = this.Nutrition_Assessment();
+			var n_ = context.Operators.ConceptInValueSet((l_ as CqlConcept), m_);
+			var o_ = context.Operators.Convert<Code<ObservationStatus>>(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.StatusElement?.Value);
+			var p_ = context.Operators.Convert<string>(o_);
+			var q_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var r_ = context.Operators.InList<string>(p_, (q_ as IEnumerable<string>));
+			var s_ = context.Operators.And(n_, r_);
+			var t_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_fnbckkyclgcbujddfesqqggfh.QualifyingEncounter);
+			var u_ = FHIRHelpers_4_3_000.ToValue(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.Effective);
+			var v_ = QICoreCommon_2_0_000.toInterval(u_);
+			var w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
+			var x_ = context.Operators.And(s_, w_);
+			var y_ = FHIRHelpers_4_3_000.ToValue(tuple_fnbckkyclgcbujddfesqqggfh.NutritionAssessment?.Value);
+			var z_ = this.Nutrition_Assessment_Status_Not_or_Mildly_Malnourished();
+			var aa_ = context.Operators.ConceptInValueSet((y_ as CqlConcept), z_);
+			var ab_ = context.Operators.And(x_, aa_);
+
+			return ab_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh>(d_, e_);
+		Encounter g_(Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh tuple_fnbckkyclgcbujddfesqqggfh) => 
+			tuple_fnbckkyclgcbujddfesqqggfh.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_FNbCKKYcLGcBUjDdFESQQgGfh, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Nutrition Assessment Not or Mildly Malnourished")]
+	public IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished() => 
+		__Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Malnutrition_Diagnosis_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Condition> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Malnutrition_Diagnosis();
+			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_DTggaXNYbDKaGBeEeceXhUMKb c_(Encounter _QualifyingEncounter, Condition _MalnutritionDiagnosis)
+		{
+			var k_ = new Tuples.Tuple_DTggaXNYbDKaGBeEeceXhUMKb
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				MalnutritionDiagnosis = _MalnutritionDiagnosis,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Condition, Tuples.Tuple_DTggaXNYbDKaGBeEeceXhUMKb>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_DTggaXNYbDKaGBeEeceXhUMKb tuple_dtggaxnybdkagbeeecexhumkb)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToConcept(tuple_dtggaxnybdkagbeeecexhumkb.MalnutritionDiagnosis?.Code);
+			var m_ = this.Malnutrition_Diagnosis();
+			var n_ = context.Operators.ConceptInValueSet((l_ as CqlConcept), m_);
+			var o_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_dtggaxnybdkagbeeecexhumkb.MalnutritionDiagnosis);
+			var p_ = context.Operators.Start(o_);
+			var q_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_dtggaxnybdkagbeeecexhumkb.QualifyingEncounter);
+			var r_ = context.Operators.ElementInInterval<CqlDateTime>(p_, q_, null);
+			var s_ = context.Operators.And(n_, r_);
+
+			return s_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_DTggaXNYbDKaGBeEeceXhUMKb>(d_, e_);
+		Encounter g_(Tuples.Tuple_DTggaXNYbDKaGBeEeceXhUMKb tuple_dtggaxnybdkagbeeecexhumkb) => 
+			tuple_dtggaxnybdkagbeeecexhumkb.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_DTggaXNYbDKaGBeEeceXhUMKb, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Malnutrition Diagnosis")]
+	public IEnumerable<Encounter> Encounter_with_Malnutrition_Diagnosis() => 
+		__Encounter_with_Malnutrition_Diagnosis.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Nutrition_Care_Plan_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Procedure> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Nutrition_Care_Plan();
+			var j_ = context.Operators.RetrieveByValueSet<Procedure>(i_, null);
+
+			return j_;
+		};
+		Tuples.Tuple_cTMBKgNETPhcWPSTMVcRebEg c_(Encounter _QualifyingEncounter, Procedure _NutritionCarePlan)
+		{
+			var k_ = new Tuples.Tuple_cTMBKgNETPhcWPSTMVcRebEg
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				NutritionCarePlan = _NutritionCarePlan,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Procedure, Tuples.Tuple_cTMBKgNETPhcWPSTMVcRebEg>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_cTMBKgNETPhcWPSTMVcRebEg tuple_ctmbkgnetphcwpstmvcrebeg)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToConcept(tuple_ctmbkgnetphcwpstmvcrebeg.NutritionCarePlan?.Code);
+			var m_ = this.Nutrition_Care_Plan();
+			var n_ = context.Operators.ConceptInValueSet((l_ as CqlConcept), m_);
+			var o_ = context.Operators.Convert<string>(tuple_ctmbkgnetphcwpstmvcrebeg.NutritionCarePlan?.StatusElement?.Value);
+			var p_ = new string[]
+			{
+				"completed",
+				"in-progress",
+			};
+			var q_ = context.Operators.InList<string>(o_, (p_ as IEnumerable<string>));
+			var r_ = context.Operators.And(n_, q_);
+			var s_ = FHIRHelpers_4_3_000.ToValue(tuple_ctmbkgnetphcwpstmvcrebeg.NutritionCarePlan?.Performed);
+			var t_ = QICoreCommon_2_0_000.earliest(s_);
+			var u_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_ctmbkgnetphcwpstmvcrebeg.QualifyingEncounter);
+			var v_ = context.Operators.ElementInInterval<CqlDateTime>(t_, u_, null);
+			var w_ = context.Operators.And(r_, v_);
+
+			return w_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_cTMBKgNETPhcWPSTMVcRebEg>(d_, e_);
+		Encounter g_(Tuples.Tuple_cTMBKgNETPhcWPSTMVcRebEg tuple_ctmbkgnetphcwpstmvcrebeg) => 
+			tuple_ctmbkgnetphcwpstmvcrebeg.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_cTMBKgNETPhcWPSTMVcRebEg, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Nutrition Care Plan")]
+	public IEnumerable<Encounter> Encounter_with_Nutrition_Care_Plan() => 
+		__Encounter_with_Nutrition_Care_Plan.Value;
+
+    [CqlDeclaration("Measure Observation 1")]
+	public int? Measure_Observation_1(Encounter MalnutritionRiskScreening) => 
+		((context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral(), MalnutritionRiskScreening) ?? false)
+			? (int?)1
+			: (int?)0);
+
+    [CqlDeclaration("Measure Observation 2")]
+	public int? Measure_Observation_2(Encounter NutritionAssessment)
+	{
+		int? a_()
+		{
+			if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral(), NutritionAssessment) ?? false))
+			{
+				return (int?)0;
+			}
+			else if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral(), NutritionAssessment) ?? false))
+			{
+				return ((context.Operators.ListContains<Encounter>(this.Encounter_with_Nutrition_Assessment_and_Identified_Status(), NutritionAssessment) ?? false)
+					? (int?)1
+					: (int?)0);
+			}
+			else
+			{
+				return (int?)0;
+			};
+		};
+
+		return a_();
+	}
+
+    [CqlDeclaration("Measure Observation 3")]
+	public int? Measure_Observation_3(Encounter MalnutritionDiagonsis)
+	{
+		int? a_()
+		{
+			if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral(), MalnutritionDiagonsis) ?? false))
+			{
+				return (int?)0;
+			}
+			else if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral(), MalnutritionDiagonsis) ?? false))
+			{
+				int? b_()
+				{
+					if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Diagnosis(), MalnutritionDiagonsis) ?? false))
+					{
+						int? c_()
+						{
+							if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished(), MalnutritionDiagonsis) ?? false))
+							{
+								return (int?)0;
+							}
+							else if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished(), MalnutritionDiagonsis) ?? false))
+							{
+								return (int?)1;
+							}
+							else
+							{
+								return (int?)0;
+							};
+						};
+
+						return c_();
+					}
+					else
+					{
+						return (int?)0;
+					};
+				};
+
+				return b_();
+			}
+			else
+			{
+				return (int?)0;
+			};
+		};
+
+		return a_();
+	}
+
+    [CqlDeclaration("Measure Observation 4")]
+	public int? Measure_Observation_4(Encounter NutritionCarePlan)
+	{
+		int? a_()
+		{
+			if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral(), NutritionCarePlan) ?? false))
+			{
+				return (int?)0;
+			}
+			else if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral(), NutritionCarePlan) ?? false))
+			{
+				int? b_()
+				{
+					if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Nutrition_Care_Plan(), NutritionCarePlan) ?? false))
+					{
+						int? c_()
+						{
+							if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished(), NutritionCarePlan) ?? false))
+							{
+								return (int?)0;
+							}
+							else if ((context.Operators.ListContains<Encounter>(this.Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished(), NutritionCarePlan) ?? false))
+							{
+								return (int?)1;
+							}
+							else
+							{
+								return (int?)0;
+							};
+						};
+
+						return c_();
+					}
+					else
+					{
+						return (int?)0;
+					};
+				};
+
+				return b_();
+			}
+			else
+			{
+				return (int?)0;
+			};
+		};
+
+		return a_();
+	}
+
+    [CqlDeclaration("Measure Observation TotalMalnutritionComponentsScore")]
+	public int? Measure_Observation_TotalMalnutritionComponentsScore(Encounter QualifyingEncounter)
+	{
+		var a_ = this.Measure_Observation_1(QualifyingEncounter);
+		var b_ = this.Measure_Observation_2(QualifyingEncounter);
+		var c_ = this.Measure_Observation_3(QualifyingEncounter);
+		var d_ = this.Measure_Observation_4(QualifyingEncounter);
+		var e_ = new int?[]
+		{
+			a_,
+			b_,
+			c_,
+			d_,
+		};
+		var f_ = context.Operators.Sum((e_ as IEnumerable<int?>));
+
+		return f_;
+	}
+
+    [CqlDeclaration("TotalMalnutritionCompositeScore Eligible Denominators")]
+	public int? TotalMalnutritionCompositeScore_Eligible_Denominators(Encounter QualifyingEncounter)
+	{
+		int? a_()
+		{
+			if ((context.Operators.And(context.Operators.And(context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral(), QualifyingEncounter), context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk(), QualifyingEncounter)), context.Operators.Not(context.Operators.ListContains<Encounter>(this.Encounter_with_Hospital_Dietitian_Referral(), QualifyingEncounter))) ?? false))
+			{
+				return (int?)1;
+			}
+			else if ((context.Operators.Or(context.Operators.And(context.Operators.Or(context.Operators.And(context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral(), QualifyingEncounter), context.Operators.ListContains<Encounter>(this.Encounter_with_Malnutrition_Risk_Screening_at_Risk(), QualifyingEncounter)), context.Operators.ListContains<Encounter>(this.Encounter_with_Hospital_Dietitian_Referral(), QualifyingEncounter)), context.Operators.ListContains<Encounter>(this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished(), QualifyingEncounter)), context.Operators.Not(context.Operators.ListContains<Encounter>(this.Encounter_with_Nutrition_Assessment_and_Identified_Status(), QualifyingEncounter))) ?? false))
+			{
+				return (int?)2;
+			}
+			else
+			{
+				return (int?)4;
+			};
+		};
+
+		return a_();
+	}
+
+    [CqlDeclaration("Measure Observation TotalMalnutritionCompositeScore as Percentage")]
+	public decimal? Measure_Observation_TotalMalnutritionCompositeScore_as_Percentage(Encounter QualifyingEncounter)
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal((int?)100);
+		var b_ = this.Measure_Observation_TotalMalnutritionComponentsScore(QualifyingEncounter);
+		var c_ = context.Operators.ConvertIntegerToDecimal(b_);
+		var d_ = this.TotalMalnutritionCompositeScore_Eligible_Denominators(QualifyingEncounter);
+		var e_ = context.Operators.ConvertIntegerToDecimal(d_);
+		var f_ = context.Operators.Divide(c_, e_);
+		var g_ = context.Operators.Multiply(a_, f_);
+
+		return g_;
+	}
+
+}

--- a/Demo/Measures-cms/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
+++ b/Demo/Measures-cms/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
@@ -1,0 +1,915 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("HFBetaBlockerTherapyforLVSDFHIR", "1.3.000")]
+public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Allergy_to_Beta_Blocker_Therapy;
+    internal Lazy<CqlValueSet> __Arrhythmia;
+    internal Lazy<CqlValueSet> __Asthma;
+    internal Lazy<CqlValueSet> __Atrioventricular_Block;
+    internal Lazy<CqlValueSet> __Beta_Blocker_Therapy_for_LVSD;
+    internal Lazy<CqlValueSet> __Beta_Blocker_Therapy_Ingredient;
+    internal Lazy<CqlValueSet> __Bradycardia;
+    internal Lazy<CqlValueSet> __Cardiac_Pacer;
+    internal Lazy<CqlValueSet> __Cardiac_Pacer_in_Situ;
+    internal Lazy<CqlValueSet> __Hypotension;
+    internal Lazy<CqlValueSet> __Intolerance_to_Beta_Blocker_Therapy;
+    internal Lazy<CqlValueSet> __Left_Ventricular_Assist_Device_Placement;
+    internal Lazy<CqlValueSet> __Medical_Reason;
+    internal Lazy<CqlValueSet> __Patient_Reason;
+    internal Lazy<CqlCode> __Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Has_Beta_Blocker_Therapy_for_LVSD_Ordered;
+    internal Lazy<bool?> __Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Has_Consecutive_Heart_Rates_Less_than_50;
+    internal Lazy<bool?> __Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD;
+    internal Lazy<bool?> __Has_Arrhythmia_Diagnosis;
+    internal Lazy<bool?> __Has_Hypotension_Diagnosis;
+    internal Lazy<bool?> __Has_Asthma_Diagnosis;
+    internal Lazy<bool?> __Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy;
+    internal Lazy<bool?> __Has_Bradycardia_Diagnosis;
+    internal Lazy<bool?> __Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient;
+    internal Lazy<bool?> __Has_Atrioventricular_Block_Diagnosis;
+    internal Lazy<bool?> __Has_Diagnosis_of_Cardiac_Pacer_in_Situ;
+    internal Lazy<bool?> __Has_Cardiac_Pacer_Device_Implanted;
+    internal Lazy<bool?> __Atrioventricular_Block_without_Cardiac_Pacer;
+    internal Lazy<bool?> __Denominator_Exceptions;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public HFBetaBlockerTherapyforLVSDFHIR_1_3_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        AHAOverall_2_6_000 = new AHAOverall_2_6_000(context);
+
+        __Allergy_to_Beta_Blocker_Therapy = new Lazy<CqlValueSet>(this.Allergy_to_Beta_Blocker_Therapy_Value);
+        __Arrhythmia = new Lazy<CqlValueSet>(this.Arrhythmia_Value);
+        __Asthma = new Lazy<CqlValueSet>(this.Asthma_Value);
+        __Atrioventricular_Block = new Lazy<CqlValueSet>(this.Atrioventricular_Block_Value);
+        __Beta_Blocker_Therapy_for_LVSD = new Lazy<CqlValueSet>(this.Beta_Blocker_Therapy_for_LVSD_Value);
+        __Beta_Blocker_Therapy_Ingredient = new Lazy<CqlValueSet>(this.Beta_Blocker_Therapy_Ingredient_Value);
+        __Bradycardia = new Lazy<CqlValueSet>(this.Bradycardia_Value);
+        __Cardiac_Pacer = new Lazy<CqlValueSet>(this.Cardiac_Pacer_Value);
+        __Cardiac_Pacer_in_Situ = new Lazy<CqlValueSet>(this.Cardiac_Pacer_in_Situ_Value);
+        __Hypotension = new Lazy<CqlValueSet>(this.Hypotension_Value);
+        __Intolerance_to_Beta_Blocker_Therapy = new Lazy<CqlValueSet>(this.Intolerance_to_Beta_Blocker_Therapy_Value);
+        __Left_Ventricular_Assist_Device_Placement = new Lazy<CqlValueSet>(this.Left_Ventricular_Assist_Device_Placement_Value);
+        __Medical_Reason = new Lazy<CqlValueSet>(this.Medical_Reason_Value);
+        __Patient_Reason = new Lazy<CqlValueSet>(this.Patient_Reason_Value);
+        __Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_ = new Lazy<CqlCode>(this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance__Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Has_Beta_Blocker_Therapy_for_LVSD_Ordered = new Lazy<bool?>(this.Has_Beta_Blocker_Therapy_for_LVSD_Ordered_Value);
+        __Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD = new Lazy<bool?>(this.Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __Has_Consecutive_Heart_Rates_Less_than_50 = new Lazy<bool?>(this.Has_Consecutive_Heart_Rates_Less_than_50_Value);
+        __Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD = new Lazy<bool?>(this.Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD_Value);
+        __Has_Arrhythmia_Diagnosis = new Lazy<bool?>(this.Has_Arrhythmia_Diagnosis_Value);
+        __Has_Hypotension_Diagnosis = new Lazy<bool?>(this.Has_Hypotension_Diagnosis_Value);
+        __Has_Asthma_Diagnosis = new Lazy<bool?>(this.Has_Asthma_Diagnosis_Value);
+        __Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy = new Lazy<bool?>(this.Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Value);
+        __Has_Bradycardia_Diagnosis = new Lazy<bool?>(this.Has_Bradycardia_Diagnosis_Value);
+        __Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient = new Lazy<bool?>(this.Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_Value);
+        __Has_Atrioventricular_Block_Diagnosis = new Lazy<bool?>(this.Has_Atrioventricular_Block_Diagnosis_Value);
+        __Has_Diagnosis_of_Cardiac_Pacer_in_Situ = new Lazy<bool?>(this.Has_Diagnosis_of_Cardiac_Pacer_in_Situ_Value);
+        __Has_Cardiac_Pacer_Device_Implanted = new Lazy<bool?>(this.Has_Cardiac_Pacer_Device_Implanted_Value);
+        __Atrioventricular_Block_without_Cardiac_Pacer = new Lazy<bool?>(this.Atrioventricular_Block_without_Cardiac_Pacer_Value);
+        __Denominator_Exceptions = new Lazy<bool?>(this.Denominator_Exceptions_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public AHAOverall_2_6_000 AHAOverall_2_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Allergy_to_Beta_Blocker_Therapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", null);
+
+    [CqlDeclaration("Allergy to Beta Blocker Therapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177")]
+	public CqlValueSet Allergy_to_Beta_Blocker_Therapy() => 
+		__Allergy_to_Beta_Blocker_Therapy.Value;
+
+	private CqlValueSet Arrhythmia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", null);
+
+    [CqlDeclaration("Arrhythmia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366")]
+	public CqlValueSet Arrhythmia() => 
+		__Arrhythmia.Value;
+
+	private CqlValueSet Asthma_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", null);
+
+    [CqlDeclaration("Asthma")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362")]
+	public CqlValueSet Asthma() => 
+		__Asthma.Value;
+
+	private CqlValueSet Atrioventricular_Block_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", null);
+
+    [CqlDeclaration("Atrioventricular Block")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367")]
+	public CqlValueSet Atrioventricular_Block() => 
+		__Atrioventricular_Block.Value;
+
+	private CqlValueSet Beta_Blocker_Therapy_for_LVSD_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", null);
+
+    [CqlDeclaration("Beta Blocker Therapy for LVSD")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184")]
+	public CqlValueSet Beta_Blocker_Therapy_for_LVSD() => 
+		__Beta_Blocker_Therapy_for_LVSD.Value;
+
+	private CqlValueSet Beta_Blocker_Therapy_Ingredient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", null);
+
+    [CqlDeclaration("Beta Blocker Therapy Ingredient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493")]
+	public CqlValueSet Beta_Blocker_Therapy_Ingredient() => 
+		__Beta_Blocker_Therapy_Ingredient.Value;
+
+	private CqlValueSet Bradycardia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", null);
+
+    [CqlDeclaration("Bradycardia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412")]
+	public CqlValueSet Bradycardia() => 
+		__Bradycardia.Value;
+
+	private CqlValueSet Cardiac_Pacer_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", null);
+
+    [CqlDeclaration("Cardiac Pacer")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53")]
+	public CqlValueSet Cardiac_Pacer() => 
+		__Cardiac_Pacer.Value;
+
+	private CqlValueSet Cardiac_Pacer_in_Situ_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", null);
+
+    [CqlDeclaration("Cardiac Pacer in Situ")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368")]
+	public CqlValueSet Cardiac_Pacer_in_Situ() => 
+		__Cardiac_Pacer_in_Situ.Value;
+
+	private CqlValueSet Hypotension_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", null);
+
+    [CqlDeclaration("Hypotension")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370")]
+	public CqlValueSet Hypotension() => 
+		__Hypotension.Value;
+
+	private CqlValueSet Intolerance_to_Beta_Blocker_Therapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", null);
+
+    [CqlDeclaration("Intolerance to Beta Blocker Therapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178")]
+	public CqlValueSet Intolerance_to_Beta_Blocker_Therapy() => 
+		__Intolerance_to_Beta_Blocker_Therapy.Value;
+
+	private CqlValueSet Left_Ventricular_Assist_Device_Placement_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", null);
+
+    [CqlDeclaration("Left Ventricular Assist Device Placement")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61")]
+	public CqlValueSet Left_Ventricular_Assist_Device_Placement() => 
+		__Left_Ventricular_Assist_Device_Placement.Value;
+
+	private CqlValueSet Medical_Reason_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlDeclaration("Medical Reason")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
+	public CqlValueSet Medical_Reason() => 
+		__Medical_Reason.Value;
+
+	private CqlValueSet Patient_Reason_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+
+    [CqlDeclaration("Patient Reason")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
+	public CqlValueSet Patient_Reason() => 
+		__Patient_Reason.Value;
+
+	private CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance__Value() => 
+		new CqlCode("373254001", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Substance with beta adrenergic receptor antagonist mechanism of action (substance)")]
+	public CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_() => 
+		__Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("373254001", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("HFBetaBlockerTherapyforLVSDFHIR-1.3.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.GreaterOrEqual(f_, (int?)18);
+		var h_ = AHAOverall_2_6_000.Qualifying_Outpatient_Encounter_During_Measurement_Period();
+		var i_ = context.Operators.CountOrNull<Encounter>(h_);
+		var j_ = context.Operators.GreaterOrEqual(i_, (int?)2);
+		var k_ = context.Operators.And(g_, j_);
+		var l_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter();
+		var m_ = context.Operators.ExistsInList<Encounter>(l_);
+		var n_ = context.Operators.And(k_, m_);
+
+		return n_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+		var b_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+		var c_ = context.Operators.ExistsInList<Encounter>(b_);
+		var d_ = context.Operators.And(a_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = AHAOverall_2_6_000.Has_Heart_Transplant();
+		var b_ = AHAOverall_2_6_000.Has_Heart_Transplant_Complications();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = AHAOverall_2_6_000.Has_Left_Ventricular_Assist_Device();
+		var e_ = context.Operators.Or(c_, d_);
+		var f_ = AHAOverall_2_6_000.Has_Left_Ventricular_Assist_Device_Complications();
+		var g_ = context.Operators.Or(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private bool? Has_Beta_Blocker_Therapy_for_LVSD_Ordered_Value()
+	{
+		var a_ = this.Beta_Blocker_Therapy_for_LVSD();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		bool? f_(MedicationRequest BetaBlockerOrdered)
+		{
+			var i_ = AHAOverall_2_6_000.isOrderedDuringHeartFailureOutpatientEncounter(BetaBlockerOrdered);
+			var j_ = context.Operators.Convert<string>(BetaBlockerOrdered?.StatusElement?.Value);
+			var k_ = new string[]
+			{
+				"active",
+				"completed",
+			};
+			var l_ = context.Operators.InList<string>(j_, (k_ as IEnumerable<string>));
+			var m_ = context.Operators.And(i_, l_);
+			var n_ = context.Operators.Convert<string>(BetaBlockerOrdered?.IntentElement?.Value);
+			var o_ = new string[]
+			{
+				"order",
+				"original-order",
+				"reflex-order",
+				"filler-order",
+				"instance-order",
+			};
+			var p_ = context.Operators.InList<string>(n_, (o_ as IEnumerable<string>));
+			var q_ = context.Operators.And(m_, p_);
+
+			return q_;
+		};
+		var g_ = context.Operators.WhereOrNull<MedicationRequest>(e_, f_);
+		var h_ = context.Operators.ExistsInList<MedicationRequest>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Has Beta Blocker Therapy for LVSD Ordered")]
+	public bool? Has_Beta_Blocker_Therapy_for_LVSD_Ordered() => 
+		__Has_Beta_Blocker_Therapy_for_LVSD_Ordered.Value;
+
+	private bool? Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD_Value()
+	{
+		var a_ = this.Beta_Blocker_Therapy_for_LVSD();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		bool? f_(MedicationRequest ActiveBetaBlocker)
+		{
+			var i_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((ActiveBetaBlocker as object));
+
+			return i_;
+		};
+		var g_ = context.Operators.WhereOrNull<MedicationRequest>(e_, f_);
+		var h_ = context.Operators.ExistsInList<MedicationRequest>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Is Currently Taking Beta Blocker Therapy for LVSD")]
+	public bool? Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD() => 
+		__Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Has_Beta_Blocker_Therapy_for_LVSD_Ordered();
+		var b_ = this.Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD();
+		var c_ = context.Operators.Or(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private bool? Has_Consecutive_Heart_Rates_Less_than_50_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Encounter> b_(Observation _HeartRate)
+		{
+			var j_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+
+			return j_;
+		};
+		Tuples.Tuple_FgYDjIJBhiXdBHJjiISjVeOjV c_(Observation _HeartRate, Encounter _ModerateOrSevereLVSDHFOutpatientEncounter)
+		{
+			var k_ = new Tuples.Tuple_FgYDjIJBhiXdBHJjiISjVeOjV
+			{
+				HeartRate = _HeartRate,
+				ModerateOrSevereLVSDHFOutpatientEncounter = _ModerateOrSevereLVSDHFOutpatientEncounter,
+			};
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Observation, Encounter, Tuples.Tuple_FgYDjIJBhiXdBHJjiISjVeOjV>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_FgYDjIJBhiXdBHJjiISjVeOjV tuple_fgydjijbhixdbhjjiisjveojv)
+		{
+			var l_ = FHIRHelpers_4_3_000.ToInterval(tuple_fgydjijbhixdbhjjiisjveojv.ModerateOrSevereLVSDHFOutpatientEncounter?.Period);
+			var m_ = FHIRHelpers_4_3_000.ToValue(tuple_fgydjijbhixdbhjjiisjveojv.HeartRate?.Effective);
+			var n_ = QICoreCommon_2_0_000.toInterval(m_);
+			var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, null);
+			var p_ = context.Operators.Convert<string>(tuple_fgydjijbhixdbhjjiisjveojv.HeartRate?.StatusElement?.Value);
+			var q_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var r_ = context.Operators.InList<string>(p_, (q_ as IEnumerable<string>));
+			var s_ = context.Operators.And(o_, r_);
+			var t_ = context.Operators.Convert<Quantity>(tuple_fgydjijbhixdbhjjiisjveojv.HeartRate?.Value);
+			var u_ = FHIRHelpers_4_3_000.ToQuantity(t_);
+			var v_ = context.Operators.Quantity(50m, "/min");
+			var w_ = context.Operators.Less(u_, v_);
+			var x_ = context.Operators.And(s_, w_);
+			var y_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? z_(Observation MostRecentPriorHeartRate)
+			{
+				var aj_ = FHIRHelpers_4_3_000.ToInterval(tuple_fgydjijbhixdbhjjiisjveojv.ModerateOrSevereLVSDHFOutpatientEncounter?.Period);
+				var ak_ = FHIRHelpers_4_3_000.ToValue(MostRecentPriorHeartRate?.Effective);
+				var al_ = QICoreCommon_2_0_000.toInterval(ak_);
+				var am_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aj_, al_, null);
+				var ao_ = QICoreCommon_2_0_000.toInterval(ak_);
+				var ap_ = FHIRHelpers_4_3_000.ToValue(tuple_fgydjijbhixdbhjjiisjveojv.HeartRate?.Effective);
+				var aq_ = QICoreCommon_2_0_000.toInterval(ap_);
+				var ar_ = context.Operators.IntervalBeforeInterval(ao_, aq_, null);
+				var as_ = context.Operators.And(am_, ar_);
+
+				return as_;
+			};
+			var aa_ = context.Operators.WhereOrNull<Observation>(y_, z_);
+			object ab_(Observation @this)
+			{
+				var at_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var au_ = QICoreCommon_2_0_000.toInterval(at_);
+				var av_ = context.Operators.Start(au_);
+
+				return av_;
+			};
+			var ac_ = context.Operators.ListSortBy<Observation>(aa_, ab_, System.ComponentModel.ListSortDirection.Ascending);
+			var ad_ = context.Operators.LastOfList<Observation>(ac_);
+			var ae_ = context.Operators.Convert<Quantity>(ad_?.Value);
+			var af_ = FHIRHelpers_4_3_000.ToQuantity(ae_);
+			var ah_ = context.Operators.Less(af_, v_);
+			var ai_ = context.Operators.And(x_, ah_);
+
+			return ai_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_FgYDjIJBhiXdBHJjiISjVeOjV>(d_, e_);
+		Observation g_(Tuples.Tuple_FgYDjIJBhiXdBHJjiISjVeOjV tuple_fgydjijbhixdbhjjiisjveojv) => 
+			tuple_fgydjijbhixdbhjjiisjveojv.HeartRate;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_FgYDjIJBhiXdBHJjiISjVeOjV, Observation>(f_, g_);
+		var i_ = context.Operators.ExistsInList<Observation>(h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Has Consecutive Heart Rates Less than 50")]
+	public bool? Has_Consecutive_Heart_Rates_Less_than_50() => 
+		__Has_Consecutive_Heart_Rates_Less_than_50.Value;
+
+	private bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<MedicationRequest>(null, null);
+		IEnumerable<MedicationRequest> b_(MedicationRequest NoBetaBlockerOrdered)
+		{
+			var g_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+			bool? h_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
+			{
+				var l_ = context.Operators.Convert<CqlDateTime>(NoBetaBlockerOrdered?.AuthoredOnElement);
+				var m_ = FHIRHelpers_4_3_000.ToInterval(ModerateOrSevereLVSDHFOutpatientEncounter?.Period);
+				var n_ = context.Operators.ElementInInterval<CqlDateTime>(l_, m_, null);
+
+				return n_;
+			};
+			var i_ = context.Operators.WhereOrNull<Encounter>(g_, h_);
+			MedicationRequest j_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => 
+				NoBetaBlockerOrdered;
+			var k_ = context.Operators.SelectOrNull<Encounter, MedicationRequest>(i_, j_);
+
+			return k_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<MedicationRequest, MedicationRequest>(a_, b_);
+		bool? d_(MedicationRequest NoBetaBlockerOrdered)
+		{
+			var o_ = context.Operators.Convert<CodeableConcept>(NoBetaBlockerOrdered?.Medication);
+			var p_ = FHIRHelpers_4_3_000.ToConcept(o_);
+			var q_ = this.Beta_Blocker_Therapy_for_LVSD();
+			var r_ = context.Operators.ConceptInValueSet(p_, q_);
+			CqlConcept s_(CodeableConcept @this)
+			{
+				var ac_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return ac_;
+			};
+			var t_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(NoBetaBlockerOrdered?.ReasonCode, s_);
+			var u_ = this.Medical_Reason();
+			var v_ = context.Operators.ConceptsInValueSet(t_, u_);
+			CqlConcept w_(CodeableConcept @this)
+			{
+				var ad_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return ad_;
+			};
+			var x_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(NoBetaBlockerOrdered?.ReasonCode, w_);
+			var y_ = this.Patient_Reason();
+			var z_ = context.Operators.ConceptsInValueSet(x_, y_);
+			var aa_ = context.Operators.Or(v_, z_);
+			var ab_ = context.Operators.And(r_, aa_);
+
+			return ab_;
+		};
+		var e_ = context.Operators.WhereOrNull<MedicationRequest>(c_, d_);
+		var f_ = context.Operators.ExistsInList<MedicationRequest>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Medical or Patient Reason for Not Ordering Beta Blocker for LVSD")]
+	public bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD() => 
+		__Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD.Value;
+
+	private bool? Has_Arrhythmia_Diagnosis_Value()
+	{
+		var a_ = this.Arrhythmia();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition Arrhythmia)
+		{
+			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Arrhythmia);
+			var g_ = QICoreCommon_2_0_000.isActive(Arrhythmia);
+			var h_ = context.Operators.And(f_, g_);
+			var i_ = FHIRHelpers_4_3_000.ToConcept(Arrhythmia?.VerificationStatus);
+			var j_ = QICoreCommon_2_0_000.confirmed();
+			var k_ = context.Operators.ConvertCodeToConcept(j_);
+			var l_ = context.Operators.Equivalent(i_, k_);
+			var m_ = context.Operators.And(h_, l_);
+
+			return m_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Arrhythmia Diagnosis")]
+	public bool? Has_Arrhythmia_Diagnosis() => 
+		__Has_Arrhythmia_Diagnosis.Value;
+
+	private bool? Has_Hypotension_Diagnosis_Value()
+	{
+		var a_ = this.Hypotension();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition Hypotension)
+		{
+			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Hypotension);
+			var g_ = QICoreCommon_2_0_000.isActive(Hypotension);
+			var h_ = context.Operators.And(f_, g_);
+			var i_ = FHIRHelpers_4_3_000.ToConcept(Hypotension?.VerificationStatus);
+			var j_ = QICoreCommon_2_0_000.confirmed();
+			var k_ = context.Operators.ConvertCodeToConcept(j_);
+			var l_ = context.Operators.Equivalent(i_, k_);
+			var m_ = context.Operators.And(h_, l_);
+
+			return m_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Hypotension Diagnosis")]
+	public bool? Has_Hypotension_Diagnosis() => 
+		__Has_Hypotension_Diagnosis.Value;
+
+	private bool? Has_Asthma_Diagnosis_Value()
+	{
+		var a_ = this.Asthma();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition Asthma)
+		{
+			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Asthma);
+			var g_ = QICoreCommon_2_0_000.isActive(Asthma);
+			var h_ = context.Operators.And(f_, g_);
+			var i_ = FHIRHelpers_4_3_000.ToConcept(Asthma?.VerificationStatus);
+			var j_ = QICoreCommon_2_0_000.confirmed();
+			var k_ = context.Operators.ConvertCodeToConcept(j_);
+			var l_ = context.Operators.Equivalent(i_, k_);
+			var m_ = context.Operators.And(h_, l_);
+
+			return m_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Asthma Diagnosis")]
+	public bool? Has_Asthma_Diagnosis() => 
+		__Has_Asthma_Diagnosis.Value;
+
+	private bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Value()
+	{
+		var a_ = this.Allergy_to_Beta_Blocker_Therapy();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = this.Intolerance_to_Beta_Blocker_Therapy();
+		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		var e_ = context.Operators.ListUnion<Condition>(b_, d_);
+		bool? f_(Condition BetaBlockerAllergyOrIntoleranceDiagnosis)
+		{
+			var i_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((BetaBlockerAllergyOrIntoleranceDiagnosis as object));
+			var j_ = QICoreCommon_2_0_000.isActive(BetaBlockerAllergyOrIntoleranceDiagnosis);
+			var k_ = context.Operators.And(i_, j_);
+			var l_ = FHIRHelpers_4_3_000.ToConcept(BetaBlockerAllergyOrIntoleranceDiagnosis?.VerificationStatus);
+			var m_ = QICoreCommon_2_0_000.confirmed();
+			var n_ = context.Operators.ConvertCodeToConcept(m_);
+			var o_ = context.Operators.Equivalent(l_, n_);
+			var p_ = context.Operators.And(k_, o_);
+
+			return p_;
+		};
+		var g_ = context.Operators.WhereOrNull<Condition>(e_, f_);
+		var h_ = context.Operators.ExistsInList<Condition>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Has Diagnosis of Allergy or Intolerance to Beta Blocker Therapy")]
+	public bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy() => 
+		__Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy.Value;
+
+	private bool? Has_Bradycardia_Diagnosis_Value()
+	{
+		var a_ = this.Bradycardia();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition Bradycardia)
+		{
+			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Bradycardia);
+			var g_ = QICoreCommon_2_0_000.isActive(Bradycardia);
+			var h_ = context.Operators.And(f_, g_);
+			var i_ = FHIRHelpers_4_3_000.ToConcept(Bradycardia?.VerificationStatus);
+			var j_ = QICoreCommon_2_0_000.confirmed();
+			var k_ = context.Operators.ConvertCodeToConcept(j_);
+			var l_ = context.Operators.Equivalent(i_, k_);
+			var m_ = context.Operators.And(h_, l_);
+
+			return m_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Bradycardia Diagnosis")]
+	public bool? Has_Bradycardia_Diagnosis() => 
+		__Has_Bradycardia_Diagnosis.Value;
+
+	private bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_Value()
+	{
+		var a_ = this.Beta_Blocker_Therapy_Ingredient();
+		var b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, null);
+		var c_ = this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_();
+		var d_ = context.Operators.ToList<CqlCode>(c_);
+		var e_ = context.Operators.RetrieveByCodes<AllergyIntolerance>(d_, null);
+		var f_ = context.Operators.ListUnion<AllergyIntolerance>(b_, e_);
+		bool? g_(AllergyIntolerance BetaBlockerAllergyIntolerance)
+		{
+			var j_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((BetaBlockerAllergyIntolerance as object));
+			var k_ = FHIRHelpers_4_3_000.ToConcept(BetaBlockerAllergyIntolerance?.ClinicalStatus);
+			var m_ = QICoreCommon_2_0_000.allergy_active();
+			var n_ = context.Operators.ConvertCodeToConcept(m_);
+			var o_ = context.Operators.Equivalent(k_, n_);
+			var p_ = context.Operators.Or((bool?)(k_ is null), o_);
+			var q_ = context.Operators.And(j_, p_);
+
+			return q_;
+		};
+		var h_ = context.Operators.WhereOrNull<AllergyIntolerance>(f_, g_);
+		var i_ = context.Operators.ExistsInList<AllergyIntolerance>(h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Has Allergy or Intolerance to Beta Blocker Therapy Ingredient")]
+	public bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient() => 
+		__Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient.Value;
+
+	private bool? Has_Atrioventricular_Block_Diagnosis_Value()
+	{
+		var a_ = this.Atrioventricular_Block();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition AtrioventricularBlock)
+		{
+			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(AtrioventricularBlock);
+			var g_ = QICoreCommon_2_0_000.isActive(AtrioventricularBlock);
+			var h_ = context.Operators.And(f_, g_);
+			var i_ = FHIRHelpers_4_3_000.ToConcept(AtrioventricularBlock?.VerificationStatus);
+			var j_ = QICoreCommon_2_0_000.confirmed();
+			var k_ = context.Operators.ConvertCodeToConcept(j_);
+			var l_ = context.Operators.Equivalent(i_, k_);
+			var m_ = context.Operators.And(h_, l_);
+
+			return m_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Atrioventricular Block Diagnosis")]
+	public bool? Has_Atrioventricular_Block_Diagnosis() => 
+		__Has_Atrioventricular_Block_Diagnosis.Value;
+
+	private bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ_Value()
+	{
+		var a_ = this.Cardiac_Pacer_in_Situ();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition CardiacPacerDiagnosis)
+		{
+			var f_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((CardiacPacerDiagnosis as object));
+			var g_ = QICoreCommon_2_0_000.isActive(CardiacPacerDiagnosis);
+			var h_ = context.Operators.And(f_, g_);
+			var i_ = FHIRHelpers_4_3_000.ToConcept(CardiacPacerDiagnosis?.VerificationStatus);
+			var j_ = QICoreCommon_2_0_000.confirmed();
+			var k_ = context.Operators.ConvertCodeToConcept(j_);
+			var l_ = context.Operators.Equivalent(i_, k_);
+			var m_ = context.Operators.And(h_, l_);
+
+			return m_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Diagnosis of Cardiac Pacer in Situ")]
+	public bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ() => 
+		__Has_Diagnosis_of_Cardiac_Pacer_in_Situ.Value;
+
+	private bool? Has_Cardiac_Pacer_Device_Implanted_Value()
+	{
+		var a_ = this.Cardiac_Pacer();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer)
+		{
+			var h_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+			bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
+			{
+				var m_ = FHIRHelpers_4_3_000.ToValue(ImplantedCardiacPacer?.Performed);
+				var n_ = QICoreCommon_2_0_000.toInterval(m_);
+				var o_ = context.Operators.Start(n_);
+				var p_ = FHIRHelpers_4_3_000.ToInterval(ModerateOrSevereLVSDHFOutpatientEncounter?.Period);
+				var q_ = context.Operators.End(p_);
+				var r_ = context.Operators.Before(o_, q_, null);
+
+				return r_;
+			};
+			var j_ = context.Operators.WhereOrNull<Encounter>(h_, i_);
+			Procedure k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => 
+				ImplantedCardiacPacer;
+			var l_ = context.Operators.SelectOrNull<Encounter, Procedure>(j_, k_);
+
+			return l_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(b_, c_);
+		bool? e_(Procedure ImplantedCardiacPacer)
+		{
+			var s_ = context.Operators.EnumEqualsString(ImplantedCardiacPacer?.StatusElement?.Value, "completed");
+
+			return s_;
+		};
+		var f_ = context.Operators.WhereOrNull<Procedure>(d_, e_);
+		var g_ = context.Operators.ExistsInList<Procedure>(f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Has Cardiac Pacer Device Implanted")]
+	public bool? Has_Cardiac_Pacer_Device_Implanted() => 
+		__Has_Cardiac_Pacer_Device_Implanted.Value;
+
+	private bool? Atrioventricular_Block_without_Cardiac_Pacer_Value()
+	{
+		var a_ = this.Has_Atrioventricular_Block_Diagnosis();
+		var b_ = this.Has_Diagnosis_of_Cardiac_Pacer_in_Situ();
+		var c_ = context.Operators.Not(b_);
+		var d_ = context.Operators.And(a_, c_);
+		var e_ = this.Has_Cardiac_Pacer_Device_Implanted();
+		var f_ = context.Operators.Not(e_);
+		var g_ = context.Operators.And(d_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Atrioventricular Block without Cardiac Pacer")]
+	public bool? Atrioventricular_Block_without_Cardiac_Pacer() => 
+		__Atrioventricular_Block_without_Cardiac_Pacer.Value;
+
+	private bool? Denominator_Exceptions_Value()
+	{
+		var a_ = this.Has_Consecutive_Heart_Rates_Less_than_50();
+		var b_ = this.Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = this.Has_Arrhythmia_Diagnosis();
+		var e_ = context.Operators.Or(c_, d_);
+		var f_ = this.Has_Hypotension_Diagnosis();
+		var g_ = context.Operators.Or(e_, f_);
+		var h_ = this.Has_Asthma_Diagnosis();
+		var i_ = context.Operators.Or(g_, h_);
+		var j_ = this.Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy();
+		var k_ = context.Operators.Or(i_, j_);
+		var l_ = this.Has_Bradycardia_Diagnosis();
+		var m_ = context.Operators.Or(k_, l_);
+		var n_ = this.Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient();
+		var o_ = context.Operators.Or(m_, n_);
+		var p_ = this.Atrioventricular_Block_without_Cardiac_Pacer();
+		var q_ = context.Operators.Or(o_, p_);
+
+		return q_;
+	}
+
+    [CqlDeclaration("Denominator Exceptions")]
+	public bool? Denominator_Exceptions() => 
+		__Denominator_Exceptions.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/HIVRetentionFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/HIVRetentionFHIR-0.1.000.g.cs
@@ -1,0 +1,777 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("HIVRetentionFHIR", "0.1.000")]
+public class HIVRetentionFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Face_to_Face_Interaction;
+    internal Lazy<CqlValueSet> __HIV;
+    internal Lazy<CqlValueSet> __HIV_Viral_Load;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care__Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Other;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<bool?> __Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period;
+    internal Lazy<bool?> __Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_During_Measurement_Period_With_HIV;
+    internal Lazy<bool?> __Has_HIV_Viral_Load_Test_During_Measurement_Period;
+    internal Lazy<bool?> __Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart;
+    internal Lazy<bool?> __Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public HIVRetentionFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CumulativeMedicationDuration_4_0_000 = new CumulativeMedicationDuration_4_0_000(context);
+
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value);
+        __Face_to_Face_Interaction = new Lazy<CqlValueSet>(this.Face_to_Face_Interaction_Value);
+        __HIV = new Lazy<CqlValueSet>(this.HIV_Value);
+        __HIV_Viral_Load = new Lazy<CqlValueSet>(this.HIV_Viral_Load_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value);
+        __Preventive_Care__Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Established_Office_Visit__0_to_17_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Preventive_Care_Services_Other = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Other_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period = new Lazy<bool?>(this.Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period_Value);
+        __Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period = new Lazy<bool?>(this.Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Encounter_During_Measurement_Period_With_HIV = new Lazy<IEnumerable<Encounter>>(this.Encounter_During_Measurement_Period_With_HIV_Value);
+        __Has_HIV_Viral_Load_Test_During_Measurement_Period = new Lazy<bool?>(this.Has_HIV_Viral_Load_Test_During_Measurement_Period_Value);
+        __Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart = new Lazy<bool?>(this.Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart_Value);
+        __Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart = new Lazy<bool?>(this.Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+    }
+    #region Dependencies
+
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CumulativeMedicationDuration_4_0_000 CumulativeMedicationDuration_4_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Annual_Wellness_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+
+    [CqlDeclaration("Annual Wellness Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit.Value;
+
+	private CqlValueSet Face_to_Face_Interaction_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+
+    [CqlDeclaration("Face-to-Face Interaction")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
+	public CqlValueSet Face_to_Face_Interaction() => 
+		__Face_to_Face_Interaction.Value;
+
+	private CqlValueSet HIV_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+
+    [CqlDeclaration("HIV")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
+	public CqlValueSet HIV() => 
+		__HIV.Value;
+
+	private CqlValueSet HIV_Viral_Load_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", null);
+
+    [CqlDeclaration("HIV Viral Load")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002")]
+	public CqlValueSet HIV_Viral_Load() => 
+		__HIV_Viral_Load.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+
+    [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
+	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+
+    [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
+	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
+		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlValueSet Preventive_Care_Services_Other_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150", null);
+
+    [CqlDeclaration("Preventive Care Services Other")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150")]
+	public CqlValueSet Preventive_Care_Services_Other() => 
+		__Preventive_Care_Services_Other.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("HIVRetentionFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		List<Extension> a_()
+		{
+			if (this.Patient() is DomainResource)
+			{
+				var i_ = this.Patient();
+
+				return (i_ as DomainResource).Extension;
+			}
+			else
+			{
+				return null;
+			};
+		};
+		bool? b_(Extension @this)
+		{
+			var j_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
+
+			return j_;
+		};
+		var c_ = context.Operators.WhereOrNull<Extension>(a_(), b_);
+		var d_ = context.Operators.SingleOrNull<Extension>(c_);
+		var e_ = new Extension[]
+		{
+			d_,
+		};
+		Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB f_(Extension E)
+		{
+			bool? k_(Extension @this)
+			{
+				var ag_ = context.Operators.Equal(@this?.Url, "ombCategory");
+
+				return ag_;
+			};
+			var l_ = context.Operators.WhereOrNull<Extension>(((E is Element)
+					? ((E as Element).Extension)
+					: null), k_);
+			DataType m_(Extension @this) => 
+				@this?.Value;
+			var n_ = context.Operators.SelectOrNull<Extension, DataType>(l_, m_);
+			var o_ = context.Operators.SingleOrNull<DataType>(n_);
+			var p_ = context.Operators.Convert<Coding>(o_);
+			var q_ = FHIRHelpers_4_3_000.ToCode(p_);
+			var r_ = new CqlCode[]
+			{
+				q_,
+			};
+			bool? s_(Extension @this)
+			{
+				var ah_ = context.Operators.Equal(@this?.Url, "detailed");
+
+				return ah_;
+			};
+			var t_ = context.Operators.WhereOrNull<Extension>(((E is Element)
+					? ((E as Element).Extension)
+					: null), s_);
+			var v_ = context.Operators.SelectOrNull<Extension, DataType>(t_, m_);
+			CqlCode w_(DataType @this)
+			{
+				var ai_ = context.Operators.Convert<Coding>(@this);
+				var aj_ = FHIRHelpers_4_3_000.ToCode(ai_);
+
+				return aj_;
+			};
+			var x_ = context.Operators.SelectOrNull<DataType, CqlCode>(v_, w_);
+			var y_ = context.Operators.ValueSetUnion((r_ as IEnumerable<CqlCode>), x_);
+			bool? z_(Extension @this)
+			{
+				var ak_ = context.Operators.Equal(@this?.Url, "text");
+
+				return ak_;
+			};
+			var aa_ = context.Operators.WhereOrNull<Extension>(((E is Element)
+					? ((E as Element).Extension)
+					: null), z_);
+			var ac_ = context.Operators.SelectOrNull<Extension, DataType>(aa_, m_);
+			var ad_ = context.Operators.SingleOrNull<DataType>(ac_);
+			var ae_ = context.Operators.Convert<string>(ad_);
+			var af_ = new Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB
+			{
+				codes = y_,
+				display = ae_,
+			};
+
+			return af_;
+		};
+		var g_ = context.Operators.SelectOrNull<Extension, Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(e_, f_);
+		var h_ = context.Operators.SingleOrNull<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		List<Extension> a_()
+		{
+			if (this.Patient() is DomainResource)
+			{
+				var i_ = this.Patient();
+
+				return (i_ as DomainResource).Extension;
+			}
+			else
+			{
+				return null;
+			};
+		};
+		bool? b_(Extension @this)
+		{
+			var j_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race");
+
+			return j_;
+		};
+		var c_ = context.Operators.WhereOrNull<Extension>(a_(), b_);
+		var d_ = context.Operators.SingleOrNull<Extension>(c_);
+		var e_ = new Extension[]
+		{
+			d_,
+		};
+		Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB f_(Extension R)
+		{
+			bool? k_(Extension @this)
+			{
+				var ae_ = context.Operators.Equal(@this?.Url, "ombCategory");
+
+				return ae_;
+			};
+			var l_ = context.Operators.WhereOrNull<Extension>(((R is Element)
+					? ((R as Element).Extension)
+					: null), k_);
+			DataType m_(Extension @this) => 
+				@this?.Value;
+			var n_ = context.Operators.SelectOrNull<Extension, DataType>(l_, m_);
+			CqlCode o_(DataType @this)
+			{
+				var af_ = context.Operators.Convert<Coding>(@this);
+				var ag_ = FHIRHelpers_4_3_000.ToCode(af_);
+
+				return ag_;
+			};
+			var p_ = context.Operators.SelectOrNull<DataType, CqlCode>(n_, o_);
+			bool? q_(Extension @this)
+			{
+				var ah_ = context.Operators.Equal(@this?.Url, "detailed");
+
+				return ah_;
+			};
+			var r_ = context.Operators.WhereOrNull<Extension>(((R is Element)
+					? ((R as Element).Extension)
+					: null), q_);
+			var t_ = context.Operators.SelectOrNull<Extension, DataType>(r_, m_);
+			CqlCode u_(DataType @this)
+			{
+				var ai_ = context.Operators.Convert<Coding>(@this);
+				var aj_ = FHIRHelpers_4_3_000.ToCode(ai_);
+
+				return aj_;
+			};
+			var v_ = context.Operators.SelectOrNull<DataType, CqlCode>(t_, u_);
+			var w_ = context.Operators.ValueSetUnion(p_, v_);
+			bool? x_(Extension @this)
+			{
+				var ak_ = context.Operators.Equal(@this?.Url, "text");
+
+				return ak_;
+			};
+			var y_ = context.Operators.WhereOrNull<Extension>(((R is Element)
+					? ((R as Element).Extension)
+					: null), x_);
+			var aa_ = context.Operators.SelectOrNull<Extension, DataType>(y_, m_);
+			var ab_ = context.Operators.SingleOrNull<DataType>(aa_);
+			var ac_ = context.Operators.Convert<string>(ab_);
+			var ad_ = new Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB
+			{
+				codes = w_,
+				display = ac_,
+			};
+
+			return ad_;
+		};
+		var g_ = context.Operators.SelectOrNull<Extension, Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(e_, f_);
+		var h_ = context.Operators.SingleOrNull<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private bool? Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period_Value()
+	{
+		var a_ = this.HIV();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition HIVDx)
+		{
+			var f_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDx);
+			var g_ = context.Operators.Start(f_);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.Quantity(240m, "days");
+			var k_ = context.Operators.Add(i_, j_);
+			var l_ = context.Operators.DateFrom(k_);
+			var m_ = context.Operators.ConvertDateToDateTime(l_);
+			var n_ = context.Operators.SameOrBefore(g_, m_, null);
+			var o_ = QICoreCommon_2_0_000.isActive(HIVDx);
+			var p_ = context.Operators.And(n_, o_);
+
+			return p_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Active HIV Diagnosis Starts On or Before First 240 Days of Measurement Period")]
+	public bool? Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period() => 
+		__Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period.Value;
+
+	private bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Outpatient_Consultation();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Annual_Wellness_Visit();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Face_to_Face_Interaction();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Home_Healthcare_Services();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
+		var x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		var z_ = this.Telephone_Visits();
+		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		var ab_ = context.Operators.ListUnion<Encounter>(y_, aa_);
+		var ac_ = context.Operators.ListUnion<Encounter>(w_, ab_);
+		var ad_ = this.Preventive_Care_Services_Other();
+		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		var af_ = context.Operators.ListUnion<Encounter>(ac_, ae_);
+		bool? ag_(Encounter QualifyingEncounter)
+		{
+			var aj_ = this.Measurement_Period();
+			var ak_ = context.Operators.Start(aj_);
+			var am_ = context.Operators.Start(aj_);
+			var an_ = context.Operators.Quantity(240m, "days");
+			var ao_ = context.Operators.Add(am_, an_);
+			var ap_ = context.Operators.Interval(ak_, ao_, true, true);
+			var aq_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+			var ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, aq_, "day");
+
+			return ar_;
+		};
+		var ah_ = context.Operators.WhereOrNull<Encounter>(af_, ag_);
+		var ai_ = context.Operators.ExistsInList<Encounter>(ah_);
+
+		return ai_;
+	}
+
+    [CqlDeclaration("Has Qualifying Encounter During First 240 Days of Measurement Period")]
+	public bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period() => 
+		__Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period();
+		var b_ = this.Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period();
+		var c_ = context.Operators.And(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Encounter> Encounter_During_Measurement_Period_With_HIV_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Outpatient_Consultation();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Annual_Wellness_Visit();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Face_to_Face_Interaction();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Home_Healthcare_Services();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
+		var x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		var z_ = this.Telephone_Visits();
+		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		var ab_ = context.Operators.ListUnion<Encounter>(y_, aa_);
+		var ac_ = context.Operators.ListUnion<Encounter>(w_, ab_);
+		var ad_ = this.Preventive_Care_Services_Other();
+		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		var af_ = context.Operators.ListUnion<Encounter>(ac_, ae_);
+		IEnumerable<Encounter> ag_(Encounter ValidEncounter)
+		{
+			var ai_ = this.HIV();
+			var aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, null);
+			bool? ak_(Condition HIVDiagnosis)
+			{
+				var ao_ = this.Measurement_Period();
+				var ap_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+				var aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, ap_, null);
+				CqlInterval<CqlDateTime> ar_()
+				{
+					if ((context.Operators.Start(QICoreCommon_2_0_000.prevalenceInterval(HIVDiagnosis)) is null))
+					{
+						return null;
+					}
+					else
+					{
+						var ax_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDiagnosis);
+						var ay_ = context.Operators.Start(ax_);
+						var ba_ = context.Operators.Start(ax_);
+						var bb_ = context.Operators.Interval(ay_, ba_, true, true);
+
+						return bb_;
+					};
+				};
+				var at_ = context.Operators.IntervalSameOrBefore(ar_(), ap_, "day");
+				var au_ = context.Operators.And(aq_, at_);
+				var av_ = QICoreCommon_2_0_000.isActive(HIVDiagnosis);
+				var aw_ = context.Operators.And(au_, av_);
+
+				return aw_;
+			};
+			var al_ = context.Operators.WhereOrNull<Condition>(aj_, ak_);
+			Encounter am_(Condition HIVDiagnosis) => 
+				ValidEncounter;
+			var an_ = context.Operators.SelectOrNull<Condition, Encounter>(al_, am_);
+
+			return an_;
+		};
+		var ah_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(af_, ag_);
+
+		return ah_;
+	}
+
+    [CqlDeclaration("Encounter During Measurement Period With HIV")]
+	public IEnumerable<Encounter> Encounter_During_Measurement_Period_With_HIV() => 
+		__Encounter_During_Measurement_Period_With_HIV.Value;
+
+	private bool? Has_HIV_Viral_Load_Test_During_Measurement_Period_Value()
+	{
+		var a_ = this.HIV_Viral_Load();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		bool? c_(Observation ViralLoadTest)
+		{
+			var f_ = this.Measurement_Period();
+			var g_ = FHIRHelpers_4_3_000.ToValue(ViralLoadTest?.Effective);
+			var h_ = QICoreCommon_2_0_000.ToInterval(g_);
+			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
+
+			return i_;
+		};
+		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Observation>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has HIV Viral Load Test During Measurement Period")]
+	public bool? Has_HIV_Viral_Load_Test_During_Measurement_Period() => 
+		__Has_HIV_Viral_Load_Test_During_Measurement_Period.Value;
+
+	private bool? Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart_Value()
+	{
+		var a_ = this.Encounter_During_Measurement_Period_With_HIV();
+		IEnumerable<Encounter> b_(Encounter EncounterWithHIV)
+		{
+			var e_ = this.HIV_Viral_Load();
+			var f_ = context.Operators.RetrieveByValueSet<Observation>(e_, null);
+			bool? g_(Observation ViralLoadTest)
+			{
+				var k_ = this.Measurement_Period();
+				var l_ = FHIRHelpers_4_3_000.ToValue(ViralLoadTest?.Effective);
+				var m_ = QICoreCommon_2_0_000.ToInterval(l_);
+				var n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, null);
+				var p_ = QICoreCommon_2_0_000.ToInterval(l_);
+				var q_ = context.Operators.Start(p_);
+				var r_ = FHIRHelpers_4_3_000.ToInterval(EncounterWithHIV?.Period);
+				var s_ = context.Operators.End(r_);
+				var t_ = context.Operators.Quantity(90m, "days");
+				var u_ = context.Operators.Add(s_, t_);
+				var v_ = context.Operators.SameOrAfter(q_, u_, "day");
+				var x_ = context.Operators.Start(r_);
+				var z_ = QICoreCommon_2_0_000.ToInterval(l_);
+				var aa_ = context.Operators.End(z_);
+				var ac_ = context.Operators.Add(aa_, t_);
+				var ad_ = context.Operators.SameOrAfter(x_, ac_, "day");
+				var ae_ = context.Operators.Or(v_, ad_);
+				var af_ = context.Operators.And(n_, ae_);
+
+				return af_;
+			};
+			var h_ = context.Operators.WhereOrNull<Observation>(f_, g_);
+			Encounter i_(Observation ViralLoadTest) => 
+				EncounterWithHIV;
+			var j_ = context.Operators.SelectOrNull<Observation, Encounter>(h_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+		var d_ = context.Operators.ExistsInList<Encounter>(c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Has One Encounter With HIV and One Viral Load Test At Least 90 Days Apart")]
+	public bool? Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart() => 
+		__Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart.Value;
+
+	private bool? Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart_Value()
+	{
+		var a_ = this.Encounter_During_Measurement_Period_With_HIV();
+		IEnumerable<Encounter> b_(Encounter EncounterWithHIV)
+		{
+			var e_ = this.Encounter_During_Measurement_Period_With_HIV();
+			bool? f_(Encounter AnotherEncounterWithHIV)
+			{
+				var j_ = context.Operators.Equivalent(EncounterWithHIV, AnotherEncounterWithHIV);
+				var k_ = context.Operators.Not(j_);
+				var l_ = FHIRHelpers_4_3_000.ToInterval(AnotherEncounterWithHIV?.Period);
+				var m_ = context.Operators.Start(l_);
+				var n_ = FHIRHelpers_4_3_000.ToInterval(EncounterWithHIV?.Period);
+				var o_ = context.Operators.End(n_);
+				var p_ = context.Operators.Quantity(90m, "days");
+				var q_ = context.Operators.Add(o_, p_);
+				var r_ = context.Operators.SameOrAfter(m_, q_, "day");
+				var s_ = context.Operators.And(k_, r_);
+
+				return s_;
+			};
+			var g_ = context.Operators.WhereOrNull<Encounter>(e_, f_);
+			Encounter h_(Encounter AnotherEncounterWithHIV) => 
+				EncounterWithHIV;
+			var i_ = context.Operators.SelectOrNull<Encounter, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+		var d_ = context.Operators.ExistsInList<Encounter>(c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Has Two Encounters With HIV At Least 90 Days Apart")]
+	public bool? Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart() => 
+		__Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart();
+		var b_ = this.Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart();
+		var c_ = context.Operators.Or(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+}

--- a/Demo/Measures-cms/HIVViralSuppressionFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/HIVViralSuppressionFHIR-0.1.000.g.cs
@@ -1,0 +1,514 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("HIVViralSuppressionFHIR", "0.1.000")]
+public class HIVViralSuppressionFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Face_to_Face_Interaction;
+    internal Lazy<CqlValueSet> __HIV;
+    internal Lazy<CqlValueSet> __HIV_Viral_Load;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Other;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care__Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Telehealth_Services;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlCode> __Below_threshold_level__qualifier_value_;
+    internal Lazy<CqlCode> __Not_detected__qualifier_value_;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<bool?> __Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period;
+    internal Lazy<bool?> __Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<Observation> __Most_Recent_Viral_Load_Test_During_Measurement_Period;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public HIVViralSuppressionFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value);
+        __Face_to_Face_Interaction = new Lazy<CqlValueSet>(this.Face_to_Face_Interaction_Value);
+        __HIV = new Lazy<CqlValueSet>(this.HIV_Value);
+        __HIV_Viral_Load = new Lazy<CqlValueSet>(this.HIV_Viral_Load_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Other = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Other_Value);
+        __Preventive_Care_Services__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value);
+        __Preventive_Care__Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Established_Office_Visit__0_to_17_Value);
+        __Telehealth_Services = new Lazy<CqlValueSet>(this.Telehealth_Services_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Below_threshold_level__qualifier_value_ = new Lazy<CqlCode>(this.Below_threshold_level__qualifier_value__Value);
+        __Not_detected__qualifier_value_ = new Lazy<CqlCode>(this.Not_detected__qualifier_value__Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period = new Lazy<bool?>(this.Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period_Value);
+        __Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period = new Lazy<bool?>(this.Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Most_Recent_Viral_Load_Test_During_Measurement_Period = new Lazy<Observation>(this.Most_Recent_Viral_Load_Test_During_Measurement_Period_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+    }
+    #region Dependencies
+
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Annual_Wellness_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+
+    [CqlDeclaration("Annual Wellness Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit.Value;
+
+	private CqlValueSet Face_to_Face_Interaction_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+
+    [CqlDeclaration("Face-to-Face Interaction")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
+	public CqlValueSet Face_to_Face_Interaction() => 
+		__Face_to_Face_Interaction.Value;
+
+	private CqlValueSet HIV_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+
+    [CqlDeclaration("HIV")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
+	public CqlValueSet HIV() => 
+		__HIV.Value;
+
+	private CqlValueSet HIV_Viral_Load_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", null);
+
+    [CqlDeclaration("HIV Viral Load")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002")]
+	public CqlValueSet HIV_Viral_Load() => 
+		__HIV_Viral_Load.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Other_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", null);
+
+    [CqlDeclaration("Preventive Care Services Other")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030")]
+	public CqlValueSet Preventive_Care_Services_Other() => 
+		__Preventive_Care_Services_Other.Value;
+
+	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+
+    [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
+	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+
+    [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
+	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
+		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Telehealth_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", null);
+
+    [CqlDeclaration("Telehealth Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031")]
+	public CqlValueSet Telehealth_Services() => 
+		__Telehealth_Services.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlCode Below_threshold_level__qualifier_value__Value() => 
+		new CqlCode("260988000", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Below threshold level (qualifier value)")]
+	public CqlCode Below_threshold_level__qualifier_value_() => 
+		__Below_threshold_level__qualifier_value_.Value;
+
+	private CqlCode Not_detected__qualifier_value__Value() => 
+		new CqlCode("260415000", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Not detected (qualifier value)")]
+	public CqlCode Not_detected__qualifier_value_() => 
+		__Not_detected__qualifier_value_.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("260988000", "http://snomed.info/sct", null, null),
+			new CqlCode("260415000", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("HIVViralSuppressionFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private bool? Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period_Value()
+	{
+		var a_ = this.HIV();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition HIVDx)
+		{
+			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HIVDx);
+			var g_ = context.Operators.Start(f_);
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.Quantity(90m, "days");
+			var k_ = context.Operators.Add(i_, j_);
+			var l_ = context.Operators.Before(g_, k_, "day");
+
+			return l_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Active HIV Diagnosis Before or in First 90 Days of Measurement Period")]
+	public bool? Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period() => 
+		__Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period.Value;
+
+	private bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Outpatient_Consultation();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Annual_Wellness_Visit();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Face_to_Face_Interaction();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Home_Healthcare_Services();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
+		var x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		var z_ = this.Telephone_Visits();
+		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		var ab_ = context.Operators.ListUnion<Encounter>(y_, aa_);
+		var ac_ = context.Operators.ListUnion<Encounter>(w_, ab_);
+		var ad_ = this.Preventive_Care_Services_Other();
+		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		var af_ = context.Operators.ListUnion<Encounter>(ac_, ae_);
+		bool? ag_(Encounter QualifyingEncounter)
+		{
+			var aj_ = this.Measurement_Period();
+			var ak_ = context.Operators.Start(aj_);
+			var am_ = context.Operators.Start(aj_);
+			var an_ = context.Operators.Quantity(240m, "days");
+			var ao_ = context.Operators.Add(am_, an_);
+			var ap_ = context.Operators.Interval(ak_, ao_, true, true);
+			var aq_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+			var ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, aq_, "day");
+
+			return ar_;
+		};
+		var ah_ = context.Operators.WhereOrNull<Encounter>(af_, ag_);
+		var ai_ = context.Operators.ExistsInList<Encounter>(ah_);
+
+		return ai_;
+	}
+
+    [CqlDeclaration("Has Qualifying Encounter During First 240 Days of Measurement Period")]
+	public bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period() => 
+		__Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period();
+		var b_ = this.Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period();
+		var c_ = context.Operators.And(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private Observation Most_Recent_Viral_Load_Test_During_Measurement_Period_Value()
+	{
+		var a_ = this.HIV_Viral_Load();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		bool? c_(Observation ViralLoad)
+		{
+			object h_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(ViralLoad?.Effective) is CqlDateTime)
+				{
+					var l_ = FHIRHelpers_4_3_000.ToValue(ViralLoad?.Effective);
+
+					return ((l_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(ViralLoad?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var m_ = FHIRHelpers_4_3_000.ToValue(ViralLoad?.Effective);
+
+					return ((m_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(ViralLoad?.Effective) is CqlDateTime)
+				{
+					var n_ = FHIRHelpers_4_3_000.ToValue(ViralLoad?.Effective);
+
+					return ((n_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var i_ = QICoreCommon_2_0_000.Latest(h_());
+			var j_ = this.Measurement_Period();
+			var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, "day");
+
+			return k_;
+		};
+		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
+		object e_(Observation @this)
+		{
+			var o_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var p_ = QICoreCommon_2_0_000.ToInterval(o_);
+			var q_ = context.Operators.Start(p_);
+
+			return q_;
+		};
+		var f_ = context.Operators.ListSortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		var g_ = context.Operators.LastOfList<Observation>(f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Most Recent Viral Load Test During Measurement Period")]
+	public Observation Most_Recent_Viral_Load_Test_During_Measurement_Period() => 
+		__Most_Recent_Viral_Load_Test_During_Measurement_Period.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Most_Recent_Viral_Load_Test_During_Measurement_Period();
+		var b_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
+		var c_ = context.Operators.Quantity(200m, "{copies}/mL");
+		var d_ = context.Operators.Less((b_ as CqlQuantity), c_);
+		var f_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
+		var g_ = this.Below_threshold_level__qualifier_value_();
+		var h_ = context.Operators.ConvertCodeToConcept(g_);
+		var i_ = context.Operators.Equivalent((f_ as CqlConcept), h_);
+		var j_ = context.Operators.Or(d_, i_);
+		var l_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
+		var m_ = this.Not_detected__qualifier_value_();
+		var n_ = context.Operators.ConvertCodeToConcept(m_);
+		var o_ = context.Operators.Equivalent((l_ as CqlConcept), n_);
+		var p_ = context.Operators.Or(j_, o_);
+
+		return p_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+}

--- a/Demo/Measures-cms/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
@@ -1,0 +1,532 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("HospitalHarmOpioidRelatedAdverseEventsFHIR", "0.1.000")]
+public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlValueSet> __Operating_Room_Suite;
+    internal Lazy<CqlValueSet> __Opioid_Antagonist;
+    internal Lazy<CqlValueSet> __Opioids__All;
+    internal Lazy<CqlValueSet> __Routes_of_Administration_for_Opioid_Antagonists;
+    internal Lazy<CqlCode> __Dead;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __HSLOC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter;
+    internal Lazy<IEnumerable<MedicationAdministration>> __Opioid_Administration;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Opioid_Administration_Outside_of_Operating_Room;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<MedicationAdministration>> __Opioid_Antagonist_Administration;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value);
+        __Operating_Room_Suite = new Lazy<CqlValueSet>(this.Operating_Room_Suite_Value);
+        __Opioid_Antagonist = new Lazy<CqlValueSet>(this.Opioid_Antagonist_Value);
+        __Opioids__All = new Lazy<CqlValueSet>(this.Opioids__All_Value);
+        __Routes_of_Administration_for_Opioid_Antagonists = new Lazy<CqlValueSet>(this.Routes_of_Administration_for_Opioid_Antagonists_Value);
+        __Dead = new Lazy<CqlCode>(this.Dead_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __HSLOC = new Lazy<CqlCode[]>(this.HSLOC_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_Value);
+        __Opioid_Administration = new Lazy<IEnumerable<MedicationAdministration>>(this.Opioid_Administration_Value);
+        __Encounter_with_Opioid_Administration_Outside_of_Operating_Room = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Opioid_Administration_Outside_of_Operating_Room_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __Opioid_Antagonist_Administration = new Lazy<IEnumerable<MedicationAdministration>>(this.Opioid_Antagonist_Administration_Value);
+        __Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Emergency_Department_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+
+    [CqlDeclaration("Emergency Department Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Observation_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+
+    [CqlDeclaration("Observation Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services.Value;
+
+	private CqlValueSet Operating_Room_Suite_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141", null);
+
+    [CqlDeclaration("Operating Room Suite")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141")]
+	public CqlValueSet Operating_Room_Suite() => 
+		__Operating_Room_Suite.Value;
+
+	private CqlValueSet Opioid_Antagonist_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119", null);
+
+    [CqlDeclaration("Opioid Antagonist")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119")]
+	public CqlValueSet Opioid_Antagonist() => 
+		__Opioid_Antagonist.Value;
+
+	private CqlValueSet Opioids__All_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226", null);
+
+    [CqlDeclaration("Opioids, All")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226")]
+	public CqlValueSet Opioids__All() => 
+		__Opioids__All.Value;
+
+	private CqlValueSet Routes_of_Administration_for_Opioid_Antagonists_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187", null);
+
+    [CqlDeclaration("Routes of Administration for Opioid Antagonists")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187")]
+	public CqlValueSet Routes_of_Administration_for_Opioid_Antagonists() => 
+		__Routes_of_Administration_for_Opioid_Antagonists.Value;
+
+	private CqlCode Dead_Value() => 
+		new CqlCode("419099009", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Dead")]
+	public CqlCode Dead() => 
+		__Dead.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("419099009", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] HSLOC_Value()
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
+    [CqlDeclaration("HSLOC")]
+	public CqlCode[] HSLOC() => 
+		__HSLOC.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_Value()
+	{
+		var a_ = this.Encounter_Inpatient();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter InpatientEncounter)
+		{
+			var e_ = this.Patient();
+			var f_ = context.Operators.Convert<CqlDate>(e_?.BirthDateElement?.Value);
+			var g_ = FHIRHelpers_4_3_000.ToInterval(InpatientEncounter?.Period);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = context.Operators.CalculateAgeAt(f_, i_, "year");
+			var k_ = context.Operators.GreaterOrEqual(j_, (int?)18);
+			var m_ = context.Operators.End(g_);
+			var n_ = this.Measurement_Period();
+			var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, "day");
+			var p_ = context.Operators.And(k_, o_);
+			var q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(InpatientEncounter?.StatusElement?.Value);
+			var r_ = context.Operators.Equal(q_, "finished");
+			var s_ = context.Operators.And(p_, r_);
+
+			return s_;
+		};
+		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter")]
+	public IEnumerable<Encounter> Qualifying_Encounter() => 
+		__Qualifying_Encounter.Value;
+
+	private IEnumerable<MedicationAdministration> Opioid_Administration_Value()
+	{
+		var a_ = this.Opioids__All();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationAdministration>(b_, d_);
+		bool? f_(MedicationAdministration Opioids)
+		{
+			var h_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(Opioids?.StatusElement?.Value);
+			var i_ = context.Operators.Equal(h_, "completed");
+			var k_ = context.Operators.Equal(h_, "not-done");
+			var l_ = context.Operators.Not(k_);
+			var m_ = context.Operators.And(i_, l_);
+
+			return m_;
+		};
+		var g_ = context.Operators.WhereOrNull<MedicationAdministration>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Opioid Administration")]
+	public IEnumerable<MedicationAdministration> Opioid_Administration() => 
+		__Opioid_Administration.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Opioid_Administration_Outside_of_Operating_Room_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> b_(Encounter InpatientEncounter)
+		{
+			var d_ = this.Opioid_Administration();
+			bool? e_(MedicationAdministration OpioidGiven)
+			{
+				var i_ = FHIRHelpers_4_3_000.ToValue(OpioidGiven?.Effective);
+				var j_ = QICoreCommon_2_0_000.ToInterval(i_);
+				var k_ = context.Operators.Start(j_);
+				var l_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientEncounter);
+				var m_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, null);
+				bool? n_(Encounter.LocationComponent EncounterLocation)
+				{
+					var s_ = CQMCommon_2_0_000.GetLocation(EncounterLocation?.Location);
+					CqlConcept t_(CodeableConcept @this)
+					{
+						var ad_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+						return ad_;
+					};
+					var u_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(s_?.Type, t_);
+					var v_ = this.Operating_Room_Suite();
+					var w_ = context.Operators.ConceptsInValueSet(u_, v_);
+					var x_ = FHIRHelpers_4_3_000.ToValue(OpioidGiven?.Effective);
+					var y_ = QICoreCommon_2_0_000.ToInterval(x_);
+					var z_ = context.Operators.Start(y_);
+					var aa_ = FHIRHelpers_4_3_000.ToInterval(EncounterLocation?.Period);
+					var ab_ = context.Operators.ElementInInterval<CqlDateTime>(z_, aa_, null);
+					var ac_ = context.Operators.And(w_, ab_);
+
+					return ac_;
+				};
+				var o_ = context.Operators.WhereOrNull<Encounter.LocationComponent>((InpatientEncounter?.Location as IEnumerable<Encounter.LocationComponent>), n_);
+				var p_ = context.Operators.ExistsInList<Encounter.LocationComponent>(o_);
+				var q_ = context.Operators.Not(p_);
+				var r_ = context.Operators.And(m_, q_);
+
+				return r_;
+			};
+			var f_ = context.Operators.WhereOrNull<MedicationAdministration>(d_, e_);
+			Encounter g_(MedicationAdministration OpioidGiven) => 
+				InpatientEncounter;
+			var h_ = context.Operators.SelectOrNull<MedicationAdministration, Encounter>(f_, g_);
+
+			return h_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Opioid Administration Outside of Operating Room")]
+	public IEnumerable<Encounter> Encounter_with_Opioid_Administration_Outside_of_Operating_Room() => 
+		__Encounter_with_Opioid_Administration_Outside_of_Operating_Room.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.Encounter_with_Opioid_Administration_Outside_of_Operating_Room();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<MedicationAdministration> Opioid_Antagonist_Administration_Value()
+	{
+		var a_ = this.Opioid_Antagonist();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationAdministration>(b_, d_);
+		bool? f_(MedicationAdministration AntagonistGiven)
+		{
+			var h_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(AntagonistGiven?.StatusElement?.Value);
+			var i_ = context.Operators.Equal(h_, "completed");
+			var k_ = context.Operators.Equal(h_, "not-done");
+			var l_ = context.Operators.Not(k_);
+			var m_ = context.Operators.And(i_, l_);
+
+			return m_;
+		};
+		var g_ = context.Operators.WhereOrNull<MedicationAdministration>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Opioid Antagonist Administration")]
+	public IEnumerable<MedicationAdministration> Opioid_Antagonist_Administration() => 
+		__Opioid_Antagonist_Administration.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid_Value()
+	{
+		var a_ = this.Opioid_Antagonist_Administration();
+		IEnumerable<MedicationAdministration> b_(MedicationAdministration _OpioidAntagonistGiven)
+		{
+			var l_ = this.Opioid_Administration();
+
+			return l_;
+		};
+		Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI c_(MedicationAdministration _OpioidAntagonistGiven, MedicationAdministration _OpioidGiven)
+		{
+			var m_ = new Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI
+			{
+				OpioidAntagonistGiven = _OpioidAntagonistGiven,
+				OpioidGiven = _OpioidGiven,
+			};
+
+			return m_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<MedicationAdministration, MedicationAdministration, Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI>(a_, b_, c_);
+		IEnumerable<Encounter> e_(Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI _OpioidAntagonistGivenOpioidGiven)
+		{
+			var n_ = this.Denominator();
+
+			return n_;
+		};
+		Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI f_(Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI OpioidAntagonistGivenOpioidGiven, Encounter _EncounterWithQualifyingAge)
+		{
+			var o_ = new Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI
+			{
+				OpioidAntagonistGiven = OpioidAntagonistGivenOpioidGiven.OpioidAntagonistGiven,
+				OpioidGiven = OpioidAntagonistGivenOpioidGiven.OpioidGiven,
+				EncounterWithQualifyingAge = _EncounterWithQualifyingAge,
+			};
+
+			return o_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI, Encounter, Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI tuple_eupiswiddkenbbaixeecrbcdi)
+		{
+			bool? p_(Encounter.LocationComponent EncounterLocation)
+			{
+				var bc_ = CQMCommon_2_0_000.GetLocation(EncounterLocation?.Location);
+				CqlConcept bd_(CodeableConcept @this)
+				{
+					var bn_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+					return bn_;
+				};
+				var be_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(bc_?.Type, bd_);
+				var bf_ = this.Operating_Room_Suite();
+				var bg_ = context.Operators.ConceptsInValueSet(be_, bf_);
+				var bh_ = FHIRHelpers_4_3_000.ToValue(tuple_eupiswiddkenbbaixeecrbcdi.OpioidAntagonistGiven?.Effective);
+				var bi_ = QICoreCommon_2_0_000.ToInterval(bh_);
+				var bj_ = context.Operators.Start(bi_);
+				var bk_ = FHIRHelpers_4_3_000.ToInterval(EncounterLocation?.Period);
+				var bl_ = context.Operators.ElementInInterval<CqlDateTime>(bj_, bk_, null);
+				var bm_ = context.Operators.And(bg_, bl_);
+
+				return bm_;
+			};
+			var q_ = context.Operators.WhereOrNull<Encounter.LocationComponent>((tuple_eupiswiddkenbbaixeecrbcdi.EncounterWithQualifyingAge?.Location as IEnumerable<Encounter.LocationComponent>), p_);
+			var r_ = context.Operators.ExistsInList<Encounter.LocationComponent>(q_);
+			var s_ = context.Operators.Not(r_);
+			var t_ = FHIRHelpers_4_3_000.ToValue(tuple_eupiswiddkenbbaixeecrbcdi.OpioidAntagonistGiven?.Effective);
+			var u_ = QICoreCommon_2_0_000.ToInterval(t_);
+			var v_ = context.Operators.Start(u_);
+			var w_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_eupiswiddkenbbaixeecrbcdi.EncounterWithQualifyingAge);
+			var x_ = context.Operators.ElementInInterval<CqlDateTime>(v_, w_, null);
+			var y_ = FHIRHelpers_4_3_000.ToValue(tuple_eupiswiddkenbbaixeecrbcdi.OpioidGiven?.Effective);
+			var z_ = QICoreCommon_2_0_000.ToInterval(y_);
+			var aa_ = context.Operators.Start(z_);
+			var ac_ = context.Operators.ElementInInterval<CqlDateTime>(aa_, w_, null);
+			var ad_ = context.Operators.And(x_, ac_);
+			var af_ = QICoreCommon_2_0_000.ToInterval(y_);
+			var ag_ = context.Operators.End(af_);
+			var ai_ = QICoreCommon_2_0_000.ToInterval(t_);
+			var aj_ = context.Operators.Start(ai_);
+			var ak_ = context.Operators.Quantity(12m, "hours");
+			var al_ = context.Operators.Subtract(aj_, ak_);
+			var an_ = QICoreCommon_2_0_000.ToInterval(t_);
+			var ao_ = context.Operators.Start(an_);
+			var ap_ = context.Operators.Interval(al_, ao_, true, false);
+			var aq_ = context.Operators.ElementInInterval<CqlDateTime>(ag_, ap_, null);
+			var as_ = QICoreCommon_2_0_000.ToInterval(t_);
+			var at_ = context.Operators.Start(as_);
+			var au_ = context.Operators.Not((bool?)(at_ is null));
+			var av_ = context.Operators.And(aq_, au_);
+			var aw_ = context.Operators.And(ad_, av_);
+			var ax_ = FHIRHelpers_4_3_000.ToConcept(tuple_eupiswiddkenbbaixeecrbcdi.OpioidAntagonistGiven?.Dosage?.Route);
+			var ay_ = this.Routes_of_Administration_for_Opioid_Antagonists();
+			var az_ = context.Operators.ConceptInValueSet(ax_, ay_);
+			var ba_ = context.Operators.And(aw_, az_);
+			var bb_ = context.Operators.And(s_, ba_);
+
+			return bb_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI>(g_, h_);
+		Encounter j_(Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI tuple_eupiswiddkenbbaixeecrbcdi) => 
+			tuple_eupiswiddkenbbaixeecrbcdi.EncounterWithQualifyingAge;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_EUPiSWiDDKENbbAiXeEcRBcdI, Encounter>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Encounter with Non Enteral Opioid Antagonist Administration Outside of Operating Room and within 12 Hrs After Opioid")]
+	public IEnumerable<Encounter> Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid() => 
+		__Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = this.Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
@@ -1,0 +1,879 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("HospitalHarmPressureInjuryFHIR", "0.1.000")]
+public class HospitalHarmPressureInjuryFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __COVID_19;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlValueSet> __Present_on_Admission_or_Clinically_Undetermined;
+    internal Lazy<CqlValueSet> __Pressure_Injury_Deep_Tissue;
+    internal Lazy<CqlValueSet> __Pressure_Injury_Deep_Tissue_Diagnoses;
+    internal Lazy<CqlValueSet> __Pressure_Injury_Stage_2__3__4_or_Unstageable;
+    internal Lazy<CqlValueSet> __Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses;
+    internal Lazy<CqlCode> __Physical_findings_of_Skin;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Age_18_and_Older;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Deep_Tissue_Pressure_Injury_POA;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Diagnosis_of_COVID19_Infection;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public HospitalHarmPressureInjuryFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __COVID_19 = new Lazy<CqlValueSet>(this.COVID_19_Value);
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine = new Lazy<CqlValueSet>(this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine_Value);
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value);
+        __Present_on_Admission_or_Clinically_Undetermined = new Lazy<CqlValueSet>(this.Present_on_Admission_or_Clinically_Undetermined_Value);
+        __Pressure_Injury_Deep_Tissue = new Lazy<CqlValueSet>(this.Pressure_Injury_Deep_Tissue_Value);
+        __Pressure_Injury_Deep_Tissue_Diagnoses = new Lazy<CqlValueSet>(this.Pressure_Injury_Deep_Tissue_Diagnoses_Value);
+        __Pressure_Injury_Stage_2__3__4_or_Unstageable = new Lazy<CqlValueSet>(this.Pressure_Injury_Stage_2__3__4_or_Unstageable_Value);
+        __Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses = new Lazy<CqlValueSet>(this.Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses_Value);
+        __Physical_findings_of_Skin = new Lazy<CqlCode>(this.Physical_findings_of_Skin_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Encounter_with_Age_18_and_Older = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Age_18_and_Older_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator_Value);
+        __Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours_Value);
+        __Encounter_with_Deep_Tissue_Pressure_Injury_POA = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Deep_Tissue_Pressure_Injury_POA_Value);
+        __Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator_Value);
+        __Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours_Value);
+        __Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_Value);
+        __Encounter_with_Diagnosis_of_COVID19_Infection = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Diagnosis_of_COVID19_Infection_Value);
+        __Denominator_Exclusions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exclusions_Value);
+        __Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator_Value);
+        __Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours_Value);
+        __Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_Value);
+        __Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator_Value);
+        __Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours_Value);
+        __Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet COVID_19_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140", null);
+
+    [CqlDeclaration("COVID 19")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140")]
+	public CqlValueSet COVID_19() => 
+		__COVID_19.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+
+    [CqlDeclaration("Emergency Department Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198", null);
+
+    [CqlDeclaration("Not Present On Admission or Documentation Insufficient to Determine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198")]
+	public CqlValueSet Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine() => 
+		__Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine.Value;
+
+	private CqlValueSet Observation_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+
+    [CqlDeclaration("Observation Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services.Value;
+
+	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", null);
+
+    [CqlDeclaration("Present on Admission or Clinically Undetermined")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
+	public CqlValueSet Present_on_Admission_or_Clinically_Undetermined() => 
+		__Present_on_Admission_or_Clinically_Undetermined.Value;
+
+	private CqlValueSet Pressure_Injury_Deep_Tissue_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112", null);
+
+    [CqlDeclaration("Pressure Injury Deep Tissue")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112")]
+	public CqlValueSet Pressure_Injury_Deep_Tissue() => 
+		__Pressure_Injury_Deep_Tissue.Value;
+
+	private CqlValueSet Pressure_Injury_Deep_Tissue_Diagnoses_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194", null);
+
+    [CqlDeclaration("Pressure Injury Deep Tissue Diagnoses")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194")]
+	public CqlValueSet Pressure_Injury_Deep_Tissue_Diagnoses() => 
+		__Pressure_Injury_Deep_Tissue_Diagnoses.Value;
+
+	private CqlValueSet Pressure_Injury_Stage_2__3__4_or_Unstageable_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113", null);
+
+    [CqlDeclaration("Pressure Injury Stage 2, 3, 4 or Unstageable")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113")]
+	public CqlValueSet Pressure_Injury_Stage_2__3__4_or_Unstageable() => 
+		__Pressure_Injury_Stage_2__3__4_or_Unstageable.Value;
+
+	private CqlValueSet Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196", null);
+
+    [CqlDeclaration("Pressure Injury Stage 2, 3, 4, or Unstageable Diagnoses")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196")]
+	public CqlValueSet Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses() => 
+		__Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses.Value;
+
+	private CqlCode Physical_findings_of_Skin_Value() => 
+		new CqlCode("8709-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Physical findings of Skin")]
+	public CqlCode Physical_findings_of_Skin() => 
+		__Physical_findings_of_Skin.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("8709-8", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("HospitalHarmPressureInjuryFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Age_18_and_Older_Value()
+	{
+		var a_ = this.Encounter_Inpatient();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter InpatientEncounter)
+		{
+			var e_ = this.Patient();
+			var f_ = context.Operators.Convert<CqlDate>(e_?.BirthDateElement?.Value);
+			var g_ = FHIRHelpers_4_3_000.ToInterval(InpatientEncounter?.Period);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = context.Operators.CalculateAgeAt(f_, i_, "year");
+			var k_ = context.Operators.GreaterOrEqual(j_, (int?)18);
+			var m_ = context.Operators.End(g_);
+			var n_ = this.Measurement_Period();
+			var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, "day");
+			var p_ = context.Operators.And(k_, o_);
+			var q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(InpatientEncounter?.StatusElement?.Value);
+			var r_ = context.Operators.Equal(q_, "finished");
+			var s_ = context.Operators.And(p_, r_);
+
+			return s_;
+		};
+		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Encounter with Age 18 and Older")]
+	public IEnumerable<Encounter> Encounter_with_Age_18_and_Older() => 
+		__Encounter_with_Age_18_and_Older.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+		bool? b_(Encounter InpatientHospitalization)
+		{
+			bool? d_(Encounter.DiagnosisComponent EncounterDiag)
+			{
+				var g_ = CQMCommon_2_0_000.getCondition(EncounterDiag?.Condition);
+				var h_ = FHIRHelpers_4_3_000.ToConcept(g_?.Code);
+				var i_ = this.Pressure_Injury_Deep_Tissue_Diagnoses();
+				var j_ = context.Operators.ConceptInValueSet(h_, i_);
+				bool? k_(Extension @this)
+				{
+					var u_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+
+					return u_;
+				};
+				var l_ = context.Operators.WhereOrNull<Extension>(((EncounterDiag is Element)
+						? ((EncounterDiag as Element).Extension)
+						: null), k_);
+				DataType m_(Extension @this) => 
+					@this?.Value;
+				var n_ = context.Operators.SelectOrNull<Extension, DataType>(l_, m_);
+				var o_ = context.Operators.SingleOrNull<DataType>(n_);
+				var p_ = context.Operators.Convert<CodeableConcept>(o_);
+				var q_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				var r_ = this.Present_on_Admission_or_Clinically_Undetermined();
+				var s_ = context.Operators.ConceptInValueSet(q_, r_);
+				var t_ = context.Operators.And(j_, s_);
+
+				return t_;
+			};
+			var e_ = context.Operators.WhereOrNull<Encounter.DiagnosisComponent>((InpatientHospitalization?.Diagnosis as IEnumerable<Encounter.DiagnosisComponent>), d_);
+			var f_ = context.Operators.ExistsInList<Encounter.DiagnosisComponent>(e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Deep Tissue Pressure Injury POA by Indicator")]
+	public IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator() => 
+		__Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
+		{
+			var d_ = this.Physical_findings_of_Skin();
+			var e_ = context.Operators.ToList<CqlCode>(d_);
+			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			bool? g_(Observation SkinExam)
+			{
+				var k_ = FHIRHelpers_4_3_000.ToValue(SkinExam?.Effective);
+				var l_ = QICoreCommon_2_0_000.ToInterval(k_);
+				var m_ = context.Operators.Start(l_);
+				var n_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				var o_ = context.Operators.Start(n_);
+				var q_ = context.Operators.Start(n_);
+				var r_ = context.Operators.Quantity(72m, "hours");
+				var s_ = context.Operators.Add(q_, r_);
+				var t_ = context.Operators.Interval(o_, s_, true, true);
+				var u_ = context.Operators.ElementInInterval<CqlDateTime>(m_, t_, null);
+				var v_ = context.Operators.Convert<Code<ObservationStatus>>(SkinExam?.StatusElement?.Value);
+				var w_ = context.Operators.Convert<string>(v_);
+				var x_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var y_ = context.Operators.InList<string>(w_, (x_ as IEnumerable<string>));
+				var z_ = context.Operators.And(u_, y_);
+				var aa_ = FHIRHelpers_4_3_000.ToConcept(SkinExam?.Code);
+				var ab_ = this.Pressure_Injury_Deep_Tissue();
+				var ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+				var ad_ = context.Operators.And(z_, ac_);
+
+				return ad_;
+			};
+			var h_ = context.Operators.WhereOrNull<Observation>(f_, g_);
+			Encounter i_(Observation SkinExam) => 
+				InpatientHospitalization;
+			var j_ = context.Operators.SelectOrNull<Observation, Encounter>(h_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Deep Tissue Pressure Injury POA by Skin Exam within First 72 Hours")]
+	public IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours() => 
+		__Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_Value()
+	{
+		var a_ = this.Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator();
+		var b_ = this.Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Deep Tissue Pressure Injury POA")]
+	public IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA() => 
+		__Encounter_with_Deep_Tissue_Pressure_Injury_POA.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+		bool? b_(Encounter InpatientHospitalization)
+		{
+			bool? d_(Encounter.DiagnosisComponent Stage234UnstageablePressureInjury)
+			{
+				var g_ = CQMCommon_2_0_000.getCondition(Stage234UnstageablePressureInjury?.Condition);
+				var h_ = FHIRHelpers_4_3_000.ToConcept(g_?.Code);
+				var i_ = this.Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses();
+				var j_ = context.Operators.ConceptInValueSet(h_, i_);
+				bool? k_(Extension @this)
+				{
+					var u_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+
+					return u_;
+				};
+				var l_ = context.Operators.WhereOrNull<Extension>(((Stage234UnstageablePressureInjury is Element)
+						? ((Stage234UnstageablePressureInjury as Element).Extension)
+						: null), k_);
+				DataType m_(Extension @this) => 
+					@this?.Value;
+				var n_ = context.Operators.SelectOrNull<Extension, DataType>(l_, m_);
+				var o_ = context.Operators.SingleOrNull<DataType>(n_);
+				var p_ = context.Operators.Convert<CodeableConcept>(o_);
+				var q_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				var r_ = this.Present_on_Admission_or_Clinically_Undetermined();
+				var s_ = context.Operators.ConceptInValueSet(q_, r_);
+				var t_ = context.Operators.And(j_, s_);
+
+				return t_;
+			};
+			var e_ = context.Operators.WhereOrNull<Encounter.DiagnosisComponent>((InpatientHospitalization?.Diagnosis as IEnumerable<Encounter.DiagnosisComponent>), d_);
+			var f_ = context.Operators.ExistsInList<Encounter.DiagnosisComponent>(e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Stage 2, 3, 4, or Unstageable Pressure Injury Present on Admission by POA Indicator")]
+	public IEnumerable<Encounter> Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator() => 
+		__Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
+		{
+			var d_ = this.Physical_findings_of_Skin();
+			var e_ = context.Operators.ToList<CqlCode>(d_);
+			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			bool? g_(Observation SkinExam)
+			{
+				var k_ = FHIRHelpers_4_3_000.ToValue(SkinExam?.Effective);
+				var l_ = QICoreCommon_2_0_000.ToInterval(k_);
+				var m_ = context.Operators.Start(l_);
+				var n_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				var o_ = context.Operators.Start(n_);
+				var q_ = context.Operators.Start(n_);
+				var r_ = context.Operators.Quantity(24m, "hours");
+				var s_ = context.Operators.Add(q_, r_);
+				var t_ = context.Operators.Interval(o_, s_, true, true);
+				var u_ = context.Operators.ElementInInterval<CqlDateTime>(m_, t_, null);
+				var v_ = context.Operators.Convert<Code<ObservationStatus>>(SkinExam?.StatusElement?.Value);
+				var w_ = context.Operators.Convert<string>(v_);
+				var x_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var y_ = context.Operators.InList<string>(w_, (x_ as IEnumerable<string>));
+				var z_ = context.Operators.And(u_, y_);
+				var aa_ = FHIRHelpers_4_3_000.ToConcept(SkinExam?.Code);
+				var ab_ = this.Pressure_Injury_Stage_2__3__4_or_Unstageable();
+				var ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+				var ad_ = context.Operators.And(z_, ac_);
+
+				return ad_;
+			};
+			var h_ = context.Operators.WhereOrNull<Observation>(f_, g_);
+			Encounter i_(Observation SkinExam) => 
+				InpatientHospitalization;
+			var j_ = context.Operators.SelectOrNull<Observation, Encounter>(h_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Stage 2, 3, 4 or Unstageable Pressure Injury POA by Skin Exam within 24 Hours")]
+	public IEnumerable<Encounter> Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours() => 
+		__Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_Value()
+	{
+		var a_ = this.Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator();
+		var b_ = this.Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Stage 2, 3, 4 or Unstageable Pressure Injury POA")]
+	public IEnumerable<Encounter> Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA() => 
+		__Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Diagnosis_of_COVID19_Infection_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+		bool? b_(Encounter InpatientHospitalization)
+		{
+			var d_ = CQMCommon_2_0_000.EncounterDiagnosis(InpatientHospitalization);
+			bool? e_(Condition EncounterDiag)
+			{
+				var h_ = FHIRHelpers_4_3_000.ToConcept(EncounterDiag?.Code);
+				var i_ = this.COVID_19();
+				var j_ = context.Operators.ConceptInValueSet(h_, i_);
+
+				return j_;
+			};
+			var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+			var g_ = context.Operators.ExistsInList<Condition>(f_);
+
+			return g_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Diagnosis of COVID19 Infection")]
+	public IEnumerable<Encounter> Encounter_with_Diagnosis_of_COVID19_Infection() => 
+		__Encounter_with_Diagnosis_of_COVID19_Infection.Value;
+
+	private IEnumerable<Encounter> Denominator_Exclusions_Value()
+	{
+		var a_ = this.Encounter_with_Deep_Tissue_Pressure_Injury_POA();
+		var b_ = this.Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+		var d_ = this.Encounter_with_Diagnosis_of_COVID19_Infection();
+		var e_ = context.Operators.ListUnion<Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public IEnumerable<Encounter> Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+		bool? b_(Encounter InpatientHospitalization)
+		{
+			bool? d_(Encounter.DiagnosisComponent EncounterDiag)
+			{
+				var g_ = CQMCommon_2_0_000.getCondition(EncounterDiag?.Condition);
+				var h_ = FHIRHelpers_4_3_000.ToConcept(g_?.Code);
+				var i_ = this.Pressure_Injury_Deep_Tissue_Diagnoses();
+				var j_ = context.Operators.ConceptInValueSet(h_, i_);
+				bool? k_(Extension @this)
+				{
+					var u_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+
+					return u_;
+				};
+				var l_ = context.Operators.WhereOrNull<Extension>(((EncounterDiag is Element)
+						? ((EncounterDiag as Element).Extension)
+						: null), k_);
+				DataType m_(Extension @this) => 
+					@this?.Value;
+				var n_ = context.Operators.SelectOrNull<Extension, DataType>(l_, m_);
+				var o_ = context.Operators.SingleOrNull<DataType>(n_);
+				var p_ = context.Operators.Convert<CodeableConcept>(o_);
+				var q_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				var r_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine();
+				var s_ = context.Operators.ConceptInValueSet(q_, r_);
+				var t_ = context.Operators.And(j_, s_);
+
+				return t_;
+			};
+			var e_ = context.Operators.WhereOrNull<Encounter.DiagnosisComponent>((InpatientHospitalization?.Diagnosis as IEnumerable<Encounter.DiagnosisComponent>), d_);
+			var f_ = context.Operators.ExistsInList<Encounter.DiagnosisComponent>(e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with New Deep Tissue Pressure Injury Not POA by Indicator")]
+	public IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator() => 
+		__Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator.Value;
+
+	private IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
+		{
+			var d_ = this.Physical_findings_of_Skin();
+			var e_ = context.Operators.ToList<CqlCode>(d_);
+			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			bool? g_(Observation SkinExam)
+			{
+				var k_ = FHIRHelpers_4_3_000.ToValue(SkinExam?.Effective);
+				var l_ = QICoreCommon_2_0_000.ToInterval(k_);
+				var m_ = context.Operators.Start(l_);
+				var n_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				var o_ = context.Operators.Start(n_);
+				var p_ = context.Operators.Quantity(72m, "hours");
+				var q_ = context.Operators.Add(o_, p_);
+				var s_ = context.Operators.End(n_);
+				var t_ = context.Operators.Interval(q_, s_, true, true);
+				var u_ = context.Operators.ElementInInterval<CqlDateTime>(m_, t_, null);
+				var v_ = context.Operators.Convert<Code<ObservationStatus>>(SkinExam?.StatusElement?.Value);
+				var w_ = context.Operators.Convert<string>(v_);
+				var x_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var y_ = context.Operators.InList<string>(w_, (x_ as IEnumerable<string>));
+				var z_ = context.Operators.And(u_, y_);
+				var aa_ = FHIRHelpers_4_3_000.ToValue(SkinExam?.Value);
+				var ab_ = this.Pressure_Injury_Deep_Tissue();
+				var ac_ = context.Operators.ConceptInValueSet((aa_ as CqlConcept), ab_);
+				bool? ad_(Observation.ComponentComponent @this)
+				{
+					var al_ = FHIRHelpers_4_3_000.ToConcept(@this?.Code);
+					var am_ = context.Operators.Not((bool?)(al_ is null));
+
+					return am_;
+				};
+				var ae_ = context.Operators.WhereOrNull<Observation.ComponentComponent>((SkinExam?.Component as IEnumerable<Observation.ComponentComponent>), ad_);
+				CqlConcept af_(Observation.ComponentComponent @this)
+				{
+					var an_ = FHIRHelpers_4_3_000.ToConcept(@this?.Code);
+
+					return an_;
+				};
+				var ag_ = context.Operators.SelectOrNull<Observation.ComponentComponent, CqlConcept>(ae_, af_);
+				var ai_ = context.Operators.ConceptsInValueSet(ag_, ab_);
+				var aj_ = context.Operators.Or(ac_, ai_);
+				var ak_ = context.Operators.And(z_, aj_);
+
+				return ak_;
+			};
+			var h_ = context.Operators.WhereOrNull<Observation>(f_, g_);
+			Encounter i_(Observation SkinExam) => 
+				InpatientHospitalization;
+			var j_ = context.Operators.SelectOrNull<Observation, Encounter>(h_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with New Deep Tissue Pressure Injury by Skin Exam after First 72 Hours")]
+	public IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours() => 
+		__Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours.Value;
+
+	private IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_Value()
+	{
+		var a_ = this.Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator();
+		var b_ = this.Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with New Deep Tissue Pressure Injury Not POA")]
+	public IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA() => 
+		__Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA.Value;
+
+	private IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+		bool? b_(Encounter InpatientHospitalization)
+		{
+			bool? d_(Encounter.DiagnosisComponent Stage234UnstageablePressureInjury)
+			{
+				var g_ = CQMCommon_2_0_000.getCondition(Stage234UnstageablePressureInjury?.Condition);
+				var h_ = FHIRHelpers_4_3_000.ToConcept(g_?.Code);
+				var i_ = this.Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses();
+				var j_ = context.Operators.ConceptInValueSet(h_, i_);
+				bool? k_(Extension @this)
+				{
+					var u_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+
+					return u_;
+				};
+				var l_ = context.Operators.WhereOrNull<Extension>(((Stage234UnstageablePressureInjury is Element)
+						? ((Stage234UnstageablePressureInjury as Element).Extension)
+						: null), k_);
+				DataType m_(Extension @this) => 
+					@this?.Value;
+				var n_ = context.Operators.SelectOrNull<Extension, DataType>(l_, m_);
+				var o_ = context.Operators.SingleOrNull<DataType>(n_);
+				var p_ = context.Operators.Convert<CodeableConcept>(o_);
+				var q_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				var r_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine();
+				var s_ = context.Operators.ConceptInValueSet(q_, r_);
+				var t_ = context.Operators.And(j_, s_);
+
+				return t_;
+			};
+			var e_ = context.Operators.WhereOrNull<Encounter.DiagnosisComponent>((InpatientHospitalization?.Diagnosis as IEnumerable<Encounter.DiagnosisComponent>), d_);
+			var f_ = context.Operators.ExistsInList<Encounter.DiagnosisComponent>(e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with New Stage 2, 3, 4 or Unstageable Pressure Injury Not POA by Indicator")]
+	public IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator() => 
+		__Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator.Value;
+
+	private IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours_Value()
+	{
+		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
+		{
+			var d_ = this.Physical_findings_of_Skin();
+			var e_ = context.Operators.ToList<CqlCode>(d_);
+			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			bool? g_(Observation SkinExam)
+			{
+				var k_ = FHIRHelpers_4_3_000.ToValue(SkinExam?.Effective);
+				var l_ = QICoreCommon_2_0_000.ToInterval(k_);
+				var m_ = context.Operators.Start(l_);
+				var n_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				var o_ = context.Operators.Start(n_);
+				var p_ = context.Operators.Quantity(24m, "hours");
+				var q_ = context.Operators.Add(o_, p_);
+				var s_ = context.Operators.End(n_);
+				var t_ = context.Operators.Interval(q_, s_, true, true);
+				var u_ = context.Operators.ElementInInterval<CqlDateTime>(m_, t_, null);
+				var v_ = context.Operators.Convert<Code<ObservationStatus>>(SkinExam?.StatusElement?.Value);
+				var w_ = context.Operators.Convert<string>(v_);
+				var x_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var y_ = context.Operators.InList<string>(w_, (x_ as IEnumerable<string>));
+				var z_ = context.Operators.And(u_, y_);
+				var aa_ = FHIRHelpers_4_3_000.ToValue(SkinExam?.Value);
+				var ab_ = this.Pressure_Injury_Stage_2__3__4_or_Unstageable();
+				var ac_ = context.Operators.ConceptInValueSet((aa_ as CqlConcept), ab_);
+				bool? ad_(Observation.ComponentComponent @this)
+				{
+					var al_ = FHIRHelpers_4_3_000.ToConcept(@this?.Code);
+					var am_ = context.Operators.Not((bool?)(al_ is null));
+
+					return am_;
+				};
+				var ae_ = context.Operators.WhereOrNull<Observation.ComponentComponent>((SkinExam?.Component as IEnumerable<Observation.ComponentComponent>), ad_);
+				CqlConcept af_(Observation.ComponentComponent @this)
+				{
+					var an_ = FHIRHelpers_4_3_000.ToConcept(@this?.Code);
+
+					return an_;
+				};
+				var ag_ = context.Operators.SelectOrNull<Observation.ComponentComponent, CqlConcept>(ae_, af_);
+				var ai_ = context.Operators.ConceptsInValueSet(ag_, ab_);
+				var aj_ = context.Operators.Or(ac_, ai_);
+				var ak_ = context.Operators.And(z_, aj_);
+
+				return ak_;
+			};
+			var h_ = context.Operators.WhereOrNull<Observation>(f_, g_);
+			Encounter i_(Observation SkinExam) => 
+				InpatientHospitalization;
+			var j_ = context.Operators.SelectOrNull<Observation, Encounter>(h_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with New Stage 2, 3, 4 or Unstageable Pressure Injury by Skin Exam after First 24 Hours")]
+	public IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours() => 
+		__Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours.Value;
+
+	private IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_Value()
+	{
+		var a_ = this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator();
+		var b_ = this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with New Stage 2, 3, 4 or Unstageable Pressure Injury Not POA")]
+	public IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA() => 
+		__Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = this.Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA();
+		var b_ = this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
@@ -1,0 +1,853 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("HospitalHarmSevereHypoglycemiaFHIR", "0.1.000")]
+public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __birth_date;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Glucose_Lab_Test_Mass_Per_Volume;
+    internal Lazy<CqlValueSet> __Hypoglycemics_Severe_Hypoglycemia;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter;
+    internal Lazy<IEnumerable<MedicationAdministration>> __Hypoglycemic_Medication_Administration;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Hypoglycemic_Medication_Administration;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Observation>> __Glucose_Test_with_Result_Less_Than_40;
+    internal Lazy<IEnumerable<Observation>> __Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80;
+    internal Lazy<IEnumerable<Observation>> __Severe_Hypoglycemic_Harm_Event;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Severe_Hypoglycemic_Harm_Event;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public HospitalHarmSevereHypoglycemiaFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+
+        __birth_date = new Lazy<CqlValueSet>(this.birth_date_Value);
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Glucose_Lab_Test_Mass_Per_Volume = new Lazy<CqlValueSet>(this.Glucose_Lab_Test_Mass_Per_Volume_Value);
+        __Hypoglycemics_Severe_Hypoglycemia = new Lazy<CqlValueSet>(this.Hypoglycemics_Severe_Hypoglycemia_Value);
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_Value);
+        __Hypoglycemic_Medication_Administration = new Lazy<IEnumerable<MedicationAdministration>>(this.Hypoglycemic_Medication_Administration_Value);
+        __Encounter_with_Hypoglycemic_Medication_Administration = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Hypoglycemic_Medication_Administration_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __Glucose_Test_with_Result_Less_Than_40 = new Lazy<IEnumerable<Observation>>(this.Glucose_Test_with_Result_Less_Than_40_Value);
+        __Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80 = new Lazy<IEnumerable<Observation>>(this.Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80_Value);
+        __Severe_Hypoglycemic_Harm_Event = new Lazy<IEnumerable<Observation>>(this.Severe_Hypoglycemic_Harm_Event_Value);
+        __Encounter_with_Severe_Hypoglycemic_Harm_Event = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Severe_Hypoglycemic_Harm_Event_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+
+    #endregion
+
+	private CqlValueSet birth_date_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
+
+    [CqlDeclaration("birth date")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
+	public CqlValueSet birth_date() => 
+		__birth_date.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+
+    [CqlDeclaration("Emergency Department Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Glucose_Lab_Test_Mass_Per_Volume_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34", null);
+
+    [CqlDeclaration("Glucose Lab Test Mass Per Volume")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34")]
+	public CqlValueSet Glucose_Lab_Test_Mass_Per_Volume() => 
+		__Glucose_Lab_Test_Mass_Per_Volume.Value;
+
+	private CqlValueSet Hypoglycemics_Severe_Hypoglycemia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", null);
+
+    [CqlDeclaration("Hypoglycemics Severe Hypoglycemia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393")]
+	public CqlValueSet Hypoglycemics_Severe_Hypoglycemia() => 
+		__Hypoglycemics_Severe_Hypoglycemia.Value;
+
+	private CqlValueSet Observation_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+
+    [CqlDeclaration("Observation Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("HospitalHarmSevereHypoglycemiaFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_Value()
+	{
+		var a_ = this.Encounter_Inpatient();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter InpatientEncounter)
+		{
+			var e_ = this.Patient();
+			var f_ = context.Operators.Convert<CqlDate>(e_?.BirthDateElement?.Value);
+			var g_ = FHIRHelpers_4_3_000.ToInterval(InpatientEncounter?.Period);
+			var h_ = context.Operators.Start(g_);
+			var i_ = context.Operators.DateFrom(h_);
+			var j_ = context.Operators.CalculateAgeAt(f_, i_, "year");
+			var k_ = context.Operators.GreaterOrEqual(j_, (int?)18);
+			var m_ = context.Operators.End(g_);
+			var n_ = this.Measurement_Period();
+			var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, "day");
+			var p_ = context.Operators.And(k_, o_);
+			var q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(InpatientEncounter?.StatusElement?.Value);
+			var r_ = context.Operators.Equal(q_, "finished");
+			var s_ = context.Operators.And(p_, r_);
+
+			return s_;
+		};
+		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter")]
+	public IEnumerable<Encounter> Qualifying_Encounter() => 
+		__Qualifying_Encounter.Value;
+
+	private IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration_Value()
+	{
+		var a_ = this.Hypoglycemics_Severe_Hypoglycemia();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationAdministration>(b_, d_);
+		bool? f_(MedicationAdministration HypoMedication)
+		{
+			var h_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(HypoMedication?.StatusElement?.Value);
+			var i_ = context.Operators.Equal(h_, "completed");
+			var k_ = context.Operators.Equal(h_, "not-done");
+			var l_ = context.Operators.Not(k_);
+			var m_ = context.Operators.And(i_, l_);
+
+			return m_;
+		};
+		var g_ = context.Operators.WhereOrNull<MedicationAdministration>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Hypoglycemic Medication Administration")]
+	public IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration() => 
+		__Hypoglycemic_Medication_Administration.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Hypoglycemic_Medication_Administration_Value()
+	{
+		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
+		{
+			var d_ = this.Hypoglycemic_Medication_Administration();
+			bool? e_(MedicationAdministration HypoglycemicMedication)
+			{
+				var i_ = FHIRHelpers_4_3_000.ToValue(HypoglycemicMedication?.Effective);
+				var j_ = QICoreCommon_2_0_000.ToInterval(i_);
+				var k_ = context.Operators.Start(j_);
+				var l_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				var m_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, null);
+
+				return m_;
+			};
+			var f_ = context.Operators.WhereOrNull<MedicationAdministration>(d_, e_);
+			Encounter g_(MedicationAdministration HypoglycemicMedication) => 
+				InpatientHospitalization;
+			var h_ = context.Operators.SelectOrNull<MedicationAdministration, Encounter>(f_, g_);
+
+			return h_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Hypoglycemic Medication Administration")]
+	public IEnumerable<Encounter> Encounter_with_Hypoglycemic_Medication_Administration() => 
+		__Encounter_with_Hypoglycemic_Medication_Administration.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.Encounter_with_Hypoglycemic_Medication_Administration();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Observation> Glucose_Test_with_Result_Less_Than_40_Value()
+	{
+		var a_ = this.Denominator();
+		IEnumerable<MedicationAdministration> b_(Encounter _QualifyingEncounter)
+		{
+			var l_ = this.Hypoglycemic_Medication_Administration();
+
+			return l_;
+		};
+		Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ c_(Encounter _QualifyingEncounter, MedicationAdministration _HypoglycemicMedication)
+		{
+			var m_ = new Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				HypoglycemicMedication = _HypoglycemicMedication,
+			};
+
+			return m_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, MedicationAdministration, Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ>(a_, b_, c_);
+		IEnumerable<Observation> e_(Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ _QualifyingEncounterHypoglycemicMedication)
+		{
+			var n_ = this.Glucose_Lab_Test_Mass_Per_Volume();
+			var o_ = context.Operators.RetrieveByValueSet<Observation>(n_, null);
+
+			return o_;
+		};
+		Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ f_(Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ QualifyingEncounterHypoglycemicMedication, Observation _GlucoseTest)
+		{
+			var p_ = new Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ
+			{
+				QualifyingEncounter = QualifyingEncounterHypoglycemicMedication.QualifyingEncounter,
+				HypoglycemicMedication = QualifyingEncounterHypoglycemicMedication.HypoglycemicMedication,
+				GlucoseTest = _GlucoseTest,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ, Observation, Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ tuple_dsfjbilfcbvjwbysgxhdjckiz)
+		{
+			object q_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlDateTime)
+				{
+					var at_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((at_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var au_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((au_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlDateTime)
+				{
+					var av_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((av_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var r_ = QICoreCommon_2_0_000.Earliest(q_());
+			var s_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_dsfjbilfcbvjwbysgxhdjckiz.QualifyingEncounter);
+			var t_ = context.Operators.ElementInInterval<CqlDateTime>(r_, s_, null);
+			var u_ = context.Operators.Convert<Code<ObservationStatus>>(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.StatusElement?.Value);
+			var v_ = context.Operators.Convert<string>(u_);
+			var w_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var x_ = context.Operators.InList<string>(v_, (w_ as IEnumerable<string>));
+			var y_ = context.Operators.And(t_, x_);
+			var z_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Value);
+			var aa_ = context.Operators.Quantity(40m, "mg/dL");
+			var ab_ = context.Operators.Less((z_ as CqlQuantity), aa_);
+			var ac_ = context.Operators.And(y_, ab_);
+			var ad_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.HypoglycemicMedication?.Effective);
+			var ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
+			var af_ = context.Operators.Start(ae_);
+			object ag_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlDateTime)
+				{
+					var aw_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((aw_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var ax_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((ax_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlDateTime)
+				{
+					var ay_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((ay_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var ah_ = QICoreCommon_2_0_000.Earliest(ag_());
+			var ai_ = context.Operators.Quantity(24m, "hours");
+			var aj_ = context.Operators.Subtract(ah_, ai_);
+			object ak_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlDateTime)
+				{
+					var az_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((az_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var ba_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((ba_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bb_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((bb_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var al_ = QICoreCommon_2_0_000.Earliest(ak_());
+			var am_ = context.Operators.Interval(aj_, al_, true, true);
+			var an_ = context.Operators.ElementInInterval<CqlDateTime>(af_, am_, null);
+			object ao_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bc_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((bc_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var bd_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((bd_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective) is CqlDateTime)
+				{
+					var be_ = FHIRHelpers_4_3_000.ToValue(tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest?.Effective);
+
+					return ((be_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var ap_ = QICoreCommon_2_0_000.Earliest(ao_());
+			var aq_ = context.Operators.Not((bool?)(ap_ is null));
+			var ar_ = context.Operators.And(an_, aq_);
+			var as_ = context.Operators.And(ac_, ar_);
+
+			return as_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ>(g_, h_);
+		Observation j_(Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ tuple_dsfjbilfcbvjwbysgxhdjckiz) => 
+			tuple_dsfjbilfcbvjwbysgxhdjckiz.GlucoseTest;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ, Observation>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Glucose Test with Result Less Than 40")]
+	public IEnumerable<Observation> Glucose_Test_with_Result_Less_Than_40() => 
+		__Glucose_Test_with_Result_Less_Than_40.Value;
+
+	private IEnumerable<Observation> Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80_Value()
+	{
+		var a_ = this.Denominator();
+		IEnumerable<Observation> b_(Encounter _QualifyingEncounter)
+		{
+			var l_ = this.Glucose_Test_with_Result_Less_Than_40();
+
+			return l_;
+		};
+		Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ c_(Encounter _QualifyingEncounter, Observation _LowGlucoseTest)
+		{
+			var m_ = new Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				LowGlucoseTest = _LowGlucoseTest,
+			};
+
+			return m_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Observation, Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ>(a_, b_, c_);
+		IEnumerable<Observation> e_(Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ _QualifyingEncounterLowGlucoseTest)
+		{
+			var n_ = this.Glucose_Lab_Test_Mass_Per_Volume();
+			var o_ = context.Operators.RetrieveByValueSet<Observation>(n_, null);
+
+			return o_;
+		};
+		Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ f_(Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ QualifyingEncounterLowGlucoseTest, Observation _FollowupGlucoseTest)
+		{
+			var p_ = new Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ
+			{
+				QualifyingEncounter = QualifyingEncounterLowGlucoseTest.QualifyingEncounter,
+				LowGlucoseTest = QualifyingEncounterLowGlucoseTest.LowGlucoseTest,
+				FollowupGlucoseTest = _FollowupGlucoseTest,
+			};
+
+			return p_;
+		};
+		var g_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ, Observation, Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ>(d_, e_, f_);
+		bool? h_(Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ tuple_cqtbbrgobhbjhtlcmkyteoihz)
+		{
+			object q_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var ba_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective);
+
+					return ((ba_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var bb_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective);
+
+					return ((bb_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bc_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective);
+
+					return ((bc_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var r_ = QICoreCommon_2_0_000.Earliest(q_());
+			object s_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bd_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bd_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var be_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((be_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bf_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bf_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var t_ = QICoreCommon_2_0_000.Earliest(s_());
+			object u_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bg_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bg_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var bh_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bh_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bi_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bi_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var v_ = QICoreCommon_2_0_000.Earliest(u_());
+			var w_ = context.Operators.Quantity(5m, "minutes");
+			var x_ = context.Operators.Add(v_, w_);
+			var y_ = context.Operators.Interval(t_, x_, false, true);
+			var z_ = context.Operators.ElementInInterval<CqlDateTime>(r_, y_, null);
+			object aa_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bj_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bj_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var bk_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bk_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bl_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bl_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var ab_ = QICoreCommon_2_0_000.Earliest(aa_());
+			var ac_ = context.Operators.Not((bool?)(ab_ is null));
+			var ad_ = context.Operators.And(z_, ac_);
+			object ae_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bm_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bm_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var bn_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bn_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bo_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.Effective);
+
+					return ((bo_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var af_ = QICoreCommon_2_0_000.Earliest(ae_());
+			var ag_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_cqtbbrgobhbjhtlcmkyteoihz.QualifyingEncounter);
+			var ah_ = context.Operators.ElementInInterval<CqlDateTime>(af_, ag_, null);
+			var ai_ = context.Operators.And(ad_, ah_);
+			object aj_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var bp_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective);
+
+					return ((bp_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var bq_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective);
+
+					return ((bq_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective) is CqlDateTime)
+				{
+					var br_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Effective);
+
+					return ((br_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var ak_ = QICoreCommon_2_0_000.Earliest(aj_());
+			var am_ = context.Operators.ElementInInterval<CqlDateTime>(ak_, ag_, null);
+			var an_ = context.Operators.And(ai_, am_);
+			var ao_ = context.Operators.Equivalent(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.IdElement?.Value, tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest?.IdElement?.Value);
+			var ap_ = context.Operators.Not(ao_);
+			var aq_ = context.Operators.And(an_, ap_);
+			var ar_ = context.Operators.Convert<Code<ObservationStatus>>(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.StatusElement?.Value);
+			var as_ = context.Operators.Convert<string>(ar_);
+			var at_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var au_ = context.Operators.InList<string>(as_, (at_ as IEnumerable<string>));
+			var av_ = context.Operators.And(aq_, au_);
+			var aw_ = FHIRHelpers_4_3_000.ToValue(tuple_cqtbbrgobhbjhtlcmkyteoihz.FollowupGlucoseTest?.Value);
+			var ax_ = context.Operators.Quantity(80m, "mg/dL");
+			var ay_ = context.Operators.Greater((aw_ as CqlQuantity), ax_);
+			var az_ = context.Operators.And(av_, ay_);
+
+			return az_;
+		};
+		var i_ = context.Operators.WhereOrNull<Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ>(g_, h_);
+		Observation j_(Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ tuple_cqtbbrgobhbjhtlcmkyteoihz) => 
+			tuple_cqtbbrgobhbjhtlcmkyteoihz.LowGlucoseTest;
+		var k_ = context.Operators.SelectOrNull<Tuples.Tuple_CQTbBRGObHbJhTLCMKYTEOihZ, Observation>(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Low Glucose Test Followed By Glucose Test Result Greater Than 80")]
+	public IEnumerable<Observation> Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80() => 
+		__Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80.Value;
+
+	private IEnumerable<Observation> Severe_Hypoglycemic_Harm_Event_Value()
+	{
+		var a_ = this.Glucose_Test_with_Result_Less_Than_40();
+		bool? b_(Observation LowGlucoseTest)
+		{
+			var d_ = this.Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80();
+			bool? e_(Observation @this)
+			{
+				var k_ = context.Operators.Not((bool?)(((@this is Resource)
+	? ((@this as Resource).IdElement)
+	: null)?.Value is null));
+
+				return k_;
+			};
+			var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+			string g_(Observation @this) => 
+				((@this is Resource)
+	? ((@this as Resource).IdElement)
+	: null)?.Value;
+			var h_ = context.Operators.SelectOrNull<Observation, string>(f_, g_);
+			var i_ = context.Operators.InList<string>(LowGlucoseTest?.IdElement?.Value, h_);
+			var j_ = context.Operators.Not(i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.WhereOrNull<Observation>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Severe Hypoglycemic Harm Event")]
+	public IEnumerable<Observation> Severe_Hypoglycemic_Harm_Event() => 
+		__Severe_Hypoglycemic_Harm_Event.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Severe_Hypoglycemic_Harm_Event_Value()
+	{
+		var a_ = this.Denominator();
+		IEnumerable<Observation> b_(Encounter _QualifyingEncounter)
+		{
+			var i_ = this.Severe_Hypoglycemic_Harm_Event();
+
+			return i_;
+		};
+		Tuples.Tuple_DKOWLZZJefTKbjLjeXPNieaFS c_(Encounter _QualifyingEncounter, Observation _HypoglycemicEvent)
+		{
+			var j_ = new Tuples.Tuple_DKOWLZZJefTKbjLjeXPNieaFS
+			{
+				QualifyingEncounter = _QualifyingEncounter,
+				HypoglycemicEvent = _HypoglycemicEvent,
+			};
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Observation, Tuples.Tuple_DKOWLZZJefTKbjLjeXPNieaFS>(a_, b_, c_);
+		bool? e_(Tuples.Tuple_DKOWLZZJefTKbjLjeXPNieaFS tuple_dkowlzzjeftkbjljexpnieafs)
+		{
+			object k_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(tuple_dkowlzzjeftkbjljexpnieafs.HypoglycemicEvent?.Effective) is CqlDateTime)
+				{
+					var o_ = FHIRHelpers_4_3_000.ToValue(tuple_dkowlzzjeftkbjljexpnieafs.HypoglycemicEvent?.Effective);
+
+					return ((o_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dkowlzzjeftkbjljexpnieafs.HypoglycemicEvent?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var p_ = FHIRHelpers_4_3_000.ToValue(tuple_dkowlzzjeftkbjljexpnieafs.HypoglycemicEvent?.Effective);
+
+					return ((p_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(tuple_dkowlzzjeftkbjljexpnieafs.HypoglycemicEvent?.Effective) is CqlDateTime)
+				{
+					var q_ = FHIRHelpers_4_3_000.ToValue(tuple_dkowlzzjeftkbjljexpnieafs.HypoglycemicEvent?.Effective);
+
+					return ((q_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var l_ = QICoreCommon_2_0_000.Earliest(k_());
+			var m_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_dkowlzzjeftkbjljexpnieafs.QualifyingEncounter);
+			var n_ = context.Operators.ElementInInterval<CqlDateTime>(l_, m_, null);
+
+			return n_;
+		};
+		var f_ = context.Operators.WhereOrNull<Tuples.Tuple_DKOWLZZJefTKbjLjeXPNieaFS>(d_, e_);
+		Encounter g_(Tuples.Tuple_DKOWLZZJefTKbjLjeXPNieaFS tuple_dkowlzzjeftkbjljexpnieafs) => 
+			tuple_dkowlzzjeftkbjljexpnieafs.QualifyingEncounter;
+		var h_ = context.Operators.SelectOrNull<Tuples.Tuple_DKOWLZZJefTKbjLjeXPNieaFS, Encounter>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Encounter with Severe Hypoglycemic Harm Event")]
+	public IEnumerable<Encounter> Encounter_with_Severe_Hypoglycemic_Harm_Event() => 
+		__Encounter_with_Severe_Hypoglycemic_Harm_Event.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = this.Encounter_with_Severe_Hypoglycemic_Harm_Event();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
+++ b/Demo/Measures-cms/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
@@ -1,0 +1,1312 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR", "1.3.000")]
+public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Active_Tuberculosis_for_Urology_Care;
+    internal Lazy<CqlValueSet> __BCG_Bacillus_Calmette_Guerin_for_Urology_Care;
+    internal Lazy<CqlValueSet> __Bladder_Cancer_for_Urology_Care;
+    internal Lazy<CqlValueSet> __Chemotherapy_Agents_for_Advanced_Cancer;
+    internal Lazy<CqlValueSet> __Cystectomy_for_Urology_Care;
+    internal Lazy<CqlValueSet> __HIV;
+    internal Lazy<CqlValueSet> __Immunocompromised_Conditions;
+    internal Lazy<CqlValueSet> __Immunosuppressive_Drugs_for_Urology_Care;
+    internal Lazy<CqlValueSet> __Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care;
+    internal Lazy<CqlCode> __Carcinoma_in_situ_of_bladder;
+    internal Lazy<CqlCode> __Combined_radiotherapy__procedure_;
+    internal Lazy<CqlCode> __T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_;
+    internal Lazy<CqlCode> __Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_;
+    internal Lazy<CqlCode> __Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_;
+    internal Lazy<CqlCode> __Tumor_staging__tumor_staging_;
+    internal Lazy<CqlCode> __Dead__finding_;
+    internal Lazy<CqlCode> __virtual;
+    internal Lazy<CqlCode> __Stage_group_pathology_Cancer;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __ICD10CM;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __ActCode;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Condition>> __Bladder_Cancer_Diagnosis;
+    internal Lazy<Procedure> __First_Bladder_Cancer_Staging_Procedure;
+    internal Lazy<CqlDateTime> __July_1_of_Year_Prior_to_the_Measurement_Period;
+    internal Lazy<CqlDateTime> __June_30_of_the_Measurement_Period;
+    internal Lazy<Procedure> __First_Qualifying_Bladder_Cancer_Staging_Procedure;
+    internal Lazy<Procedure> __First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period;
+    internal Lazy<bool?> __Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1;
+    internal Lazy<bool?> __Has_Qualifying_Encounter;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<MedicationAdministration>> __BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging;
+    internal Lazy<bool?> __Denominator_Exception;
+    internal Lazy<MedicationAdministration> __First_BCG_Administered;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Condition>> __Acute_Tuberculosis_Diagnosis;
+    internal Lazy<IEnumerable<MedicationRequest>> __Immunosuppressive_Drugs;
+    internal Lazy<IEnumerable<Procedure>> __Cystectomy_Done;
+    internal Lazy<bool?> __Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging;
+    internal Lazy<bool?> __Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging;
+    internal Lazy<bool?> __Denominator_Exclusion;
+
+    #endregion
+    public IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CumulativeMedicationDuration_4_0_000 = new CumulativeMedicationDuration_4_0_000(context);
+
+        __Active_Tuberculosis_for_Urology_Care = new Lazy<CqlValueSet>(this.Active_Tuberculosis_for_Urology_Care_Value);
+        __BCG_Bacillus_Calmette_Guerin_for_Urology_Care = new Lazy<CqlValueSet>(this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care_Value);
+        __Bladder_Cancer_for_Urology_Care = new Lazy<CqlValueSet>(this.Bladder_Cancer_for_Urology_Care_Value);
+        __Chemotherapy_Agents_for_Advanced_Cancer = new Lazy<CqlValueSet>(this.Chemotherapy_Agents_for_Advanced_Cancer_Value);
+        __Cystectomy_for_Urology_Care = new Lazy<CqlValueSet>(this.Cystectomy_for_Urology_Care_Value);
+        __HIV = new Lazy<CqlValueSet>(this.HIV_Value);
+        __Immunocompromised_Conditions = new Lazy<CqlValueSet>(this.Immunocompromised_Conditions_Value);
+        __Immunosuppressive_Drugs_for_Urology_Care = new Lazy<CqlValueSet>(this.Immunosuppressive_Drugs_for_Urology_Care_Value);
+        __Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care = new Lazy<CqlValueSet>(this.Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care = new Lazy<CqlValueSet>(this.Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care_Value);
+        __Carcinoma_in_situ_of_bladder = new Lazy<CqlCode>(this.Carcinoma_in_situ_of_bladder_Value);
+        __Combined_radiotherapy__procedure_ = new Lazy<CqlCode>(this.Combined_radiotherapy__procedure__Value);
+        __T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_ = new Lazy<CqlCode>(this.T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding__Value);
+        __Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_ = new Lazy<CqlCode>(this.Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding__Value);
+        __Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_ = new Lazy<CqlCode>(this.Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding__Value);
+        __Tumor_staging__tumor_staging_ = new Lazy<CqlCode>(this.Tumor_staging__tumor_staging__Value);
+        __Dead__finding_ = new Lazy<CqlCode>(this.Dead__finding__Value);
+        __virtual = new Lazy<CqlCode>(this.@virtual_Value);
+        __Stage_group_pathology_Cancer = new Lazy<CqlCode>(this.Stage_group_pathology_Cancer_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __ICD10CM = new Lazy<CqlCode[]>(this.ICD10CM_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __ActCode = new Lazy<CqlCode[]>(this.ActCode_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Bladder_Cancer_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Bladder_Cancer_Diagnosis_Value);
+        __First_Bladder_Cancer_Staging_Procedure = new Lazy<Procedure>(this.First_Bladder_Cancer_Staging_Procedure_Value);
+        __July_1_of_Year_Prior_to_the_Measurement_Period = new Lazy<CqlDateTime>(this.July_1_of_Year_Prior_to_the_Measurement_Period_Value);
+        __June_30_of_the_Measurement_Period = new Lazy<CqlDateTime>(this.June_30_of_the_Measurement_Period_Value);
+        __First_Qualifying_Bladder_Cancer_Staging_Procedure = new Lazy<Procedure>(this.First_Qualifying_Bladder_Cancer_Staging_Procedure_Value);
+        __First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period = new Lazy<Procedure>(this.First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period_Value);
+        __Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1 = new Lazy<bool?>(this.Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1_Value);
+        __Has_Qualifying_Encounter = new Lazy<bool?>(this.Has_Qualifying_Encounter_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging = new Lazy<IEnumerable<MedicationAdministration>>(this.BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging_Value);
+        __Denominator_Exception = new Lazy<bool?>(this.Denominator_Exception_Value);
+        __First_BCG_Administered = new Lazy<MedicationAdministration>(this.First_BCG_Administered_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Acute_Tuberculosis_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Acute_Tuberculosis_Diagnosis_Value);
+        __Immunosuppressive_Drugs = new Lazy<IEnumerable<MedicationRequest>>(this.Immunosuppressive_Drugs_Value);
+        __Cystectomy_Done = new Lazy<IEnumerable<Procedure>>(this.Cystectomy_Done_Value);
+        __Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging = new Lazy<bool?>(this.Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging_Value);
+        __Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging = new Lazy<bool?>(this.Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging_Value);
+        __Denominator_Exclusion = new Lazy<bool?>(this.Denominator_Exclusion_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CumulativeMedicationDuration_4_0_000 CumulativeMedicationDuration_4_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Active_Tuberculosis_for_Urology_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56", null);
+
+    [CqlDeclaration("Active Tuberculosis for Urology Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56")]
+	public CqlValueSet Active_Tuberculosis_for_Urology_Care() => 
+		__Active_Tuberculosis_for_Urology_Care.Value;
+
+	private CqlValueSet BCG_Bacillus_Calmette_Guerin_for_Urology_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52", null);
+
+    [CqlDeclaration("BCG Bacillus Calmette Guerin for Urology Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52")]
+	public CqlValueSet BCG_Bacillus_Calmette_Guerin_for_Urology_Care() => 
+		__BCG_Bacillus_Calmette_Guerin_for_Urology_Care.Value;
+
+	private CqlValueSet Bladder_Cancer_for_Urology_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45", null);
+
+    [CqlDeclaration("Bladder Cancer for Urology Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45")]
+	public CqlValueSet Bladder_Cancer_for_Urology_Care() => 
+		__Bladder_Cancer_for_Urology_Care.Value;
+
+	private CqlValueSet Chemotherapy_Agents_for_Advanced_Cancer_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60", null);
+
+    [CqlDeclaration("Chemotherapy Agents for Advanced Cancer")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60")]
+	public CqlValueSet Chemotherapy_Agents_for_Advanced_Cancer() => 
+		__Chemotherapy_Agents_for_Advanced_Cancer.Value;
+
+	private CqlValueSet Cystectomy_for_Urology_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55", null);
+
+    [CqlDeclaration("Cystectomy for Urology Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55")]
+	public CqlValueSet Cystectomy_for_Urology_Care() => 
+		__Cystectomy_for_Urology_Care.Value;
+
+	private CqlValueSet HIV_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+
+    [CqlDeclaration("HIV")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
+	public CqlValueSet HIV() => 
+		__HIV.Value;
+
+	private CqlValueSet Immunocompromised_Conditions_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940", null);
+
+    [CqlDeclaration("Immunocompromised Conditions")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940")]
+	public CqlValueSet Immunocompromised_Conditions() => 
+		__Immunocompromised_Conditions.Value;
+
+	private CqlValueSet Immunosuppressive_Drugs_for_Urology_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32", null);
+
+    [CqlDeclaration("Immunosuppressive Drugs for Urology Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32")]
+	public CqlValueSet Immunosuppressive_Drugs_for_Urology_Care() => 
+		__Immunosuppressive_Drugs_for_Urology_Care.Value;
+
+	private CqlValueSet Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39", null);
+
+    [CqlDeclaration("Mixed histology urothelial cell carcinoma for Urology Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39")]
+	public CqlValueSet Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care() => 
+		__Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44", null);
+
+    [CqlDeclaration("Unavailability of Bacillus Calmette Guerin for urology care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44")]
+	public CqlValueSet Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care() => 
+		__Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care.Value;
+
+	private CqlCode Carcinoma_in_situ_of_bladder_Value() => 
+		new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
+
+    [CqlDeclaration("Carcinoma in situ of bladder")]
+	public CqlCode Carcinoma_in_situ_of_bladder() => 
+		__Carcinoma_in_situ_of_bladder.Value;
+
+	private CqlCode Combined_radiotherapy__procedure__Value() => 
+		new CqlCode("169331000", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Combined radiotherapy (procedure)")]
+	public CqlCode Combined_radiotherapy__procedure_() => 
+		__Combined_radiotherapy__procedure_.Value;
+
+	private CqlCode T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding__Value() => 
+		new CqlCode("369935001", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("T1: Urinary tract tumor invades subepithelial connective tissue (finding)")]
+	public CqlCode T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_() => 
+		__T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_.Value;
+
+	private CqlCode Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding__Value() => 
+		new CqlCode("369949005", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Ta: Noninvasive papillary carcinoma (urinary tract) (finding)")]
+	public CqlCode Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_() => 
+		__Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_.Value;
+
+	private CqlCode Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding__Value() => 
+		new CqlCode("369934002", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Tis: Carcinoma in situ (flat tumor of urinary bladder) (finding)")]
+	public CqlCode Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_() => 
+		__Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_.Value;
+
+	private CqlCode Tumor_staging__tumor_staging__Value() => 
+		new CqlCode("254292007", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Tumor staging (tumor staging)")]
+	public CqlCode Tumor_staging__tumor_staging_() => 
+		__Tumor_staging__tumor_staging_.Value;
+
+	private CqlCode Dead__finding__Value() => 
+		new CqlCode("419099009", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Dead (finding)")]
+	public CqlCode Dead__finding_() => 
+		__Dead__finding_.Value;
+
+	private CqlCode @virtual_Value() => 
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+
+    [CqlDeclaration("virtual")]
+	public CqlCode @virtual() => 
+		__virtual.Value;
+
+	private CqlCode Stage_group_pathology_Cancer_Value() => 
+		new CqlCode("21902-2", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Stage group.pathology Cancer")]
+	public CqlCode Stage_group_pathology_Cancer() => 
+		__Stage_group_pathology_Cancer.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("169331000", "http://snomed.info/sct", null, null),
+			new CqlCode("369935001", "http://snomed.info/sct", null, null),
+			new CqlCode("369949005", "http://snomed.info/sct", null, null),
+			new CqlCode("369934002", "http://snomed.info/sct", null, null),
+			new CqlCode("254292007", "http://snomed.info/sct", null, null),
+			new CqlCode("419099009", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] ICD10CM_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ICD10CM")]
+	public CqlCode[] ICD10CM() => 
+		__ICD10CM.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("21902-2", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] ActCode_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ActCode")]
+	public CqlCode[] ActCode() => 
+		__ActCode.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+    [CqlDeclaration("isConfirmedActiveDiagnosis")]
+	public bool? isConfirmedActiveDiagnosis(Condition Condition)
+	{
+		var a_ = new Condition[]
+		{
+			Condition,
+		};
+		bool? b_(Condition Diagnosis)
+		{
+			var f_ = FHIRHelpers_4_3_000.ToConcept(Diagnosis?.ClinicalStatus);
+			var g_ = QICoreCommon_2_0_000.active();
+			var h_ = context.Operators.ConvertCodeToConcept(g_);
+			var i_ = context.Operators.Equivalent(f_, h_);
+			var j_ = FHIRHelpers_4_3_000.ToConcept(Diagnosis?.VerificationStatus);
+			var k_ = QICoreCommon_2_0_000.unconfirmed();
+			var l_ = context.Operators.ConvertCodeToConcept(k_);
+			var m_ = context.Operators.Equivalent(j_, l_);
+			var o_ = QICoreCommon_2_0_000.refuted();
+			var p_ = context.Operators.ConvertCodeToConcept(o_);
+			var q_ = context.Operators.Equivalent(j_, p_);
+			var r_ = context.Operators.Or(m_, q_);
+			var t_ = QICoreCommon_2_0_000.entered_in_error();
+			var u_ = context.Operators.ConvertCodeToConcept(t_);
+			var v_ = context.Operators.Equivalent(j_, u_);
+			var w_ = context.Operators.Or(r_, v_);
+			var x_ = context.Operators.Not(w_);
+			var y_ = context.Operators.And(i_, x_);
+
+			return y_;
+		};
+		var c_ = context.Operators.WhereOrNull<Condition>(a_, b_);
+		var d_ = context.Operators.SingleOrNull<Condition>(c_);
+		var e_ = context.Operators.Not((bool?)(d_ is null));
+
+		return e_;
+	}
+
+	private IEnumerable<Condition> Bladder_Cancer_Diagnosis_Value()
+	{
+		var a_ = this.Bladder_Cancer_for_Urology_Care();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition BladderCancer)
+		{
+			var e_ = QICoreCommon_2_0_000.prevalenceInterval(BladderCancer);
+			var f_ = context.Operators.Start(e_);
+			var g_ = this.Measurement_Period();
+			var h_ = context.Operators.End(g_);
+			var i_ = context.Operators.Before(f_, h_, null);
+			var j_ = this.isConfirmedActiveDiagnosis(BladderCancer);
+			var k_ = context.Operators.And(i_, j_);
+
+			return k_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Bladder Cancer Diagnosis")]
+	public IEnumerable<Condition> Bladder_Cancer_Diagnosis() => 
+		__Bladder_Cancer_Diagnosis.Value;
+
+	private Procedure First_Bladder_Cancer_Staging_Procedure_Value()
+	{
+		var a_ = this.Tumor_staging__tumor_staging_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Procedure>(b_, null);
+		IEnumerable<Procedure> d_(Procedure BladderCancerStaging)
+		{
+			var k_ = this.Bladder_Cancer_Diagnosis();
+			bool? l_(Condition BladderCancer)
+			{
+				var p_ = FHIRHelpers_4_3_000.ToValue(BladderCancerStaging?.Performed);
+				var q_ = QICoreCommon_2_0_000.toInterval(p_);
+				var r_ = context.Operators.Start(q_);
+				var s_ = QICoreCommon_2_0_000.prevalenceInterval(BladderCancer);
+				var t_ = context.Operators.Start(s_);
+				var u_ = context.Operators.SameOrBefore(r_, t_, "day");
+				var w_ = QICoreCommon_2_0_000.toInterval(p_);
+				var y_ = context.Operators.Overlaps(w_, s_, "day");
+				var z_ = context.Operators.And(u_, y_);
+
+				return z_;
+			};
+			var m_ = context.Operators.WhereOrNull<Condition>(k_, l_);
+			Procedure n_(Condition BladderCancer) => 
+				BladderCancerStaging;
+			var o_ = context.Operators.SelectOrNull<Condition, Procedure>(m_, n_);
+
+			return o_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(c_, d_);
+		bool? f_(Procedure BladderCancerStaging)
+		{
+			var aa_ = context.Operators.EnumEqualsString(BladderCancerStaging?.StatusElement?.Value, "completed");
+
+			return aa_;
+		};
+		var g_ = context.Operators.WhereOrNull<Procedure>(e_, f_);
+		object h_(Procedure @this)
+		{
+			var ab_ = FHIRHelpers_4_3_000.ToValue(@this?.Performed);
+			var ac_ = QICoreCommon_2_0_000.toInterval(ab_);
+			var ad_ = context.Operators.Start(ac_);
+
+			return ad_;
+		};
+		var i_ = context.Operators.ListSortBy<Procedure>(g_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		var j_ = context.Operators.FirstOfList<Procedure>(i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("First Bladder Cancer Staging Procedure")]
+	public Procedure First_Bladder_Cancer_Staging_Procedure() => 
+		__First_Bladder_Cancer_Staging_Procedure.Value;
+
+	private CqlDateTime July_1_of_Year_Prior_to_the_Measurement_Period_Value()
+	{
+		var a_ = this.Measurement_Period();
+		var b_ = context.Operators.Start(a_);
+		var c_ = context.Operators.ComponentFrom(b_, "year");
+		var d_ = context.Operators.Subtract(c_, (int?)1);
+		var e_ = context.Operators.ConvertIntegerToDecimal((int?)0);
+		var f_ = context.Operators.DateTime(d_, (int?)7, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("July 1 of Year Prior to the Measurement Period")]
+	public CqlDateTime July_1_of_Year_Prior_to_the_Measurement_Period() => 
+		__July_1_of_Year_Prior_to_the_Measurement_Period.Value;
+
+	private CqlDateTime June_30_of_the_Measurement_Period_Value()
+	{
+		var a_ = this.Measurement_Period();
+		var b_ = context.Operators.Start(a_);
+		var c_ = context.Operators.ComponentFrom(b_, "year");
+		var d_ = context.Operators.ConvertIntegerToDecimal((int?)0);
+		var e_ = context.Operators.DateTime(c_, (int?)6, (int?)30, (int?)23, (int?)59, (int?)59, (int?)0, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("June 30 of the Measurement Period")]
+	public CqlDateTime June_30_of_the_Measurement_Period() => 
+		__June_30_of_the_Measurement_Period.Value;
+
+	private Procedure First_Qualifying_Bladder_Cancer_Staging_Procedure_Value()
+	{
+		var a_ = this.First_Bladder_Cancer_Staging_Procedure();
+		var b_ = new Procedure[]
+		{
+			a_,
+		};
+		bool? c_(Procedure FirstBladderCancerStaging)
+		{
+			var f_ = this.July_1_of_Year_Prior_to_the_Measurement_Period();
+			var g_ = this.June_30_of_the_Measurement_Period();
+			var h_ = context.Operators.Interval(f_, g_, true, true);
+			var i_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+			var j_ = QICoreCommon_2_0_000.toInterval(i_);
+			var k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, "day");
+
+			return k_;
+		};
+		var d_ = context.Operators.WhereOrNull<Procedure>(b_, c_);
+		var e_ = context.Operators.SingleOrNull<Procedure>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("First Qualifying Bladder Cancer Staging Procedure")]
+	public Procedure First_Qualifying_Bladder_Cancer_Staging_Procedure() => 
+		__First_Qualifying_Bladder_Cancer_Staging_Procedure.Value;
+
+	private Procedure First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period_Value()
+	{
+		var a_ = this.First_Bladder_Cancer_Staging_Procedure();
+		var b_ = new Procedure[]
+		{
+			a_,
+		};
+		bool? c_(Procedure FirstBladderCancerStaging)
+		{
+			var f_ = this.July_1_of_Year_Prior_to_the_Measurement_Period();
+			var g_ = this.June_30_of_the_Measurement_Period();
+			var h_ = context.Operators.Interval(f_, g_, true, true);
+			var i_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+			var j_ = QICoreCommon_2_0_000.toInterval(i_);
+			var k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, "day");
+
+			return k_;
+		};
+		var d_ = context.Operators.WhereOrNull<Procedure>(b_, c_);
+		var e_ = context.Operators.SingleOrNull<Procedure>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("First Bladder Cancer Staging Procedure during 6 Months Prior to Measurement Period through the First 6 Months of Measurement Period")]
+	public Procedure First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period() => 
+		__First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period.Value;
+
+    [CqlDeclaration("getStagingProcedure")]
+	public IEnumerable<Procedure> getStagingProcedure(Observation StagingObservation)
+	{
+		Procedure a_(ResourceReference StagingReference)
+		{
+			var c_ = this.First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period();
+			var d_ = new Procedure[]
+			{
+				c_,
+			};
+			bool? e_(Procedure FirstBladderCancerStagingMP)
+			{
+				var h_ = QICoreCommon_2_0_000.getId(StagingReference?.ReferenceElement?.Value);
+				var i_ = context.Operators.Equal(FirstBladderCancerStagingMP?.IdElement?.Value, h_);
+
+				return i_;
+			};
+			var f_ = context.Operators.WhereOrNull<Procedure>(d_, e_);
+			var g_ = context.Operators.SingleOrNull<Procedure>(f_);
+
+			return g_;
+		};
+		var b_ = context.Operators.SelectOrNull<ResourceReference, Procedure>((StagingObservation?.PartOf as IEnumerable<ResourceReference>), a_);
+
+		return b_;
+	}
+
+	private bool? Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1_Value()
+	{
+		var a_ = this.Stage_group_pathology_Cancer();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		bool? d_(Observation StagingObservation)
+		{
+			var g_ = this.getStagingProcedure(StagingObservation);
+			var h_ = context.Operators.Not((bool?)(g_ is null));
+			var i_ = FHIRHelpers_4_3_000.ToValue(StagingObservation?.Value);
+			var j_ = this.T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_();
+			var k_ = context.Operators.ConvertCodeToConcept(j_);
+			var l_ = context.Operators.Equivalent((i_ as CqlConcept), k_);
+			var n_ = this.Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_();
+			var o_ = context.Operators.ConvertCodeToConcept(n_);
+			var p_ = context.Operators.Equivalent((i_ as CqlConcept), o_);
+			var q_ = context.Operators.Or(l_, p_);
+			var s_ = this.Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_();
+			var t_ = context.Operators.ConvertCodeToConcept(s_);
+			var u_ = context.Operators.Equivalent((i_ as CqlConcept), t_);
+			var v_ = context.Operators.Or(q_, u_);
+			var x_ = this.Carcinoma_in_situ_of_bladder();
+			var y_ = context.Operators.ConvertCodeToConcept(x_);
+			var z_ = context.Operators.Equivalent((i_ as CqlConcept), y_);
+			var aa_ = context.Operators.Or(v_, z_);
+			var ab_ = context.Operators.And(h_, aa_);
+			var ac_ = context.Operators.Convert<Code<ObservationStatus>>(StagingObservation?.StatusElement?.Value);
+			var ad_ = context.Operators.Convert<string>(ac_);
+			var ae_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var af_ = context.Operators.InList<string>(ad_, (ae_ as IEnumerable<string>));
+			var ag_ = context.Operators.And(ab_, af_);
+
+			return ag_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Observation>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Has Most Recent Bladder Cancer Tumor Staging is Ta HG, Tis, T1")]
+	public bool? Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1() => 
+		__Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1.Value;
+
+	private bool? Has_Qualifying_Encounter_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter ValidEncounter)
+		{
+			var f_ = this.Measurement_Period();
+			var g_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, g_, null);
+			var i_ = FHIRHelpers_4_3_000.ToCode(ValidEncounter?.Class);
+			var j_ = this.@virtual();
+			var k_ = context.Operators.Equivalent(i_, j_);
+			var l_ = context.Operators.Not(k_);
+			var m_ = context.Operators.And(h_, l_);
+			var n_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ValidEncounter?.StatusElement?.Value);
+			var o_ = context.Operators.Equal(n_, "finished");
+			var p_ = context.Operators.And(m_, o_);
+
+			return p_;
+		};
+		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Encounter>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Qualifying Encounter")]
+	public bool? Has_Qualifying_Encounter() => 
+		__Has_Qualifying_Encounter.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.First_Qualifying_Bladder_Cancer_Staging_Procedure();
+		var b_ = context.Operators.Not((bool?)(a_ is null));
+		var c_ = this.Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1();
+		var d_ = context.Operators.And(b_, c_);
+		var e_ = this.Has_Qualifying_Encounter();
+		var f_ = context.Operators.And(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<MedicationAdministration> BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging_Value()
+	{
+		var a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationAdministration>(b_, d_);
+		IEnumerable<MedicationAdministration> f_(MedicationAdministration BCGNotGiven)
+		{
+			var j_ = this.First_Bladder_Cancer_Staging_Procedure();
+			var k_ = new Procedure[]
+			{
+				j_,
+			};
+			bool? l_(Procedure FirstBladderCancerStaging)
+			{
+				bool? p_(Extension @this)
+				{
+					var at_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+
+					return at_;
+				};
+				var q_ = context.Operators.WhereOrNull<Extension>(((BCGNotGiven is DomainResource)
+						? ((BCGNotGiven as DomainResource).Extension)
+						: null), p_);
+				DataType r_(Extension @this) => 
+					@this?.Value;
+				var s_ = context.Operators.SelectOrNull<Extension, DataType>(q_, r_);
+				var t_ = context.Operators.SingleOrNull<DataType>(s_);
+				var u_ = context.Operators.Convert<CqlDateTime>(t_);
+				var v_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+				var w_ = QICoreCommon_2_0_000.toInterval(v_);
+				var x_ = context.Operators.Start(w_);
+				var z_ = QICoreCommon_2_0_000.toInterval(v_);
+				var aa_ = context.Operators.Start(z_);
+				var ab_ = context.Operators.Quantity(6m, "months");
+				var ac_ = context.Operators.Add(aa_, ab_);
+				var ad_ = context.Operators.Interval(x_, ac_, false, true);
+				var ae_ = context.Operators.ElementInInterval<CqlDateTime>(u_, ad_, null);
+				var ag_ = QICoreCommon_2_0_000.toInterval(v_);
+				var ah_ = context.Operators.Start(ag_);
+				var ai_ = context.Operators.Not((bool?)(ah_ is null));
+				var aj_ = context.Operators.And(ae_, ai_);
+				bool? ak_(Extension @this)
+				{
+					var au_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+
+					return au_;
+				};
+				var al_ = context.Operators.WhereOrNull<Extension>(((BCGNotGiven is DomainResource)
+						? ((BCGNotGiven as DomainResource).Extension)
+						: null), ak_);
+				var an_ = context.Operators.SelectOrNull<Extension, DataType>(al_, r_);
+				var ao_ = context.Operators.SingleOrNull<DataType>(an_);
+				var ap_ = context.Operators.Convert<CqlDateTime>(ao_);
+				var aq_ = this.Measurement_Period();
+				var ar_ = context.Operators.ElementInInterval<CqlDateTime>(ap_, aq_, null);
+				var as_ = context.Operators.And(aj_, ar_);
+
+				return as_;
+			};
+			var m_ = context.Operators.WhereOrNull<Procedure>(k_, l_);
+			MedicationAdministration n_(Procedure FirstBladderCancerStaging) => 
+				BCGNotGiven;
+			var o_ = context.Operators.SelectOrNull<Procedure, MedicationAdministration>(m_, n_);
+
+			return o_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<MedicationAdministration, MedicationAdministration>(e_, f_);
+		bool? h_(MedicationAdministration BCGNotGiven)
+		{
+			CqlConcept av_(CodeableConcept @this)
+			{
+				var az_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return az_;
+			};
+			var aw_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(BCGNotGiven?.StatusReason, av_);
+			var ax_ = this.Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care();
+			var ay_ = context.Operators.ConceptsInValueSet(aw_, ax_);
+
+			return ay_;
+		};
+		var i_ = context.Operators.WhereOrNull<MedicationAdministration>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("BCG Not Available Within 6 Months After Bladder Cancer Staging")]
+	public IEnumerable<MedicationAdministration> BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging() => 
+		__BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging.Value;
+
+	private bool? Denominator_Exception_Value()
+	{
+		var a_ = this.BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging();
+		var b_ = context.Operators.ExistsInList<MedicationAdministration>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Denominator Exception")]
+	public bool? Denominator_Exception() => 
+		__Denominator_Exception.Value;
+
+	private MedicationAdministration First_BCG_Administered_Value()
+	{
+		var a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationAdministration>(b_, d_);
+		IEnumerable<MedicationAdministration> f_(MedicationAdministration BCG)
+		{
+			var m_ = this.First_Bladder_Cancer_Staging_Procedure();
+			var n_ = new Procedure[]
+			{
+				m_,
+			};
+			bool? o_(Procedure FirstBladderCancerStaging)
+			{
+				var s_ = FHIRHelpers_4_3_000.ToValue(BCG?.Effective);
+				var t_ = QICoreCommon_2_0_000.toInterval(s_);
+				var u_ = context.Operators.Start(t_);
+				var v_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+				var w_ = QICoreCommon_2_0_000.toInterval(v_);
+				var x_ = context.Operators.Start(w_);
+				var z_ = QICoreCommon_2_0_000.toInterval(v_);
+				var aa_ = context.Operators.Start(z_);
+				var ab_ = context.Operators.Quantity(6m, "months");
+				var ac_ = context.Operators.Add(aa_, ab_);
+				var ad_ = context.Operators.Interval(x_, ac_, false, true);
+				var ae_ = context.Operators.ElementInInterval<CqlDateTime>(u_, ad_, null);
+				var ag_ = QICoreCommon_2_0_000.toInterval(v_);
+				var ah_ = context.Operators.Start(ag_);
+				var ai_ = context.Operators.Not((bool?)(ah_ is null));
+				var aj_ = context.Operators.And(ae_, ai_);
+				var al_ = QICoreCommon_2_0_000.toInterval(s_);
+				var am_ = context.Operators.Start(al_);
+				var an_ = this.Measurement_Period();
+				var ao_ = context.Operators.ElementInInterval<CqlDateTime>(am_, an_, null);
+				var ap_ = context.Operators.And(aj_, ao_);
+
+				return ap_;
+			};
+			var p_ = context.Operators.WhereOrNull<Procedure>(n_, o_);
+			MedicationAdministration q_(Procedure FirstBladderCancerStaging) => 
+				BCG;
+			var r_ = context.Operators.SelectOrNull<Procedure, MedicationAdministration>(p_, q_);
+
+			return r_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<MedicationAdministration, MedicationAdministration>(e_, f_);
+		bool? h_(MedicationAdministration BCG)
+		{
+			var aq_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(BCG?.StatusElement?.Value);
+			var ar_ = context.Operators.Convert<string>(aq_);
+			var as_ = new string[]
+			{
+				"in-progress",
+				"completed",
+			};
+			var at_ = context.Operators.InList<string>(ar_, (as_ as IEnumerable<string>));
+
+			return at_;
+		};
+		var i_ = context.Operators.WhereOrNull<MedicationAdministration>(g_, h_);
+		object j_(MedicationAdministration @this)
+		{
+			var au_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var av_ = QICoreCommon_2_0_000.toInterval(au_);
+			var aw_ = context.Operators.Start(av_);
+
+			return aw_;
+		};
+		var k_ = context.Operators.ListSortBy<MedicationAdministration>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+		var l_ = context.Operators.FirstOfList<MedicationAdministration>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("First BCG Administered")]
+	public MedicationAdministration First_BCG_Administered() => 
+		__First_BCG_Administered.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.First_BCG_Administered();
+		var b_ = context.Operators.Not((bool?)(a_ is null));
+
+		return b_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Condition> Acute_Tuberculosis_Diagnosis_Value()
+	{
+		var a_ = this.Active_Tuberculosis_for_Urology_Care();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_(Condition ActiveTuberculosis)
+		{
+			var g_ = this.First_Bladder_Cancer_Staging_Procedure();
+			var h_ = new Procedure[]
+			{
+				g_,
+			};
+			bool? i_(Procedure FirstBladderCancerStaging)
+			{
+				var m_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveTuberculosis);
+				var n_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+				var o_ = QICoreCommon_2_0_000.toInterval(n_);
+				var p_ = context.Operators.OverlapsAfter(m_, o_, null);
+
+				return p_;
+			};
+			var j_ = context.Operators.WhereOrNull<Procedure>(h_, i_);
+			Condition k_(Procedure FirstBladderCancerStaging) => 
+				ActiveTuberculosis;
+			var l_ = context.Operators.SelectOrNull<Procedure, Condition>(j_, k_);
+
+			return l_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Condition, Condition>(b_, c_);
+		bool? e_(Condition ActiveTuberculosis)
+		{
+			var q_ = this.isConfirmedActiveDiagnosis(ActiveTuberculosis);
+
+			return q_;
+		};
+		var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Acute Tuberculosis Diagnosis")]
+	public IEnumerable<Condition> Acute_Tuberculosis_Diagnosis() => 
+		__Acute_Tuberculosis_Diagnosis.Value;
+
+	private IEnumerable<MedicationRequest> Immunosuppressive_Drugs_Value()
+	{
+		var a_ = this.Immunosuppressive_Drugs_for_Urology_Care();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_(MedicationRequest ImmunosuppressiveDrugs)
+		{
+			var h_ = this.First_Bladder_Cancer_Staging_Procedure();
+			var i_ = new Procedure[]
+			{
+				h_,
+			};
+			bool? j_(Procedure FirstBladderCancerStaging)
+			{
+				var n_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ImmunosuppressiveDrugs);
+				var o_ = context.Operators.Start(n_);
+				var p_ = context.Operators.ConvertDateToDateTime(o_);
+				var q_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+				var r_ = QICoreCommon_2_0_000.toInterval(q_);
+				var s_ = context.Operators.Start(r_);
+				var t_ = context.Operators.SameOrBefore(p_, s_, null);
+
+				return t_;
+			};
+			var k_ = context.Operators.WhereOrNull<Procedure>(i_, j_);
+			MedicationRequest l_(Procedure FirstBladderCancerStaging) => 
+				ImmunosuppressiveDrugs;
+			var m_ = context.Operators.SelectOrNull<Procedure, MedicationRequest>(k_, l_);
+
+			return m_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<MedicationRequest, MedicationRequest>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Immunosuppressive Drugs")]
+	public IEnumerable<MedicationRequest> Immunosuppressive_Drugs() => 
+		__Immunosuppressive_Drugs.Value;
+
+	private IEnumerable<Procedure> Cystectomy_Done_Value()
+	{
+		var a_ = this.Cystectomy_for_Urology_Care();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_(Procedure Cystectomy)
+		{
+			var g_ = this.First_Bladder_Cancer_Staging_Procedure();
+			var h_ = new Procedure[]
+			{
+				g_,
+			};
+			bool? i_(Procedure FirstBladderCancerStaging)
+			{
+				var m_ = FHIRHelpers_4_3_000.ToValue(Cystectomy?.Performed);
+				var n_ = QICoreCommon_2_0_000.toInterval(m_);
+				var o_ = context.Operators.End(n_);
+				var p_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+				var q_ = QICoreCommon_2_0_000.toInterval(p_);
+				var r_ = context.Operators.Start(q_);
+				var s_ = context.Operators.Quantity(6m, "months");
+				var t_ = context.Operators.Subtract(r_, s_);
+				var v_ = QICoreCommon_2_0_000.toInterval(p_);
+				var w_ = context.Operators.Start(v_);
+				var x_ = context.Operators.Interval(t_, w_, true, false);
+				var y_ = context.Operators.ElementInInterval<CqlDateTime>(o_, x_, null);
+				var aa_ = QICoreCommon_2_0_000.toInterval(p_);
+				var ab_ = context.Operators.Start(aa_);
+				var ac_ = context.Operators.Not((bool?)(ab_ is null));
+				var ad_ = context.Operators.And(y_, ac_);
+
+				return ad_;
+			};
+			var j_ = context.Operators.WhereOrNull<Procedure>(h_, i_);
+			Procedure k_(Procedure FirstBladderCancerStaging) => 
+				Cystectomy;
+			var l_ = context.Operators.SelectOrNull<Procedure, Procedure>(j_, k_);
+
+			return l_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(b_, c_);
+		bool? e_(Procedure Cystectomy)
+		{
+			var ae_ = context.Operators.EnumEqualsString(Cystectomy?.StatusElement?.Value, "completed");
+
+			return ae_;
+		};
+		var f_ = context.Operators.WhereOrNull<Procedure>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Cystectomy Done")]
+	public IEnumerable<Procedure> Cystectomy_Done() => 
+		__Cystectomy_Done.Value;
+
+	private bool? Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging_Value()
+	{
+		var a_ = this.HIV();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = this.Immunocompromised_Conditions();
+		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		var e_ = context.Operators.ListUnion<Condition>(b_, d_);
+		var f_ = this.Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care();
+		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		var h_ = context.Operators.ListUnion<Condition>(e_, g_);
+		IEnumerable<Condition> i_(Condition ExclusionDiagnosis)
+		{
+			var n_ = this.First_Bladder_Cancer_Staging_Procedure();
+			var o_ = new Procedure[]
+			{
+				n_,
+			};
+			bool? p_(Procedure FirstBladderCancerStaging)
+			{
+				var t_ = QICoreCommon_2_0_000.prevalenceInterval(ExclusionDiagnosis);
+				var u_ = context.Operators.Start(t_);
+				var v_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+				var w_ = QICoreCommon_2_0_000.toInterval(v_);
+				var x_ = context.Operators.Start(w_);
+				var y_ = context.Operators.SameOrBefore(u_, x_, null);
+
+				return y_;
+			};
+			var q_ = context.Operators.WhereOrNull<Procedure>(o_, p_);
+			Condition r_(Procedure FirstBladderCancerStaging) => 
+				ExclusionDiagnosis;
+			var s_ = context.Operators.SelectOrNull<Procedure, Condition>(q_, r_);
+
+			return s_;
+		};
+		var j_ = context.Operators.SelectManyOrNull<Condition, Condition>(h_, i_);
+		bool? k_(Condition ExclusionDiagnosis)
+		{
+			var z_ = this.isConfirmedActiveDiagnosis(ExclusionDiagnosis);
+
+			return z_;
+		};
+		var l_ = context.Operators.WhereOrNull<Condition>(j_, k_);
+		var m_ = context.Operators.ExistsInList<Condition>(l_);
+
+		return m_;
+	}
+
+    [CqlDeclaration("Has Excluding  HIV, Immunocompromised Conditions or Mixed Histology Before Staging")]
+	public bool? Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging() => 
+		__Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging.Value;
+
+	private bool? Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging_Value()
+	{
+		var a_ = this.Chemotherapy_Agents_for_Advanced_Cancer();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_(MedicationRequest ExclusionMed)
+		{
+			var s_ = this.First_Bladder_Cancer_Staging_Procedure();
+			var t_ = new Procedure[]
+			{
+				s_,
+			};
+			bool? u_(Procedure FirstBladderCancerStaging)
+			{
+				var y_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ExclusionMed);
+				var z_ = context.Operators.Start(y_);
+				var aa_ = context.Operators.ConvertDateToDateTime(z_);
+				var ab_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+				var ac_ = QICoreCommon_2_0_000.toInterval(ab_);
+				var ad_ = context.Operators.Start(ac_);
+				var ae_ = context.Operators.Quantity(6m, "months");
+				var af_ = context.Operators.Subtract(ad_, ae_);
+				var ah_ = QICoreCommon_2_0_000.toInterval(ab_);
+				var ai_ = context.Operators.Start(ah_);
+				var aj_ = context.Operators.Interval(af_, ai_, true, false);
+				var ak_ = context.Operators.ElementInInterval<CqlDateTime>(aa_, aj_, null);
+				var am_ = QICoreCommon_2_0_000.toInterval(ab_);
+				var an_ = context.Operators.Start(am_);
+				var ao_ = context.Operators.Not((bool?)(an_ is null));
+				var ap_ = context.Operators.And(ak_, ao_);
+
+				return ap_;
+			};
+			var v_ = context.Operators.WhereOrNull<Procedure>(t_, u_);
+			MedicationRequest w_(Procedure FirstBladderCancerStaging) => 
+				ExclusionMed;
+			var x_ = context.Operators.SelectOrNull<Procedure, MedicationRequest>(v_, w_);
+
+			return x_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<MedicationRequest, MedicationRequest>(e_, f_);
+		bool? h_(MedicationRequest ExclusionMed)
+		{
+			var aq_ = context.Operators.Convert<string>(ExclusionMed?.StatusElement?.Value);
+			var ar_ = new string[]
+			{
+				"active",
+				"completed",
+			};
+			var as_ = context.Operators.InList<string>(aq_, (ar_ as IEnumerable<string>));
+			var at_ = context.Operators.EnumEqualsString(ExclusionMed?.IntentElement?.Value, "order");
+			var au_ = context.Operators.And(as_, at_);
+			var av_ = context.Operators.IsTrue(ExclusionMed?.DoNotPerformElement?.Value);
+			var aw_ = context.Operators.Not(av_);
+			var ax_ = context.Operators.And(au_, aw_);
+
+			return ax_;
+		};
+		var i_ = context.Operators.WhereOrNull<MedicationRequest>(g_, h_);
+		var j_ = this.Combined_radiotherapy__procedure_();
+		var k_ = context.Operators.ToList<CqlCode>(j_);
+		var l_ = context.Operators.RetrieveByCodes<Procedure>(k_, null);
+		IEnumerable<Procedure> m_(Procedure ExclusionProcedure)
+		{
+			var ay_ = this.First_Bladder_Cancer_Staging_Procedure();
+			var az_ = new Procedure[]
+			{
+				ay_,
+			};
+			bool? ba_(Procedure FirstBladderCancerStaging)
+			{
+				var be_ = FHIRHelpers_4_3_000.ToValue(ExclusionProcedure?.Performed);
+				var bf_ = QICoreCommon_2_0_000.toInterval(be_);
+				var bg_ = context.Operators.Start(bf_);
+				var bh_ = FHIRHelpers_4_3_000.ToValue(FirstBladderCancerStaging?.Performed);
+				var bi_ = QICoreCommon_2_0_000.toInterval(bh_);
+				var bj_ = context.Operators.Start(bi_);
+				var bk_ = context.Operators.Quantity(6m, "months");
+				var bl_ = context.Operators.Subtract(bj_, bk_);
+				var bn_ = QICoreCommon_2_0_000.toInterval(bh_);
+				var bo_ = context.Operators.Start(bn_);
+				var bp_ = context.Operators.Interval(bl_, bo_, true, false);
+				var bq_ = context.Operators.ElementInInterval<CqlDateTime>(bg_, bp_, null);
+				var bs_ = QICoreCommon_2_0_000.toInterval(bh_);
+				var bt_ = context.Operators.Start(bs_);
+				var bu_ = context.Operators.Not((bool?)(bt_ is null));
+				var bv_ = context.Operators.And(bq_, bu_);
+
+				return bv_;
+			};
+			var bb_ = context.Operators.WhereOrNull<Procedure>(az_, ba_);
+			Procedure bc_(Procedure FirstBladderCancerStaging) => 
+				ExclusionProcedure;
+			var bd_ = context.Operators.SelectOrNull<Procedure, Procedure>(bb_, bc_);
+
+			return bd_;
+		};
+		var n_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(l_, m_);
+		bool? o_(Procedure ExclusionProcedure)
+		{
+			var bw_ = context.Operators.EnumEqualsString(ExclusionProcedure?.StatusElement?.Value, "completed");
+
+			return bw_;
+		};
+		var p_ = context.Operators.WhereOrNull<Procedure>(n_, o_);
+		var q_ = context.Operators.ListUnion<object>((i_ as IEnumerable<object>), (p_ as IEnumerable<object>));
+		var r_ = context.Operators.ExistsInList<object>(q_);
+
+		return r_;
+	}
+
+    [CqlDeclaration("Has Excluding Chemotherapy or Radiotherapy Procedure Before Staging")]
+	public bool? Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging() => 
+		__Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging.Value;
+
+	private bool? Denominator_Exclusion_Value()
+	{
+		var a_ = this.Acute_Tuberculosis_Diagnosis();
+		var b_ = context.Operators.ExistsInList<Condition>(a_);
+		var c_ = this.Immunosuppressive_Drugs();
+		var d_ = context.Operators.ExistsInList<MedicationRequest>(c_);
+		var e_ = context.Operators.Or(b_, d_);
+		var f_ = this.Cystectomy_Done();
+		var g_ = context.Operators.ExistsInList<Procedure>(f_);
+		var h_ = context.Operators.Or(e_, g_);
+		var i_ = this.Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging();
+		var j_ = context.Operators.Or(h_, i_);
+		var k_ = this.Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging();
+		var l_ = context.Operators.Or(j_, k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Denominator Exclusion")]
+	public bool? Denominator_Exclusion() => 
+		__Denominator_Exclusion.Value;
+
+    [CqlDeclaration("NormalizePeriod")]
+	public CqlInterval<CqlDateTime> NormalizePeriod(CqlDateTime pointInTime, CqlInterval<CqlDateTime> dateTimeInterval)
+	{
+		CqlInterval<CqlDateTime> a_()
+		{
+			if ((context.Operators.Not((bool?)(pointInTime is null)) ?? false))
+			{
+				var b_ = context.Operators.Interval(pointInTime, pointInTime, true, true);
+
+				return b_;
+			}
+			else if ((context.Operators.Not((bool?)(dateTimeInterval is null)) ?? false))
+			{
+				return dateTimeInterval;
+			}
+			else
+			{
+				CqlInterval<CqlDateTime> c_ = null;
+
+				return (c_ as CqlInterval<CqlDateTime>);
+			};
+		};
+
+		return a_();
+	}
+
+}

--- a/Demo/Measures-cms/KidneyHealthEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/KidneyHealthEvaluationFHIR-0.1.000.g.cs
@@ -1,0 +1,613 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("KidneyHealthEvaluationFHIR", "0.1.000")]
+public class KidneyHealthEvaluationFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Acute_Inpatient;
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Chronic_Kidney_Disease__Stage_5;
+    internal Lazy<CqlValueSet> __Diabetes;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __End_Stage_Renal_Disease;
+    internal Lazy<CqlValueSet> __Estimated_Glomerular_Filtration_Rate;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Hospice_Care_Ambulatory;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Palliative_or_Hospice_Care;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Urine_Albumin_Creatinine_Ratio;
+    internal Lazy<CqlCode> __Discharge_to_healthcare_facility_for_hospice_care__procedure_;
+    internal Lazy<CqlCode> __Discharge_to_home_for_hospice_care__procedure_;
+    internal Lazy<CqlCode> __AMB;
+    internal Lazy<CqlCode> __active;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __ActCode;
+    internal Lazy<CqlCode[]> __ConditionClinicalStatusCodes;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<bool?> __Has_Active_Diabetes_Overlaps_Measurement_Period;
+    internal Lazy<bool?> __Has_Outpatient_Visit_During_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Condition>> __Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Has_Kidney_Panel_Performed_During_Measurement_Period;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public KidneyHealthEvaluationFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        PalliativeCare_1_9_000 = new PalliativeCare_1_9_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Acute_Inpatient = new Lazy<CqlValueSet>(this.Acute_Inpatient_Value);
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value);
+        __Chronic_Kidney_Disease__Stage_5 = new Lazy<CqlValueSet>(this.Chronic_Kidney_Disease__Stage_5_Value);
+        __Diabetes = new Lazy<CqlValueSet>(this.Diabetes_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __End_Stage_Renal_Disease = new Lazy<CqlValueSet>(this.End_Stage_Renal_Disease_Value);
+        __Estimated_Glomerular_Filtration_Rate = new Lazy<CqlValueSet>(this.Estimated_Glomerular_Filtration_Rate_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Hospice_Care_Ambulatory = new Lazy<CqlValueSet>(this.Hospice_Care_Ambulatory_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Palliative_or_Hospice_Care = new Lazy<CqlValueSet>(this.Palliative_or_Hospice_Care_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Urine_Albumin_Creatinine_Ratio = new Lazy<CqlValueSet>(this.Urine_Albumin_Creatinine_Ratio_Value);
+        __Discharge_to_healthcare_facility_for_hospice_care__procedure_ = new Lazy<CqlCode>(this.Discharge_to_healthcare_facility_for_hospice_care__procedure__Value);
+        __Discharge_to_home_for_hospice_care__procedure_ = new Lazy<CqlCode>(this.Discharge_to_home_for_hospice_care__procedure__Value);
+        __AMB = new Lazy<CqlCode>(this.AMB_Value);
+        __active = new Lazy<CqlCode>(this.active_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __ActCode = new Lazy<CqlCode[]>(this.ActCode_Value);
+        __ConditionClinicalStatusCodes = new Lazy<CqlCode[]>(this.ConditionClinicalStatusCodes_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Has_Active_Diabetes_Overlaps_Measurement_Period = new Lazy<bool?>(this.Has_Active_Diabetes_Overlaps_Measurement_Period_Value);
+        __Has_Outpatient_Visit_During_Measurement_Period = new Lazy<bool?>(this.Has_Outpatient_Visit_During_Measurement_Period_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period = new Lazy<IEnumerable<Condition>>(this.Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Has_Kidney_Panel_Performed_During_Measurement_Period = new Lazy<bool?>(this.Has_Kidney_Panel_Performed_During_Measurement_Period_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public PalliativeCare_1_9_000 PalliativeCare_1_9_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Acute_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
+
+    [CqlDeclaration("Acute Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
+	public CqlValueSet Acute_Inpatient() => 
+		__Acute_Inpatient.Value;
+
+	private CqlValueSet Annual_Wellness_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+
+    [CqlDeclaration("Annual Wellness Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit.Value;
+
+	private CqlValueSet Chronic_Kidney_Disease__Stage_5_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002", null);
+
+    [CqlDeclaration("Chronic Kidney Disease, Stage 5")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002")]
+	public CqlValueSet Chronic_Kidney_Disease__Stage_5() => 
+		__Chronic_Kidney_Disease__Stage_5.Value;
+
+	private CqlValueSet Diabetes_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+
+    [CqlDeclaration("Diabetes")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
+	public CqlValueSet Diabetes() => 
+		__Diabetes.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet End_Stage_Renal_Disease_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", null);
+
+    [CqlDeclaration("End Stage Renal Disease")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
+	public CqlValueSet End_Stage_Renal_Disease() => 
+		__End_Stage_Renal_Disease.Value;
+
+	private CqlValueSet Estimated_Glomerular_Filtration_Rate_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000", null);
+
+    [CqlDeclaration("Estimated Glomerular Filtration Rate")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000")]
+	public CqlValueSet Estimated_Glomerular_Filtration_Rate() => 
+		__Estimated_Glomerular_Filtration_Rate.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", null);
+
+    [CqlDeclaration("Hospice Care Ambulatory")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
+	public CqlValueSet Hospice_Care_Ambulatory() => 
+		__Hospice_Care_Ambulatory.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Palliative_or_Hospice_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", null);
+
+    [CqlDeclaration("Palliative or Hospice Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
+	public CqlValueSet Palliative_or_Hospice_Care() => 
+		__Palliative_or_Hospice_Care.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlValueSet Urine_Albumin_Creatinine_Ratio_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007", null);
+
+    [CqlDeclaration("Urine Albumin Creatinine Ratio")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007")]
+	public CqlValueSet Urine_Albumin_Creatinine_Ratio() => 
+		__Urine_Albumin_Creatinine_Ratio.Value;
+
+	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
+		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
+	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
+		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
+
+	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
+		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Discharge to home for hospice care (procedure)")]
+	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
+		__Discharge_to_home_for_hospice_care__procedure_.Value;
+
+	private CqlCode AMB_Value() => 
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+
+    [CqlDeclaration("AMB")]
+	public CqlCode AMB() => 
+		__AMB.Value;
+
+	private CqlCode active_Value() => 
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+
+    [CqlDeclaration("active")]
+	public CqlCode active() => 
+		__active.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
+			new CqlCode("428361000124107", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlCode[] ActCode_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ActCode")]
+	public CqlCode[] ActCode() => 
+		__ActCode.Value;
+
+	private CqlCode[] ConditionClinicalStatusCodes_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ConditionClinicalStatusCodes")]
+	public CqlCode[] ConditionClinicalStatusCodes() => 
+		__ConditionClinicalStatusCodes.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("KidneyHealthEvaluationFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private bool? Has_Active_Diabetes_Overlaps_Measurement_Period_Value()
+	{
+		var a_ = this.Diabetes();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition Diabetes)
+		{
+			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
+			var g_ = this.Measurement_Period();
+			var h_ = context.Operators.Overlaps(f_, g_, null);
+			var i_ = FHIRHelpers_4_3_000.ToConcept(Diabetes?.ClinicalStatus);
+			var j_ = this.active();
+			var k_ = context.Operators.ConvertCodeToConcept(j_);
+			var l_ = context.Operators.Equivalent(i_, k_);
+			var m_ = context.Operators.And(h_, l_);
+
+			return m_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Active Diabetes Overlaps Measurement Period")]
+	public bool? Has_Active_Diabetes_Overlaps_Measurement_Period() => 
+		__Has_Active_Diabetes_Overlaps_Measurement_Period.Value;
+
+	private bool? Has_Outpatient_Visit_During_Measurement_Period_Value()
+	{
+		var a_ = this.Annual_Wellness_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Home_Healthcare_Services();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Office_Visit();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Outpatient_Consultation();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Telephone_Visits();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = context.Operators.ListUnion<Encounter>(q_, s_);
+		bool? u_(Encounter ValidEncounter)
+		{
+			var x_ = this.Measurement_Period();
+			var y_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var z_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, y_, null);
+			var aa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ValidEncounter?.StatusElement?.Value);
+			var ab_ = context.Operators.Equal(aa_, "finished");
+			var ac_ = context.Operators.And(z_, ab_);
+
+			return ac_;
+		};
+		var v_ = context.Operators.WhereOrNull<Encounter>(t_, u_);
+		var w_ = context.Operators.ExistsInList<Encounter>(v_);
+
+		return w_;
+	}
+
+    [CqlDeclaration("Has Outpatient Visit During Measurement Period")]
+	public bool? Has_Outpatient_Visit_During_Measurement_Period() => 
+		__Has_Outpatient_Visit_During_Measurement_Period.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)18, (int?)85, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var i_ = this.Has_Active_Diabetes_Overlaps_Measurement_Period();
+		var j_ = context.Operators.And(h_, i_);
+		var k_ = this.Has_Outpatient_Visit_During_Measurement_Period();
+		var l_ = context.Operators.And(j_, k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Condition> Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period_Value()
+	{
+		var a_ = this.Chronic_Kidney_Disease__Stage_5();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = this.End_Stage_Renal_Disease();
+		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		var e_ = context.Operators.ListUnion<Condition>(b_, d_);
+		bool? f_(Condition CKDOrESRD)
+		{
+			var h_ = QICoreCommon_2_0_000.ToPrevalenceInterval(CKDOrESRD);
+			var i_ = this.Measurement_Period();
+			var j_ = context.Operators.Overlaps(h_, i_, null);
+			var k_ = FHIRHelpers_4_3_000.ToConcept(CKDOrESRD?.ClinicalStatus);
+			var l_ = this.active();
+			var m_ = context.Operators.ConvertCodeToConcept(l_);
+			var n_ = context.Operators.Equivalent(k_, m_);
+			var o_ = context.Operators.And(j_, n_);
+
+			return o_;
+		};
+		var g_ = context.Operators.WhereOrNull<Condition>(e_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Has CKD Stage 5 or ESRD Diagnosis Overlaps Measurement Period")]
+	public IEnumerable<Condition> Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period() => 
+		__Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = this.Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period();
+		var b_ = context.Operators.ExistsInList<Condition>(a_);
+		var c_ = Hospice_6_9_000.Has_Hospice_Services();
+		var d_ = context.Operators.Or(b_, c_);
+		var e_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		var f_ = context.Operators.Or(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private bool? Has_Kidney_Panel_Performed_During_Measurement_Period_Value()
+	{
+		var a_ = this.Estimated_Glomerular_Filtration_Rate();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		bool? c_(Observation eGFRTest)
+		{
+			var l_ = this.Measurement_Period();
+			var m_ = FHIRHelpers_4_3_000.ToValue(eGFRTest?.Effective);
+			var n_ = QICoreCommon_2_0_000.ToInterval(m_);
+			var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, null);
+			var p_ = FHIRHelpers_4_3_000.ToValue(eGFRTest?.Value);
+			var q_ = context.Operators.Not((bool?)(p_ is null));
+			var r_ = context.Operators.And(o_, q_);
+			var s_ = context.Operators.Convert<Code<ObservationStatus>>(eGFRTest?.StatusElement?.Value);
+			var t_ = context.Operators.Convert<string>(s_);
+			var u_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var v_ = context.Operators.InList<string>(t_, (u_ as IEnumerable<string>));
+			var w_ = context.Operators.And(r_, v_);
+
+			return w_;
+		};
+		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Observation>(d_);
+		var f_ = this.Urine_Albumin_Creatinine_Ratio();
+		var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+		bool? h_(Observation uACRTest)
+		{
+			var x_ = this.Measurement_Period();
+			var y_ = FHIRHelpers_4_3_000.ToValue(uACRTest?.Effective);
+			var z_ = QICoreCommon_2_0_000.ToInterval(y_);
+			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, null);
+			var ab_ = FHIRHelpers_4_3_000.ToValue(uACRTest?.Value);
+			var ac_ = context.Operators.Not((bool?)(ab_ is null));
+			var ad_ = context.Operators.And(aa_, ac_);
+			var ae_ = context.Operators.Convert<Code<ObservationStatus>>(uACRTest?.StatusElement?.Value);
+			var af_ = context.Operators.Convert<string>(ae_);
+			var ag_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var ah_ = context.Operators.InList<string>(af_, (ag_ as IEnumerable<string>));
+			var ai_ = context.Operators.And(ad_, ah_);
+
+			return ai_;
+		};
+		var i_ = context.Operators.WhereOrNull<Observation>(g_, h_);
+		var j_ = context.Operators.ExistsInList<Observation>(i_);
+		var k_ = context.Operators.And(e_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Has Kidney Panel Performed During Measurement Period")]
+	public bool? Has_Kidney_Panel_Performed_During_Measurement_Period() => 
+		__Has_Kidney_Panel_Performed_During_Measurement_Period.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Has_Kidney_Panel_Performed_During_Measurement_Period();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
@@ -1,0 +1,550 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("OncologyPainIntensityQuantifiedFHIR", "0.1.000")]
+public class OncologyPainIntensityQuantifiedFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Cancer;
+    internal Lazy<CqlValueSet> __Chemotherapy_Administration;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Radiation_Treatment_Management;
+    internal Lazy<CqlValueSet> __Standardized_Pain_Assessment_Tool;
+    internal Lazy<CqlCode> __Radiation_treatment_management__5_treatments;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Procedure>> __Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population_1;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_1;
+    internal Lazy<IEnumerable<Encounter>> __Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population_2;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_2;
+    internal Lazy<IEnumerable<Encounter>> __Numerator_1;
+    internal Lazy<IEnumerable<Encounter>> __Numerator_2;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public OncologyPainIntensityQuantifiedFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+
+        __Cancer = new Lazy<CqlValueSet>(this.Cancer_Value);
+        __Chemotherapy_Administration = new Lazy<CqlValueSet>(this.Chemotherapy_Administration_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Radiation_Treatment_Management = new Lazy<CqlValueSet>(this.Radiation_Treatment_Management_Value);
+        __Standardized_Pain_Assessment_Tool = new Lazy<CqlValueSet>(this.Standardized_Pain_Assessment_Tool_Value);
+        __Radiation_treatment_management__5_treatments = new Lazy<CqlCode>(this.Radiation_treatment_management__5_treatments_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period = new Lazy<IEnumerable<Procedure>>(this.Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period_Value);
+        __Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy = new Lazy<IEnumerable<Encounter>>(this.Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy_Value);
+        __Initial_Population_1 = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_1_Value);
+        __Denominator_1 = new Lazy<IEnumerable<Encounter>>(this.Denominator_1_Value);
+        __Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis = new Lazy<IEnumerable<Encounter>>(this.Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis_Value);
+        __Initial_Population_2 = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_2_Value);
+        __Denominator_2 = new Lazy<IEnumerable<Encounter>>(this.Denominator_2_Value);
+        __Numerator_1 = new Lazy<IEnumerable<Encounter>>(this.Numerator_1_Value);
+        __Numerator_2 = new Lazy<IEnumerable<Encounter>>(this.Numerator_2_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Cancer_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010", null);
+
+    [CqlDeclaration("Cancer")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010")]
+	public CqlValueSet Cancer() => 
+		__Cancer.Value;
+
+	private CqlValueSet Chemotherapy_Administration_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027", null);
+
+    [CqlDeclaration("Chemotherapy Administration")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027")]
+	public CqlValueSet Chemotherapy_Administration() => 
+		__Chemotherapy_Administration.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Radiation_Treatment_Management_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026", null);
+
+    [CqlDeclaration("Radiation Treatment Management")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026")]
+	public CqlValueSet Radiation_Treatment_Management() => 
+		__Radiation_Treatment_Management.Value;
+
+	private CqlValueSet Standardized_Pain_Assessment_Tool_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028", null);
+
+    [CqlDeclaration("Standardized Pain Assessment Tool")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028")]
+	public CqlValueSet Standardized_Pain_Assessment_Tool() => 
+		__Standardized_Pain_Assessment_Tool.Value;
+
+	private CqlCode Radiation_treatment_management__5_treatments_Value() => 
+		new CqlCode("77427", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Radiation treatment management, 5 treatments")]
+	public CqlCode Radiation_treatment_management__5_treatments() => 
+		__Radiation_treatment_management__5_treatments.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("77427", "http://www.ama-assn.org/go/cpt", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("OncologyPainIntensityQuantifiedFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Procedure> Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period_Value()
+	{
+		var a_ = this.Chemotherapy_Administration();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		bool? d_(Procedure ChemoAdministration)
+		{
+			var f_ = this.Measurement_Period();
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.Quantity(31m, "days");
+			var i_ = context.Operators.Subtract(g_, h_);
+			var k_ = context.Operators.End(f_);
+			var l_ = context.Operators.Interval(i_, k_, true, true);
+			var m_ = FHIRHelpers_4_3_000.ToValue(ChemoAdministration?.Performed);
+			var n_ = QICoreCommon_2_0_000.toInterval(m_);
+			var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, null);
+
+			return o_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Chemotherapy Within 31 Days Prior and During Measurement Period")]
+	public IEnumerable<Procedure> Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period() => 
+		__Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period.Value;
+
+	private IEnumerable<Encounter> Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = Status_1_6_000.Finished_Encounter(b_);
+		IEnumerable<Procedure> d_(Encounter _FaceToFaceOrTelehealthEncounter)
+		{
+			var q_ = this.Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period();
+
+			return q_;
+		};
+		Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT e_(Encounter _FaceToFaceOrTelehealthEncounter, Procedure _ChemoBeforeEncounter)
+		{
+			var r_ = new Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT
+			{
+				FaceToFaceOrTelehealthEncounter = _FaceToFaceOrTelehealthEncounter,
+				ChemoBeforeEncounter = _ChemoBeforeEncounter,
+			};
+
+			return r_;
+		};
+		var f_ = context.Operators.SelectManyResultsOrNull<Encounter, Procedure, Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT>(c_, d_, e_);
+		IEnumerable<Procedure> g_(Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT _FaceToFaceOrTelehealthEncounterChemoBeforeEncounter)
+		{
+			var s_ = this.Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period();
+
+			return s_;
+		};
+		Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT h_(Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT FaceToFaceOrTelehealthEncounterChemoBeforeEncounter, Procedure _ChemoAfterEncounter)
+		{
+			var t_ = new Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT
+			{
+				FaceToFaceOrTelehealthEncounter = FaceToFaceOrTelehealthEncounterChemoBeforeEncounter.FaceToFaceOrTelehealthEncounter,
+				ChemoBeforeEncounter = FaceToFaceOrTelehealthEncounterChemoBeforeEncounter.ChemoBeforeEncounter,
+				ChemoAfterEncounter = _ChemoAfterEncounter,
+			};
+
+			return t_;
+		};
+		var i_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT, Procedure, Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT>(f_, g_, h_);
+		IEnumerable<Condition> j_(Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT _FaceToFaceOrTelehealthEncounterChemoBeforeEncounterChemoAfterEncounter)
+		{
+			var u_ = this.Cancer();
+			var v_ = context.Operators.RetrieveByValueSet<Condition>(u_, null);
+
+			return v_;
+		};
+		Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT k_(Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT FaceToFaceOrTelehealthEncounterChemoBeforeEncounterChemoAfterEncounter, Condition _Cancer)
+		{
+			var w_ = new Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT
+			{
+				FaceToFaceOrTelehealthEncounter = FaceToFaceOrTelehealthEncounterChemoBeforeEncounterChemoAfterEncounter.FaceToFaceOrTelehealthEncounter,
+				ChemoBeforeEncounter = FaceToFaceOrTelehealthEncounterChemoBeforeEncounterChemoAfterEncounter.ChemoBeforeEncounter,
+				ChemoAfterEncounter = FaceToFaceOrTelehealthEncounterChemoBeforeEncounterChemoAfterEncounter.ChemoAfterEncounter,
+				Cancer = _Cancer,
+			};
+
+			return w_;
+		};
+		var l_ = context.Operators.SelectManyResultsOrNull<Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT, Condition, Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT>(i_, j_, k_);
+		bool? m_(Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT tuple_hehdgghaahjzgibaaamlgasgt)
+		{
+			var x_ = QICoreCommon_2_0_000.isActive(tuple_hehdgghaahjzgibaaamlgasgt.Cancer);
+			var y_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_hehdgghaahjzgibaaamlgasgt.Cancer);
+			var z_ = FHIRHelpers_4_3_000.ToInterval(tuple_hehdgghaahjzgibaaamlgasgt.FaceToFaceOrTelehealthEncounter?.Period);
+			var aa_ = context.Operators.Overlaps(y_, z_, null);
+			var ab_ = context.Operators.And(x_, aa_);
+			var ac_ = FHIRHelpers_4_3_000.ToValue(tuple_hehdgghaahjzgibaaamlgasgt.ChemoBeforeEncounter?.Performed);
+			var ad_ = QICoreCommon_2_0_000.toInterval(ac_);
+			var ae_ = context.Operators.Start(ad_);
+			var ag_ = context.Operators.End(z_);
+			var ah_ = context.Operators.Quantity(30m, "days");
+			var ai_ = context.Operators.Subtract(ag_, ah_);
+			var ak_ = context.Operators.End(z_);
+			var al_ = context.Operators.Interval(ai_, ak_, true, true);
+			var am_ = context.Operators.ElementInInterval<CqlDateTime>(ae_, al_, "day");
+			var ao_ = context.Operators.End(z_);
+			var ap_ = context.Operators.Not((bool?)(ao_ is null));
+			var aq_ = context.Operators.And(am_, ap_);
+			var ar_ = context.Operators.And(ab_, aq_);
+			var as_ = FHIRHelpers_4_3_000.ToValue(tuple_hehdgghaahjzgibaaamlgasgt.ChemoAfterEncounter?.Performed);
+			var at_ = QICoreCommon_2_0_000.toInterval(as_);
+			var au_ = context.Operators.Start(at_);
+			var aw_ = context.Operators.End(z_);
+			var ay_ = context.Operators.End(z_);
+			var ba_ = context.Operators.Add(ay_, ah_);
+			var bb_ = context.Operators.Interval(aw_, ba_, true, true);
+			var bc_ = context.Operators.ElementInInterval<CqlDateTime>(au_, bb_, "day");
+			var be_ = context.Operators.End(z_);
+			var bf_ = context.Operators.Not((bool?)(be_ is null));
+			var bg_ = context.Operators.And(bc_, bf_);
+			var bh_ = context.Operators.And(ar_, bg_);
+			var bj_ = QICoreCommon_2_0_000.toInterval(as_);
+			var bl_ = QICoreCommon_2_0_000.toInterval(ac_);
+			var bm_ = context.Operators.IntervalSameAs<CqlDateTime>(bj_, bl_, "day");
+			var bn_ = context.Operators.Not(bm_);
+			var bo_ = context.Operators.And(bh_, bn_);
+			var bp_ = this.Measurement_Period();
+			var br_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bp_, z_, null);
+			var bs_ = context.Operators.And(bo_, br_);
+
+			return bs_;
+		};
+		var n_ = context.Operators.WhereOrNull<Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT>(l_, m_);
+		Encounter o_(Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT tuple_hehdgghaahjzgibaaamlgasgt) => 
+			tuple_hehdgghaahjzgibaaamlgasgt.FaceToFaceOrTelehealthEncounter;
+		var p_ = context.Operators.SelectOrNull<Tuples.Tuple_HEhDGGHAahjZgibAaAMLGaSGT, Encounter>(n_, o_);
+
+		return p_;
+	}
+
+    [CqlDeclaration("Face to Face or Telehealth Encounter with Ongoing Chemotherapy")]
+	public IEnumerable<Encounter> Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy() => 
+		__Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy.Value;
+
+	private IEnumerable<Encounter> Initial_Population_1_Value()
+	{
+		var a_ = this.Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population 1")]
+	public IEnumerable<Encounter> Initial_Population_1() => 
+		__Initial_Population_1.Value;
+
+	private IEnumerable<Encounter> Denominator_1_Value()
+	{
+		var a_ = this.Initial_Population_1();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator 1")]
+	public IEnumerable<Encounter> Denominator_1() => 
+		__Denominator_1.Value;
+
+	private IEnumerable<Encounter> Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis_Value()
+	{
+		var a_ = this.Radiation_Treatment_Management();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = Status_1_6_000.Finished_Encounter(b_);
+		IEnumerable<Encounter> d_(Encounter RadiationTreatmentManagement)
+		{
+			var f_ = this.Cancer();
+			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			bool? h_(Condition Cancer)
+			{
+				var l_ = QICoreCommon_2_0_000.isActive(Cancer);
+				var m_ = QICoreCommon_2_0_000.prevalenceInterval(Cancer);
+				var n_ = FHIRHelpers_4_3_000.ToInterval(RadiationTreatmentManagement?.Period);
+				var o_ = context.Operators.Overlaps(m_, n_, null);
+				var p_ = context.Operators.And(l_, o_);
+				var q_ = this.Measurement_Period();
+				var s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, n_, null);
+				var t_ = context.Operators.And(p_, s_);
+
+				return t_;
+			};
+			var i_ = context.Operators.WhereOrNull<Condition>(g_, h_);
+			Encounter j_(Condition Cancer) => 
+				RadiationTreatmentManagement;
+			var k_ = context.Operators.SelectOrNull<Condition, Encounter>(i_, j_);
+
+			return k_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Radiation Treatment Management During Measurement Period with Cancer Diagnosis")]
+	public IEnumerable<Encounter> Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis() => 
+		__Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis.Value;
+
+	private IEnumerable<Encounter> Initial_Population_2_Value()
+	{
+		var a_ = this.Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population 2")]
+	public IEnumerable<Encounter> Initial_Population_2() => 
+		__Initial_Population_2.Value;
+
+	private IEnumerable<Encounter> Denominator_2_Value()
+	{
+		var a_ = this.Initial_Population_2();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator 2")]
+	public IEnumerable<Encounter> Denominator_2() => 
+		__Denominator_2.Value;
+
+	private IEnumerable<Encounter> Numerator_1_Value()
+	{
+		var a_ = this.Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy();
+		IEnumerable<Encounter> b_(Encounter FaceToFaceOrTelehealthEncounterWithChemo)
+		{
+			var d_ = this.Standardized_Pain_Assessment_Tool();
+			var e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			bool? f_(Observation PainAssessed)
+			{
+				var j_ = FHIRHelpers_4_3_000.ToInterval(FaceToFaceOrTelehealthEncounterWithChemo?.Period);
+				var k_ = FHIRHelpers_4_3_000.ToValue(PainAssessed?.Effective);
+				var l_ = QICoreCommon_2_0_000.toInterval(k_);
+				var m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, null);
+				var n_ = FHIRHelpers_4_3_000.ToValue(PainAssessed?.Value);
+				var o_ = context.Operators.Not((bool?)(n_ is null));
+				var p_ = context.Operators.And(m_, o_);
+				var q_ = context.Operators.Convert<Code<ObservationStatus>>(PainAssessed?.StatusElement?.Value);
+				var r_ = context.Operators.Equal(q_, "final");
+				var s_ = context.Operators.And(p_, r_);
+
+				return s_;
+			};
+			var g_ = context.Operators.WhereOrNull<Observation>(e_, f_);
+			Encounter h_(Observation PainAssessed) => 
+				FaceToFaceOrTelehealthEncounterWithChemo;
+			var i_ = context.Operators.SelectOrNull<Observation, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Numerator 1")]
+	public IEnumerable<Encounter> Numerator_1() => 
+		__Numerator_1.Value;
+
+	private IEnumerable<Encounter> Numerator_2_Value()
+	{
+		var a_ = this.Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis();
+		IEnumerable<Encounter> b_(Encounter RadiationManagementEncounter)
+		{
+			var d_ = this.Standardized_Pain_Assessment_Tool();
+			var e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			bool? f_(Observation PainAssessed)
+			{
+				bool? j_()
+				{
+					if ((context.Operators.ExistsInList<CqlConcept>(context.Operators.WhereOrNull<CqlConcept>(context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(RadiationManagementEncounter?.Type, (CodeableConcept @this) => 
+										FHIRHelpers_4_3_000.ToConcept(@this)), (CqlConcept RadiationManagement) => 
+									context.Operators.Equivalent(RadiationManagement, context.Operators.ConvertCodeToConcept(this.Radiation_treatment_management__5_treatments())))) ?? false))
+					{
+						var q_ = FHIRHelpers_4_3_000.ToValue(PainAssessed?.Effective);
+						var r_ = QICoreCommon_2_0_000.toInterval(q_);
+						var s_ = context.Operators.End(r_);
+						var t_ = FHIRHelpers_4_3_000.ToInterval(RadiationManagementEncounter?.Period);
+						var u_ = context.Operators.Start(t_);
+						var v_ = context.Operators.Quantity(6m, "days");
+						var w_ = context.Operators.Subtract(u_, v_);
+						var y_ = context.Operators.Start(t_);
+						var z_ = context.Operators.Interval(w_, y_, true, true);
+						var aa_ = context.Operators.ElementInInterval<CqlDateTime>(s_, z_, "day");
+						var ac_ = context.Operators.Start(t_);
+						var ad_ = context.Operators.Not((bool?)(ac_ is null));
+						var ae_ = context.Operators.And(aa_, ad_);
+
+						return ae_;
+					}
+					else
+					{
+						var af_ = FHIRHelpers_4_3_000.ToInterval(RadiationManagementEncounter?.Period);
+						var ag_ = FHIRHelpers_4_3_000.ToValue(PainAssessed?.Effective);
+						var ah_ = QICoreCommon_2_0_000.toInterval(ag_);
+						var ai_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ah_, "day");
+
+						return ai_;
+					};
+				};
+				var k_ = FHIRHelpers_4_3_000.ToValue(PainAssessed?.Value);
+				var l_ = context.Operators.Not((bool?)(k_ is null));
+				var m_ = context.Operators.And(j_(), l_);
+				var n_ = context.Operators.Convert<Code<ObservationStatus>>(PainAssessed?.StatusElement?.Value);
+				var o_ = context.Operators.Equal(n_, "final");
+				var p_ = context.Operators.And(m_, o_);
+
+				return p_;
+			};
+			var g_ = context.Operators.WhereOrNull<Observation>(e_, f_);
+			Encounter h_(Observation PainAssessed) => 
+				RadiationManagementEncounter;
+			var i_ = context.Operators.SelectOrNull<Observation, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Numerator 2")]
+	public IEnumerable<Encounter> Numerator_2() => 
+		__Numerator_2.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/PCMaternal-5.16.000.g.cs
+++ b/Demo/Measures-cms/PCMaternal-5.16.000.g.cs
@@ -1,0 +1,791 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("PCMaternal", "5.16.000")]
+public class PCMaternal_5_16_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Delivery_Procedures;
+    internal Lazy<CqlValueSet> __ED_Visit_and_OB_Triage;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Estimated_Gestational_Age_at_Delivery;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlCode> __Date_and_time_of_obstetric_delivery;
+    internal Lazy<CqlCode> __Delivery_date_Estimated;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Age_Range;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounter_with_Age_Range;
+    internal Lazy<IEnumerable<Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM>> __Variable_Calculated_Gestational_Age;
+
+    #endregion
+    public PCMaternal_5_16_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Delivery_Procedures = new Lazy<CqlValueSet>(this.Delivery_Procedures_Value);
+        __ED_Visit_and_OB_Triage = new Lazy<CqlValueSet>(this.ED_Visit_and_OB_Triage_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Estimated_Gestational_Age_at_Delivery = new Lazy<CqlValueSet>(this.Estimated_Gestational_Age_at_Delivery_Value);
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value);
+        __Date_and_time_of_obstetric_delivery = new Lazy<CqlCode>(this.Date_and_time_of_obstetric_delivery_Value);
+        __Delivery_date_Estimated = new Lazy<CqlCode>(this.Delivery_date_Estimated_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Encounter_with_Age_Range = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Age_Range_Value);
+        __Delivery_Encounter_with_Age_Range = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounter_with_Age_Range_Value);
+        __Variable_Calculated_Gestational_Age = new Lazy<IEnumerable<Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM>>(this.Variable_Calculated_Gestational_Age_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Delivery_Procedures_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", null);
+
+    [CqlDeclaration("Delivery Procedures")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
+	public CqlValueSet Delivery_Procedures() => 
+		__Delivery_Procedures.Value;
+
+	private CqlValueSet ED_Visit_and_OB_Triage_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", null);
+
+    [CqlDeclaration("ED Visit and OB Triage")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369")]
+	public CqlValueSet ED_Visit_and_OB_Triage() => 
+		__ED_Visit_and_OB_Triage.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Estimated_Gestational_Age_at_Delivery_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26", null);
+
+    [CqlDeclaration("Estimated Gestational Age at Delivery")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26")]
+	public CqlValueSet Estimated_Gestational_Age_at_Delivery() => 
+		__Estimated_Gestational_Age_at_Delivery.Value;
+
+	private CqlValueSet Observation_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+
+    [CqlDeclaration("Observation Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services.Value;
+
+	private CqlCode Date_and_time_of_obstetric_delivery_Value() => 
+		new CqlCode("93857-1", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Date and time of obstetric delivery")]
+	public CqlCode Date_and_time_of_obstetric_delivery() => 
+		__Date_and_time_of_obstetric_delivery.Value;
+
+	private CqlCode Delivery_date_Estimated_Value() => 
+		new CqlCode("11778-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Delivery date Estimated")]
+	public CqlCode Delivery_date_Estimated() => 
+		__Delivery_date_Estimated.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("93857-1", "http://loinc.org", null, null),
+			new CqlCode("11778-8", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("PCMaternal-5.16.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Age_Range_Value()
+	{
+		var a_ = CQMCommon_2_0_000.Inpatient_Encounter();
+		bool? b_(Encounter InpatientEncounter)
+		{
+			var d_ = this.Patient();
+			var e_ = context.Operators.Convert<CqlDate>(d_?.BirthDateElement?.Value);
+			var f_ = FHIRHelpers_4_3_000.ToInterval(InpatientEncounter?.Period);
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.DateFrom(g_);
+			var i_ = context.Operators.CalculateAgeAt(e_, h_, "year");
+			var j_ = context.Operators.Interval((int?)8, (int?)65, true, false);
+			var k_ = context.Operators.ElementInInterval<int?>(i_, j_, null);
+
+			return k_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Age Range")]
+	public IEnumerable<Encounter> Encounter_with_Age_Range() => 
+		__Encounter_with_Age_Range.Value;
+
+    [CqlDeclaration("hospitalizationWithEDOBTriageObservation")]
+	public CqlInterval<CqlDateTime> hospitalizationWithEDOBTriageObservation(Encounter TheEncounter)
+	{
+		var a_ = new Encounter[]
+		{
+			TheEncounter,
+		};
+		CqlInterval<CqlDateTime> b_(Encounter Visit)
+		{
+			var e_ = this.ED_Visit_and_OB_Triage();
+			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			bool? g_(Encounter LastEDOBTriage)
+			{
+				var ab_ = FHIRHelpers_4_3_000.ToInterval(LastEDOBTriage?.Period);
+				var ac_ = context.Operators.End(ab_);
+				var ad_ = this.Observation_Services();
+				var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+				bool? af_(Encounter LastObs)
+				{
+					var bt_ = FHIRHelpers_4_3_000.ToInterval(LastObs?.Period);
+					var bu_ = context.Operators.End(bt_);
+					var bv_ = FHIRHelpers_4_3_000.ToInterval(Visit?.Period);
+					var bw_ = context.Operators.Start(bv_);
+					var bx_ = context.Operators.Quantity(1m, "hour");
+					var by_ = context.Operators.Subtract(bw_, bx_);
+					var ca_ = context.Operators.Start(bv_);
+					var cb_ = context.Operators.Interval(by_, ca_, true, true);
+					var cc_ = context.Operators.ElementInInterval<CqlDateTime>(bu_, cb_, null);
+					var ce_ = context.Operators.Start(bv_);
+					var cf_ = context.Operators.Not((bool?)(ce_ is null));
+					var cg_ = context.Operators.And(cc_, cf_);
+					var ch_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(LastObs?.StatusElement?.Value);
+					var ci_ = context.Operators.Equal(ch_, "finished");
+					var cj_ = context.Operators.And(cg_, ci_);
+
+					return cj_;
+				};
+				var ag_ = context.Operators.WhereOrNull<Encounter>(ae_, af_);
+				object ah_(Encounter @this)
+				{
+					var ck_ = FHIRHelpers_4_3_000.ToInterval(@this?.Period);
+					var cl_ = context.Operators.End(ck_);
+
+					return cl_;
+				};
+				var ai_ = context.Operators.ListSortBy<Encounter>(ag_, ah_, System.ComponentModel.ListSortDirection.Ascending);
+				var aj_ = context.Operators.LastOfList<Encounter>(ai_);
+				var ak_ = FHIRHelpers_4_3_000.ToInterval(aj_?.Period);
+				var al_ = context.Operators.Start(ak_);
+				var am_ = FHIRHelpers_4_3_000.ToInterval(Visit?.Period);
+				var an_ = context.Operators.Start(am_);
+				var ao_ = context.Operators.Quantity(1m, "hour");
+				var ap_ = context.Operators.Subtract((al_ ?? an_), ao_);
+				var ar_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+				bool? as_(Encounter LastObs)
+				{
+					var cm_ = FHIRHelpers_4_3_000.ToInterval(LastObs?.Period);
+					var cn_ = context.Operators.End(cm_);
+					var co_ = FHIRHelpers_4_3_000.ToInterval(Visit?.Period);
+					var cp_ = context.Operators.Start(co_);
+					var cq_ = context.Operators.Quantity(1m, "hour");
+					var cr_ = context.Operators.Subtract(cp_, cq_);
+					var ct_ = context.Operators.Start(co_);
+					var cu_ = context.Operators.Interval(cr_, ct_, true, true);
+					var cv_ = context.Operators.ElementInInterval<CqlDateTime>(cn_, cu_, null);
+					var cx_ = context.Operators.Start(co_);
+					var cy_ = context.Operators.Not((bool?)(cx_ is null));
+					var cz_ = context.Operators.And(cv_, cy_);
+					var da_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(LastObs?.StatusElement?.Value);
+					var db_ = context.Operators.Equal(da_, "finished");
+					var dc_ = context.Operators.And(cz_, db_);
+
+					return dc_;
+				};
+				var at_ = context.Operators.WhereOrNull<Encounter>(ar_, as_);
+				object au_(Encounter @this)
+				{
+					var dd_ = FHIRHelpers_4_3_000.ToInterval(@this?.Period);
+					var de_ = context.Operators.End(dd_);
+
+					return de_;
+				};
+				var av_ = context.Operators.ListSortBy<Encounter>(at_, au_, System.ComponentModel.ListSortDirection.Ascending);
+				var aw_ = context.Operators.LastOfList<Encounter>(av_);
+				var ax_ = FHIRHelpers_4_3_000.ToInterval(aw_?.Period);
+				var ay_ = context.Operators.Start(ax_);
+				var ba_ = context.Operators.Start(am_);
+				var bb_ = context.Operators.Interval(ap_, (ay_ ?? ba_), true, true);
+				var bc_ = context.Operators.ElementInInterval<CqlDateTime>(ac_, bb_, null);
+				var be_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+				bool? bf_(Encounter LastObs)
+				{
+					var df_ = FHIRHelpers_4_3_000.ToInterval(LastObs?.Period);
+					var dg_ = context.Operators.End(df_);
+					var dh_ = FHIRHelpers_4_3_000.ToInterval(Visit?.Period);
+					var di_ = context.Operators.Start(dh_);
+					var dj_ = context.Operators.Quantity(1m, "hour");
+					var dk_ = context.Operators.Subtract(di_, dj_);
+					var dm_ = context.Operators.Start(dh_);
+					var dn_ = context.Operators.Interval(dk_, dm_, true, true);
+					var do_ = context.Operators.ElementInInterval<CqlDateTime>(dg_, dn_, null);
+					var dq_ = context.Operators.Start(dh_);
+					var dr_ = context.Operators.Not((bool?)(dq_ is null));
+					var ds_ = context.Operators.And(do_, dr_);
+					var dt_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(LastObs?.StatusElement?.Value);
+					var du_ = context.Operators.Equal(dt_, "finished");
+					var dv_ = context.Operators.And(ds_, du_);
+
+					return dv_;
+				};
+				var bg_ = context.Operators.WhereOrNull<Encounter>(be_, bf_);
+				object bh_(Encounter @this)
+				{
+					var dw_ = FHIRHelpers_4_3_000.ToInterval(@this?.Period);
+					var dx_ = context.Operators.End(dw_);
+
+					return dx_;
+				};
+				var bi_ = context.Operators.ListSortBy<Encounter>(bg_, bh_, System.ComponentModel.ListSortDirection.Ascending);
+				var bj_ = context.Operators.LastOfList<Encounter>(bi_);
+				var bk_ = FHIRHelpers_4_3_000.ToInterval(bj_?.Period);
+				var bl_ = context.Operators.Start(bk_);
+				var bn_ = context.Operators.Start(am_);
+				var bo_ = context.Operators.Not((bool?)((bl_ ?? bn_) is null));
+				var bp_ = context.Operators.And(bc_, bo_);
+				var bq_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(LastEDOBTriage?.StatusElement?.Value);
+				var br_ = context.Operators.Equal(bq_, "finished");
+				var bs_ = context.Operators.And(bp_, br_);
+
+				return bs_;
+			};
+			var h_ = context.Operators.WhereOrNull<Encounter>(f_, g_);
+			object i_(Encounter @this)
+			{
+				var dy_ = FHIRHelpers_4_3_000.ToInterval(@this?.Period);
+				var dz_ = context.Operators.End(dy_);
+
+				return dz_;
+			};
+			var j_ = context.Operators.ListSortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			var k_ = context.Operators.LastOfList<Encounter>(j_);
+			var l_ = FHIRHelpers_4_3_000.ToInterval(k_?.Period);
+			var m_ = context.Operators.Start(l_);
+			var n_ = this.Observation_Services();
+			var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+			bool? p_(Encounter LastObs)
+			{
+				var ea_ = FHIRHelpers_4_3_000.ToInterval(LastObs?.Period);
+				var eb_ = context.Operators.End(ea_);
+				var ec_ = FHIRHelpers_4_3_000.ToInterval(Visit?.Period);
+				var ed_ = context.Operators.Start(ec_);
+				var ee_ = context.Operators.Quantity(1m, "hour");
+				var ef_ = context.Operators.Subtract(ed_, ee_);
+				var eh_ = context.Operators.Start(ec_);
+				var ei_ = context.Operators.Interval(ef_, eh_, true, true);
+				var ej_ = context.Operators.ElementInInterval<CqlDateTime>(eb_, ei_, null);
+				var el_ = context.Operators.Start(ec_);
+				var em_ = context.Operators.Not((bool?)(el_ is null));
+				var en_ = context.Operators.And(ej_, em_);
+				var eo_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(LastObs?.StatusElement?.Value);
+				var ep_ = context.Operators.Equal(eo_, "finished");
+				var eq_ = context.Operators.And(en_, ep_);
+
+				return eq_;
+			};
+			var q_ = context.Operators.WhereOrNull<Encounter>(o_, p_);
+			object r_(Encounter @this)
+			{
+				var er_ = FHIRHelpers_4_3_000.ToInterval(@this?.Period);
+				var es_ = context.Operators.End(er_);
+
+				return es_;
+			};
+			var s_ = context.Operators.ListSortBy<Encounter>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
+			var t_ = context.Operators.LastOfList<Encounter>(s_);
+			var u_ = FHIRHelpers_4_3_000.ToInterval(t_?.Period);
+			var v_ = context.Operators.Start(u_);
+			var w_ = FHIRHelpers_4_3_000.ToInterval(Visit?.Period);
+			var x_ = context.Operators.Start(w_);
+			var z_ = context.Operators.End(w_);
+			var aa_ = context.Operators.Interval((m_ ?? (v_ ?? x_)), z_, true, true);
+
+			return aa_;
+		};
+		var c_ = context.Operators.SelectOrNull<Encounter, CqlInterval<CqlDateTime>>(a_, b_);
+		var d_ = context.Operators.SingleOrNull<CqlInterval<CqlDateTime>>(c_);
+
+		return d_;
+	}
+
+	private IEnumerable<Encounter> Delivery_Encounter_with_Age_Range_Value()
+	{
+		var a_ = this.Encounter_with_Age_Range();
+		IEnumerable<Encounter> b_(Encounter EncounterWithAge)
+		{
+			var d_ = this.Delivery_Procedures();
+			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			bool? f_(Procedure DeliveryProcedure)
+			{
+				var j_ = context.Operators.EnumEqualsString(DeliveryProcedure?.StatusElement?.Value, "completed");
+				var k_ = FHIRHelpers_4_3_000.ToValue(DeliveryProcedure?.Performed);
+				var l_ = QICoreCommon_2_0_000.toInterval(k_);
+				var m_ = context.Operators.Start(l_);
+				var n_ = this.hospitalizationWithEDOBTriageObservation(EncounterWithAge);
+				var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, null);
+				var p_ = context.Operators.And(j_, o_);
+
+				return p_;
+			};
+			var g_ = context.Operators.WhereOrNull<Procedure>(e_, f_);
+			Encounter h_(Procedure DeliveryProcedure) => 
+				EncounterWithAge;
+			var i_ = context.Operators.SelectOrNull<Procedure, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Delivery Encounter with Age Range")]
+	public IEnumerable<Encounter> Delivery_Encounter_with_Age_Range() => 
+		__Delivery_Encounter_with_Age_Range.Value;
+
+    [CqlDeclaration("lastTimeOfDelivery")]
+	public CqlDateTime lastTimeOfDelivery(Encounter TheEncounter)
+	{
+		var a_ = this.Date_and_time_of_obstetric_delivery();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		bool? d_(Observation TimeOfDelivery)
+		{
+			var j_ = FHIRHelpers_4_3_000.ToValue(TimeOfDelivery?.Value);
+			var k_ = context.Operators.Not((bool?)((j_ as CqlDateTime) is null));
+			var l_ = context.Operators.Convert<Code<ObservationStatus>>(TimeOfDelivery?.StatusElement?.Value);
+			var m_ = context.Operators.Convert<string>(l_);
+			var n_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var o_ = context.Operators.InList<string>(m_, (n_ as IEnumerable<string>));
+			var p_ = context.Operators.And(k_, o_);
+			object q_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(TimeOfDelivery?.Effective) is CqlDateTime)
+				{
+					var z_ = FHIRHelpers_4_3_000.ToValue(TimeOfDelivery?.Effective);
+
+					return ((z_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(TimeOfDelivery?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var aa_ = FHIRHelpers_4_3_000.ToValue(TimeOfDelivery?.Effective);
+
+					return ((aa_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(TimeOfDelivery?.Effective) is CqlDateTime)
+				{
+					var ab_ = FHIRHelpers_4_3_000.ToValue(TimeOfDelivery?.Effective);
+
+					return ((ab_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var r_ = QICoreCommon_2_0_000.earliest(q_());
+			var s_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
+			var t_ = context.Operators.ElementInInterval<CqlDateTime>(r_, s_, null);
+			var u_ = context.Operators.And(p_, t_);
+			var x_ = context.Operators.ElementInInterval<CqlDateTime>((j_ as CqlDateTime), s_, null);
+			var y_ = context.Operators.And(u_, x_);
+
+			return y_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		object f_(Observation @this)
+		{
+			object ac_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(@this?.Effective) is CqlDateTime)
+				{
+					var ae_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+
+					return ((ae_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(@this?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var af_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+
+					return ((af_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(@this?.Effective) is CqlDateTime)
+				{
+					var ag_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+
+					return ((ag_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var ad_ = QICoreCommon_2_0_000.earliest(ac_());
+
+			return ad_;
+		};
+		var g_ = context.Operators.ListSortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		var h_ = context.Operators.LastOfList<Observation>(g_);
+		var i_ = FHIRHelpers_4_3_000.ToValue(h_?.Value);
+
+		return (i_ as CqlDateTime);
+	}
+
+    [CqlDeclaration("lastEstimatedDeliveryDate")]
+	public CqlDateTime lastEstimatedDeliveryDate(Encounter TheEncounter)
+	{
+		var a_ = this.Delivery_date_Estimated();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		bool? d_(Observation EstimatedDateOfDelivery)
+		{
+			var j_ = FHIRHelpers_4_3_000.ToValue(EstimatedDateOfDelivery?.Value);
+			var k_ = context.Operators.Not((bool?)((j_ as CqlDateTime) is null));
+			var l_ = context.Operators.Convert<Code<ObservationStatus>>(EstimatedDateOfDelivery?.StatusElement?.Value);
+			var m_ = context.Operators.Convert<string>(l_);
+			var n_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var o_ = context.Operators.InList<string>(m_, (n_ as IEnumerable<string>));
+			var p_ = context.Operators.And(k_, o_);
+			object q_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(EstimatedDateOfDelivery?.Effective) is CqlDateTime)
+				{
+					var ac_ = FHIRHelpers_4_3_000.ToValue(EstimatedDateOfDelivery?.Effective);
+
+					return ((ac_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(EstimatedDateOfDelivery?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var ad_ = FHIRHelpers_4_3_000.ToValue(EstimatedDateOfDelivery?.Effective);
+
+					return ((ad_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(EstimatedDateOfDelivery?.Effective) is CqlDateTime)
+				{
+					var ae_ = FHIRHelpers_4_3_000.ToValue(EstimatedDateOfDelivery?.Effective);
+
+					return ((ae_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var r_ = QICoreCommon_2_0_000.earliest(q_());
+			var s_ = this.lastTimeOfDelivery(TheEncounter);
+			var t_ = context.Operators.Quantity(42m, "weeks");
+			var u_ = context.Operators.Subtract(s_, t_);
+			var w_ = context.Operators.Interval(u_, s_, true, true);
+			var x_ = context.Operators.ElementInInterval<CqlDateTime>(r_, w_, null);
+			var z_ = context.Operators.Not((bool?)(s_ is null));
+			var aa_ = context.Operators.And(x_, z_);
+			var ab_ = context.Operators.And(p_, aa_);
+
+			return ab_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		object f_(Observation @this)
+		{
+			object af_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(@this?.Effective) is CqlDateTime)
+				{
+					var ah_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+
+					return ((ah_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(@this?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var ai_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+
+					return ((ai_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(@this?.Effective) is CqlDateTime)
+				{
+					var aj_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+
+					return ((aj_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var ag_ = QICoreCommon_2_0_000.earliest(af_());
+
+			return ag_;
+		};
+		var g_ = context.Operators.ListSortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		var h_ = context.Operators.LastOfList<Observation>(g_);
+		var i_ = FHIRHelpers_4_3_000.ToValue(h_?.Value);
+
+		return (i_ as CqlDateTime);
+	}
+
+    [CqlDeclaration("calculatedGestationalAge")]
+	public int? calculatedGestationalAge(Encounter TheEncounter)
+	{
+		var a_ = this.lastTimeOfDelivery(TheEncounter);
+		var b_ = this.lastEstimatedDeliveryDate(TheEncounter);
+		var c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		var d_ = context.Operators.Subtract((int?)280, c_);
+		var e_ = context.Operators.TruncateDivide(d_, (int?)7);
+
+		return e_;
+	}
+
+	private IEnumerable<Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM> Variable_Calculated_Gestational_Age_Value()
+	{
+		var a_ = this.Delivery_Encounter_with_Age_Range();
+		Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM b_(Encounter DeliveryEncounter)
+		{
+			var d_ = this.calculatedGestationalAge(DeliveryEncounter);
+			var e_ = new Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM
+			{
+				EncounterID = DeliveryEncounter?.IdElement?.Value,
+				CalculatedCGA = d_,
+			};
+
+			return e_;
+		};
+		var c_ = context.Operators.SelectOrNull<Encounter, Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Variable Calculated Gestational Age")]
+	public IEnumerable<Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM> Variable_Calculated_Gestational_Age() => 
+		__Variable_Calculated_Gestational_Age.Value;
+
+    [CqlDeclaration("lastEstimatedGestationalAge")]
+	public CqlQuantity lastEstimatedGestationalAge(Encounter TheEncounter)
+	{
+		var a_ = this.Estimated_Gestational_Age_at_Delivery();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		bool? c_(Observation EstimatedGestationalAge)
+		{
+			object i_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective) is CqlDateTime)
+				{
+					var ao_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective);
+
+					return ((ao_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var ap_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective);
+
+					return ((ap_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective) is CqlDateTime)
+				{
+					var aq_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective);
+
+					return ((aq_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var j_ = QICoreCommon_2_0_000.earliest(i_());
+			var k_ = this.lastTimeOfDelivery(TheEncounter);
+			var l_ = context.Operators.Quantity(24m, "hours");
+			var m_ = context.Operators.Subtract(k_, l_);
+			var o_ = context.Operators.Interval(m_, k_, true, true);
+			var p_ = context.Operators.ElementInInterval<CqlDateTime>(j_, o_, null);
+			var r_ = context.Operators.Not((bool?)(k_ is null));
+			var s_ = context.Operators.And(p_, r_);
+			var t_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Value);
+			var u_ = context.Operators.Not((bool?)(t_ is null));
+			var v_ = context.Operators.And(s_, u_);
+			var w_ = context.Operators.Convert<Code<ObservationStatus>>(EstimatedGestationalAge?.StatusElement?.Value);
+			var x_ = context.Operators.Convert<string>(w_);
+			var y_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var z_ = context.Operators.InList<string>(x_, (y_ as IEnumerable<string>));
+			var aa_ = context.Operators.And(v_, z_);
+			object ab_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective) is CqlDateTime)
+				{
+					var ar_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective);
+
+					return ((ar_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var as_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective);
+
+					return ((as_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective) is CqlDateTime)
+				{
+					var at_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective);
+
+					return ((at_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var ac_ = QICoreCommon_2_0_000.earliest(ab_());
+			var ae_ = context.Operators.SameAs(ac_, k_, "day");
+			object af_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective) is CqlDateTime)
+				{
+					var au_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective);
+
+					return ((au_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var av_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective);
+
+					return ((av_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective) is CqlDateTime)
+				{
+					var aw_ = FHIRHelpers_4_3_000.ToValue(EstimatedGestationalAge?.Effective);
+
+					return ((aw_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var ag_ = QICoreCommon_2_0_000.earliest(af_());
+			var ah_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
+			var ai_ = context.Operators.ElementInInterval<CqlDateTime>(ag_, ah_, null);
+			var aj_ = context.Operators.And(ae_, ai_);
+			var al_ = context.Operators.Not((bool?)(t_ is null));
+			var am_ = context.Operators.And(aj_, al_);
+			var an_ = context.Operators.Or(aa_, am_);
+
+			return an_;
+		};
+		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
+		object e_(Observation @this)
+		{
+			object ax_()
+			{
+				if (FHIRHelpers_4_3_000.ToValue(@this?.Effective) is CqlDateTime)
+				{
+					var az_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+
+					return ((az_ as CqlDateTime) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(@this?.Effective) is CqlInterval<CqlDateTime>)
+				{
+					var ba_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+
+					return ((ba_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (FHIRHelpers_4_3_000.ToValue(@this?.Effective) is CqlDateTime)
+				{
+					var bb_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+
+					return ((bb_ as CqlDateTime) as object);
+				}
+				else
+				{
+					return null;
+				};
+			};
+			var ay_ = QICoreCommon_2_0_000.earliest(ax_());
+
+			return ay_;
+		};
+		var f_ = context.Operators.ListSortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		var g_ = context.Operators.LastOfList<Observation>(f_);
+		var h_ = FHIRHelpers_4_3_000.ToValue(g_?.Value);
+
+		return (h_ as CqlQuantity);
+	}
+
+}

--- a/Demo/Measures-cms/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures-cms/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
@@ -1,0 +1,2615 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("PCSBPScreeningFollowUpFHIR", "0.2.000")]
+public class PCSBPScreeningFollowUpFHIR_0_2_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Diagnosis_of_Hypertension;
+    internal Lazy<CqlValueSet> __Dietary_Recommendations;
+    internal Lazy<CqlValueSet> __Encounter_to_Screen_for_Blood_Pressure;
+    internal Lazy<CqlValueSet> __Finding_of_Elevated_Blood_Pressure_or_Hypertension;
+    internal Lazy<CqlValueSet> __Follow_Up_Within_4_Weeks;
+    internal Lazy<CqlValueSet> __Laboratory_Tests_for_Hypertension;
+    internal Lazy<CqlValueSet> __Lifestyle_Recommendation;
+    internal Lazy<CqlValueSet> __Medical_Reason;
+    internal Lazy<CqlValueSet> __Patient_Declined;
+    internal Lazy<CqlValueSet> __Pharmacologic_Therapy_for_Hypertension;
+    internal Lazy<CqlValueSet> __Recommendation_to_Increase_Physical_Activity;
+    internal Lazy<CqlValueSet> __Referral_or_Counseling_for_Alcohol_Consumption;
+    internal Lazy<CqlValueSet> __Referral_to_Primary_Care_or_Alternate_Provider;
+    internal Lazy<CqlValueSet> __Weight_Reduction_Recommended;
+    internal Lazy<CqlCode> __Diastolic_blood_pressure;
+    internal Lazy<CqlCode> ___12_lead_EKG_panel;
+    internal Lazy<CqlCode> __EKG_study;
+    internal Lazy<CqlCode> __Follow_up_2_3_months__finding_;
+    internal Lazy<CqlCode> __Follow_up_4_6_months__finding_;
+    internal Lazy<CqlCode> __Systolic_blood_pressure;
+    internal Lazy<CqlCode> __virtual;
+    internal Lazy<CqlCode[]> __ActCode;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter_during_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Normal_Blood_Pressure_Reading;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80;
+    internal Lazy<IEnumerable<ServiceRequest>> __Follow_up_with_Rescreen_in_2_to_6_Months;
+    internal Lazy<IEnumerable<ServiceRequest>> __NonPharmacological_Interventions;
+    internal Lazy<IEnumerable<ServiceRequest>> __Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Hypertensive_Reading_Within_Year_Prior;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80;
+    internal Lazy<IEnumerable<ServiceRequest>> __First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89;
+    internal Lazy<IEnumerable<ServiceRequest>> __Laboratory_Test_or_ECG_for_Hypertension;
+    internal Lazy<IEnumerable<ServiceRequest>> __Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90;
+    internal Lazy<IEnumerable<ServiceRequest>> __Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement;
+    internal Lazy<IEnumerable<ServiceRequest>> __NonPharmacological_Intervention_Not_Ordered;
+    internal Lazy<IEnumerable<ServiceRequest>> __Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered;
+    internal Lazy<IEnumerable<ServiceRequest>> __Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined;
+    internal Lazy<IEnumerable<object>> __Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exceptions;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public PCSBPScreeningFollowUpFHIR_0_2_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+
+        __Diagnosis_of_Hypertension = new Lazy<CqlValueSet>(this.Diagnosis_of_Hypertension_Value);
+        __Dietary_Recommendations = new Lazy<CqlValueSet>(this.Dietary_Recommendations_Value);
+        __Encounter_to_Screen_for_Blood_Pressure = new Lazy<CqlValueSet>(this.Encounter_to_Screen_for_Blood_Pressure_Value);
+        __Finding_of_Elevated_Blood_Pressure_or_Hypertension = new Lazy<CqlValueSet>(this.Finding_of_Elevated_Blood_Pressure_or_Hypertension_Value);
+        __Follow_Up_Within_4_Weeks = new Lazy<CqlValueSet>(this.Follow_Up_Within_4_Weeks_Value);
+        __Laboratory_Tests_for_Hypertension = new Lazy<CqlValueSet>(this.Laboratory_Tests_for_Hypertension_Value);
+        __Lifestyle_Recommendation = new Lazy<CqlValueSet>(this.Lifestyle_Recommendation_Value);
+        __Medical_Reason = new Lazy<CqlValueSet>(this.Medical_Reason_Value);
+        __Patient_Declined = new Lazy<CqlValueSet>(this.Patient_Declined_Value);
+        __Pharmacologic_Therapy_for_Hypertension = new Lazy<CqlValueSet>(this.Pharmacologic_Therapy_for_Hypertension_Value);
+        __Recommendation_to_Increase_Physical_Activity = new Lazy<CqlValueSet>(this.Recommendation_to_Increase_Physical_Activity_Value);
+        __Referral_or_Counseling_for_Alcohol_Consumption = new Lazy<CqlValueSet>(this.Referral_or_Counseling_for_Alcohol_Consumption_Value);
+        __Referral_to_Primary_Care_or_Alternate_Provider = new Lazy<CqlValueSet>(this.Referral_to_Primary_Care_or_Alternate_Provider_Value);
+        __Weight_Reduction_Recommended = new Lazy<CqlValueSet>(this.Weight_Reduction_Recommended_Value);
+        __Diastolic_blood_pressure = new Lazy<CqlCode>(this.Diastolic_blood_pressure_Value);
+        ___12_lead_EKG_panel = new Lazy<CqlCode>(this._12_lead_EKG_panel_Value);
+        __EKG_study = new Lazy<CqlCode>(this.EKG_study_Value);
+        __Follow_up_2_3_months__finding_ = new Lazy<CqlCode>(this.Follow_up_2_3_months__finding__Value);
+        __Follow_up_4_6_months__finding_ = new Lazy<CqlCode>(this.Follow_up_4_6_months__finding__Value);
+        __Systolic_blood_pressure = new Lazy<CqlCode>(this.Systolic_blood_pressure_Value);
+        __virtual = new Lazy<CqlCode>(this.@virtual_Value);
+        __ActCode = new Lazy<CqlCode[]>(this.ActCode_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Encounter_during_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_during_Measurement_Period_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exclusions_Value);
+        __Encounter_with_Normal_Blood_Pressure_Reading = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Normal_Blood_Pressure_Reading_Value);
+        __Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80 = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_Value);
+        __Follow_up_with_Rescreen_in_2_to_6_Months = new Lazy<IEnumerable<ServiceRequest>>(this.Follow_up_with_Rescreen_in_2_to_6_Months_Value);
+        __NonPharmacological_Interventions = new Lazy<IEnumerable<ServiceRequest>>(this.NonPharmacological_Interventions_Value);
+        __Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading = new Lazy<IEnumerable<ServiceRequest>>(this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading_Value);
+        __Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions_Value);
+        __Encounter_with_Hypertensive_Reading_Within_Year_Prior = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Hypertensive_Reading_Within_Year_Prior_Value);
+        __Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80 = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_Value);
+        __First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional = new Lazy<IEnumerable<ServiceRequest>>(this.First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional_Value);
+        __Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions_Value);
+        __Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89 = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Value);
+        __Laboratory_Test_or_ECG_for_Hypertension = new Lazy<IEnumerable<ServiceRequest>>(this.Laboratory_Test_or_ECG_for_Hypertension_Value);
+        __Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions = new Lazy<IEnumerable<ServiceRequest>>(this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions_Value);
+        __Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions_Value);
+        __Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90 = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Value);
+        __Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions = new Lazy<IEnumerable<ServiceRequest>>(this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Value);
+        __Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+        __Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement_Value);
+        __NonPharmacological_Intervention_Not_Ordered = new Lazy<IEnumerable<ServiceRequest>>(this.NonPharmacological_Intervention_Not_Ordered_Value);
+        __Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered = new Lazy<IEnumerable<ServiceRequest>>(this.Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered_Value);
+        __Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined = new Lazy<IEnumerable<ServiceRequest>>(this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined_Value);
+        __Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined = new Lazy<IEnumerable<object>>(this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined_Value);
+        __Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient_Value);
+        __Denominator_Exceptions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exceptions_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Diagnosis_of_Hypertension_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263", null);
+
+    [CqlDeclaration("Diagnosis of Hypertension")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263")]
+	public CqlValueSet Diagnosis_of_Hypertension() => 
+		__Diagnosis_of_Hypertension.Value;
+
+	private CqlValueSet Dietary_Recommendations_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515", null);
+
+    [CqlDeclaration("Dietary Recommendations")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515")]
+	public CqlValueSet Dietary_Recommendations() => 
+		__Dietary_Recommendations.Value;
+
+	private CqlValueSet Encounter_to_Screen_for_Blood_Pressure_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920", null);
+
+    [CqlDeclaration("Encounter to Screen for Blood Pressure")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920")]
+	public CqlValueSet Encounter_to_Screen_for_Blood_Pressure() => 
+		__Encounter_to_Screen_for_Blood_Pressure.Value;
+
+	private CqlValueSet Finding_of_Elevated_Blood_Pressure_or_Hypertension_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514", null);
+
+    [CqlDeclaration("Finding of Elevated Blood Pressure or Hypertension")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514")]
+	public CqlValueSet Finding_of_Elevated_Blood_Pressure_or_Hypertension() => 
+		__Finding_of_Elevated_Blood_Pressure_or_Hypertension.Value;
+
+	private CqlValueSet Follow_Up_Within_4_Weeks_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578", null);
+
+    [CqlDeclaration("Follow Up Within 4 Weeks")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578")]
+	public CqlValueSet Follow_Up_Within_4_Weeks() => 
+		__Follow_Up_Within_4_Weeks.Value;
+
+	private CqlValueSet Laboratory_Tests_for_Hypertension_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482", null);
+
+    [CqlDeclaration("Laboratory Tests for Hypertension")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482")]
+	public CqlValueSet Laboratory_Tests_for_Hypertension() => 
+		__Laboratory_Tests_for_Hypertension.Value;
+
+	private CqlValueSet Lifestyle_Recommendation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581", null);
+
+    [CqlDeclaration("Lifestyle Recommendation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581")]
+	public CqlValueSet Lifestyle_Recommendation() => 
+		__Lifestyle_Recommendation.Value;
+
+	private CqlValueSet Medical_Reason_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlDeclaration("Medical Reason")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
+	public CqlValueSet Medical_Reason() => 
+		__Medical_Reason.Value;
+
+	private CqlValueSet Patient_Declined_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582", null);
+
+    [CqlDeclaration("Patient Declined")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582")]
+	public CqlValueSet Patient_Declined() => 
+		__Patient_Declined.Value;
+
+	private CqlValueSet Pharmacologic_Therapy_for_Hypertension_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577", null);
+
+    [CqlDeclaration("Pharmacologic Therapy for Hypertension")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577")]
+	public CqlValueSet Pharmacologic_Therapy_for_Hypertension() => 
+		__Pharmacologic_Therapy_for_Hypertension.Value;
+
+	private CqlValueSet Recommendation_to_Increase_Physical_Activity_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518", null);
+
+    [CqlDeclaration("Recommendation to Increase Physical Activity")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518")]
+	public CqlValueSet Recommendation_to_Increase_Physical_Activity() => 
+		__Recommendation_to_Increase_Physical_Activity.Value;
+
+	private CqlValueSet Referral_or_Counseling_for_Alcohol_Consumption_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583", null);
+
+    [CqlDeclaration("Referral or Counseling for Alcohol Consumption")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583")]
+	public CqlValueSet Referral_or_Counseling_for_Alcohol_Consumption() => 
+		__Referral_or_Counseling_for_Alcohol_Consumption.Value;
+
+	private CqlValueSet Referral_to_Primary_Care_or_Alternate_Provider_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580", null);
+
+    [CqlDeclaration("Referral to Primary Care or Alternate Provider")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580")]
+	public CqlValueSet Referral_to_Primary_Care_or_Alternate_Provider() => 
+		__Referral_to_Primary_Care_or_Alternate_Provider.Value;
+
+	private CqlValueSet Weight_Reduction_Recommended_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510", null);
+
+    [CqlDeclaration("Weight Reduction Recommended")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510")]
+	public CqlValueSet Weight_Reduction_Recommended() => 
+		__Weight_Reduction_Recommended.Value;
+
+	private CqlCode Diastolic_blood_pressure_Value() => 
+		new CqlCode("8462-4", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Diastolic blood pressure")]
+	public CqlCode Diastolic_blood_pressure() => 
+		__Diastolic_blood_pressure.Value;
+
+	private CqlCode _12_lead_EKG_panel_Value() => 
+		new CqlCode("34534-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("12 lead EKG panel")]
+	public CqlCode _12_lead_EKG_panel() => 
+		___12_lead_EKG_panel.Value;
+
+	private CqlCode EKG_study_Value() => 
+		new CqlCode("11524-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("EKG study")]
+	public CqlCode EKG_study() => 
+		__EKG_study.Value;
+
+	private CqlCode Follow_up_2_3_months__finding__Value() => 
+		new CqlCode("183624006", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Follow-up 2-3 months (finding)")]
+	public CqlCode Follow_up_2_3_months__finding_() => 
+		__Follow_up_2_3_months__finding_.Value;
+
+	private CqlCode Follow_up_4_6_months__finding__Value() => 
+		new CqlCode("183625007", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Follow-up 4-6 months (finding)")]
+	public CqlCode Follow_up_4_6_months__finding_() => 
+		__Follow_up_4_6_months__finding_.Value;
+
+	private CqlCode Systolic_blood_pressure_Value() => 
+		new CqlCode("8480-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Systolic blood pressure")]
+	public CqlCode Systolic_blood_pressure() => 
+		__Systolic_blood_pressure.Value;
+
+	private CqlCode @virtual_Value() => 
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+
+    [CqlDeclaration("virtual")]
+	public CqlCode @virtual() => 
+		__virtual.Value;
+
+	private CqlCode[] ActCode_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ActCode")]
+	public CqlCode[] ActCode() => 
+		__ActCode.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("8462-4", "http://loinc.org", null, null),
+			new CqlCode("34534-8", "http://loinc.org", null, null),
+			new CqlCode("11524-6", "http://loinc.org", null, null),
+			new CqlCode("8480-6", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("183624006", "http://snomed.info/sct", null, null),
+			new CqlCode("183625007", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("PCSBPScreeningFollowUpFHIR-0.2.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period_Value()
+	{
+		var a_ = this.Encounter_to_Screen_for_Blood_Pressure();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter ValidEncounter)
+		{
+			var e_ = this.Measurement_Period();
+			var f_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var g_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, f_, "day");
+			var h_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ValidEncounter?.StatusElement?.Value);
+			var i_ = context.Operators.Equivalent(h_, "finished");
+			var j_ = context.Operators.And(g_, i_);
+			var k_ = FHIRHelpers_4_3_000.ToCode(ValidEncounter?.Class);
+			var l_ = this.@virtual();
+			var m_ = context.Operators.Equivalent(k_, l_);
+			var n_ = context.Operators.Not(m_);
+			var o_ = context.Operators.And(j_, n_);
+
+			return o_;
+		};
+		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter during Measurement Period")]
+	public IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period() => 
+		__Qualifying_Encounter_during_Measurement_Period.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var d_ = this.Patient();
+			var e_ = context.Operators.ConvertStringToDateTime(d_?.BirthDateElement?.Value);
+			var f_ = this.Measurement_Period();
+			var g_ = context.Operators.Start(f_);
+			var h_ = context.Operators.CalculateAgeAt(e_, g_, "year");
+			var i_ = context.Operators.GreaterOrEqual(h_, (int?)18);
+
+			return i_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Encounter> Denominator_Exclusions_Value()
+	{
+		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> b_(Encounter QualifyingEncounter)
+		{
+			var d_ = this.Diagnosis_of_Hypertension();
+			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			bool? f_(Condition Hypertension)
+			{
+				var j_ = QICoreCommon_2_0_000.isProblemListItem(Hypertension);
+				var k_ = QICoreCommon_2_0_000.isHealthConcern(Hypertension);
+				var l_ = context.Operators.Or(j_, k_);
+				var m_ = QICoreCommon_2_0_000.isActive(Hypertension);
+				var n_ = context.Operators.And(l_, m_);
+				CqlInterval<CqlDateTime> o_()
+				{
+					if ((context.Operators.Start(QICoreCommon_2_0_000.prevalenceInterval(Hypertension)) is null))
+					{
+						return null;
+					}
+					else
+					{
+						var s_ = QICoreCommon_2_0_000.prevalenceInterval(Hypertension);
+						var t_ = context.Operators.Start(s_);
+						var v_ = context.Operators.Start(s_);
+						var w_ = context.Operators.Interval(t_, v_, true, true);
+
+						return w_;
+					};
+				};
+				var p_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var q_ = context.Operators.IntervalSameOrBefore(o_(), p_, "day");
+				var r_ = context.Operators.And(n_, q_);
+
+				return r_;
+			};
+			var g_ = context.Operators.WhereOrNull<Condition>(e_, f_);
+			Encounter h_(Condition Hypertension) => 
+				QualifyingEncounter;
+			var i_ = context.Operators.SelectOrNull<Condition, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public IEnumerable<Encounter> Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Normal_Blood_Pressure_Reading_Value()
+	{
+		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? e_(Observation BloodPressure)
+			{
+				var ag_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var ah_ = QICoreCommon_2_0_000.toInterval(ag_);
+				var ai_ = context.Operators.End(ah_);
+				var aj_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var ak_ = context.Operators.ElementInInterval<CqlDateTime>(ai_, aj_, null);
+				var al_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var am_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var an_ = context.Operators.InList<string>(al_, (am_ as IEnumerable<string>));
+				var ao_ = context.Operators.And(ak_, an_);
+
+				return ao_;
+			};
+			var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+			object g_(Observation @this)
+			{
+				var ap_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var aq_ = QICoreCommon_2_0_000.toInterval(ap_);
+				var ar_ = context.Operators.Start(aq_);
+
+				return ar_;
+			};
+			var h_ = context.Operators.ListSortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			var i_ = context.Operators.LastOfList<Observation>(h_);
+			bool? j_(Observation.ComponentComponent @this)
+			{
+				var as_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var at_ = context.Operators.Convert<string>(as_?.SystemElement);
+				var au_ = context.Operators.Equal(at_, "http://loinc.org");
+				var aw_ = context.Operators.Convert<string>(as_?.CodeElement);
+				var ax_ = context.Operators.Equal(aw_, "8480-6");
+				var ay_ = context.Operators.And(au_, ax_);
+
+				return ay_;
+			};
+			var k_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(i_?.Component, j_);
+			var l_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(k_);
+			var m_ = FHIRHelpers_4_3_000.ToValue(l_?.Value);
+			var n_ = context.Operators.Quantity(1m, "mm[Hg]");
+			var o_ = context.Operators.Quantity(120m, "mm[Hg]");
+			var p_ = context.Operators.Interval(n_, o_, true, false);
+			var q_ = context.Operators.ElementInInterval<CqlQuantity>((m_ as CqlQuantity), p_, null);
+			bool? s_(Observation BloodPressure)
+			{
+				var az_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var ba_ = QICoreCommon_2_0_000.toInterval(az_);
+				var bb_ = context.Operators.End(ba_);
+				var bc_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var bd_ = context.Operators.ElementInInterval<CqlDateTime>(bb_, bc_, null);
+				var be_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var bf_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var bg_ = context.Operators.InList<string>(be_, (bf_ as IEnumerable<string>));
+				var bh_ = context.Operators.And(bd_, bg_);
+
+				return bh_;
+			};
+			var t_ = context.Operators.WhereOrNull<Observation>(d_, s_);
+			object u_(Observation @this)
+			{
+				var bi_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var bj_ = QICoreCommon_2_0_000.toInterval(bi_);
+				var bk_ = context.Operators.Start(bj_);
+
+				return bk_;
+			};
+			var v_ = context.Operators.ListSortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
+			var w_ = context.Operators.LastOfList<Observation>(v_);
+			bool? x_(Observation.ComponentComponent @this)
+			{
+				var bl_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var bm_ = context.Operators.Convert<string>(bl_?.SystemElement);
+				var bn_ = context.Operators.Equal(bm_, "http://loinc.org");
+				var bp_ = context.Operators.Convert<string>(bl_?.CodeElement);
+				var bq_ = context.Operators.Equal(bp_, "8462-4");
+				var br_ = context.Operators.And(bn_, bq_);
+
+				return br_;
+			};
+			var y_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(w_?.Component, x_);
+			var z_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(y_);
+			var aa_ = FHIRHelpers_4_3_000.ToValue(z_?.Value);
+			var ac_ = context.Operators.Quantity(80m, "mm[Hg]");
+			var ad_ = context.Operators.Interval(n_, ac_, true, false);
+			var ae_ = context.Operators.ElementInInterval<CqlQuantity>((aa_ as CqlQuantity), ad_, null);
+			var af_ = context.Operators.And(q_, ae_);
+
+			return af_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Normal Blood Pressure Reading")]
+	public IEnumerable<Encounter> Encounter_with_Normal_Blood_Pressure_Reading() => 
+		__Encounter_with_Normal_Blood_Pressure_Reading.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_Value()
+	{
+		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? e_(Observation BloodPressure)
+			{
+				var ag_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var ah_ = QICoreCommon_2_0_000.toInterval(ag_);
+				var ai_ = context.Operators.End(ah_);
+				var aj_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var ak_ = context.Operators.ElementInInterval<CqlDateTime>(ai_, aj_, null);
+				var al_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var am_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var an_ = context.Operators.InList<string>(al_, (am_ as IEnumerable<string>));
+				var ao_ = context.Operators.And(ak_, an_);
+
+				return ao_;
+			};
+			var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+			object g_(Observation @this)
+			{
+				var ap_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var aq_ = QICoreCommon_2_0_000.toInterval(ap_);
+				var ar_ = context.Operators.Start(aq_);
+
+				return ar_;
+			};
+			var h_ = context.Operators.ListSortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			var i_ = context.Operators.LastOfList<Observation>(h_);
+			bool? j_(Observation.ComponentComponent @this)
+			{
+				var as_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var at_ = context.Operators.Convert<string>(as_?.SystemElement);
+				var au_ = context.Operators.Equal(at_, "http://loinc.org");
+				var aw_ = context.Operators.Convert<string>(as_?.CodeElement);
+				var ax_ = context.Operators.Equal(aw_, "8480-6");
+				var ay_ = context.Operators.And(au_, ax_);
+
+				return ay_;
+			};
+			var k_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(i_?.Component, j_);
+			var l_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(k_);
+			var m_ = FHIRHelpers_4_3_000.ToValue(l_?.Value);
+			var n_ = context.Operators.Quantity(120m, "mm[Hg]");
+			var o_ = context.Operators.Quantity(129m, "mm[Hg]");
+			var p_ = context.Operators.Interval(n_, o_, true, true);
+			var q_ = context.Operators.ElementInInterval<CqlQuantity>((m_ as CqlQuantity), p_, null);
+			bool? s_(Observation BloodPressure)
+			{
+				var az_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var ba_ = QICoreCommon_2_0_000.toInterval(az_);
+				var bb_ = context.Operators.End(ba_);
+				var bc_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var bd_ = context.Operators.ElementInInterval<CqlDateTime>(bb_, bc_, null);
+				var be_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var bf_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var bg_ = context.Operators.InList<string>(be_, (bf_ as IEnumerable<string>));
+				var bh_ = context.Operators.And(bd_, bg_);
+
+				return bh_;
+			};
+			var t_ = context.Operators.WhereOrNull<Observation>(d_, s_);
+			object u_(Observation @this)
+			{
+				var bi_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var bj_ = QICoreCommon_2_0_000.toInterval(bi_);
+				var bk_ = context.Operators.Start(bj_);
+
+				return bk_;
+			};
+			var v_ = context.Operators.ListSortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
+			var w_ = context.Operators.LastOfList<Observation>(v_);
+			bool? x_(Observation.ComponentComponent @this)
+			{
+				var bl_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var bm_ = context.Operators.Convert<string>(bl_?.SystemElement);
+				var bn_ = context.Operators.Equal(bm_, "http://loinc.org");
+				var bp_ = context.Operators.Convert<string>(bl_?.CodeElement);
+				var bq_ = context.Operators.Equal(bp_, "8462-4");
+				var br_ = context.Operators.And(bn_, bq_);
+
+				return br_;
+			};
+			var y_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(w_?.Component, x_);
+			var z_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(y_);
+			var aa_ = FHIRHelpers_4_3_000.ToValue(z_?.Value);
+			var ab_ = context.Operators.Quantity(1m, "mm[Hg]");
+			var ac_ = context.Operators.Quantity(80m, "mm[Hg]");
+			var ad_ = context.Operators.Interval(ab_, ac_, true, false);
+			var ae_ = context.Operators.ElementInInterval<CqlQuantity>((aa_ as CqlQuantity), ad_, null);
+			var af_ = context.Operators.And(q_, ae_);
+
+			return af_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Elevated Blood Pressure Reading SBP 120 to 129 AND DBP less than 80")]
+	public IEnumerable<Encounter> Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80() => 
+		__Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80.Value;
+
+	private IEnumerable<ServiceRequest> Follow_up_with_Rescreen_in_2_to_6_Months_Value()
+	{
+		var a_ = this.Follow_up_2_3_months__finding_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
+		var d_ = this.Follow_up_4_6_months__finding_();
+		var e_ = context.Operators.ToList<CqlCode>(d_);
+		var f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
+		var g_ = context.Operators.ListUnion<ServiceRequest>(c_, f_);
+		bool? h_(ServiceRequest FollowUp)
+		{
+			var j_ = context.Operators.Convert<Code<RequestIntent>>(FollowUp?.IntentElement?.Value);
+			var k_ = context.Operators.Equivalent(j_, "order");
+
+			return k_;
+		};
+		var i_ = context.Operators.WhereOrNull<ServiceRequest>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Follow up with Rescreen in 2 to 6 Months")]
+	public IEnumerable<ServiceRequest> Follow_up_with_Rescreen_in_2_to_6_Months() => 
+		__Follow_up_with_Rescreen_in_2_to_6_Months.Value;
+
+	private IEnumerable<ServiceRequest> NonPharmacological_Interventions_Value()
+	{
+		var a_ = this.Lifestyle_Recommendation();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var c_ = this.Weight_Reduction_Recommended();
+		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
+		var e_ = context.Operators.ListUnion<ServiceRequest>(b_, d_);
+		var f_ = this.Dietary_Recommendations();
+		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		var h_ = this.Recommendation_to_Increase_Physical_Activity();
+		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		var j_ = context.Operators.ListUnion<ServiceRequest>(g_, i_);
+		var k_ = context.Operators.ListUnion<ServiceRequest>(e_, j_);
+		var l_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
+		var m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
+		var n_ = context.Operators.ListUnion<ServiceRequest>(k_, m_);
+		bool? o_(ServiceRequest NonPharmaInterventions)
+		{
+			var q_ = context.Operators.Convert<Code<RequestIntent>>(NonPharmaInterventions?.IntentElement?.Value);
+			var r_ = context.Operators.Equivalent(q_, "order");
+
+			return r_;
+		};
+		var p_ = context.Operators.WhereOrNull<ServiceRequest>(n_, o_);
+
+		return p_;
+	}
+
+    [CqlDeclaration("NonPharmacological Interventions")]
+	public IEnumerable<ServiceRequest> NonPharmacological_Interventions() => 
+		__NonPharmacological_Interventions.Value;
+
+	private IEnumerable<ServiceRequest> Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading_Value()
+	{
+		var a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		bool? c_(ServiceRequest Referral)
+		{
+			CqlConcept e_(CodeableConcept @this)
+			{
+				var l_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return l_;
+			};
+			var f_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(Referral?.ReasonCode, e_);
+			var g_ = this.Finding_of_Elevated_Blood_Pressure_or_Hypertension();
+			var h_ = context.Operators.ConceptsInValueSet(f_, g_);
+			var i_ = context.Operators.Convert<Code<RequestIntent>>(Referral?.IntentElement?.Value);
+			var j_ = context.Operators.Equivalent(i_, "order");
+			var k_ = context.Operators.And(h_, j_);
+
+			return k_;
+		};
+		var d_ = context.Operators.WhereOrNull<ServiceRequest>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Referral to Alternate or Primary Healthcare Professional for Hypertensive Reading")]
+	public IEnumerable<ServiceRequest> Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading() => 
+		__Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions_Value()
+	{
+		var a_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80();
+		IEnumerable<Encounter> b_(Encounter ElevatedEncounter)
+		{
+			var j_ = this.Follow_up_with_Rescreen_in_2_to_6_Months();
+			bool? k_(ServiceRequest Twoto6MonthRescreen)
+			{
+				var o_ = context.Operators.Convert<CqlDateTime>(Twoto6MonthRescreen?.AuthoredOnElement);
+				var p_ = FHIRHelpers_4_3_000.ToInterval(ElevatedEncounter?.Period);
+				var q_ = context.Operators.ElementInInterval<CqlDateTime>(o_, p_, "day");
+
+				return q_;
+			};
+			var l_ = context.Operators.WhereOrNull<ServiceRequest>(j_, k_);
+			Encounter m_(ServiceRequest Twoto6MonthRescreen) => 
+				ElevatedEncounter;
+			var n_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(l_, m_);
+
+			return n_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> d_(Encounter ElevatedEncounter)
+		{
+			var r_ = this.NonPharmacological_Interventions();
+			bool? s_(ServiceRequest NonPharmInterventions)
+			{
+				var w_ = context.Operators.Convert<CqlDateTime>(NonPharmInterventions?.AuthoredOnElement);
+				var x_ = FHIRHelpers_4_3_000.ToInterval(ElevatedEncounter?.Period);
+				var y_ = context.Operators.ElementInInterval<CqlDateTime>(w_, x_, "day");
+
+				return y_;
+			};
+			var t_ = context.Operators.WhereOrNull<ServiceRequest>(r_, s_);
+			Encounter u_(ServiceRequest NonPharmInterventions) => 
+				ElevatedEncounter;
+			var v_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(t_, u_);
+
+			return v_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> g_(Encounter ElevatedEncounter)
+		{
+			var z_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
+			bool? aa_(ServiceRequest Referral)
+			{
+				var ae_ = context.Operators.Convert<CqlDateTime>(Referral?.AuthoredOnElement);
+				var af_ = FHIRHelpers_4_3_000.ToInterval(ElevatedEncounter?.Period);
+				var ag_ = context.Operators.ElementInInterval<CqlDateTime>(ae_, af_, "day");
+
+				return ag_;
+			};
+			var ab_ = context.Operators.WhereOrNull<ServiceRequest>(z_, aa_);
+			Encounter ac_(ServiceRequest Referral) => 
+				ElevatedEncounter;
+			var ad_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(ab_, ac_);
+
+			return ad_;
+		};
+		var h_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, g_);
+		var i_ = context.Operators.ListUnion<Encounter>(e_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Encounter with Elevated Blood Pressure Reading SBP 120 to 129 AND DBP less than 80 and Interventions")]
+	public IEnumerable<Encounter> Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions() => 
+		__Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Hypertensive_Reading_Within_Year_Prior_Value()
+	{
+		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? e_(Observation BloodPressure)
+			{
+				var bc_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var bd_ = QICoreCommon_2_0_000.toInterval(bc_);
+				var be_ = context.Operators.End(bd_);
+				var bf_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var bg_ = context.Operators.Start(bf_);
+				var bh_ = context.Operators.Quantity(1m, "year");
+				var bi_ = context.Operators.Subtract(bg_, bh_);
+				var bk_ = context.Operators.Start(bf_);
+				var bl_ = context.Operators.Interval(bi_, bk_, true, true);
+				var bm_ = context.Operators.ElementInInterval<CqlDateTime>(be_, bl_, null);
+				var bo_ = context.Operators.Start(bf_);
+				var bp_ = context.Operators.Not((bool?)(bo_ is null));
+				var bq_ = context.Operators.And(bm_, bp_);
+				var br_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var bs_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var bt_ = context.Operators.InList<string>(br_, (bs_ as IEnumerable<string>));
+				var bu_ = context.Operators.And(bq_, bt_);
+
+				return bu_;
+			};
+			var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+			object g_(Observation @this)
+			{
+				var bv_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var bw_ = QICoreCommon_2_0_000.toInterval(bv_);
+				var bx_ = context.Operators.Start(bw_);
+
+				return bx_;
+			};
+			var h_ = context.Operators.ListSortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			var i_ = context.Operators.LastOfList<Observation>(h_);
+			bool? j_(Observation.ComponentComponent @this)
+			{
+				var by_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var bz_ = context.Operators.Convert<string>(by_?.SystemElement);
+				var ca_ = context.Operators.Equal(bz_, "http://loinc.org");
+				var cc_ = context.Operators.Convert<string>(by_?.CodeElement);
+				var cd_ = context.Operators.Equal(cc_, "8480-6");
+				var ce_ = context.Operators.And(ca_, cd_);
+
+				return ce_;
+			};
+			var k_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(i_?.Component, j_);
+			var l_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(k_);
+			var m_ = FHIRHelpers_4_3_000.ToValue(l_?.Value);
+			var n_ = context.Operators.Quantity(0m, "mm[Hg]");
+			var o_ = context.Operators.Greater((m_ as CqlQuantity), n_);
+			bool? q_(Observation BloodPressure)
+			{
+				var cf_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var cg_ = QICoreCommon_2_0_000.toInterval(cf_);
+				var ch_ = context.Operators.End(cg_);
+				var ci_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var cj_ = context.Operators.Start(ci_);
+				var ck_ = context.Operators.Quantity(1m, "year");
+				var cl_ = context.Operators.Subtract(cj_, ck_);
+				var cn_ = context.Operators.Start(ci_);
+				var co_ = context.Operators.Interval(cl_, cn_, true, true);
+				var cp_ = context.Operators.ElementInInterval<CqlDateTime>(ch_, co_, null);
+				var cr_ = context.Operators.Start(ci_);
+				var cs_ = context.Operators.Not((bool?)(cr_ is null));
+				var ct_ = context.Operators.And(cp_, cs_);
+				var cu_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var cv_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var cw_ = context.Operators.InList<string>(cu_, (cv_ as IEnumerable<string>));
+				var cx_ = context.Operators.And(ct_, cw_);
+
+				return cx_;
+			};
+			var r_ = context.Operators.WhereOrNull<Observation>(d_, q_);
+			object s_(Observation @this)
+			{
+				var cy_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var cz_ = QICoreCommon_2_0_000.toInterval(cy_);
+				var da_ = context.Operators.Start(cz_);
+
+				return da_;
+			};
+			var t_ = context.Operators.ListSortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			var u_ = context.Operators.LastOfList<Observation>(t_);
+			bool? v_(Observation.ComponentComponent @this)
+			{
+				var db_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var dc_ = context.Operators.Convert<string>(db_?.SystemElement);
+				var dd_ = context.Operators.Equal(dc_, "http://loinc.org");
+				var df_ = context.Operators.Convert<string>(db_?.CodeElement);
+				var dg_ = context.Operators.Equal(df_, "8462-4");
+				var dh_ = context.Operators.And(dd_, dg_);
+
+				return dh_;
+			};
+			var w_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(u_?.Component, v_);
+			var x_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(w_);
+			var y_ = FHIRHelpers_4_3_000.ToValue(x_?.Value);
+			var aa_ = context.Operators.Greater((y_ as CqlQuantity), n_);
+			var ab_ = context.Operators.And(o_, aa_);
+			bool? ad_(Observation BloodPressure)
+			{
+				var di_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var dj_ = QICoreCommon_2_0_000.toInterval(di_);
+				var dk_ = context.Operators.End(dj_);
+				var dl_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var dm_ = context.Operators.Start(dl_);
+				var dn_ = context.Operators.Quantity(1m, "year");
+				var do_ = context.Operators.Subtract(dm_, dn_);
+				var dq_ = context.Operators.Start(dl_);
+				var dr_ = context.Operators.Interval(do_, dq_, true, true);
+				var ds_ = context.Operators.ElementInInterval<CqlDateTime>(dk_, dr_, null);
+				var du_ = context.Operators.Start(dl_);
+				var dv_ = context.Operators.Not((bool?)(du_ is null));
+				var dw_ = context.Operators.And(ds_, dv_);
+				var dx_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var dy_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var dz_ = context.Operators.InList<string>(dx_, (dy_ as IEnumerable<string>));
+				var ea_ = context.Operators.And(dw_, dz_);
+
+				return ea_;
+			};
+			var ae_ = context.Operators.WhereOrNull<Observation>(d_, ad_);
+			object af_(Observation @this)
+			{
+				var eb_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var ec_ = QICoreCommon_2_0_000.toInterval(eb_);
+				var ed_ = context.Operators.Start(ec_);
+
+				return ed_;
+			};
+			var ag_ = context.Operators.ListSortBy<Observation>(ae_, af_, System.ComponentModel.ListSortDirection.Ascending);
+			var ah_ = context.Operators.LastOfList<Observation>(ag_);
+			bool? ai_(Observation.ComponentComponent @this)
+			{
+				var ee_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var ef_ = context.Operators.Convert<string>(ee_?.SystemElement);
+				var eg_ = context.Operators.Equal(ef_, "http://loinc.org");
+				var ei_ = context.Operators.Convert<string>(ee_?.CodeElement);
+				var ej_ = context.Operators.Equal(ei_, "8480-6");
+				var ek_ = context.Operators.And(eg_, ej_);
+
+				return ek_;
+			};
+			var aj_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(ah_?.Component, ai_);
+			var ak_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(aj_);
+			var al_ = FHIRHelpers_4_3_000.ToValue(ak_?.Value);
+			var am_ = context.Operators.Quantity(130m, "mm[Hg]");
+			var an_ = context.Operators.GreaterOrEqual((al_ as CqlQuantity), am_);
+			bool? ap_(Observation BloodPressure)
+			{
+				var el_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var em_ = QICoreCommon_2_0_000.toInterval(el_);
+				var en_ = context.Operators.End(em_);
+				var eo_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var ep_ = context.Operators.Start(eo_);
+				var eq_ = context.Operators.Quantity(1m, "year");
+				var er_ = context.Operators.Subtract(ep_, eq_);
+				var et_ = context.Operators.Start(eo_);
+				var eu_ = context.Operators.Interval(er_, et_, true, true);
+				var ev_ = context.Operators.ElementInInterval<CqlDateTime>(en_, eu_, null);
+				var ex_ = context.Operators.Start(eo_);
+				var ey_ = context.Operators.Not((bool?)(ex_ is null));
+				var ez_ = context.Operators.And(ev_, ey_);
+				var fa_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var fb_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var fc_ = context.Operators.InList<string>(fa_, (fb_ as IEnumerable<string>));
+				var fd_ = context.Operators.And(ez_, fc_);
+
+				return fd_;
+			};
+			var aq_ = context.Operators.WhereOrNull<Observation>(d_, ap_);
+			object ar_(Observation @this)
+			{
+				var fe_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var ff_ = QICoreCommon_2_0_000.toInterval(fe_);
+				var fg_ = context.Operators.Start(ff_);
+
+				return fg_;
+			};
+			var as_ = context.Operators.ListSortBy<Observation>(aq_, ar_, System.ComponentModel.ListSortDirection.Ascending);
+			var at_ = context.Operators.LastOfList<Observation>(as_);
+			bool? au_(Observation.ComponentComponent @this)
+			{
+				var fh_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var fi_ = context.Operators.Convert<string>(fh_?.SystemElement);
+				var fj_ = context.Operators.Equal(fi_, "http://loinc.org");
+				var fl_ = context.Operators.Convert<string>(fh_?.CodeElement);
+				var fm_ = context.Operators.Equal(fl_, "8462-4");
+				var fn_ = context.Operators.And(fj_, fm_);
+
+				return fn_;
+			};
+			var av_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(at_?.Component, au_);
+			var aw_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(av_);
+			var ax_ = FHIRHelpers_4_3_000.ToValue(aw_?.Value);
+			var ay_ = context.Operators.Quantity(80m, "mm[Hg]");
+			var az_ = context.Operators.GreaterOrEqual((ax_ as CqlQuantity), ay_);
+			var ba_ = context.Operators.Or(an_, az_);
+			var bb_ = context.Operators.And(ab_, ba_);
+
+			return bb_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Hypertensive Reading Within Year Prior")]
+	public IEnumerable<Encounter> Encounter_with_Hypertensive_Reading_Within_Year_Prior() => 
+		__Encounter_with_Hypertensive_Reading_Within_Year_Prior.Value;
+
+	private IEnumerable<Encounter> Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_Value()
+	{
+		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? g_(Observation BloodPressure)
+			{
+				var be_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var bf_ = QICoreCommon_2_0_000.toInterval(be_);
+				var bg_ = context.Operators.End(bf_);
+				var bh_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var bi_ = context.Operators.ElementInInterval<CqlDateTime>(bg_, bh_, "day");
+
+				return bi_;
+			};
+			var h_ = context.Operators.WhereOrNull<Observation>(f_, g_);
+			object i_(Observation @this)
+			{
+				var bj_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var bk_ = QICoreCommon_2_0_000.toInterval(bj_);
+				var bl_ = context.Operators.Start(bk_);
+
+				return bl_;
+			};
+			var j_ = context.Operators.ListSortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			var k_ = context.Operators.LastOfList<Observation>(j_);
+			bool? l_(Observation.ComponentComponent @this)
+			{
+				var bm_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var bn_ = context.Operators.Convert<string>(bm_?.SystemElement);
+				var bo_ = context.Operators.Equal(bn_, "http://loinc.org");
+				var bq_ = context.Operators.Convert<string>(bm_?.CodeElement);
+				var br_ = context.Operators.Equal(bq_, "8480-6");
+				var bs_ = context.Operators.And(bo_, br_);
+
+				return bs_;
+			};
+			var m_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(k_?.Component, l_);
+			var n_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(m_);
+			var o_ = FHIRHelpers_4_3_000.ToValue(n_?.Value);
+			var p_ = context.Operators.Quantity(0m, "mm[Hg]");
+			var q_ = context.Operators.Greater((o_ as CqlQuantity), p_);
+			bool? s_(Observation BloodPressure)
+			{
+				var bt_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var bu_ = QICoreCommon_2_0_000.toInterval(bt_);
+				var bv_ = context.Operators.End(bu_);
+				var bw_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var bx_ = context.Operators.ElementInInterval<CqlDateTime>(bv_, bw_, "day");
+
+				return bx_;
+			};
+			var t_ = context.Operators.WhereOrNull<Observation>(f_, s_);
+			object u_(Observation @this)
+			{
+				var by_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var bz_ = QICoreCommon_2_0_000.toInterval(by_);
+				var ca_ = context.Operators.Start(bz_);
+
+				return ca_;
+			};
+			var v_ = context.Operators.ListSortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
+			var w_ = context.Operators.LastOfList<Observation>(v_);
+			bool? x_(Observation.ComponentComponent @this)
+			{
+				var cb_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var cc_ = context.Operators.Convert<string>(cb_?.SystemElement);
+				var cd_ = context.Operators.Equal(cc_, "http://loinc.org");
+				var cf_ = context.Operators.Convert<string>(cb_?.CodeElement);
+				var cg_ = context.Operators.Equal(cf_, "8462-4");
+				var ch_ = context.Operators.And(cd_, cg_);
+
+				return ch_;
+			};
+			var y_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(w_?.Component, x_);
+			var z_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(y_);
+			var aa_ = FHIRHelpers_4_3_000.ToValue(z_?.Value);
+			var ac_ = context.Operators.Greater((aa_ as CqlQuantity), p_);
+			var ad_ = context.Operators.And(q_, ac_);
+			bool? af_(Observation BloodPressure)
+			{
+				var ci_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var cj_ = QICoreCommon_2_0_000.toInterval(ci_);
+				var ck_ = context.Operators.End(cj_);
+				var cl_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var cm_ = context.Operators.ElementInInterval<CqlDateTime>(ck_, cl_, "day");
+
+				return cm_;
+			};
+			var ag_ = context.Operators.WhereOrNull<Observation>(f_, af_);
+			object ah_(Observation @this)
+			{
+				var cn_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var co_ = QICoreCommon_2_0_000.toInterval(cn_);
+				var cp_ = context.Operators.Start(co_);
+
+				return cp_;
+			};
+			var ai_ = context.Operators.ListSortBy<Observation>(ag_, ah_, System.ComponentModel.ListSortDirection.Ascending);
+			var aj_ = context.Operators.LastOfList<Observation>(ai_);
+			bool? ak_(Observation.ComponentComponent @this)
+			{
+				var cq_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var cr_ = context.Operators.Convert<string>(cq_?.SystemElement);
+				var cs_ = context.Operators.Equal(cr_, "http://loinc.org");
+				var cu_ = context.Operators.Convert<string>(cq_?.CodeElement);
+				var cv_ = context.Operators.Equal(cu_, "8480-6");
+				var cw_ = context.Operators.And(cs_, cv_);
+
+				return cw_;
+			};
+			var al_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(aj_?.Component, ak_);
+			var am_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(al_);
+			var an_ = FHIRHelpers_4_3_000.ToValue(am_?.Value);
+			var ao_ = context.Operators.Quantity(130m, "mm[Hg]");
+			var ap_ = context.Operators.GreaterOrEqual((an_ as CqlQuantity), ao_);
+			bool? ar_(Observation BloodPressure)
+			{
+				var cx_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var cy_ = QICoreCommon_2_0_000.toInterval(cx_);
+				var cz_ = context.Operators.End(cy_);
+				var da_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var db_ = context.Operators.ElementInInterval<CqlDateTime>(cz_, da_, "day");
+
+				return db_;
+			};
+			var as_ = context.Operators.WhereOrNull<Observation>(f_, ar_);
+			object at_(Observation @this)
+			{
+				var dc_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var dd_ = QICoreCommon_2_0_000.toInterval(dc_);
+				var de_ = context.Operators.Start(dd_);
+
+				return de_;
+			};
+			var au_ = context.Operators.ListSortBy<Observation>(as_, at_, System.ComponentModel.ListSortDirection.Ascending);
+			var av_ = context.Operators.LastOfList<Observation>(au_);
+			bool? aw_(Observation.ComponentComponent @this)
+			{
+				var df_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var dg_ = context.Operators.Convert<string>(df_?.SystemElement);
+				var dh_ = context.Operators.Equal(dg_, "http://loinc.org");
+				var dj_ = context.Operators.Convert<string>(df_?.CodeElement);
+				var dk_ = context.Operators.Equal(dj_, "8462-4");
+				var dl_ = context.Operators.And(dh_, dk_);
+
+				return dl_;
+			};
+			var ax_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(av_?.Component, aw_);
+			var ay_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(ax_);
+			var az_ = FHIRHelpers_4_3_000.ToValue(ay_?.Value);
+			var ba_ = context.Operators.Quantity(80m, "mm[Hg]");
+			var bb_ = context.Operators.GreaterOrEqual((az_ as CqlQuantity), ba_);
+			var bc_ = context.Operators.Or(ap_, bb_);
+			var bd_ = context.Operators.And(ad_, bc_);
+
+			return bd_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		var d_ = this.Encounter_with_Hypertensive_Reading_Within_Year_Prior();
+		var e_ = context.Operators.ListExcept<Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Encounter with First Hypertensive Reading SBP Greater than or Equal to 130 OR DBP Greater than or Equal to 80")]
+	public IEnumerable<Encounter> Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80() => 
+		__Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80.Value;
+
+	private IEnumerable<ServiceRequest> First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional_Value()
+	{
+		var a_ = this.Follow_Up_Within_4_Weeks();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> c_(ServiceRequest FourWeekRescreen)
+		{
+			var g_ = this.NonPharmacological_Interventions();
+			bool? h_(ServiceRequest NonPharmInterventionsHTN)
+			{
+				var l_ = context.Operators.Convert<CqlDateTime>(FourWeekRescreen?.AuthoredOnElement);
+				var m_ = this.Measurement_Period();
+				var n_ = context.Operators.ElementInInterval<CqlDateTime>(l_, m_, "day");
+				var o_ = context.Operators.Convert<CqlDateTime>(NonPharmInterventionsHTN?.AuthoredOnElement);
+				var q_ = context.Operators.ElementInInterval<CqlDateTime>(o_, m_, "day");
+				var r_ = context.Operators.And(n_, q_);
+				var s_ = context.Operators.Convert<Code<RequestIntent>>(FourWeekRescreen?.IntentElement?.Value);
+				var t_ = context.Operators.Equivalent(s_, "order");
+				var u_ = context.Operators.And(r_, t_);
+
+				return u_;
+			};
+			var i_ = context.Operators.WhereOrNull<ServiceRequest>(g_, h_);
+			ServiceRequest j_(ServiceRequest NonPharmInterventionsHTN) => 
+				FourWeekRescreen;
+			var k_ = context.Operators.SelectOrNull<ServiceRequest, ServiceRequest>(i_, j_);
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<ServiceRequest, ServiceRequest>(b_, c_);
+		var e_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
+		var f_ = context.Operators.ListUnion<ServiceRequest>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("First Hypertensive Reading Interventions or Referral to Alternate Professional")]
+	public IEnumerable<ServiceRequest> First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional() => 
+		__First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional.Value;
+
+	private IEnumerable<Encounter> Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions_Value()
+	{
+		var a_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80();
+		IEnumerable<Encounter> b_(Encounter FirstHTNEncounter)
+		{
+			var d_ = this.First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional();
+			bool? e_(ServiceRequest FirstHTNIntervention)
+			{
+				var i_ = context.Operators.Convert<CqlDateTime>(FirstHTNIntervention?.AuthoredOnElement);
+				var j_ = FHIRHelpers_4_3_000.ToInterval(FirstHTNEncounter?.Period);
+				var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, "day");
+
+				return k_;
+			};
+			var f_ = context.Operators.WhereOrNull<ServiceRequest>(d_, e_);
+			Encounter g_(ServiceRequest FirstHTNIntervention) => 
+				FirstHTNEncounter;
+			var h_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(f_, g_);
+
+			return h_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with First Hypertensive Reading SBP Greater than or Equal to 130 OR DBP Greater than or Equal to 80 and Interventions")]
+	public IEnumerable<Encounter> Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions() => 
+		__Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Value()
+	{
+		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? e_(Observation BloodPressure)
+			{
+				var bk_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var bl_ = QICoreCommon_2_0_000.toInterval(bk_);
+				var bm_ = context.Operators.End(bl_);
+				var bn_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var bo_ = context.Operators.ElementInInterval<CqlDateTime>(bm_, bn_, "day");
+				var bp_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var bq_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var br_ = context.Operators.InList<string>(bp_, (bq_ as IEnumerable<string>));
+				var bs_ = context.Operators.And(bo_, br_);
+
+				return bs_;
+			};
+			var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+			object g_(Observation @this)
+			{
+				var bt_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var bu_ = QICoreCommon_2_0_000.toInterval(bt_);
+				var bv_ = context.Operators.Start(bu_);
+
+				return bv_;
+			};
+			var h_ = context.Operators.ListSortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			var i_ = context.Operators.LastOfList<Observation>(h_);
+			bool? j_(Observation.ComponentComponent @this)
+			{
+				var bw_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var bx_ = context.Operators.Convert<string>(bw_?.SystemElement);
+				var by_ = context.Operators.Equal(bx_, "http://loinc.org");
+				var ca_ = context.Operators.Convert<string>(bw_?.CodeElement);
+				var cb_ = context.Operators.Equal(ca_, "8480-6");
+				var cc_ = context.Operators.And(by_, cb_);
+
+				return cc_;
+			};
+			var k_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(i_?.Component, j_);
+			var l_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(k_);
+			var m_ = FHIRHelpers_4_3_000.ToValue(l_?.Value);
+			var n_ = context.Operators.Quantity(130m, "mm[Hg]");
+			var o_ = context.Operators.Quantity(139m, "mm[Hg]");
+			var p_ = context.Operators.Interval(n_, o_, true, true);
+			var q_ = context.Operators.ElementInInterval<CqlQuantity>((m_ as CqlQuantity), p_, null);
+			bool? s_(Observation BloodPressure)
+			{
+				var cd_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var ce_ = QICoreCommon_2_0_000.toInterval(cd_);
+				var cf_ = context.Operators.End(ce_);
+				var cg_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var ch_ = context.Operators.ElementInInterval<CqlDateTime>(cf_, cg_, "day");
+				var ci_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var cj_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var ck_ = context.Operators.InList<string>(ci_, (cj_ as IEnumerable<string>));
+				var cl_ = context.Operators.And(ch_, ck_);
+
+				return cl_;
+			};
+			var t_ = context.Operators.WhereOrNull<Observation>(d_, s_);
+			object u_(Observation @this)
+			{
+				var cm_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var cn_ = QICoreCommon_2_0_000.toInterval(cm_);
+				var co_ = context.Operators.Start(cn_);
+
+				return co_;
+			};
+			var v_ = context.Operators.ListSortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
+			var w_ = context.Operators.LastOfList<Observation>(v_);
+			bool? x_(Observation.ComponentComponent @this)
+			{
+				var cp_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var cq_ = context.Operators.Convert<string>(cp_?.SystemElement);
+				var cr_ = context.Operators.Equal(cq_, "http://loinc.org");
+				var ct_ = context.Operators.Convert<string>(cp_?.CodeElement);
+				var cu_ = context.Operators.Equal(ct_, "8462-4");
+				var cv_ = context.Operators.And(cr_, cu_);
+
+				return cv_;
+			};
+			var y_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(w_?.Component, x_);
+			var z_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(y_);
+			var aa_ = FHIRHelpers_4_3_000.ToValue(z_?.Value);
+			var ab_ = context.Operators.Quantity(80m, "mm[Hg]");
+			var ac_ = context.Operators.Quantity(89m, "mm[Hg]");
+			var ad_ = context.Operators.Interval(ab_, ac_, true, true);
+			var ae_ = context.Operators.ElementInInterval<CqlQuantity>((aa_ as CqlQuantity), ad_, null);
+			var af_ = context.Operators.Or(q_, ae_);
+			bool? ah_(Observation BloodPressure)
+			{
+				var cw_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var cx_ = QICoreCommon_2_0_000.toInterval(cw_);
+				var cy_ = context.Operators.End(cx_);
+				var cz_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var da_ = context.Operators.ElementInInterval<CqlDateTime>(cy_, cz_, "day");
+				var db_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var dc_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var dd_ = context.Operators.InList<string>(db_, (dc_ as IEnumerable<string>));
+				var de_ = context.Operators.And(da_, dd_);
+
+				return de_;
+			};
+			var ai_ = context.Operators.WhereOrNull<Observation>(d_, ah_);
+			object aj_(Observation @this)
+			{
+				var df_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var dg_ = QICoreCommon_2_0_000.toInterval(df_);
+				var dh_ = context.Operators.Start(dg_);
+
+				return dh_;
+			};
+			var ak_ = context.Operators.ListSortBy<Observation>(ai_, aj_, System.ComponentModel.ListSortDirection.Ascending);
+			var al_ = context.Operators.LastOfList<Observation>(ak_);
+			bool? am_(Observation.ComponentComponent @this)
+			{
+				var di_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var dj_ = context.Operators.Convert<string>(di_?.SystemElement);
+				var dk_ = context.Operators.Equal(dj_, "http://loinc.org");
+				var dm_ = context.Operators.Convert<string>(di_?.CodeElement);
+				var dn_ = context.Operators.Equal(dm_, "8480-6");
+				var do_ = context.Operators.And(dk_, dn_);
+
+				return do_;
+			};
+			var an_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(al_?.Component, am_);
+			var ao_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(an_);
+			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_?.Value);
+			var aq_ = context.Operators.Quantity(140m, "mm[Hg]");
+			var ar_ = context.Operators.GreaterOrEqual((ap_ as CqlQuantity), aq_);
+			bool? at_(Observation BloodPressure)
+			{
+				var dp_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var dq_ = QICoreCommon_2_0_000.toInterval(dp_);
+				var dr_ = context.Operators.End(dq_);
+				var ds_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var dt_ = context.Operators.ElementInInterval<CqlDateTime>(dr_, ds_, "day");
+				var du_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var dv_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var dw_ = context.Operators.InList<string>(du_, (dv_ as IEnumerable<string>));
+				var dx_ = context.Operators.And(dt_, dw_);
+
+				return dx_;
+			};
+			var au_ = context.Operators.WhereOrNull<Observation>(d_, at_);
+			object av_(Observation @this)
+			{
+				var dy_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var dz_ = QICoreCommon_2_0_000.toInterval(dy_);
+				var ea_ = context.Operators.Start(dz_);
+
+				return ea_;
+			};
+			var aw_ = context.Operators.ListSortBy<Observation>(au_, av_, System.ComponentModel.ListSortDirection.Ascending);
+			var ax_ = context.Operators.LastOfList<Observation>(aw_);
+			bool? ay_(Observation.ComponentComponent @this)
+			{
+				var eb_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var ec_ = context.Operators.Convert<string>(eb_?.SystemElement);
+				var ed_ = context.Operators.Equal(ec_, "http://loinc.org");
+				var ef_ = context.Operators.Convert<string>(eb_?.CodeElement);
+				var eg_ = context.Operators.Equal(ef_, "8462-4");
+				var eh_ = context.Operators.And(ed_, eg_);
+
+				return eh_;
+			};
+			var az_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(ax_?.Component, ay_);
+			var ba_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(az_);
+			var bb_ = FHIRHelpers_4_3_000.ToValue(ba_?.Value);
+			var bc_ = context.Operators.Quantity(90m, "mm[Hg]");
+			var bd_ = context.Operators.GreaterOrEqual((bb_ as CqlQuantity), bc_);
+			var be_ = context.Operators.Or(ar_, bd_);
+			var bf_ = context.Operators.Not(be_);
+			var bg_ = context.Operators.And(af_, bf_);
+			var bh_ = this.Encounter_with_Hypertensive_Reading_Within_Year_Prior();
+			var bi_ = context.Operators.ExistsInList<Encounter>(bh_);
+			var bj_ = context.Operators.And(bg_, bi_);
+
+			return bj_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Second Hypertensive Reading SBP 130 to 139 OR DBP 80 to 89")]
+	public IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89() => 
+		__Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89.Value;
+
+	private IEnumerable<ServiceRequest> Laboratory_Test_or_ECG_for_Hypertension_Value()
+	{
+		var a_ = this._12_lead_EKG_panel();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
+		var d_ = this.EKG_study();
+		var e_ = context.Operators.ToList<CqlCode>(d_);
+		var f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
+		var g_ = context.Operators.ListUnion<ServiceRequest>(c_, f_);
+		var h_ = this.Laboratory_Tests_for_Hypertension();
+		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		var j_ = context.Operators.ListUnion<ServiceRequest>(g_, i_);
+		bool? k_(ServiceRequest EKGLab)
+		{
+			var m_ = context.Operators.Convert<Code<RequestIntent>>(EKGLab?.IntentElement?.Value);
+			var n_ = context.Operators.Equivalent(m_, "order");
+
+			return n_;
+		};
+		var l_ = context.Operators.WhereOrNull<ServiceRequest>(j_, k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Laboratory Test or ECG for Hypertension")]
+	public IEnumerable<ServiceRequest> Laboratory_Test_or_ECG_for_Hypertension() => 
+		__Laboratory_Test_or_ECG_for_Hypertension.Value;
+
+	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions_Value()
+	{
+		var a_ = this.Follow_up_with_Rescreen_in_2_to_6_Months();
+		IEnumerable<ServiceRequest> b_(ServiceRequest Rescreen2to6)
+		{
+			var f_ = this.Laboratory_Test_or_ECG_for_Hypertension();
+			bool? g_(ServiceRequest LabECGIntervention)
+			{
+				var k_ = context.Operators.Convert<CqlDateTime>(Rescreen2to6?.AuthoredOnElement);
+				var l_ = this.Measurement_Period();
+				var m_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, "day");
+				var n_ = context.Operators.Convert<CqlDateTime>(LabECGIntervention?.AuthoredOnElement);
+				var p_ = context.Operators.ElementInInterval<CqlDateTime>(n_, l_, "day");
+				var q_ = context.Operators.And(m_, p_);
+
+				return q_;
+			};
+			var h_ = context.Operators.WhereOrNull<ServiceRequest>(f_, g_);
+			ServiceRequest i_(ServiceRequest LabECGIntervention) => 
+				Rescreen2to6;
+			var j_ = context.Operators.SelectOrNull<ServiceRequest, ServiceRequest>(h_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<ServiceRequest, ServiceRequest>(a_, b_);
+		IEnumerable<ServiceRequest> d_(ServiceRequest Rescreen2to6)
+		{
+			var r_ = this.NonPharmacological_Interventions();
+			bool? s_(ServiceRequest NonPharmSecondIntervention)
+			{
+				var w_ = context.Operators.Convert<CqlDateTime>(NonPharmSecondIntervention?.AuthoredOnElement);
+				var x_ = this.Measurement_Period();
+				var y_ = context.Operators.ElementInInterval<CqlDateTime>(w_, x_, "day");
+
+				return y_;
+			};
+			var t_ = context.Operators.WhereOrNull<ServiceRequest>(r_, s_);
+			ServiceRequest u_(ServiceRequest NonPharmSecondIntervention) => 
+				Rescreen2to6;
+			var v_ = context.Operators.SelectOrNull<ServiceRequest, ServiceRequest>(t_, u_);
+
+			return v_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<ServiceRequest, ServiceRequest>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Second Hypertensive Reading SBP 130 to 139 OR DBP 80 to 89 and Interventions")]
+	public IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions() => 
+		__Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions_Value()
+	{
+		var a_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89();
+		IEnumerable<Encounter> b_(Encounter SecondHTNEncounterReading)
+		{
+			var h_ = this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions();
+			bool? i_(ServiceRequest EncounterInterventions)
+			{
+				var m_ = context.Operators.Convert<CqlDateTime>(EncounterInterventions?.AuthoredOnElement);
+				var n_ = FHIRHelpers_4_3_000.ToInterval(SecondHTNEncounterReading?.Period);
+				var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, "day");
+
+				return o_;
+			};
+			var j_ = context.Operators.WhereOrNull<ServiceRequest>(h_, i_);
+			Encounter k_(ServiceRequest EncounterInterventions) => 
+				SecondHTNEncounterReading;
+			var l_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(j_, k_);
+
+			return l_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> e_(Encounter SecondHTNEncounterReading)
+		{
+			var p_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
+			bool? q_(ServiceRequest ReferralForHTN)
+			{
+				var u_ = context.Operators.Convert<CqlDateTime>(ReferralForHTN?.AuthoredOnElement);
+				var v_ = FHIRHelpers_4_3_000.ToInterval(SecondHTNEncounterReading?.Period);
+				var w_ = context.Operators.ElementInInterval<CqlDateTime>(u_, v_, "day");
+
+				return w_;
+			};
+			var r_ = context.Operators.WhereOrNull<ServiceRequest>(p_, q_);
+			Encounter s_(ServiceRequest ReferralForHTN) => 
+				SecondHTNEncounterReading;
+			var t_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(r_, s_);
+
+			return t_;
+		};
+		var f_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, e_);
+		var g_ = context.Operators.ListUnion<Encounter>(c_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Encounter with Second Hypertensive Reading SBP 130 to 139 OR DBP 80 to 89 and Interventions")]
+	public IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions() => 
+		__Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Value()
+	{
+		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		bool? b_(Encounter QualifyingEncounter)
+		{
+			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? e_(Observation BloodPressure)
+			{
+				var bf_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var bg_ = QICoreCommon_2_0_000.toInterval(bf_);
+				var bh_ = context.Operators.End(bg_);
+				var bi_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var bj_ = context.Operators.ElementInInterval<CqlDateTime>(bh_, bi_, null);
+				var bk_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var bl_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var bm_ = context.Operators.InList<string>(bk_, (bl_ as IEnumerable<string>));
+				var bn_ = context.Operators.And(bj_, bm_);
+
+				return bn_;
+			};
+			var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+			object g_(Observation @this)
+			{
+				var bo_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var bp_ = QICoreCommon_2_0_000.toInterval(bo_);
+				var bq_ = context.Operators.Start(bp_);
+
+				return bq_;
+			};
+			var h_ = context.Operators.ListSortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			var i_ = context.Operators.LastOfList<Observation>(h_);
+			bool? j_(Observation.ComponentComponent @this)
+			{
+				var br_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var bs_ = context.Operators.Convert<string>(br_?.SystemElement);
+				var bt_ = context.Operators.Equal(bs_, "http://loinc.org");
+				var bv_ = context.Operators.Convert<string>(br_?.CodeElement);
+				var bw_ = context.Operators.Equal(bv_, "8480-6");
+				var bx_ = context.Operators.And(bt_, bw_);
+
+				return bx_;
+			};
+			var k_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(i_?.Component, j_);
+			var l_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(k_);
+			var m_ = FHIRHelpers_4_3_000.ToValue(l_?.Value);
+			var n_ = context.Operators.Quantity(0m, "mm[Hg]");
+			var o_ = context.Operators.Greater((m_ as CqlQuantity), n_);
+			bool? q_(Observation BloodPressure)
+			{
+				var by_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var bz_ = QICoreCommon_2_0_000.toInterval(by_);
+				var ca_ = context.Operators.End(bz_);
+				var cb_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var cc_ = context.Operators.ElementInInterval<CqlDateTime>(ca_, cb_, null);
+				var cd_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var ce_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var cf_ = context.Operators.InList<string>(cd_, (ce_ as IEnumerable<string>));
+				var cg_ = context.Operators.And(cc_, cf_);
+
+				return cg_;
+			};
+			var r_ = context.Operators.WhereOrNull<Observation>(d_, q_);
+			object s_(Observation @this)
+			{
+				var ch_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var ci_ = QICoreCommon_2_0_000.toInterval(ch_);
+				var cj_ = context.Operators.Start(ci_);
+
+				return cj_;
+			};
+			var t_ = context.Operators.ListSortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			var u_ = context.Operators.LastOfList<Observation>(t_);
+			bool? v_(Observation.ComponentComponent @this)
+			{
+				var ck_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var cl_ = context.Operators.Convert<string>(ck_?.SystemElement);
+				var cm_ = context.Operators.Equal(cl_, "http://loinc.org");
+				var co_ = context.Operators.Convert<string>(ck_?.CodeElement);
+				var cp_ = context.Operators.Equal(co_, "8462-4");
+				var cq_ = context.Operators.And(cm_, cp_);
+
+				return cq_;
+			};
+			var w_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(u_?.Component, v_);
+			var x_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(w_);
+			var y_ = FHIRHelpers_4_3_000.ToValue(x_?.Value);
+			var aa_ = context.Operators.Greater((y_ as CqlQuantity), n_);
+			var ab_ = context.Operators.And(o_, aa_);
+			bool? ad_(Observation BloodPressure)
+			{
+				var cr_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var cs_ = QICoreCommon_2_0_000.toInterval(cr_);
+				var ct_ = context.Operators.End(cs_);
+				var cu_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var cv_ = context.Operators.ElementInInterval<CqlDateTime>(ct_, cu_, null);
+				var cw_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var cx_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var cy_ = context.Operators.InList<string>(cw_, (cx_ as IEnumerable<string>));
+				var cz_ = context.Operators.And(cv_, cy_);
+
+				return cz_;
+			};
+			var ae_ = context.Operators.WhereOrNull<Observation>(d_, ad_);
+			object af_(Observation @this)
+			{
+				var da_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var db_ = QICoreCommon_2_0_000.toInterval(da_);
+				var dc_ = context.Operators.Start(db_);
+
+				return dc_;
+			};
+			var ag_ = context.Operators.ListSortBy<Observation>(ae_, af_, System.ComponentModel.ListSortDirection.Ascending);
+			var ah_ = context.Operators.LastOfList<Observation>(ag_);
+			bool? ai_(Observation.ComponentComponent @this)
+			{
+				var dd_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var de_ = context.Operators.Convert<string>(dd_?.SystemElement);
+				var df_ = context.Operators.Equal(de_, "http://loinc.org");
+				var dh_ = context.Operators.Convert<string>(dd_?.CodeElement);
+				var di_ = context.Operators.Equal(dh_, "8480-6");
+				var dj_ = context.Operators.And(df_, di_);
+
+				return dj_;
+			};
+			var aj_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(ah_?.Component, ai_);
+			var ak_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(aj_);
+			var al_ = FHIRHelpers_4_3_000.ToValue(ak_?.Value);
+			var am_ = context.Operators.Quantity(140m, "mm[Hg]");
+			var an_ = context.Operators.GreaterOrEqual((al_ as CqlQuantity), am_);
+			bool? ap_(Observation BloodPressure)
+			{
+				var dk_ = FHIRHelpers_4_3_000.ToValue(BloodPressure?.Effective);
+				var dl_ = QICoreCommon_2_0_000.toInterval(dk_);
+				var dm_ = context.Operators.End(dl_);
+				var dn_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var do_ = context.Operators.ElementInInterval<CqlDateTime>(dm_, dn_, null);
+				var dp_ = context.Operators.Convert<string>(BloodPressure?.StatusElement?.Value);
+				var dq_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var dr_ = context.Operators.InList<string>(dp_, (dq_ as IEnumerable<string>));
+				var ds_ = context.Operators.And(do_, dr_);
+
+				return ds_;
+			};
+			var aq_ = context.Operators.WhereOrNull<Observation>(d_, ap_);
+			object ar_(Observation @this)
+			{
+				var dt_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var du_ = QICoreCommon_2_0_000.toInterval(dt_);
+				var dv_ = context.Operators.Start(du_);
+
+				return dv_;
+			};
+			var as_ = context.Operators.ListSortBy<Observation>(aq_, ar_, System.ComponentModel.ListSortDirection.Ascending);
+			var at_ = context.Operators.LastOfList<Observation>(as_);
+			bool? au_(Observation.ComponentComponent @this)
+			{
+				var dw_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
+				var dx_ = context.Operators.Convert<string>(dw_?.SystemElement);
+				var dy_ = context.Operators.Equal(dx_, "http://loinc.org");
+				var ea_ = context.Operators.Convert<string>(dw_?.CodeElement);
+				var eb_ = context.Operators.Equal(ea_, "8462-4");
+				var ec_ = context.Operators.And(dy_, eb_);
+
+				return ec_;
+			};
+			var av_ = context.Operators.WhereOrNull<Observation.ComponentComponent>(at_?.Component, au_);
+			var aw_ = context.Operators.SingleOrNull<Observation.ComponentComponent>(av_);
+			var ax_ = FHIRHelpers_4_3_000.ToValue(aw_?.Value);
+			var ay_ = context.Operators.Quantity(90m, "mm[Hg]");
+			var az_ = context.Operators.GreaterOrEqual((ax_ as CqlQuantity), ay_);
+			var ba_ = context.Operators.Or(an_, az_);
+			var bb_ = context.Operators.And(ab_, ba_);
+			var bc_ = this.Encounter_with_Hypertensive_Reading_Within_Year_Prior();
+			var bd_ = context.Operators.ExistsInList<Encounter>(bc_);
+			var be_ = context.Operators.And(bb_, bd_);
+
+			return be_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Second Hypertensive Reading SBP Greater than or Equal to 140 OR DBP Greater than or Equal to 90")]
+	public IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90() => 
+		__Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90.Value;
+
+	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Value()
+	{
+		var a_ = this.Follow_Up_Within_4_Weeks();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> c_(ServiceRequest WeeksRescreen)
+		{
+			var i_ = this.Laboratory_Test_or_ECG_for_Hypertension();
+			bool? j_(ServiceRequest ECGLabTest)
+			{
+				var n_ = context.Operators.Convert<CqlDateTime>(WeeksRescreen?.AuthoredOnElement);
+				var o_ = this.Measurement_Period();
+				var p_ = context.Operators.ElementInInterval<CqlDateTime>(n_, o_, "day");
+				var q_ = context.Operators.Convert<CqlDateTime>(ECGLabTest?.AuthoredOnElement);
+				var s_ = context.Operators.ElementInInterval<CqlDateTime>(q_, o_, "day");
+				var t_ = context.Operators.And(p_, s_);
+				var u_ = context.Operators.Convert<Code<RequestIntent>>(WeeksRescreen?.IntentElement?.Value);
+				var v_ = context.Operators.Equivalent(u_, "order");
+				var w_ = context.Operators.And(t_, v_);
+				var x_ = context.Operators.Convert<Code<RequestIntent>>(ECGLabTest?.IntentElement?.Value);
+				var y_ = context.Operators.Equivalent(x_, "order");
+				var z_ = context.Operators.And(w_, y_);
+
+				return z_;
+			};
+			var k_ = context.Operators.WhereOrNull<ServiceRequest>(i_, j_);
+			ServiceRequest l_(ServiceRequest ECGLabTest) => 
+				WeeksRescreen;
+			var m_ = context.Operators.SelectOrNull<ServiceRequest, ServiceRequest>(k_, l_);
+
+			return m_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<ServiceRequest, ServiceRequest>(b_, c_);
+		IEnumerable<ServiceRequest> e_(ServiceRequest WeeksRescreen)
+		{
+			var aa_ = this.NonPharmacological_Interventions();
+			bool? ab_(ServiceRequest HTNInterventions)
+			{
+				var af_ = context.Operators.Convert<CqlDateTime>(HTNInterventions?.AuthoredOnElement);
+				var ag_ = this.Measurement_Period();
+				var ah_ = context.Operators.ElementInInterval<CqlDateTime>(af_, ag_, "day");
+
+				return ah_;
+			};
+			var ac_ = context.Operators.WhereOrNull<ServiceRequest>(aa_, ab_);
+			ServiceRequest ad_(ServiceRequest HTNInterventions) => 
+				WeeksRescreen;
+			var ae_ = context.Operators.SelectOrNull<ServiceRequest, ServiceRequest>(ac_, ad_);
+
+			return ae_;
+		};
+		var f_ = context.Operators.SelectManyOrNull<ServiceRequest, ServiceRequest>(d_, e_);
+		IEnumerable<ServiceRequest> g_(ServiceRequest WeeksRescreen)
+		{
+			var ai_ = this.Pharmacologic_Therapy_for_Hypertension();
+			var aj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ai_, null);
+			var al_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ai_, null);
+			var am_ = context.Operators.ListUnion<MedicationRequest>(aj_, al_);
+			bool? an_(MedicationRequest Medications)
+			{
+				var ar_ = context.Operators.Convert<CqlDateTime>(Medications?.AuthoredOnElement);
+				var as_ = this.Measurement_Period();
+				var at_ = context.Operators.ElementInInterval<CqlDateTime>(ar_, as_, "day");
+				var au_ = context.Operators.Equivalent(Medications?.StatusElement?.Value, "active");
+				var av_ = context.Operators.And(at_, au_);
+
+				return av_;
+			};
+			var ao_ = context.Operators.WhereOrNull<MedicationRequest>(am_, an_);
+			ServiceRequest ap_(MedicationRequest Medications) => 
+				WeeksRescreen;
+			var aq_ = context.Operators.SelectOrNull<MedicationRequest, ServiceRequest>(ao_, ap_);
+
+			return aq_;
+		};
+		var h_ = context.Operators.SelectManyOrNull<ServiceRequest, ServiceRequest>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Second Hypertensive Reading SBP Greater than or Equal to 140 OR DBP Greater than or Equal to 90 Interventions")]
+	public IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions() => 
+		__Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions_Value()
+	{
+		var a_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90();
+		IEnumerable<Encounter> b_(Encounter SecondHTNEncounterReading140Over90)
+		{
+			var h_ = this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions();
+			bool? i_(ServiceRequest SecondHTN140Over90Interventions)
+			{
+				var m_ = context.Operators.Convert<CqlDateTime>(SecondHTN140Over90Interventions?.AuthoredOnElement);
+				var n_ = FHIRHelpers_4_3_000.ToInterval(SecondHTNEncounterReading140Over90?.Period);
+				var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, "day");
+
+				return o_;
+			};
+			var j_ = context.Operators.WhereOrNull<ServiceRequest>(h_, i_);
+			Encounter k_(ServiceRequest SecondHTN140Over90Interventions) => 
+				SecondHTNEncounterReading140Over90;
+			var l_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(j_, k_);
+
+			return l_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> e_(Encounter SecondHTNEncounterReading140Over90)
+		{
+			var p_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
+			bool? q_(ServiceRequest ReferralToProfessional)
+			{
+				var u_ = context.Operators.Convert<CqlDateTime>(ReferralToProfessional?.AuthoredOnElement);
+				var v_ = FHIRHelpers_4_3_000.ToInterval(SecondHTNEncounterReading140Over90?.Period);
+				var w_ = context.Operators.ElementInInterval<CqlDateTime>(u_, v_, "day");
+
+				return w_;
+			};
+			var r_ = context.Operators.WhereOrNull<ServiceRequest>(p_, q_);
+			Encounter s_(ServiceRequest ReferralToProfessional) => 
+				SecondHTNEncounterReading140Over90;
+			var t_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(r_, s_);
+
+			return t_;
+		};
+		var f_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, e_);
+		var g_ = context.Operators.ListUnion<Encounter>(c_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Encounter with Second Hypertensive Reading SBP Greater than or Equal to 140 OR DBP Greater than or Equal to 90 and Interventions")]
+	public IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions() => 
+		__Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = this.Encounter_with_Normal_Blood_Pressure_Reading();
+		var b_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+		var d_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions();
+		var e_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions();
+		var f_ = context.Operators.ListUnion<Encounter>(d_, e_);
+		var g_ = context.Operators.ListUnion<Encounter>(c_, f_);
+		var h_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions();
+		var i_ = context.Operators.ListUnion<Encounter>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement_Value()
+	{
+		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> b_(Encounter QualifyingEncounter)
+		{
+			var d_ = this.Systolic_blood_pressure();
+			var e_ = context.Operators.ToList<CqlCode>(d_);
+			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			var g_ = this.Diastolic_blood_pressure();
+			var h_ = context.Operators.ToList<CqlCode>(g_);
+			var i_ = context.Operators.RetrieveByCodes<Observation>(h_, null);
+			var j_ = context.Operators.ListUnion<Observation>(f_, i_);
+			bool? k_(Observation NoBPScreen)
+			{
+				var o_ = context.Operators.Convert<CqlDateTime>(NoBPScreen?.IssuedElement?.Value);
+				var p_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+				var q_ = context.Operators.ElementInInterval<CqlDateTime>(o_, p_, "day");
+				bool? r_(Extension @this)
+				{
+					var ao_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+					return ao_;
+				};
+				var s_ = context.Operators.WhereOrNull<Extension>(((NoBPScreen is DomainResource)
+						? ((NoBPScreen as DomainResource).Extension)
+						: null), r_);
+				DataType t_(Extension @this) => 
+					@this?.Value;
+				var u_ = context.Operators.SelectOrNull<Extension, DataType>(s_, t_);
+				var v_ = context.Operators.SingleOrNull<DataType>(u_);
+				var w_ = context.Operators.Convert<CodeableConcept>(v_);
+				var x_ = FHIRHelpers_4_3_000.ToConcept(w_);
+				var y_ = this.Patient_Declined();
+				var z_ = context.Operators.ConceptInValueSet(x_, y_);
+				bool? aa_(Extension @this)
+				{
+					var ap_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+					return ap_;
+				};
+				var ab_ = context.Operators.WhereOrNull<Extension>(((NoBPScreen is DomainResource)
+						? ((NoBPScreen as DomainResource).Extension)
+						: null), aa_);
+				var ad_ = context.Operators.SelectOrNull<Extension, DataType>(ab_, t_);
+				var ae_ = context.Operators.SingleOrNull<DataType>(ad_);
+				var af_ = context.Operators.Convert<CodeableConcept>(ae_);
+				var ag_ = FHIRHelpers_4_3_000.ToConcept(af_);
+				var ah_ = this.Medical_Reason();
+				var ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+				var aj_ = context.Operators.Or(z_, ai_);
+				var ak_ = context.Operators.And(q_, aj_);
+				var al_ = context.Operators.Convert<Code<ObservationStatus>>(NoBPScreen?.StatusElement?.Value);
+				var am_ = context.Operators.Equal(al_, "cancelled");
+				var an_ = context.Operators.And(ak_, am_);
+
+				return an_;
+			};
+			var l_ = context.Operators.WhereOrNull<Observation>(j_, k_);
+			Encounter m_(Observation NoBPScreen) => 
+				QualifyingEncounter;
+			var n_ = context.Operators.SelectOrNull<Observation, Encounter>(l_, m_);
+
+			return n_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Encounter with Medical Reason for Not Obtaining or Patient Declined Blood Pressure Measurement")]
+	public IEnumerable<Encounter> Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement() => 
+		__Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement.Value;
+
+	private IEnumerable<ServiceRequest> NonPharmacological_Intervention_Not_Ordered_Value()
+	{
+		var a_ = this.Lifestyle_Recommendation();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<ServiceRequest>(b_, d_);
+		var f_ = this.Weight_Reduction_Recommended();
+		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		var j_ = context.Operators.ListUnion<ServiceRequest>(g_, i_);
+		var k_ = context.Operators.ListUnion<ServiceRequest>(e_, j_);
+		var l_ = this.Dietary_Recommendations();
+		var m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
+		var o_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
+		var p_ = context.Operators.ListUnion<ServiceRequest>(m_, o_);
+		var q_ = context.Operators.ListUnion<ServiceRequest>(k_, p_);
+		var r_ = this.Recommendation_to_Increase_Physical_Activity();
+		var s_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, null);
+		var u_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, null);
+		var v_ = context.Operators.ListUnion<ServiceRequest>(s_, u_);
+		var w_ = context.Operators.ListUnion<ServiceRequest>(q_, v_);
+		var x_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
+		var y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+		var aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+		var ab_ = context.Operators.ListUnion<ServiceRequest>(y_, aa_);
+		var ac_ = context.Operators.ListUnion<ServiceRequest>(w_, ab_);
+		bool? ad_(ServiceRequest NonPharmIntervention)
+		{
+			bool? af_(Extension @this)
+			{
+				var ar_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+
+				return ar_;
+			};
+			var ag_ = context.Operators.WhereOrNull<Extension>(((NonPharmIntervention is DomainResource)
+					? ((NonPharmIntervention as DomainResource).Extension)
+					: null), af_);
+			DataType ah_(Extension @this) => 
+				@this?.Value;
+			var ai_ = context.Operators.SelectOrNull<Extension, DataType>(ag_, ah_);
+			var aj_ = context.Operators.SingleOrNull<DataType>(ai_);
+			var ak_ = context.Operators.Convert<CodeableConcept>(aj_);
+			var al_ = FHIRHelpers_4_3_000.ToConcept(ak_);
+			var am_ = this.Patient_Declined();
+			var an_ = context.Operators.ConceptInValueSet(al_, am_);
+			var ao_ = context.Operators.Convert<Code<RequestStatus>>(NonPharmIntervention?.StatusElement?.Value);
+			var ap_ = context.Operators.Equal(ao_, "completed");
+			var aq_ = context.Operators.And(an_, ap_);
+
+			return aq_;
+		};
+		var ae_ = context.Operators.WhereOrNull<ServiceRequest>(ac_, ad_);
+
+		return ae_;
+	}
+
+    [CqlDeclaration("NonPharmacological Intervention Not Ordered")]
+	public IEnumerable<ServiceRequest> NonPharmacological_Intervention_Not_Ordered() => 
+		__NonPharmacological_Intervention_Not_Ordered.Value;
+
+	private IEnumerable<ServiceRequest> Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered_Value()
+	{
+		var a_ = this._12_lead_EKG_panel();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
+		var d_ = this.EKG_study();
+		var e_ = context.Operators.ToList<CqlCode>(d_);
+		var f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
+		var g_ = context.Operators.ListUnion<ServiceRequest>(c_, f_);
+		var h_ = this.Laboratory_Tests_for_Hypertension();
+		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		var k_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		var l_ = context.Operators.ListUnion<ServiceRequest>(i_, k_);
+		var m_ = context.Operators.ListUnion<ServiceRequest>(g_, l_);
+		bool? n_(ServiceRequest LabECGNotDone)
+		{
+			bool? p_(Extension @this)
+			{
+				var y_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+
+				return y_;
+			};
+			var q_ = context.Operators.WhereOrNull<Extension>(((LabECGNotDone is DomainResource)
+					? ((LabECGNotDone as DomainResource).Extension)
+					: null), p_);
+			DataType r_(Extension @this) => 
+				@this?.Value;
+			var s_ = context.Operators.SelectOrNull<Extension, DataType>(q_, r_);
+			var t_ = context.Operators.SingleOrNull<DataType>(s_);
+			var u_ = context.Operators.Convert<CodeableConcept>(t_);
+			var v_ = FHIRHelpers_4_3_000.ToConcept(u_);
+			var w_ = this.Patient_Declined();
+			var x_ = context.Operators.ConceptInValueSet(v_, w_);
+
+			return x_;
+		};
+		var o_ = context.Operators.WhereOrNull<ServiceRequest>(m_, n_);
+
+		return o_;
+	}
+
+    [CqlDeclaration("Laboratory Test or ECG for Hypertension Not Ordered")]
+	public IEnumerable<ServiceRequest> Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered() => 
+		__Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered.Value;
+
+	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined_Value()
+	{
+		var a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<ServiceRequest>(b_, d_);
+		var f_ = this.Follow_up_2_3_months__finding_();
+		var g_ = context.Operators.ToList<CqlCode>(f_);
+		var h_ = context.Operators.RetrieveByCodes<ServiceRequest>(g_, null);
+		var i_ = this.Follow_up_4_6_months__finding_();
+		var j_ = context.Operators.ToList<CqlCode>(i_);
+		var k_ = context.Operators.RetrieveByCodes<ServiceRequest>(j_, null);
+		var l_ = context.Operators.ListUnion<ServiceRequest>(h_, k_);
+		var m_ = context.Operators.ListUnion<ServiceRequest>(e_, l_);
+		bool? n_(ServiceRequest SecondHTNDeclinedReferralAndFollowUp)
+		{
+			bool? t_(Extension @this)
+			{
+				var af_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+
+				return af_;
+			};
+			var u_ = context.Operators.WhereOrNull<Extension>(((SecondHTNDeclinedReferralAndFollowUp is DomainResource)
+					? ((SecondHTNDeclinedReferralAndFollowUp as DomainResource).Extension)
+					: null), t_);
+			DataType v_(Extension @this) => 
+				@this?.Value;
+			var w_ = context.Operators.SelectOrNull<Extension, DataType>(u_, v_);
+			var x_ = context.Operators.SingleOrNull<DataType>(w_);
+			var y_ = context.Operators.Convert<CodeableConcept>(x_);
+			var z_ = FHIRHelpers_4_3_000.ToConcept(y_);
+			var aa_ = this.Patient_Declined();
+			var ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+			var ac_ = context.Operators.Convert<Code<RequestStatus>>(SecondHTNDeclinedReferralAndFollowUp?.StatusElement?.Value);
+			var ad_ = context.Operators.Equal(ac_, "completed");
+			var ae_ = context.Operators.And(ab_, ad_);
+
+			return ae_;
+		};
+		var o_ = context.Operators.WhereOrNull<ServiceRequest>(m_, n_);
+		var p_ = this.Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered();
+		var q_ = context.Operators.ListUnion<ServiceRequest>(o_, p_);
+		var r_ = this.NonPharmacological_Intervention_Not_Ordered();
+		var s_ = context.Operators.ListUnion<ServiceRequest>(q_, r_);
+
+		return s_;
+	}
+
+    [CqlDeclaration("Second Hypertensive Reading SBP 130 to 139 OR DBP 80 to 89 Interventions Declined")]
+	public IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined() => 
+		__Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined.Value;
+
+	private IEnumerable<object> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined_Value()
+	{
+		var a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<ServiceRequest>(b_, d_);
+		var f_ = this.Follow_Up_Within_4_Weeks();
+		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		var j_ = context.Operators.ListUnion<ServiceRequest>(g_, i_);
+		var k_ = context.Operators.ListUnion<ServiceRequest>(e_, j_);
+		bool? l_(ServiceRequest SecondHTN140Over90ReferralFollowUpNotDone)
+		{
+			bool? z_(Extension @this)
+			{
+				var al_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+
+				return al_;
+			};
+			var aa_ = context.Operators.WhereOrNull<Extension>(((SecondHTN140Over90ReferralFollowUpNotDone is DomainResource)
+					? ((SecondHTN140Over90ReferralFollowUpNotDone as DomainResource).Extension)
+					: null), z_);
+			DataType ab_(Extension @this) => 
+				@this?.Value;
+			var ac_ = context.Operators.SelectOrNull<Extension, DataType>(aa_, ab_);
+			var ad_ = context.Operators.SingleOrNull<DataType>(ac_);
+			var ae_ = context.Operators.Convert<CodeableConcept>(ad_);
+			var af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
+			var ag_ = this.Patient_Declined();
+			var ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+			var ai_ = context.Operators.Convert<Code<RequestStatus>>(SecondHTN140Over90ReferralFollowUpNotDone?.StatusElement?.Value);
+			var aj_ = context.Operators.Equal(ai_, "completed");
+			var ak_ = context.Operators.And(ah_, aj_);
+
+			return ak_;
+		};
+		var m_ = context.Operators.WhereOrNull<ServiceRequest>(k_, l_);
+		var n_ = this.Pharmacologic_Therapy_for_Hypertension();
+		var o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		var q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		var r_ = context.Operators.ListUnion<MedicationRequest>(o_, q_);
+		bool? s_(MedicationRequest MedicationRequestNotOrdered)
+		{
+			var am_ = context.Operators.EnumEqualsString(MedicationRequestNotOrdered?.StatusElement?.Value, "completed");
+
+			return am_;
+		};
+		var t_ = context.Operators.WhereOrNull<MedicationRequest>(r_, s_);
+		var u_ = context.Operators.ListUnion<object>((m_ as IEnumerable<object>), (t_ as IEnumerable<object>));
+		var v_ = this.Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered();
+		var w_ = context.Operators.ListUnion<object>((u_ as IEnumerable<object>), (v_ as IEnumerable<object>));
+		var x_ = this.NonPharmacological_Intervention_Not_Ordered();
+		var y_ = context.Operators.ListUnion<object>((w_ as IEnumerable<object>), (x_ as IEnumerable<object>));
+
+		return y_;
+	}
+
+    [CqlDeclaration("Second Hypertensive Reading SBP Greater than or Equal to 140 OR DBP Greater than or Equal to 90 Interventions Declined")]
+	public IEnumerable<object> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined() => 
+		__Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient_Value()
+	{
+		var a_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80();
+		IEnumerable<Encounter> b_(Encounter ElevatedBPEncounter)
+		{
+			var x_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+			var y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+			var aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+			var ab_ = context.Operators.ListUnion<ServiceRequest>(y_, aa_);
+			var ac_ = this.Follow_up_2_3_months__finding_();
+			var ad_ = context.Operators.ToList<CqlCode>(ac_);
+			var ae_ = context.Operators.RetrieveByCodes<ServiceRequest>(ad_, null);
+			var af_ = this.Follow_up_4_6_months__finding_();
+			var ag_ = context.Operators.ToList<CqlCode>(af_);
+			var ah_ = context.Operators.RetrieveByCodes<ServiceRequest>(ag_, null);
+			var ai_ = context.Operators.ListUnion<ServiceRequest>(ae_, ah_);
+			var aj_ = context.Operators.ListUnion<ServiceRequest>(ab_, ai_);
+			bool? ak_(ServiceRequest ElevatedBPDeclinedInterventions)
+			{
+				bool? ao_(Extension @this)
+				{
+					var be_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+
+					return be_;
+				};
+				var ap_ = context.Operators.WhereOrNull<Extension>(((ElevatedBPDeclinedInterventions is DomainResource)
+						? ((ElevatedBPDeclinedInterventions as DomainResource).Extension)
+						: null), ao_);
+				DataType aq_(Extension @this) => 
+					@this?.Value;
+				var ar_ = context.Operators.SelectOrNull<Extension, DataType>(ap_, aq_);
+				var as_ = context.Operators.SingleOrNull<DataType>(ar_);
+				var at_ = context.Operators.Convert<CodeableConcept>(as_);
+				var au_ = FHIRHelpers_4_3_000.ToConcept(at_);
+				var av_ = this.Patient_Declined();
+				var aw_ = context.Operators.ConceptInValueSet(au_, av_);
+				var ax_ = context.Operators.Convert<CqlDateTime>(ElevatedBPDeclinedInterventions?.AuthoredOnElement);
+				var ay_ = FHIRHelpers_4_3_000.ToInterval(ElevatedBPEncounter?.Period);
+				var az_ = context.Operators.ElementInInterval<CqlDateTime>(ax_, ay_, "day");
+				var ba_ = context.Operators.And(aw_, az_);
+				var bb_ = context.Operators.Convert<Code<RequestStatus>>(ElevatedBPDeclinedInterventions?.StatusElement?.Value);
+				var bc_ = context.Operators.Equal(bb_, "completed");
+				var bd_ = context.Operators.And(ba_, bc_);
+
+				return bd_;
+			};
+			var al_ = context.Operators.WhereOrNull<ServiceRequest>(aj_, ak_);
+			Encounter am_(ServiceRequest ElevatedBPDeclinedInterventions) => 
+				ElevatedBPEncounter;
+			var an_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(al_, am_);
+
+			return an_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> e_(Encounter ElevatedBPEncounter)
+		{
+			var bf_ = this.NonPharmacological_Intervention_Not_Ordered();
+			bool? bg_(ServiceRequest NotOrdered)
+			{
+				var bk_ = context.Operators.Convert<CqlDateTime>(NotOrdered?.AuthoredOnElement);
+				var bl_ = FHIRHelpers_4_3_000.ToInterval(ElevatedBPEncounter?.Period);
+				var bm_ = context.Operators.ElementInInterval<CqlDateTime>(bk_, bl_, "day");
+
+				return bm_;
+			};
+			var bh_ = context.Operators.WhereOrNull<ServiceRequest>(bf_, bg_);
+			Encounter bi_(ServiceRequest NotOrdered) => 
+				ElevatedBPEncounter;
+			var bj_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(bh_, bi_);
+
+			return bj_;
+		};
+		var f_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, e_);
+		var g_ = context.Operators.ListUnion<Encounter>(c_, f_);
+		var h_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80();
+		IEnumerable<Encounter> i_(Encounter FirstHTNEncounter)
+		{
+			var bn_ = this.Follow_Up_Within_4_Weeks();
+			var bo_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bn_, null);
+			var bq_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bn_, null);
+			var br_ = context.Operators.ListUnion<ServiceRequest>(bo_, bq_);
+			var bs_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+			var bt_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bs_, null);
+			var bv_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bs_, null);
+			var bw_ = context.Operators.ListUnion<ServiceRequest>(bt_, bv_);
+			var bx_ = context.Operators.ListUnion<ServiceRequest>(br_, bw_);
+			bool? by_(ServiceRequest FirstHTNDeclinedInterventions)
+			{
+				bool? cc_(Extension @this)
+				{
+					var cs_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+
+					return cs_;
+				};
+				var cd_ = context.Operators.WhereOrNull<Extension>(((FirstHTNDeclinedInterventions is DomainResource)
+						? ((FirstHTNDeclinedInterventions as DomainResource).Extension)
+						: null), cc_);
+				DataType ce_(Extension @this) => 
+					@this?.Value;
+				var cf_ = context.Operators.SelectOrNull<Extension, DataType>(cd_, ce_);
+				var cg_ = context.Operators.SingleOrNull<DataType>(cf_);
+				var ch_ = context.Operators.Convert<CodeableConcept>(cg_);
+				var ci_ = FHIRHelpers_4_3_000.ToConcept(ch_);
+				var cj_ = this.Patient_Declined();
+				var ck_ = context.Operators.ConceptInValueSet(ci_, cj_);
+				var cl_ = context.Operators.Convert<CqlDateTime>(FirstHTNDeclinedInterventions?.AuthoredOnElement);
+				var cm_ = FHIRHelpers_4_3_000.ToInterval(FirstHTNEncounter?.Period);
+				var cn_ = context.Operators.ElementInInterval<CqlDateTime>(cl_, cm_, "day");
+				var co_ = context.Operators.And(ck_, cn_);
+				var cp_ = context.Operators.Convert<Code<RequestStatus>>(FirstHTNDeclinedInterventions?.StatusElement?.Value);
+				var cq_ = context.Operators.Equal(cp_, "completed");
+				var cr_ = context.Operators.And(co_, cq_);
+
+				return cr_;
+			};
+			var bz_ = context.Operators.WhereOrNull<ServiceRequest>(bx_, by_);
+			Encounter ca_(ServiceRequest FirstHTNDeclinedInterventions) => 
+				FirstHTNEncounter;
+			var cb_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(bz_, ca_);
+
+			return cb_;
+		};
+		var j_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(h_, i_);
+		IEnumerable<Encounter> l_(Encounter FirstHTNEncounter)
+		{
+			var ct_ = this.NonPharmacological_Intervention_Not_Ordered();
+			bool? cu_(ServiceRequest NoNonPharm)
+			{
+				var cy_ = context.Operators.Convert<CqlDateTime>(NoNonPharm?.AuthoredOnElement);
+				var cz_ = FHIRHelpers_4_3_000.ToInterval(FirstHTNEncounter?.Period);
+				var da_ = context.Operators.ElementInInterval<CqlDateTime>(cy_, cz_, "day");
+
+				return da_;
+			};
+			var cv_ = context.Operators.WhereOrNull<ServiceRequest>(ct_, cu_);
+			Encounter cw_(ServiceRequest NoNonPharm) => 
+				FirstHTNEncounter;
+			var cx_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(cv_, cw_);
+
+			return cx_;
+		};
+		var m_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(h_, l_);
+		var n_ = context.Operators.ListUnion<Encounter>(j_, m_);
+		var o_ = context.Operators.ListUnion<Encounter>(g_, n_);
+		var p_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89();
+		IEnumerable<Encounter> q_(Encounter SecondHTNEncounter)
+		{
+			var db_ = this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined();
+			bool? dc_(ServiceRequest SecondHTNDeclinedInterventions)
+			{
+				var dg_ = context.Operators.Convert<CqlDateTime>(SecondHTNDeclinedInterventions?.AuthoredOnElement);
+				var dh_ = FHIRHelpers_4_3_000.ToInterval(SecondHTNEncounter?.Period);
+				var di_ = context.Operators.ElementInInterval<CqlDateTime>(dg_, dh_, "day");
+
+				return di_;
+			};
+			var dd_ = context.Operators.WhereOrNull<ServiceRequest>(db_, dc_);
+			Encounter de_(ServiceRequest SecondHTNDeclinedInterventions) => 
+				SecondHTNEncounter;
+			var df_ = context.Operators.SelectOrNull<ServiceRequest, Encounter>(dd_, de_);
+
+			return df_;
+		};
+		var r_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(p_, q_);
+		var s_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90();
+		IEnumerable<Encounter> t_(Encounter SecondHTN140Over90Encounter)
+		{
+			var dj_ = this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined();
+			bool? dk_(object SecondHTN140Over90DeclinedInterventions)
+			{
+				var do_ = context.Operators.LateBoundProperty<object>(SecondHTN140Over90DeclinedInterventions, "authoredOn");
+				var dp_ = context.Operators.LateBoundProperty<CqlDateTime>(do_, "value");
+				var dq_ = FHIRHelpers_4_3_000.ToInterval(SecondHTN140Over90Encounter?.Period);
+				var dr_ = context.Operators.ElementInInterval<CqlDateTime>(dp_, dq_, "day");
+
+				return dr_;
+			};
+			var dl_ = context.Operators.WhereOrNull<object>(dj_, dk_);
+			Encounter dm_(object SecondHTN140Over90DeclinedInterventions) => 
+				SecondHTN140Over90Encounter;
+			var dn_ = context.Operators.SelectOrNull<object, Encounter>(dl_, dm_);
+
+			return dn_;
+		};
+		var u_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(s_, t_);
+		var v_ = context.Operators.ListUnion<Encounter>(r_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(o_, v_);
+
+		return w_;
+	}
+
+    [CqlDeclaration("Encounter with Order for Hypertension Follow Up Declined by Patient")]
+	public IEnumerable<Encounter> Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient() => 
+		__Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient.Value;
+
+	private IEnumerable<Encounter> Denominator_Exceptions_Value()
+	{
+		var a_ = this.Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement();
+		var b_ = this.Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Denominator Exceptions")]
+	public IEnumerable<Encounter> Denominator_Exceptions() => 
+		__Denominator_Exceptions.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
@@ -1,0 +1,640 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("POAGOpticNerveEvaluationFHIR", "0.1.000")]
+public class POAGOpticNerveEvaluationFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Care_Services_in_Long_Term_Residential_Facility;
+    internal Lazy<CqlValueSet> __Cup_to_Disc_Ratio;
+    internal Lazy<CqlValueSet> __Face_to_Face_Interaction;
+    internal Lazy<CqlValueSet> __Medical_Reason;
+    internal Lazy<CqlValueSet> __Nursing_Facility_Visit;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Ophthalmological_Services;
+    internal Lazy<CqlValueSet> __Optic_Disc_Exam_for_Structural_Abnormalities;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Primary_Open_Angle_Glaucoma;
+    internal Lazy<CqlCode> __virtual;
+    internal Lazy<CqlCode> __AMB;
+    internal Lazy<CqlCode[]> __ActCode;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter_During_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Primary_Open_Angle_Glaucoma_Encounter;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Observation>> __Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio;
+    internal Lazy<IEnumerable<Observation>> __Medical_Reason_for_Not_Performing_Optic_Disc_Exam;
+    internal Lazy<bool?> __Denominator_Exceptions;
+    internal Lazy<IEnumerable<Observation>> __Cup_to_Disc_Ratio_Performed_with_Result;
+    internal Lazy<IEnumerable<Observation>> __Optic_Disc_Exam_Performed_with_Result;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public POAGOpticNerveEvaluationFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Care_Services_in_Long_Term_Residential_Facility = new Lazy<CqlValueSet>(this.Care_Services_in_Long_Term_Residential_Facility_Value);
+        __Cup_to_Disc_Ratio = new Lazy<CqlValueSet>(this.Cup_to_Disc_Ratio_Value);
+        __Face_to_Face_Interaction = new Lazy<CqlValueSet>(this.Face_to_Face_Interaction_Value);
+        __Medical_Reason = new Lazy<CqlValueSet>(this.Medical_Reason_Value);
+        __Nursing_Facility_Visit = new Lazy<CqlValueSet>(this.Nursing_Facility_Visit_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Ophthalmological_Services = new Lazy<CqlValueSet>(this.Ophthalmological_Services_Value);
+        __Optic_Disc_Exam_for_Structural_Abnormalities = new Lazy<CqlValueSet>(this.Optic_Disc_Exam_for_Structural_Abnormalities_Value);
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value);
+        __Primary_Open_Angle_Glaucoma = new Lazy<CqlValueSet>(this.Primary_Open_Angle_Glaucoma_Value);
+        __virtual = new Lazy<CqlCode>(this.@virtual_Value);
+        __AMB = new Lazy<CqlCode>(this.AMB_Value);
+        __ActCode = new Lazy<CqlCode[]>(this.ActCode_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounter_During_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_During_Measurement_Period_Value);
+        __Primary_Open_Angle_Glaucoma_Encounter = new Lazy<IEnumerable<Encounter>>(this.Primary_Open_Angle_Glaucoma_Encounter_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio = new Lazy<IEnumerable<Observation>>(this.Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio_Value);
+        __Medical_Reason_for_Not_Performing_Optic_Disc_Exam = new Lazy<IEnumerable<Observation>>(this.Medical_Reason_for_Not_Performing_Optic_Disc_Exam_Value);
+        __Denominator_Exceptions = new Lazy<bool?>(this.Denominator_Exceptions_Value);
+        __Cup_to_Disc_Ratio_Performed_with_Result = new Lazy<IEnumerable<Observation>>(this.Cup_to_Disc_Ratio_Performed_with_Result_Value);
+        __Optic_Disc_Exam_Performed_with_Result = new Lazy<IEnumerable<Observation>>(this.Optic_Disc_Exam_Performed_with_Result_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+
+    [CqlDeclaration("Care Services in Long-Term Residential Facility")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
+	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
+		__Care_Services_in_Long_Term_Residential_Facility.Value;
+
+	private CqlValueSet Cup_to_Disc_Ratio_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333", null);
+
+    [CqlDeclaration("Cup to Disc Ratio")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333")]
+	public CqlValueSet Cup_to_Disc_Ratio() => 
+		__Cup_to_Disc_Ratio.Value;
+
+	private CqlValueSet Face_to_Face_Interaction_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+
+    [CqlDeclaration("Face-to-Face Interaction")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
+	public CqlValueSet Face_to_Face_Interaction() => 
+		__Face_to_Face_Interaction.Value;
+
+	private CqlValueSet Medical_Reason_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlDeclaration("Medical Reason")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
+	public CqlValueSet Medical_Reason() => 
+		__Medical_Reason.Value;
+
+	private CqlValueSet Nursing_Facility_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+
+    [CqlDeclaration("Nursing Facility Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
+	public CqlValueSet Nursing_Facility_Visit() => 
+		__Nursing_Facility_Visit.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Ophthalmological_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+
+    [CqlDeclaration("Ophthalmological Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
+	public CqlValueSet Ophthalmological_Services() => 
+		__Ophthalmological_Services.Value;
+
+	private CqlValueSet Optic_Disc_Exam_for_Structural_Abnormalities_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334", null);
+
+    [CqlDeclaration("Optic Disc Exam for Structural Abnormalities")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334")]
+	public CqlValueSet Optic_Disc_Exam_for_Structural_Abnormalities() => 
+		__Optic_Disc_Exam_for_Structural_Abnormalities.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlDeclaration("Outpatient Consultation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation.Value;
+
+	private CqlValueSet Primary_Open_Angle_Glaucoma_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326", null);
+
+    [CqlDeclaration("Primary Open-Angle Glaucoma")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326")]
+	public CqlValueSet Primary_Open_Angle_Glaucoma() => 
+		__Primary_Open_Angle_Glaucoma.Value;
+
+	private CqlCode @virtual_Value() => 
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+
+    [CqlDeclaration("virtual")]
+	public CqlCode @virtual() => 
+		__virtual.Value;
+
+	private CqlCode AMB_Value() => 
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+
+    [CqlDeclaration("AMB")]
+	public CqlCode AMB() => 
+		__AMB.Value;
+
+	private CqlCode[] ActCode_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ActCode")]
+	public CqlCode[] ActCode() => 
+		__ActCode.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("POAGOpticNerveEvaluationFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Ophthalmological_Services();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Outpatient_Consultation();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Nursing_Facility_Visit();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = context.Operators.ListUnion<Encounter>(k_, m_);
+		bool? o_(Encounter QualifyingEncounter)
+		{
+			var q_ = this.Measurement_Period();
+			var r_ = FHIRHelpers_4_3_000.ToInterval(QualifyingEncounter?.Period);
+			var s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, r_, null);
+			var t_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(QualifyingEncounter?.StatusElement?.Value);
+			var u_ = context.Operators.Equal(t_, "finished");
+			var v_ = context.Operators.And(s_, u_);
+			var w_ = FHIRHelpers_4_3_000.ToCode(QualifyingEncounter?.Class);
+			var x_ = this.@virtual();
+			var y_ = context.Operators.Equivalent(w_, x_);
+			var z_ = context.Operators.Not(y_);
+			var aa_ = context.Operators.And(v_, z_);
+
+			return aa_;
+		};
+		var p_ = context.Operators.WhereOrNull<Encounter>(n_, o_);
+
+		return p_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter During Measurement Period")]
+	public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period() => 
+		__Qualifying_Encounter_During_Measurement_Period.Value;
+
+	private IEnumerable<Encounter> Primary_Open_Angle_Glaucoma_Encounter_Value()
+	{
+		var a_ = this.Qualifying_Encounter_During_Measurement_Period();
+		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
+		{
+			var d_ = this.Primary_Open_Angle_Glaucoma();
+			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			bool? f_(Condition PrimaryOpenAngleGlaucoma)
+			{
+				var j_ = QICoreCommon_2_0_000.prevalenceInterval(PrimaryOpenAngleGlaucoma);
+				var k_ = FHIRHelpers_4_3_000.ToInterval(ValidQualifyingEncounter?.Period);
+				var l_ = context.Operators.Overlaps(j_, k_, null);
+				var m_ = QICoreCommon_2_0_000.isActive(PrimaryOpenAngleGlaucoma);
+				var n_ = context.Operators.And(l_, m_);
+				var o_ = FHIRHelpers_4_3_000.ToConcept(PrimaryOpenAngleGlaucoma?.VerificationStatus);
+				var p_ = QICoreCommon_2_0_000.unconfirmed();
+				var q_ = context.Operators.ConvertCodeToConcept(p_);
+				var r_ = context.Operators.Equivalent(o_, q_);
+				var t_ = QICoreCommon_2_0_000.refuted();
+				var u_ = context.Operators.ConvertCodeToConcept(t_);
+				var v_ = context.Operators.Equivalent(o_, u_);
+				var w_ = context.Operators.Or(r_, v_);
+				var y_ = QICoreCommon_2_0_000.entered_in_error();
+				var z_ = context.Operators.ConvertCodeToConcept(y_);
+				var aa_ = context.Operators.Equivalent(o_, z_);
+				var ab_ = context.Operators.Or(w_, aa_);
+				var ac_ = context.Operators.Not(ab_);
+				var ad_ = context.Operators.And(n_, ac_);
+
+				return ad_;
+			};
+			var g_ = context.Operators.WhereOrNull<Condition>(e_, f_);
+			Encounter h_(Condition PrimaryOpenAngleGlaucoma) => 
+				ValidQualifyingEncounter;
+			var i_ = context.Operators.SelectOrNull<Condition, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Primary Open Angle Glaucoma Encounter")]
+	public IEnumerable<Encounter> Primary_Open_Angle_Glaucoma_Encounter() => 
+		__Primary_Open_Angle_Glaucoma_Encounter.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.GreaterOrEqual(f_, (int?)18);
+		var h_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+		var i_ = context.Operators.ExistsInList<Encounter>(h_);
+		var j_ = context.Operators.And(g_, i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Observation> Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio_Value()
+	{
+		var a_ = this.Cup_to_Disc_Ratio();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var e_ = context.Operators.ListUnion<Observation>(b_, d_);
+		IEnumerable<Observation> f_(Observation CupToDiscExamNotPerformed)
+		{
+			var j_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+			bool? k_(Encounter EncounterWithPOAG)
+			{
+				var o_ = context.Operators.Convert<CqlDateTime>(CupToDiscExamNotPerformed?.IssuedElement?.Value);
+				var p_ = FHIRHelpers_4_3_000.ToInterval(EncounterWithPOAG?.Period);
+				var q_ = context.Operators.ElementInInterval<CqlDateTime>(o_, p_, null);
+
+				return q_;
+			};
+			var l_ = context.Operators.WhereOrNull<Encounter>(j_, k_);
+			Observation m_(Encounter EncounterWithPOAG) => 
+				CupToDiscExamNotPerformed;
+			var n_ = context.Operators.SelectOrNull<Encounter, Observation>(l_, m_);
+
+			return n_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<Observation, Observation>(e_, f_);
+		bool? h_(Observation CupToDiscExamNotPerformed)
+		{
+			bool? r_(Extension @this)
+			{
+				var aa_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+				return aa_;
+			};
+			var s_ = context.Operators.WhereOrNull<Extension>(((CupToDiscExamNotPerformed is DomainResource)
+					? ((CupToDiscExamNotPerformed as DomainResource).Extension)
+					: null), r_);
+			DataType t_(Extension @this) => 
+				@this?.Value;
+			var u_ = context.Operators.SelectOrNull<Extension, DataType>(s_, t_);
+			var v_ = context.Operators.SingleOrNull<DataType>(u_);
+			var w_ = context.Operators.Convert<CodeableConcept>(v_);
+			var x_ = FHIRHelpers_4_3_000.ToConcept(w_);
+			var y_ = this.Medical_Reason();
+			var z_ = context.Operators.ConceptInValueSet(x_, y_);
+
+			return z_;
+		};
+		var i_ = context.Operators.WhereOrNull<Observation>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Medical Reason for Not Performing Cup to Disc Ratio")]
+	public IEnumerable<Observation> Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio() => 
+		__Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio.Value;
+
+	private IEnumerable<Observation> Medical_Reason_for_Not_Performing_Optic_Disc_Exam_Value()
+	{
+		var a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var e_ = context.Operators.ListUnion<Observation>(b_, d_);
+		IEnumerable<Observation> f_(Observation OpticDiscExamNotPerformed)
+		{
+			var j_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+			bool? k_(Encounter EncounterWithPOAG)
+			{
+				var o_ = context.Operators.Convert<CqlDateTime>(OpticDiscExamNotPerformed?.IssuedElement?.Value);
+				var p_ = FHIRHelpers_4_3_000.ToInterval(EncounterWithPOAG?.Period);
+				var q_ = context.Operators.ElementInInterval<CqlDateTime>(o_, p_, null);
+
+				return q_;
+			};
+			var l_ = context.Operators.WhereOrNull<Encounter>(j_, k_);
+			Observation m_(Encounter EncounterWithPOAG) => 
+				OpticDiscExamNotPerformed;
+			var n_ = context.Operators.SelectOrNull<Encounter, Observation>(l_, m_);
+
+			return n_;
+		};
+		var g_ = context.Operators.SelectManyOrNull<Observation, Observation>(e_, f_);
+		bool? h_(Observation OpticDiscExamNotPerformed)
+		{
+			bool? r_(Extension @this)
+			{
+				var aa_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+				return aa_;
+			};
+			var s_ = context.Operators.WhereOrNull<Extension>(((OpticDiscExamNotPerformed is DomainResource)
+					? ((OpticDiscExamNotPerformed as DomainResource).Extension)
+					: null), r_);
+			DataType t_(Extension @this) => 
+				@this?.Value;
+			var u_ = context.Operators.SelectOrNull<Extension, DataType>(s_, t_);
+			var v_ = context.Operators.SingleOrNull<DataType>(u_);
+			var w_ = context.Operators.Convert<CodeableConcept>(v_);
+			var x_ = FHIRHelpers_4_3_000.ToConcept(w_);
+			var y_ = this.Medical_Reason();
+			var z_ = context.Operators.ConceptInValueSet(x_, y_);
+
+			return z_;
+		};
+		var i_ = context.Operators.WhereOrNull<Observation>(g_, h_);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Medical Reason for Not Performing Optic Disc Exam")]
+	public IEnumerable<Observation> Medical_Reason_for_Not_Performing_Optic_Disc_Exam() => 
+		__Medical_Reason_for_Not_Performing_Optic_Disc_Exam.Value;
+
+	private bool? Denominator_Exceptions_Value()
+	{
+		var a_ = this.Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio();
+		var b_ = context.Operators.ExistsInList<Observation>(a_);
+		var c_ = this.Medical_Reason_for_Not_Performing_Optic_Disc_Exam();
+		var d_ = context.Operators.ExistsInList<Observation>(c_);
+		var e_ = context.Operators.Or(b_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Denominator Exceptions")]
+	public bool? Denominator_Exceptions() => 
+		__Denominator_Exceptions.Value;
+
+	private IEnumerable<Observation> Cup_to_Disc_Ratio_Performed_with_Result_Value()
+	{
+		var a_ = this.Cup_to_Disc_Ratio();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_(Observation CupToDiscExamPerformed)
+		{
+			var g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+			bool? h_(Encounter EncounterWithPOAG)
+			{
+				var l_ = FHIRHelpers_4_3_000.ToInterval(EncounterWithPOAG?.Period);
+				var m_ = FHIRHelpers_4_3_000.ToValue(CupToDiscExamPerformed?.Effective);
+				var n_ = QICoreCommon_2_0_000.toInterval(m_);
+				var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, null);
+
+				return o_;
+			};
+			var i_ = context.Operators.WhereOrNull<Encounter>(g_, h_);
+			Observation j_(Encounter EncounterWithPOAG) => 
+				CupToDiscExamPerformed;
+			var k_ = context.Operators.SelectOrNull<Encounter, Observation>(i_, j_);
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Observation, Observation>(b_, c_);
+		bool? e_(Observation CupToDiscExamPerformed)
+		{
+			var p_ = FHIRHelpers_4_3_000.ToValue(CupToDiscExamPerformed?.Value);
+			var q_ = context.Operators.Not((bool?)(p_ is null));
+			var r_ = context.Operators.Convert<Code<ObservationStatus>>(CupToDiscExamPerformed?.StatusElement?.Value);
+			var s_ = context.Operators.Convert<string>(r_);
+			var t_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var u_ = context.Operators.InList<string>(s_, (t_ as IEnumerable<string>));
+			var v_ = context.Operators.And(q_, u_);
+
+			return v_;
+		};
+		var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Cup to Disc Ratio Performed with Result")]
+	public IEnumerable<Observation> Cup_to_Disc_Ratio_Performed_with_Result() => 
+		__Cup_to_Disc_Ratio_Performed_with_Result.Value;
+
+	private IEnumerable<Observation> Optic_Disc_Exam_Performed_with_Result_Value()
+	{
+		var a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_(Observation OpticDiscExamPerformed)
+		{
+			var g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+			bool? h_(Encounter EncounterWithPOAG)
+			{
+				var l_ = FHIRHelpers_4_3_000.ToInterval(EncounterWithPOAG?.Period);
+				var m_ = FHIRHelpers_4_3_000.ToValue(OpticDiscExamPerformed?.Effective);
+				var n_ = QICoreCommon_2_0_000.toInterval(m_);
+				var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, n_, null);
+
+				return o_;
+			};
+			var i_ = context.Operators.WhereOrNull<Encounter>(g_, h_);
+			Observation j_(Encounter EncounterWithPOAG) => 
+				OpticDiscExamPerformed;
+			var k_ = context.Operators.SelectOrNull<Encounter, Observation>(i_, j_);
+
+			return k_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Observation, Observation>(b_, c_);
+		bool? e_(Observation OpticDiscExamPerformed)
+		{
+			var p_ = FHIRHelpers_4_3_000.ToValue(OpticDiscExamPerformed?.Value);
+			var q_ = context.Operators.Not((bool?)(p_ is null));
+			var r_ = context.Operators.Convert<Code<ObservationStatus>>(OpticDiscExamPerformed?.StatusElement?.Value);
+			var s_ = context.Operators.Convert<string>(r_);
+			var t_ = new string[]
+			{
+				"final",
+				"amended",
+				"corrected",
+			};
+			var u_ = context.Operators.InList<string>(s_, (t_ as IEnumerable<string>));
+			var v_ = context.Operators.And(q_, u_);
+
+			return v_;
+		};
+		var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Optic Disc Exam Performed with Result")]
+	public IEnumerable<Observation> Optic_Disc_Exam_Performed_with_Result() => 
+		__Optic_Disc_Exam_Performed_with_Result.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Cup_to_Disc_Ratio_Performed_with_Result();
+		var b_ = context.Operators.ExistsInList<Observation>(a_);
+		var c_ = this.Optic_Disc_Exam_Performed_with_Result();
+		var d_ = context.Operators.ExistsInList<Observation>(c_);
+		var e_ = context.Operators.And(b_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+}

--- a/Demo/Measures-cms/PalliativeCare-1.9.000.g.cs
+++ b/Demo/Measures-cms/PalliativeCare-1.9.000.g.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("PalliativeCare", "1.9.000")]
+public class PalliativeCare_1_9_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Palliative_Care_Encounter;
+    internal Lazy<CqlValueSet> __Palliative_Care_Intervention;
+    internal Lazy<CqlValueSet> __Palliative_Care_Diagnosis;
+    internal Lazy<CqlCode> __Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<bool?> __Has_Palliative_Care_in_the_Measurement_Period;
+
+    #endregion
+    public PalliativeCare_1_9_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+
+        __Palliative_Care_Encounter = new Lazy<CqlValueSet>(this.Palliative_Care_Encounter_Value);
+        __Palliative_Care_Intervention = new Lazy<CqlValueSet>(this.Palliative_Care_Intervention_Value);
+        __Palliative_Care_Diagnosis = new Lazy<CqlValueSet>(this.Palliative_Care_Diagnosis_Value);
+        __Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_ = new Lazy<CqlCode>(this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Has_Palliative_Care_in_the_Measurement_Period = new Lazy<bool?>(this.Has_Palliative_Care_in_the_Measurement_Period_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Palliative_Care_Encounter_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", null);
+
+    [CqlDeclaration("Palliative Care Encounter")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090")]
+	public CqlValueSet Palliative_Care_Encounter() => 
+		__Palliative_Care_Encounter.Value;
+
+	private CqlValueSet Palliative_Care_Intervention_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", null);
+
+    [CqlDeclaration("Palliative Care Intervention")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135")]
+	public CqlValueSet Palliative_Care_Intervention() => 
+		__Palliative_Care_Intervention.Value;
+
+	private CqlValueSet Palliative_Care_Diagnosis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167", null);
+
+    [CqlDeclaration("Palliative Care Diagnosis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167")]
+	public CqlValueSet Palliative_Care_Diagnosis() => 
+		__Palliative_Care_Diagnosis.Value;
+
+	private CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value() => 
+		new CqlCode("71007-9", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)")]
+	public CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_() => 
+		__Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("71007-9", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.ResolveParameter("PalliativeCare-1.9.000", "Measurement Period", null);
+
+		return (CqlInterval<CqlDateTime>)a_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private bool? Has_Palliative_Care_in_the_Measurement_Period_Value()
+	{
+		var a_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		var d_ = Status_1_6_000.isAssessmentPerformed(c_);
+		bool? e_(Observation PalliativeAssessment)
+		{
+			var ab_ = FHIRHelpers_4_3_000.ToValue(PalliativeAssessment?.Effective);
+			var ac_ = QICoreCommon_2_0_000.toInterval(ab_);
+			var ad_ = this.Measurement_Period();
+			var ae_ = context.Operators.Overlaps(ac_, ad_, "day");
+
+			return ae_;
+		};
+		var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+		var g_ = context.Operators.ExistsInList<Observation>(f_);
+		var h_ = this.Palliative_Care_Diagnosis();
+		var i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
+		bool? j_(Condition PalliativeDiagnosis)
+		{
+			var af_ = QICoreCommon_2_0_000.prevalenceInterval(PalliativeDiagnosis);
+			var ag_ = this.Measurement_Period();
+			var ah_ = context.Operators.Overlaps(af_, ag_, "day");
+
+			return ah_;
+		};
+		var k_ = context.Operators.WhereOrNull<Condition>(i_, j_);
+		var l_ = context.Operators.ExistsInList<Condition>(k_);
+		var m_ = context.Operators.Or(g_, l_);
+		var n_ = this.Palliative_Care_Encounter();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = Status_1_6_000.isEncounterPerformed(o_);
+		bool? q_(Encounter PalliativeEncounter)
+		{
+			var ai_ = FHIRHelpers_4_3_000.ToInterval(PalliativeEncounter?.Period);
+			var aj_ = QICoreCommon_2_0_000.toInterval((ai_ as object));
+			var ak_ = this.Measurement_Period();
+			var al_ = context.Operators.Overlaps(aj_, ak_, "day");
+
+			return al_;
+		};
+		var r_ = context.Operators.WhereOrNull<Encounter>(p_, q_);
+		var s_ = context.Operators.ExistsInList<Encounter>(r_);
+		var t_ = context.Operators.Or(m_, s_);
+		var u_ = this.Palliative_Care_Intervention();
+		var v_ = context.Operators.RetrieveByValueSet<Procedure>(u_, null);
+		var w_ = Status_1_6_000.isInterventionPerformed(v_);
+		bool? x_(Procedure PalliativeIntervention)
+		{
+			var am_ = FHIRHelpers_4_3_000.ToValue(PalliativeIntervention?.Performed);
+			var an_ = QICoreCommon_2_0_000.toInterval(am_);
+			var ao_ = this.Measurement_Period();
+			var ap_ = context.Operators.Overlaps(an_, ao_, "day");
+
+			return ap_;
+		};
+		var y_ = context.Operators.WhereOrNull<Procedure>(w_, x_);
+		var z_ = context.Operators.ExistsInList<Procedure>(y_);
+		var aa_ = context.Operators.Or(t_, z_);
+
+		return aa_;
+	}
+
+    [CqlDeclaration("Has Palliative Care in the Measurement Period")]
+	public bool? Has_Palliative_Care_in_the_Measurement_Period() => 
+		__Has_Palliative_Care_in_the_Measurement_Period.Value;
+
+}

--- a/Demo/Measures-cms/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
+++ b/Demo/Measures-cms/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
@@ -1,0 +1,998 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR", "0.0.001")]
+public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR_0_0_001
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Limited_Life_Expectancy;
+    internal Lazy<CqlValueSet> __Medical_Reason;
+    internal Lazy<CqlValueSet> __Nutrition_Services;
+    internal Lazy<CqlValueSet> __Occupational_Therapy_Evaluation;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Ophthalmological_Services;
+    internal Lazy<CqlValueSet> __Physical_Therapy_Evaluation;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Group_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Individual_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Psych_Visit_Diagnostic_Evaluation;
+    internal Lazy<CqlValueSet> __Psych_Visit_Psychotherapy;
+    internal Lazy<CqlValueSet> __Psychoanalysis;
+    internal Lazy<CqlValueSet> __Speech_and_Hearing_Evaluation;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Tobacco_Non_User;
+    internal Lazy<CqlValueSet> __Tobacco_Use_Cessation_Counseling;
+    internal Lazy<CqlValueSet> __Tobacco_Use_Cessation_Pharmacotherapy;
+    internal Lazy<CqlValueSet> __Tobacco_Use_Screening;
+    internal Lazy<CqlValueSet> __Tobacco_User;
+    internal Lazy<CqlCode> __Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_;
+    internal Lazy<CqlCode> __Health_behavior_intervention__individual__face_to_face__initial_30_minutes;
+    internal Lazy<CqlCode> __Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure;
+    internal Lazy<CqlCode> __Tobacco_abuse_counseling;
+    internal Lazy<CqlCode> __Unlisted_preventive_medicine_service;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlCode[]> __ICD10CM;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Visit_During_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Preventive_Visit_During_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator_1;
+    internal Lazy<Observation> __Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User;
+    internal Lazy<bool?> __Denominator_2;
+    internal Lazy<bool?> __Denominator_3;
+    internal Lazy<Observation> __Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User;
+    internal Lazy<bool?> __Numerator_1;
+    internal Lazy<IEnumerable<object>> __Tobacco_Cessation_Counseling_Given;
+    internal Lazy<IEnumerable<MedicationRequest>> __Tobacco_Cessation_Pharmacotherapy_Ordered;
+    internal Lazy<IEnumerable<MedicationRequest>> __Active_Pharmacotherapy_for_Tobacco_Cessation;
+    internal Lazy<bool?> __Numerator_2;
+    internal Lazy<bool?> __Numerator_3;
+    internal Lazy<bool?> __Denominator_Exclusion;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR_0_0_001(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        CumulativeMedicationDuration_4_0_000 = new CumulativeMedicationDuration_4_0_000(context);
+
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Limited_Life_Expectancy = new Lazy<CqlValueSet>(this.Limited_Life_Expectancy_Value);
+        __Medical_Reason = new Lazy<CqlValueSet>(this.Medical_Reason_Value);
+        __Nutrition_Services = new Lazy<CqlValueSet>(this.Nutrition_Services_Value);
+        __Occupational_Therapy_Evaluation = new Lazy<CqlValueSet>(this.Occupational_Therapy_Evaluation_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Ophthalmological_Services = new Lazy<CqlValueSet>(this.Ophthalmological_Services_Value);
+        __Physical_Therapy_Evaluation = new Lazy<CqlValueSet>(this.Physical_Therapy_Evaluation_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Group_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Group_Counseling_Value);
+        __Preventive_Care_Services_Individual_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Individual_Counseling_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __Psych_Visit_Diagnostic_Evaluation = new Lazy<CqlValueSet>(this.Psych_Visit_Diagnostic_Evaluation_Value);
+        __Psych_Visit_Psychotherapy = new Lazy<CqlValueSet>(this.Psych_Visit_Psychotherapy_Value);
+        __Psychoanalysis = new Lazy<CqlValueSet>(this.Psychoanalysis_Value);
+        __Speech_and_Hearing_Evaluation = new Lazy<CqlValueSet>(this.Speech_and_Hearing_Evaluation_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Tobacco_Non_User = new Lazy<CqlValueSet>(this.Tobacco_Non_User_Value);
+        __Tobacco_Use_Cessation_Counseling = new Lazy<CqlValueSet>(this.Tobacco_Use_Cessation_Counseling_Value);
+        __Tobacco_Use_Cessation_Pharmacotherapy = new Lazy<CqlValueSet>(this.Tobacco_Use_Cessation_Pharmacotherapy_Value);
+        __Tobacco_Use_Screening = new Lazy<CqlValueSet>(this.Tobacco_Use_Screening_Value);
+        __Tobacco_User = new Lazy<CqlValueSet>(this.Tobacco_User_Value);
+        __Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_ = new Lazy<CqlCode>(this.Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making__Value);
+        __Health_behavior_intervention__individual__face_to_face__initial_30_minutes = new Lazy<CqlCode>(this.Health_behavior_intervention__individual__face_to_face__initial_30_minutes_Value);
+        __Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure = new Lazy<CqlCode>(this.Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value);
+        __Tobacco_abuse_counseling = new Lazy<CqlCode>(this.Tobacco_abuse_counseling_Value);
+        __Unlisted_preventive_medicine_service = new Lazy<CqlCode>(this.Unlisted_preventive_medicine_service_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __ICD10CM = new Lazy<CqlCode[]>(this.ICD10CM_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Visit_During_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Visit_During_Measurement_Period_Value);
+        __Preventive_Visit_During_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Preventive_Visit_During_Measurement_Period_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator_1 = new Lazy<bool?>(this.Denominator_1_Value);
+        __Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User = new Lazy<Observation>(this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User_Value);
+        __Denominator_2 = new Lazy<bool?>(this.Denominator_2_Value);
+        __Denominator_3 = new Lazy<bool?>(this.Denominator_3_Value);
+        __Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User = new Lazy<Observation>(this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User_Value);
+        __Numerator_1 = new Lazy<bool?>(this.Numerator_1_Value);
+        __Tobacco_Cessation_Counseling_Given = new Lazy<IEnumerable<object>>(this.Tobacco_Cessation_Counseling_Given_Value);
+        __Tobacco_Cessation_Pharmacotherapy_Ordered = new Lazy<IEnumerable<MedicationRequest>>(this.Tobacco_Cessation_Pharmacotherapy_Ordered_Value);
+        __Active_Pharmacotherapy_for_Tobacco_Cessation = new Lazy<IEnumerable<MedicationRequest>>(this.Active_Pharmacotherapy_for_Tobacco_Cessation_Value);
+        __Numerator_2 = new Lazy<bool?>(this.Numerator_2_Value);
+        __Numerator_3 = new Lazy<bool?>(this.Numerator_3_Value);
+        __Denominator_Exclusion = new Lazy<bool?>(this.Denominator_Exclusion_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public CumulativeMedicationDuration_4_0_000 CumulativeMedicationDuration_4_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Annual_Wellness_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+
+    [CqlDeclaration("Annual Wellness Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Limited_Life_Expectancy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259", null);
+
+    [CqlDeclaration("Limited Life Expectancy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259")]
+	public CqlValueSet Limited_Life_Expectancy() => 
+		__Limited_Life_Expectancy.Value;
+
+	private CqlValueSet Medical_Reason_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlDeclaration("Medical Reason")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
+	public CqlValueSet Medical_Reason() => 
+		__Medical_Reason.Value;
+
+	private CqlValueSet Nutrition_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006", null);
+
+    [CqlDeclaration("Nutrition Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006")]
+	public CqlValueSet Nutrition_Services() => 
+		__Nutrition_Services.Value;
+
+	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", null);
+
+    [CqlDeclaration("Occupational Therapy Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
+	public CqlValueSet Occupational_Therapy_Evaluation() => 
+		__Occupational_Therapy_Evaluation.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Ophthalmological_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+
+    [CqlDeclaration("Ophthalmological Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
+	public CqlValueSet Ophthalmological_Services() => 
+		__Ophthalmological_Services.Value;
+
+	private CqlValueSet Physical_Therapy_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", null);
+
+    [CqlDeclaration("Physical Therapy Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022")]
+	public CqlValueSet Physical_Therapy_Evaluation() => 
+		__Physical_Therapy_Evaluation.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+
+    [CqlDeclaration("Preventive Care Services Group Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
+	public CqlValueSet Preventive_Care_Services_Group_Counseling() => 
+		__Preventive_Care_Services_Group_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+
+    [CqlDeclaration("Preventive Care Services Individual Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
+	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
+		__Preventive_Care_Services_Individual_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
+
+    [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
+	public CqlValueSet Psych_Visit_Diagnostic_Evaluation() => 
+		__Psych_Visit_Diagnostic_Evaluation.Value;
+
+	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
+
+    [CqlDeclaration("Psych Visit Psychotherapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
+	public CqlValueSet Psych_Visit_Psychotherapy() => 
+		__Psych_Visit_Psychotherapy.Value;
+
+	private CqlValueSet Psychoanalysis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", null);
+
+    [CqlDeclaration("Psychoanalysis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141")]
+	public CqlValueSet Psychoanalysis() => 
+		__Psychoanalysis.Value;
+
+	private CqlValueSet Speech_and_Hearing_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530", null);
+
+    [CqlDeclaration("Speech and Hearing Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530")]
+	public CqlValueSet Speech_and_Hearing_Evaluation() => 
+		__Speech_and_Hearing_Evaluation.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlValueSet Tobacco_Non_User_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189", null);
+
+    [CqlDeclaration("Tobacco Non User")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189")]
+	public CqlValueSet Tobacco_Non_User() => 
+		__Tobacco_Non_User.Value;
+
+	private CqlValueSet Tobacco_Use_Cessation_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509", null);
+
+    [CqlDeclaration("Tobacco Use Cessation Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509")]
+	public CqlValueSet Tobacco_Use_Cessation_Counseling() => 
+		__Tobacco_Use_Cessation_Counseling.Value;
+
+	private CqlValueSet Tobacco_Use_Cessation_Pharmacotherapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190", null);
+
+    [CqlDeclaration("Tobacco Use Cessation Pharmacotherapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190")]
+	public CqlValueSet Tobacco_Use_Cessation_Pharmacotherapy() => 
+		__Tobacco_Use_Cessation_Pharmacotherapy.Value;
+
+	private CqlValueSet Tobacco_Use_Screening_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278", null);
+
+    [CqlDeclaration("Tobacco Use Screening")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278")]
+	public CqlValueSet Tobacco_Use_Screening() => 
+		__Tobacco_Use_Screening.Value;
+
+	private CqlValueSet Tobacco_User_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170", null);
+
+    [CqlDeclaration("Tobacco User")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170")]
+	public CqlValueSet Tobacco_User() => 
+		__Tobacco_User.Value;
+
+	private CqlCode Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making__Value() => 
+		new CqlCode("96156", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Health behavior assessment, or re-assessment (ie, health-focused clinical interview, behavioral observations, clinical decision making)")]
+	public CqlCode Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_() => 
+		__Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_.Value;
+
+	private CqlCode Health_behavior_intervention__individual__face_to_face__initial_30_minutes_Value() => 
+		new CqlCode("96158", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Health behavior intervention, individual, face-to-face; initial 30 minutes")]
+	public CqlCode Health_behavior_intervention__individual__face_to_face__initial_30_minutes() => 
+		__Health_behavior_intervention__individual__face_to_face__initial_30_minutes.Value;
+
+	private CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value() => 
+		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Postoperative follow-up visit, normally included in the surgical package, to indicate that an evaluation and management service was performed during a postoperative period for a reason(s) related to the original procedure")]
+	public CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure() => 
+		__Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure.Value;
+
+	private CqlCode Tobacco_abuse_counseling_Value() => 
+		new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
+
+    [CqlDeclaration("Tobacco abuse counseling")]
+	public CqlCode Tobacco_abuse_counseling() => 
+		__Tobacco_abuse_counseling.Value;
+
+	private CqlCode Unlisted_preventive_medicine_service_Value() => 
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Unlisted preventive medicine service")]
+	public CqlCode Unlisted_preventive_medicine_service() => 
+		__Unlisted_preventive_medicine_service.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("96156", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("96158", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlCode[] ICD10CM_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ICD10CM")]
+	public CqlCode[] ICD10CM() => 
+		__ICD10CM.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Visit_During_Measurement_Period_Value()
+	{
+		var a_ = this.Home_Healthcare_Services();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		bool? d_(Encounter E)
+		{
+			CqlConcept ar_(CodeableConcept @this)
+			{
+				var aw_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return aw_;
+			};
+			var as_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, ar_);
+			bool? at_(CqlConcept T)
+			{
+				var ax_ = this.Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_();
+				var ay_ = context.Operators.ConvertCodeToConcept(ax_);
+				var az_ = context.Operators.Equivalent(T, ay_);
+
+				return az_;
+			};
+			var au_ = context.Operators.WhereOrNull<CqlConcept>(as_, at_);
+			var av_ = context.Operators.ExistsInList<CqlConcept>(au_);
+
+			return av_;
+		};
+		var e_ = context.Operators.WhereOrNull<Encounter>(c_, d_);
+		var f_ = context.Operators.ListUnion<Encounter>(b_, e_);
+		bool? h_(Encounter E)
+		{
+			CqlConcept ba_(CodeableConcept @this)
+			{
+				var bf_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return bf_;
+			};
+			var bb_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, ba_);
+			bool? bc_(CqlConcept T)
+			{
+				var bg_ = this.Health_behavior_intervention__individual__face_to_face__initial_30_minutes();
+				var bh_ = context.Operators.ConvertCodeToConcept(bg_);
+				var bi_ = context.Operators.Equivalent(T, bh_);
+
+				return bi_;
+			};
+			var bd_ = context.Operators.WhereOrNull<CqlConcept>(bb_, bc_);
+			var be_ = context.Operators.ExistsInList<CqlConcept>(bd_);
+
+			return be_;
+		};
+		var i_ = context.Operators.WhereOrNull<Encounter>(c_, h_);
+		var j_ = this.Occupational_Therapy_Evaluation();
+		var k_ = context.Operators.RetrieveByValueSet<Encounter>(j_, null);
+		var l_ = context.Operators.ListUnion<Encounter>(i_, k_);
+		var m_ = context.Operators.ListUnion<Encounter>(f_, l_);
+		var n_ = this.Office_Visit();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = this.Ophthalmological_Services();
+		var q_ = context.Operators.RetrieveByValueSet<Encounter>(p_, null);
+		var r_ = context.Operators.ListUnion<Encounter>(o_, q_);
+		var s_ = context.Operators.ListUnion<Encounter>(m_, r_);
+		var t_ = this.Physical_Therapy_Evaluation();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = this.Psych_Visit_Diagnostic_Evaluation();
+		var w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
+		var x_ = context.Operators.ListUnion<Encounter>(u_, w_);
+		var y_ = context.Operators.ListUnion<Encounter>(s_, x_);
+		var z_ = this.Psych_Visit_Psychotherapy();
+		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		var ab_ = this.Psychoanalysis();
+		var ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, null);
+		var ad_ = context.Operators.ListUnion<Encounter>(aa_, ac_);
+		var ae_ = context.Operators.ListUnion<Encounter>(y_, ad_);
+		var af_ = this.Speech_and_Hearing_Evaluation();
+		var ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		var ah_ = this.Telephone_Visits();
+		var ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, null);
+		var aj_ = context.Operators.ListUnion<Encounter>(ag_, ai_);
+		var ak_ = context.Operators.ListUnion<Encounter>(ae_, aj_);
+		var al_ = this.Online_Assessments();
+		var am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		var an_ = context.Operators.ListUnion<Encounter>(ak_, am_);
+		var ao_ = Status_1_6_000.isEncounterPerformed(an_);
+		bool? ap_(Encounter OfficeBasedEncounter)
+		{
+			var bj_ = this.Measurement_Period();
+			var bk_ = FHIRHelpers_4_3_000.ToInterval(OfficeBasedEncounter?.Period);
+			var bl_ = QICoreCommon_2_0_000.toInterval((bk_ as object));
+			var bm_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bj_, bl_, "day");
+
+			return bm_;
+		};
+		var aq_ = context.Operators.WhereOrNull<Encounter>(ao_, ap_);
+
+		return aq_;
+	}
+
+    [CqlDeclaration("Qualifying Visit During Measurement Period")]
+	public IEnumerable<Encounter> Qualifying_Visit_During_Measurement_Period() => 
+		__Qualifying_Visit_During_Measurement_Period.Value;
+
+	private IEnumerable<Encounter> Preventive_Visit_During_Measurement_Period_Value()
+	{
+		var a_ = this.Annual_Wellness_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care_Services_Group_Counseling();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		bool? i_(Encounter E)
+		{
+			CqlConcept ac_(CodeableConcept @this)
+			{
+				var ah_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return ah_;
+			};
+			var ad_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, ac_);
+			bool? ae_(CqlConcept T)
+			{
+				var ai_ = this.Unlisted_preventive_medicine_service();
+				var aj_ = context.Operators.ConvertCodeToConcept(ai_);
+				var ak_ = context.Operators.Equivalent(T, aj_);
+
+				return ak_;
+			};
+			var af_ = context.Operators.WhereOrNull<CqlConcept>(ad_, ae_);
+			var ag_ = context.Operators.ExistsInList<CqlConcept>(af_);
+
+			return ag_;
+		};
+		var j_ = context.Operators.WhereOrNull<Encounter>(h_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(g_, j_);
+		var l_ = context.Operators.ListUnion<Encounter>(e_, k_);
+		var m_ = this.Preventive_Care_Services_Individual_Counseling();
+		var n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		bool? p_(Encounter E)
+		{
+			CqlConcept al_(CodeableConcept @this)
+			{
+				var aq_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return aq_;
+			};
+			var am_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, al_);
+			bool? an_(CqlConcept T)
+			{
+				var ar_ = this.Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure();
+				var as_ = context.Operators.ConvertCodeToConcept(ar_);
+				var at_ = context.Operators.Equivalent(T, as_);
+
+				return at_;
+			};
+			var ao_ = context.Operators.WhereOrNull<CqlConcept>(am_, an_);
+			var ap_ = context.Operators.ExistsInList<CqlConcept>(ao_);
+
+			return ap_;
+		};
+		var q_ = context.Operators.WhereOrNull<Encounter>(h_, p_);
+		var r_ = context.Operators.ListUnion<Encounter>(n_, q_);
+		var s_ = context.Operators.ListUnion<Encounter>(l_, r_);
+		var t_ = this.Nutrition_Services();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
+		var x_ = context.Operators.ListUnion<Encounter>(u_, w_);
+		var y_ = context.Operators.ListUnion<Encounter>(s_, x_);
+		var z_ = Status_1_6_000.isEncounterPerformed(y_);
+		bool? aa_(Encounter PreventiveEncounter)
+		{
+			var au_ = this.Measurement_Period();
+			var av_ = FHIRHelpers_4_3_000.ToInterval(PreventiveEncounter?.Period);
+			var aw_ = QICoreCommon_2_0_000.toInterval((av_ as object));
+			var ax_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(au_, aw_, "day");
+
+			return ax_;
+		};
+		var ab_ = context.Operators.WhereOrNull<Encounter>(z_, aa_);
+
+		return ab_;
+	}
+
+    [CqlDeclaration("Preventive Visit During Measurement Period")]
+	public IEnumerable<Encounter> Preventive_Visit_During_Measurement_Period() => 
+		__Preventive_Visit_During_Measurement_Period.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.GreaterOrEqual(f_, (int?)12);
+		var h_ = this.Qualifying_Visit_During_Measurement_Period();
+		var i_ = context.Operators.CountOrNull<Encounter>(h_);
+		var j_ = context.Operators.GreaterOrEqual(i_, (int?)2);
+		var k_ = this.Preventive_Visit_During_Measurement_Period();
+		var l_ = context.Operators.ExistsInList<Encounter>(k_);
+		var m_ = context.Operators.Or(j_, l_);
+		var n_ = context.Operators.And(g_, m_);
+
+		return n_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_1_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator 1")]
+	public bool? Denominator_1() => 
+		__Denominator_1.Value;
+
+	private Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User_Value()
+	{
+		var a_ = this.Tobacco_Use_Screening();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		bool? d_(Observation TobaccoUseScreening)
+		{
+			var m_ = this.Measurement_Period();
+			var n_ = FHIRHelpers_4_3_000.ToValue(TobaccoUseScreening?.Effective);
+			var o_ = QICoreCommon_2_0_000.toInterval(n_);
+			var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
+
+			return p_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		object f_(Observation @this)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var r_ = QICoreCommon_2_0_000.toInterval(q_);
+			var s_ = context.Operators.Start(r_);
+
+			return s_;
+		};
+		var g_ = context.Operators.ListSortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		var h_ = context.Operators.LastOfList<Observation>(g_);
+		var i_ = new Observation[]
+		{
+			h_,
+		};
+		bool? j_(Observation MostRecentTobaccoUseScreening)
+		{
+			var t_ = FHIRHelpers_4_3_000.ToValue(MostRecentTobaccoUseScreening?.Value);
+			var u_ = this.Tobacco_User();
+			var v_ = context.Operators.ConceptInValueSet((t_ as CqlConcept), u_);
+
+			return v_;
+		};
+		var k_ = context.Operators.WhereOrNull<Observation>(i_, j_);
+		var l_ = context.Operators.SingleOrNull<Observation>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Most Recent Tobacco Use Screening Indicates Tobacco User")]
+	public Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User() => 
+		__Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User.Value;
+
+	private bool? Denominator_2_Value()
+	{
+		var a_ = this.Initial_Population();
+		var b_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User();
+		var c_ = context.Operators.Not((bool?)(b_ is null));
+		var d_ = context.Operators.And(a_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Denominator 2")]
+	public bool? Denominator_2() => 
+		__Denominator_2.Value;
+
+	private bool? Denominator_3_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator 3")]
+	public bool? Denominator_3() => 
+		__Denominator_3.Value;
+
+	private Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User_Value()
+	{
+		var a_ = this.Tobacco_Use_Screening();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		bool? d_(Observation TobaccoUseScreening)
+		{
+			var m_ = this.Measurement_Period();
+			var n_ = FHIRHelpers_4_3_000.ToValue(TobaccoUseScreening?.Effective);
+			var o_ = QICoreCommon_2_0_000.toInterval(n_);
+			var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, "day");
+
+			return p_;
+		};
+		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
+		object f_(Observation @this)
+		{
+			var q_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var r_ = QICoreCommon_2_0_000.toInterval(q_);
+			var s_ = context.Operators.Start(r_);
+
+			return s_;
+		};
+		var g_ = context.Operators.ListSortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		var h_ = context.Operators.LastOfList<Observation>(g_);
+		var i_ = new Observation[]
+		{
+			h_,
+		};
+		bool? j_(Observation MostRecentTobaccoUseScreening)
+		{
+			var t_ = FHIRHelpers_4_3_000.ToValue(MostRecentTobaccoUseScreening?.Value);
+			var u_ = this.Tobacco_Non_User();
+			var v_ = context.Operators.ConceptInValueSet((t_ as CqlConcept), u_);
+
+			return v_;
+		};
+		var k_ = context.Operators.WhereOrNull<Observation>(i_, j_);
+		var l_ = context.Operators.SingleOrNull<Observation>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Most Recent Tobacco Use Screening Indicates Tobacco Non User")]
+	public Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User() => 
+		__Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User.Value;
+
+	private bool? Numerator_1_Value()
+	{
+		var a_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User();
+		var b_ = context.Operators.Not((bool?)(a_ is null));
+		var c_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User();
+		var d_ = context.Operators.Not((bool?)(c_ is null));
+		var e_ = context.Operators.Or(b_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Numerator 1")]
+	public bool? Numerator_1() => 
+		__Numerator_1.Value;
+
+	private IEnumerable<object> Tobacco_Cessation_Counseling_Given_Value()
+	{
+		var a_ = this.Tobacco_Use_Cessation_Counseling();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.isInterventionPerformed(b_);
+		bool? d_(Procedure TobaccoCessationCounseling)
+		{
+			var l_ = this.Measurement_Period();
+			var m_ = context.Operators.Start(l_);
+			var n_ = context.Operators.Quantity(6m, "months");
+			var o_ = context.Operators.Subtract(m_, n_);
+			var q_ = context.Operators.End(l_);
+			var r_ = context.Operators.Interval(o_, q_, true, true);
+			var s_ = FHIRHelpers_4_3_000.ToValue(TobaccoCessationCounseling?.Performed);
+			var t_ = QICoreCommon_2_0_000.toInterval(s_);
+			var u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, "day");
+
+			return u_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+		var f_ = this.Tobacco_abuse_counseling();
+		var g_ = context.Operators.ToList<CqlCode>(f_);
+		var h_ = context.Operators.RetrieveByCodes<Condition>(g_, null);
+		bool? i_(Condition TobaccoCounseling)
+		{
+			var v_ = QICoreCommon_2_0_000.prevalenceInterval(TobaccoCounseling);
+			var w_ = context.Operators.Start(v_);
+			var x_ = this.Measurement_Period();
+			var y_ = context.Operators.Start(x_);
+			var z_ = context.Operators.Quantity(6m, "months");
+			var aa_ = context.Operators.Subtract(y_, z_);
+			var ac_ = context.Operators.End(x_);
+			var ad_ = context.Operators.Interval(aa_, ac_, true, true);
+			var ae_ = context.Operators.ElementInInterval<CqlDateTime>(w_, ad_, "day");
+
+			return ae_;
+		};
+		var j_ = context.Operators.WhereOrNull<Condition>(h_, i_);
+		var k_ = context.Operators.ListUnion<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
+
+		return k_;
+	}
+
+    [CqlDeclaration("Tobacco Cessation Counseling Given")]
+	public IEnumerable<object> Tobacco_Cessation_Counseling_Given() => 
+		__Tobacco_Cessation_Counseling_Given.Value;
+
+	private IEnumerable<MedicationRequest> Tobacco_Cessation_Pharmacotherapy_Ordered_Value()
+	{
+		var a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = Status_1_6_000.isMedicationOrder(e_);
+		bool? g_(MedicationRequest CessationPharmacotherapyOrdered)
+		{
+			var i_ = context.Operators.Convert<CqlDateTime>(CessationPharmacotherapyOrdered?.AuthoredOnElement);
+			var j_ = this.Measurement_Period();
+			var k_ = context.Operators.Start(j_);
+			var l_ = context.Operators.Quantity(6m, "months");
+			var m_ = context.Operators.Subtract(k_, l_);
+			var o_ = context.Operators.End(j_);
+			var p_ = context.Operators.Interval(m_, o_, true, true);
+			var q_ = context.Operators.ElementInInterval<CqlDateTime>(i_, p_, "day");
+
+			return q_;
+		};
+		var h_ = context.Operators.WhereOrNull<MedicationRequest>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Tobacco Cessation Pharmacotherapy Ordered")]
+	public IEnumerable<MedicationRequest> Tobacco_Cessation_Pharmacotherapy_Ordered() => 
+		__Tobacco_Cessation_Pharmacotherapy_Ordered.Value;
+
+	private IEnumerable<MedicationRequest> Active_Pharmacotherapy_for_Tobacco_Cessation_Value()
+	{
+		var a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = Status_1_6_000.isMedicationActive(e_);
+		bool? g_(MedicationRequest TakingCessationPharmacotherapy)
+		{
+			var i_ = context.Operators.Convert<CqlDateTime>(TakingCessationPharmacotherapy?.AuthoredOnElement);
+			var j_ = this.Measurement_Period();
+			var k_ = context.Operators.Start(j_);
+			var l_ = context.Operators.Quantity(6m, "months");
+			var m_ = context.Operators.Subtract(k_, l_);
+			var o_ = context.Operators.End(j_);
+			var p_ = context.Operators.Interval(m_, o_, true, true);
+			var q_ = context.Operators.ElementInInterval<CqlDateTime>(i_, p_, "day");
+
+			return q_;
+		};
+		var h_ = context.Operators.WhereOrNull<MedicationRequest>(f_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Active Pharmacotherapy for Tobacco Cessation")]
+	public IEnumerable<MedicationRequest> Active_Pharmacotherapy_for_Tobacco_Cessation() => 
+		__Active_Pharmacotherapy_for_Tobacco_Cessation.Value;
+
+	private bool? Numerator_2_Value()
+	{
+		var a_ = this.Tobacco_Cessation_Counseling_Given();
+		var b_ = context.Operators.ExistsInList<object>(a_);
+		var c_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered();
+		var d_ = context.Operators.ExistsInList<MedicationRequest>(c_);
+		var e_ = context.Operators.Or(b_, d_);
+		var f_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation();
+		var g_ = context.Operators.ExistsInList<MedicationRequest>(f_);
+		var h_ = context.Operators.Or(e_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Numerator 2")]
+	public bool? Numerator_2() => 
+		__Numerator_2.Value;
+
+	private bool? Numerator_3_Value()
+	{
+		var a_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User();
+		var b_ = context.Operators.Not((bool?)(a_ is null));
+		var c_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User();
+		var d_ = context.Operators.Not((bool?)(c_ is null));
+		var e_ = this.Tobacco_Cessation_Counseling_Given();
+		var f_ = context.Operators.ExistsInList<object>(e_);
+		var g_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered();
+		var h_ = context.Operators.ExistsInList<MedicationRequest>(g_);
+		var i_ = context.Operators.Or(f_, h_);
+		var j_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation();
+		var k_ = context.Operators.ExistsInList<MedicationRequest>(j_);
+		var l_ = context.Operators.Or(i_, k_);
+		var m_ = context.Operators.And(d_, l_);
+		var n_ = context.Operators.Or(b_, m_);
+
+		return n_;
+	}
+
+    [CqlDeclaration("Numerator 3")]
+	public bool? Numerator_3() => 
+		__Numerator_3.Value;
+
+	private bool? Denominator_Exclusion_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator Exclusion")]
+	public bool? Denominator_Exclusion() => 
+		__Denominator_Exclusion.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
+++ b/Demo/Measures-cms/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
@@ -1,0 +1,359 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("PrimaryCariesPreventionasOfferedbyDentistsFHIR", "0.0.002")]
+public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Clinical_Oral_Evaluation;
+    internal Lazy<CqlValueSet> __Discharged_to_Health_Care_Facility_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Discharged_to_Home_for_Hosice_Care;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Fluoride_Varnish_Application_for_Children;
+    internal Lazy<CqlValueSet> __Hospice_care_ambulatory;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Stratification_1;
+    internal Lazy<bool?> __Stratification_2;
+    internal Lazy<bool?> __Stratification_3;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+
+        __Clinical_Oral_Evaluation = new Lazy<CqlValueSet>(this.Clinical_Oral_Evaluation_Value);
+        __Discharged_to_Health_Care_Facility_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Health_Care_Facility_for_Hospice_Care_Value);
+        __Discharged_to_Home_for_Hosice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Home_for_Hosice_Care_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Fluoride_Varnish_Application_for_Children = new Lazy<CqlValueSet>(this.Fluoride_Varnish_Application_for_Children_Value);
+        __Hospice_care_ambulatory = new Lazy<CqlValueSet>(this.Hospice_care_ambulatory_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __Stratification_1 = new Lazy<bool?>(this.Stratification_1_Value);
+        __Stratification_2 = new Lazy<bool?>(this.Stratification_2_Value);
+        __Stratification_3 = new Lazy<bool?>(this.Stratification_3_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", null);
+
+    [CqlDeclaration("Clinical Oral Evaluation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
+	public CqlValueSet Clinical_Oral_Evaluation() => 
+		__Clinical_Oral_Evaluation.Value;
+
+	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+
+    [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
+	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
+		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
+
+	private CqlValueSet Discharged_to_Home_for_Hosice_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+
+    [CqlDeclaration("Discharged to Home for Hosice Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
+	public CqlValueSet Discharged_to_Home_for_Hosice_Care() => 
+		__Discharged_to_Home_for_Hosice_Care.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Fluoride_Varnish_Application_for_Children_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", null);
+
+    [CqlDeclaration("Fluoride Varnish Application for Children")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002")]
+	public CqlValueSet Fluoride_Varnish_Application_for_Children() => 
+		__Fluoride_Varnish_Application_for_Children.Value;
+
+	private CqlValueSet Hospice_care_ambulatory_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+
+    [CqlDeclaration("Hospice care ambulatory")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
+	public CqlValueSet Hospice_care_ambulatory() => 
+		__Hospice_care_ambulatory.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value()
+	{
+		var a_ = this.Clinical_Oral_Evaluation();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = Status_1_6_000.isEncounterPerformed(b_);
+		bool? d_(Encounter ValidEncounter)
+		{
+			var f_ = this.Measurement_Period();
+			var g_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounter?.Period);
+			var h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, g_, "day");
+
+			return h_;
+		};
+		var e_ = context.Operators.WhereOrNull<Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)1, (int?)20, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var i_ = this.Qualifying_Encounters();
+		var j_ = context.Operators.ExistsInList<Encounter>(i_);
+		var k_ = context.Operators.And(h_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Fluoride_Varnish_Application_for_Children();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.isProcedurePerformed(b_);
+		bool? d_(Procedure FluorideApplication)
+		{
+			var j_ = FHIRHelpers_4_3_000.ToValue(FluorideApplication?.Performed);
+			var k_ = QICoreCommon_2_0_000.toInterval(j_);
+			var l_ = context.Operators.End(k_);
+			var m_ = this.Measurement_Period();
+			var n_ = context.Operators.ElementInInterval<CqlDateTime>(l_, m_, "day");
+
+			return n_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+		CqlDate f_(Procedure FluorideApplication)
+		{
+			var o_ = FHIRHelpers_4_3_000.ToValue(FluorideApplication?.Performed);
+			var p_ = QICoreCommon_2_0_000.toInterval(o_);
+			var q_ = context.Operators.End(p_);
+			var r_ = context.Operators.DateFrom(q_);
+
+			return r_;
+		};
+		var g_ = context.Operators.SelectOrNull<Procedure, CqlDate>(e_, f_);
+		var h_ = context.Operators.CountOrNull<CqlDate>(g_);
+		var i_ = context.Operators.GreaterOrEqual(h_, (int?)2);
+
+		return i_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private bool? Stratification_1_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)1, (int?)5, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Stratification 1")]
+	public bool? Stratification_1() => 
+		__Stratification_1.Value;
+
+	private bool? Stratification_2_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)6, (int?)12, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Stratification 2")]
+	public bool? Stratification_2() => 
+		__Stratification_2.Value;
+
+	private bool? Stratification_3_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.Start(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)13, (int?)20, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Stratification 3")]
+	public bool? Stratification_3() => 
+		__Stratification_3.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
+++ b/Demo/Measures-cms/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
@@ -1,0 +1,813 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("ProstateCaAvoidanceBoneScanOveruseFHIR", "0.2.000")]
+public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Bone_Scan;
+    internal Lazy<CqlValueSet> __Pain_Warranting_Further_Investigation_for_Prostate_Cancer;
+    internal Lazy<CqlValueSet> __Prostate_Cancer;
+    internal Lazy<CqlValueSet> __Prostate_Cancer_Treatment;
+    internal Lazy<CqlValueSet> __Prostate_Specific_Antigen_Test;
+    internal Lazy<CqlValueSet> __Salvage_Therapy;
+    internal Lazy<CqlCode> __Gleason_score_in_Specimen_Qualitative;
+    internal Lazy<CqlCode> __Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_;
+    internal Lazy<CqlCode> __Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_;
+    internal Lazy<CqlCode> __Procedure_reason_record__record_artifact_;
+    internal Lazy<CqlCode> __T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_;
+    internal Lazy<CqlCode> __T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_;
+    internal Lazy<CqlCode> __Tumor_staging__tumor_staging_;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Condition>> __Prostate_Cancer_Diagnosis;
+    internal Lazy<bool?> __Has_Diagnosis_of_Pain_related_to_Prostate_Cancer;
+    internal Lazy<bool?> __Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis;
+    internal Lazy<IEnumerable<Observation>> __Bone_Scan_Study_Performed;
+    internal Lazy<bool?> __Has_Bone_Scan_Study_Performed_with_Documented_Reason;
+    internal Lazy<bool?> __Denominator_Exceptions;
+    internal Lazy<Procedure> __First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Most_Recent_Gleason_Score_is_Low;
+    internal Lazy<Observation> __Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Most_Recent_PSA_Test_Result_is_Low;
+    internal Lazy<bool?> __Denominator;
+
+    #endregion
+    public ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        __Bone_Scan = new Lazy<CqlValueSet>(this.Bone_Scan_Value);
+        __Pain_Warranting_Further_Investigation_for_Prostate_Cancer = new Lazy<CqlValueSet>(this.Pain_Warranting_Further_Investigation_for_Prostate_Cancer_Value);
+        __Prostate_Cancer = new Lazy<CqlValueSet>(this.Prostate_Cancer_Value);
+        __Prostate_Cancer_Treatment = new Lazy<CqlValueSet>(this.Prostate_Cancer_Treatment_Value);
+        __Prostate_Specific_Antigen_Test = new Lazy<CqlValueSet>(this.Prostate_Specific_Antigen_Test_Value);
+        __Salvage_Therapy = new Lazy<CqlValueSet>(this.Salvage_Therapy_Value);
+        __Gleason_score_in_Specimen_Qualitative = new Lazy<CqlCode>(this.Gleason_score_in_Specimen_Qualitative_Value);
+        __Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_ = new Lazy<CqlCode>(this.Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding__Value);
+        __Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_ = new Lazy<CqlCode>(this.Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding__Value);
+        __Procedure_reason_record__record_artifact_ = new Lazy<CqlCode>(this.Procedure_reason_record__record_artifact__Value);
+        __T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_ = new Lazy<CqlCode>(this.T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding__Value);
+        __T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_ = new Lazy<CqlCode>(this.T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding__Value);
+        __Tumor_staging__tumor_staging_ = new Lazy<CqlCode>(this.Tumor_staging__tumor_staging__Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Prostate_Cancer_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Prostate_Cancer_Diagnosis_Value);
+        __Has_Diagnosis_of_Pain_related_to_Prostate_Cancer = new Lazy<bool?>(this.Has_Diagnosis_of_Pain_related_to_Prostate_Cancer_Value);
+        __Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis = new Lazy<bool?>(this.Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis_Value);
+        __Bone_Scan_Study_Performed = new Lazy<IEnumerable<Observation>>(this.Bone_Scan_Study_Performed_Value);
+        __Has_Bone_Scan_Study_Performed_with_Documented_Reason = new Lazy<bool?>(this.Has_Bone_Scan_Study_Performed_with_Documented_Reason_Value);
+        __Denominator_Exceptions = new Lazy<bool?>(this.Denominator_Exceptions_Value);
+        __First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period = new Lazy<Procedure>(this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Most_Recent_Gleason_Score_is_Low = new Lazy<bool?>(this.Most_Recent_Gleason_Score_is_Low_Value);
+        __Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a = new Lazy<Observation>(this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a_Value);
+        __Numerator = new Lazy<bool?>(this.Numerator_Value);
+        __Most_Recent_PSA_Test_Result_is_Low = new Lazy<bool?>(this.Most_Recent_PSA_Test_Result_is_Low_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Bone_Scan_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320", null);
+
+    [CqlDeclaration("Bone Scan")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320")]
+	public CqlValueSet Bone_Scan() => 
+		__Bone_Scan.Value;
+
+	private CqlValueSet Pain_Warranting_Further_Investigation_for_Prostate_Cancer_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451", null);
+
+    [CqlDeclaration("Pain Warranting Further Investigation for Prostate Cancer")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451")]
+	public CqlValueSet Pain_Warranting_Further_Investigation_for_Prostate_Cancer() => 
+		__Pain_Warranting_Further_Investigation_for_Prostate_Cancer.Value;
+
+	private CqlValueSet Prostate_Cancer_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319", null);
+
+    [CqlDeclaration("Prostate Cancer")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319")]
+	public CqlValueSet Prostate_Cancer() => 
+		__Prostate_Cancer.Value;
+
+	private CqlValueSet Prostate_Cancer_Treatment_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398", null);
+
+    [CqlDeclaration("Prostate Cancer Treatment")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398")]
+	public CqlValueSet Prostate_Cancer_Treatment() => 
+		__Prostate_Cancer_Treatment.Value;
+
+	private CqlValueSet Prostate_Specific_Antigen_Test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401", null);
+
+    [CqlDeclaration("Prostate Specific Antigen Test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401")]
+	public CqlValueSet Prostate_Specific_Antigen_Test() => 
+		__Prostate_Specific_Antigen_Test.Value;
+
+	private CqlValueSet Salvage_Therapy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399", null);
+
+    [CqlDeclaration("Salvage Therapy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399")]
+	public CqlValueSet Salvage_Therapy() => 
+		__Salvage_Therapy.Value;
+
+	private CqlCode Gleason_score_in_Specimen_Qualitative_Value() => 
+		new CqlCode("35266-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Gleason score in Specimen Qualitative")]
+	public CqlCode Gleason_score_in_Specimen_Qualitative() => 
+		__Gleason_score_in_Specimen_Qualitative.Value;
+
+	private CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding__Value() => 
+		new CqlCode("433351000124101", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Neoplasm of prostate primary tumor staging category T1c: Tumor identified by needle biopsy (finding)")]
+	public CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_() => 
+		__Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_.Value;
+
+	private CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding__Value() => 
+		new CqlCode("433361000124104", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Neoplasm of prostate primary tumor staging category T2a: Involves one-half of one lobe or less (finding)")]
+	public CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_() => 
+		__Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_.Value;
+
+	private CqlCode Procedure_reason_record__record_artifact__Value() => 
+		new CqlCode("433611000124109", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Procedure reason record (record artifact)")]
+	public CqlCode Procedure_reason_record__record_artifact_() => 
+		__Procedure_reason_record__record_artifact_.Value;
+
+	private CqlCode T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding__Value() => 
+		new CqlCode("369833007", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("T1a: Prostate tumor incidental histologic finding in 5 percent or less of tissue resected (finding)")]
+	public CqlCode T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_() => 
+		__T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_.Value;
+
+	private CqlCode T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding__Value() => 
+		new CqlCode("369834001", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("T1b: Prostate tumor incidental histologic finding in greater than 5 percent of tissue resected (finding)")]
+	public CqlCode T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_() => 
+		__T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_.Value;
+
+	private CqlCode Tumor_staging__tumor_staging__Value() => 
+		new CqlCode("254292007", "http://snomed.info/sct", null, null);
+
+    [CqlDeclaration("Tumor staging (tumor staging)")]
+	public CqlCode Tumor_staging__tumor_staging_() => 
+		__Tumor_staging__tumor_staging_.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("35266-6", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("433351000124101", "http://snomed.info/sct", null, null),
+			new CqlCode("433361000124104", "http://snomed.info/sct", null, null),
+			new CqlCode("433611000124109", "http://snomed.info/sct", null, null),
+			new CqlCode("369833007", "http://snomed.info/sct", null, null),
+			new CqlCode("369834001", "http://snomed.info/sct", null, null),
+			new CqlCode("254292007", "http://snomed.info/sct", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Condition> Prostate_Cancer_Diagnosis_Value()
+	{
+		var a_ = this.Prostate_Cancer();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		bool? c_(Condition ProstateCancer)
+		{
+			var e_ = QICoreCommon_2_0_000.prevalenceInterval(ProstateCancer);
+			var f_ = this.Measurement_Period();
+			var g_ = context.Operators.Overlaps(e_, f_, "day");
+			var h_ = QICoreCommon_2_0_000.isProblemListItem(ProstateCancer);
+			var i_ = QICoreCommon_2_0_000.isHealthConcern(ProstateCancer);
+			var j_ = context.Operators.Or(h_, i_);
+			var k_ = context.Operators.And(g_, j_);
+			var l_ = QICoreCommon_2_0_000.isActive(ProstateCancer);
+			var m_ = context.Operators.And(k_, l_);
+
+			return m_;
+		};
+		var d_ = context.Operators.WhereOrNull<Condition>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Prostate Cancer Diagnosis")]
+	public IEnumerable<Condition> Prostate_Cancer_Diagnosis() => 
+		__Prostate_Cancer_Diagnosis.Value;
+
+	private bool? Has_Diagnosis_of_Pain_related_to_Prostate_Cancer_Value()
+	{
+		var a_ = this.Pain_Warranting_Further_Investigation_for_Prostate_Cancer();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_(Condition ProstateCancerPain)
+		{
+			var f_ = this.Prostate_Cancer_Diagnosis();
+			bool? g_(Condition ActiveProstateCancer)
+			{
+				var k_ = QICoreCommon_2_0_000.prevalenceInterval(ProstateCancerPain);
+				var l_ = context.Operators.Start(k_);
+				var m_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
+				var n_ = context.Operators.Start(m_);
+				var o_ = context.Operators.After(l_, n_, null);
+				var p_ = QICoreCommon_2_0_000.isProblemListItem(ProstateCancerPain);
+				var q_ = QICoreCommon_2_0_000.isHealthConcern(ProstateCancerPain);
+				var r_ = context.Operators.Or(p_, q_);
+				var s_ = context.Operators.And(o_, r_);
+				var t_ = QICoreCommon_2_0_000.isActive(ProstateCancerPain);
+				var u_ = context.Operators.And(s_, t_);
+
+				return u_;
+			};
+			var h_ = context.Operators.WhereOrNull<Condition>(f_, g_);
+			Condition i_(Condition ActiveProstateCancer) => 
+				ProstateCancerPain;
+			var j_ = context.Operators.SelectOrNull<Condition, Condition>(h_, i_);
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Condition, Condition>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Condition>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Diagnosis of Pain related to Prostate Cancer")]
+	public bool? Has_Diagnosis_of_Pain_related_to_Prostate_Cancer() => 
+		__Has_Diagnosis_of_Pain_related_to_Prostate_Cancer.Value;
+
+	private bool? Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis_Value()
+	{
+		var a_ = this.Salvage_Therapy();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_(Procedure SalvageTherapy)
+		{
+			var f_ = this.Prostate_Cancer_Diagnosis();
+			bool? g_(Condition ActiveProstateCancer)
+			{
+				var k_ = FHIRHelpers_4_3_000.ToValue(SalvageTherapy?.Performed);
+				var l_ = QICoreCommon_2_0_000.toInterval(k_);
+				var m_ = context.Operators.Start(l_);
+				var n_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
+				var o_ = context.Operators.Start(n_);
+				var p_ = context.Operators.After(m_, o_, null);
+				var q_ = context.Operators.EnumEqualsString(SalvageTherapy?.StatusElement?.Value, "completed");
+				var r_ = context.Operators.And(p_, q_);
+
+				return r_;
+			};
+			var h_ = context.Operators.WhereOrNull<Condition>(f_, g_);
+			Procedure i_(Condition ActiveProstateCancer) => 
+				SalvageTherapy;
+			var j_ = context.Operators.SelectOrNull<Condition, Procedure>(h_, i_);
+
+			return j_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Procedure, Procedure>(b_, c_);
+		var e_ = context.Operators.ExistsInList<Procedure>(d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Has Salvage Therapy Performed after Prostate Cancer Diagnosis")]
+	public bool? Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis() => 
+		__Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis.Value;
+
+	private IEnumerable<Observation> Bone_Scan_Study_Performed_Value()
+	{
+		var a_ = this.Bone_Scan();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_(Observation BoneScan)
+		{
+			var e_ = this.Prostate_Cancer_Diagnosis();
+			bool? f_(Condition ActiveProstateCancer)
+			{
+				var j_ = FHIRHelpers_4_3_000.ToValue(BoneScan?.Effective);
+				var k_ = QICoreCommon_2_0_000.toInterval(j_);
+				var l_ = context.Operators.Start(k_);
+				var m_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
+				var n_ = context.Operators.Start(m_);
+				var o_ = context.Operators.After(l_, n_, null);
+
+				return o_;
+			};
+			var g_ = context.Operators.WhereOrNull<Condition>(e_, f_);
+			Observation h_(Condition ActiveProstateCancer) => 
+				BoneScan;
+			var i_ = context.Operators.SelectOrNull<Condition, Observation>(g_, h_);
+
+			return i_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Observation, Observation>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Bone Scan Study Performed")]
+	public IEnumerable<Observation> Bone_Scan_Study_Performed() => 
+		__Bone_Scan_Study_Performed.Value;
+
+	private bool? Has_Bone_Scan_Study_Performed_with_Documented_Reason_Value()
+	{
+		var a_ = this.Bone_Scan_Study_Performed();
+		bool? b_(Observation BoneScanAfterDiagnosis)
+		{
+			var e_ = FHIRHelpers_4_3_000.ToValue(BoneScanAfterDiagnosis?.Value);
+			var f_ = this.Procedure_reason_record__record_artifact_();
+			var g_ = context.Operators.ConvertCodeToConcept(f_);
+			var h_ = context.Operators.Equivalent((e_ as CqlConcept), g_);
+
+			return h_;
+		};
+		var c_ = context.Operators.WhereOrNull<Observation>(a_, b_);
+		var d_ = context.Operators.ExistsInList<Observation>(c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Has Bone Scan Study Performed with Documented Reason")]
+	public bool? Has_Bone_Scan_Study_Performed_with_Documented_Reason() => 
+		__Has_Bone_Scan_Study_Performed_with_Documented_Reason.Value;
+
+	private bool? Denominator_Exceptions_Value()
+	{
+		var a_ = this.Has_Diagnosis_of_Pain_related_to_Prostate_Cancer();
+		var b_ = this.Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis();
+		var c_ = context.Operators.Or(a_, b_);
+		var d_ = this.Has_Bone_Scan_Study_Performed_with_Documented_Reason();
+		var e_ = context.Operators.Or(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Denominator Exceptions")]
+	public bool? Denominator_Exceptions() => 
+		__Denominator_Exceptions.Value;
+
+	private Procedure First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period_Value()
+	{
+		var a_ = this.Prostate_Cancer_Treatment();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		bool? c_(Procedure ProstateCancerTreatment)
+		{
+			var h_ = FHIRHelpers_4_3_000.ToValue(ProstateCancerTreatment?.Performed);
+			var i_ = QICoreCommon_2_0_000.toInterval(h_);
+			var j_ = context.Operators.End(i_);
+			var k_ = this.Measurement_Period();
+			var l_ = context.Operators.ElementInInterval<CqlDateTime>(j_, k_, "day");
+			var m_ = context.Operators.EnumEqualsString(ProstateCancerTreatment?.StatusElement?.Value, "completed");
+			var n_ = context.Operators.And(l_, m_);
+
+			return n_;
+		};
+		var d_ = context.Operators.WhereOrNull<Procedure>(b_, c_);
+		object e_(Procedure @this)
+		{
+			var o_ = FHIRHelpers_4_3_000.ToValue(@this?.Performed);
+			var p_ = QICoreCommon_2_0_000.toInterval(o_);
+			var q_ = context.Operators.Start(p_);
+
+			return q_;
+		};
+		var f_ = context.Operators.ListSortBy<Procedure>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		var g_ = context.Operators.FirstOfList<Procedure>(f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("First Prostate Cancer Treatment during day of Measurement Period")]
+	public Procedure First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period() => 
+		__First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Prostate_Cancer_Diagnosis();
+		var b_ = context.Operators.ExistsInList<Condition>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Most_Recent_Gleason_Score_is_Low_Value()
+	{
+		var a_ = this.Gleason_score_in_Specimen_Qualitative();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_(Observation GleasonScore)
+		{
+			var m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
+			var n_ = new Procedure[]
+			{
+				m_,
+			};
+			bool? o_(Procedure FirstProstateCancerTreatment)
+			{
+				var s_ = FHIRHelpers_4_3_000.ToValue(GleasonScore?.Effective);
+				var t_ = QICoreCommon_2_0_000.toInterval(s_);
+				var u_ = context.Operators.Start(t_);
+				var v_ = FHIRHelpers_4_3_000.ToValue(FirstProstateCancerTreatment?.Performed);
+				var w_ = QICoreCommon_2_0_000.toInterval(v_);
+				var x_ = context.Operators.Start(w_);
+				var y_ = context.Operators.Before(u_, x_, null);
+				var z_ = context.Operators.Convert<Code<ObservationStatus>>(GleasonScore?.StatusElement?.Value);
+				var aa_ = context.Operators.Convert<string>(z_);
+				var ab_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var ac_ = context.Operators.InList<string>(aa_, (ab_ as IEnumerable<string>));
+				var ad_ = context.Operators.And(y_, ac_);
+
+				return ad_;
+			};
+			var p_ = context.Operators.WhereOrNull<Procedure>(n_, o_);
+			Observation q_(Procedure FirstProstateCancerTreatment) => 
+				GleasonScore;
+			var r_ = context.Operators.SelectOrNull<Procedure, Observation>(p_, q_);
+
+			return r_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<Observation, Observation>(c_, d_);
+		object f_(Observation @this)
+		{
+			var ae_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var af_ = QICoreCommon_2_0_000.toInterval(ae_);
+			var ag_ = context.Operators.Start(af_);
+
+			return ag_;
+		};
+		var g_ = context.Operators.ListSortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		var h_ = context.Operators.LastOfList<Observation>(g_);
+		var i_ = new Observation[]
+		{
+			h_,
+		};
+		bool? j_(Observation LastGleasonScore)
+		{
+			var ah_ = FHIRHelpers_4_3_000.ToValue(LastGleasonScore?.Value);
+			var ai_ = context.Operators.LessOrEqual((int?)ah_, (int?)6);
+
+			return ai_;
+		};
+		var k_ = context.Operators.SelectOrNull<Observation, bool?>(i_, j_);
+		var l_ = context.Operators.SingleOrNull<bool?>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Most Recent Gleason Score is Low")]
+	public bool? Most_Recent_Gleason_Score_is_Low() => 
+		__Most_Recent_Gleason_Score_is_Low.Value;
+
+	private Observation Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a_Value()
+	{
+		var a_ = this.Tumor_staging__tumor_staging_();
+		var b_ = context.Operators.ToList<CqlCode>(a_);
+		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_(Observation ProstateCancerStaging)
+		{
+			var m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
+			var n_ = new Procedure[]
+			{
+				m_,
+			};
+			bool? o_(Procedure FirstProstateCancerTreatment)
+			{
+				var s_ = FHIRHelpers_4_3_000.ToValue(ProstateCancerStaging?.Effective);
+				var t_ = QICoreCommon_2_0_000.toInterval(s_);
+				var u_ = context.Operators.Start(t_);
+				var v_ = FHIRHelpers_4_3_000.ToValue(FirstProstateCancerTreatment?.Performed);
+				var w_ = QICoreCommon_2_0_000.toInterval(v_);
+				var x_ = context.Operators.Start(w_);
+				var y_ = context.Operators.Before(u_, x_, null);
+				var z_ = context.Operators.Convert<Code<ObservationStatus>>(ProstateCancerStaging?.StatusElement?.Value);
+				var aa_ = context.Operators.Convert<string>(z_);
+				var ab_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var ac_ = context.Operators.InList<string>(aa_, (ab_ as IEnumerable<string>));
+				var ad_ = context.Operators.And(y_, ac_);
+
+				return ad_;
+			};
+			var p_ = context.Operators.WhereOrNull<Procedure>(n_, o_);
+			Observation q_(Procedure FirstProstateCancerTreatment) => 
+				ProstateCancerStaging;
+			var r_ = context.Operators.SelectOrNull<Procedure, Observation>(p_, q_);
+
+			return r_;
+		};
+		var e_ = context.Operators.SelectManyOrNull<Observation, Observation>(c_, d_);
+		object f_(Observation @this)
+		{
+			var ae_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var af_ = QICoreCommon_2_0_000.toInterval(ae_);
+			var ag_ = context.Operators.Start(af_);
+
+			return ag_;
+		};
+		var g_ = context.Operators.ListSortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		var h_ = context.Operators.LastOfList<Observation>(g_);
+		var i_ = new Observation[]
+		{
+			h_,
+		};
+		bool? j_(Observation LastProstateCancerStaging)
+		{
+			var ah_ = FHIRHelpers_4_3_000.ToValue(LastProstateCancerStaging?.Value);
+			var ai_ = this.T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_();
+			var aj_ = context.Operators.ConvertCodeToConcept(ai_);
+			var ak_ = context.Operators.Equivalent((ah_ as CqlConcept), aj_);
+			var am_ = this.T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_();
+			var an_ = context.Operators.ConvertCodeToConcept(am_);
+			var ao_ = context.Operators.Equivalent((ah_ as CqlConcept), an_);
+			var ap_ = context.Operators.Or(ak_, ao_);
+			var ar_ = this.Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_();
+			var as_ = context.Operators.ConvertCodeToConcept(ar_);
+			var at_ = context.Operators.Equivalent((ah_ as CqlConcept), as_);
+			var au_ = context.Operators.Or(ap_, at_);
+			var aw_ = this.Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_();
+			var ax_ = context.Operators.ConvertCodeToConcept(aw_);
+			var ay_ = context.Operators.Equivalent((ah_ as CqlConcept), ax_);
+			var az_ = context.Operators.Or(au_, ay_);
+
+			return az_;
+		};
+		var k_ = context.Operators.WhereOrNull<Observation>(i_, j_);
+		var l_ = context.Operators.SingleOrNull<Observation>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Most Recent Prostate Cancer Staging Tumor Size T1a to T2a")]
+	public Observation Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a() => 
+		__Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a.Value;
+
+	private bool? Numerator_Value()
+	{
+		var a_ = this.Bone_Scan_Study_Performed();
+		var b_ = context.Operators.ExistsInList<Observation>(a_);
+		var c_ = context.Operators.Not(b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator.Value;
+
+	private bool? Most_Recent_PSA_Test_Result_is_Low_Value()
+	{
+		var a_ = this.Prostate_Specific_Antigen_Test();
+		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_(Observation PSATest)
+		{
+			var l_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a();
+			var m_ = new Observation[]
+			{
+				l_,
+			};
+			bool? n_(Observation MostRecentProstateCancerStaging)
+			{
+				CqlInterval<CqlDateTime> r_()
+				{
+					if ((context.Operators.Start(QICoreCommon_2_0_000.toInterval(FHIRHelpers_4_3_000.ToValue(PSATest?.Effective))) is null))
+					{
+						return null;
+					}
+					else
+					{
+						var aa_ = FHIRHelpers_4_3_000.ToValue(PSATest?.Effective);
+						var ab_ = QICoreCommon_2_0_000.toInterval(aa_);
+						var ac_ = context.Operators.Start(ab_);
+						var ae_ = QICoreCommon_2_0_000.toInterval(aa_);
+						var af_ = context.Operators.Start(ae_);
+						var ag_ = context.Operators.Interval(ac_, af_, true, true);
+
+						return ag_;
+					};
+				};
+				var s_ = FHIRHelpers_4_3_000.ToValue(MostRecentProstateCancerStaging?.Effective);
+				var t_ = QICoreCommon_2_0_000.toInterval(s_);
+				var u_ = context.Operators.IntervalBeforeInterval(r_(), t_, null);
+				var v_ = context.Operators.Convert<Code<ObservationStatus>>(PSATest?.StatusElement?.Value);
+				var w_ = context.Operators.Convert<string>(v_);
+				var x_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var y_ = context.Operators.InList<string>(w_, (x_ as IEnumerable<string>));
+				var z_ = context.Operators.And(u_, y_);
+
+				return z_;
+			};
+			var o_ = context.Operators.WhereOrNull<Observation>(m_, n_);
+			Observation p_(Observation MostRecentProstateCancerStaging) => 
+				PSATest;
+			var q_ = context.Operators.SelectOrNull<Observation, Observation>(o_, p_);
+
+			return q_;
+		};
+		var d_ = context.Operators.SelectManyOrNull<Observation, Observation>(b_, c_);
+		object e_(Observation @this)
+		{
+			var ah_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+			var ai_ = QICoreCommon_2_0_000.toInterval(ah_);
+			var aj_ = context.Operators.Start(ai_);
+
+			return aj_;
+		};
+		var f_ = context.Operators.ListSortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		var g_ = context.Operators.LastOfList<Observation>(f_);
+		var h_ = new Observation[]
+		{
+			g_,
+		};
+		bool? i_(Observation LastPSATest)
+		{
+			var ak_ = FHIRHelpers_4_3_000.ToValue(LastPSATest?.Value);
+			var al_ = context.Operators.Quantity(10m, "ng/mL");
+			var am_ = context.Operators.Less((ak_ as CqlQuantity), al_);
+
+			return am_;
+		};
+		var j_ = context.Operators.SelectOrNull<Observation, bool?>(h_, i_);
+		var k_ = context.Operators.SingleOrNull<bool?>(j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Most Recent PSA Test Result is Low")]
+	public bool? Most_Recent_PSA_Test_Result_is_Low() => 
+		__Most_Recent_PSA_Test_Result_is_Low.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+		var b_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
+		var c_ = context.Operators.Not((bool?)(b_ is null));
+		var d_ = context.Operators.And(a_, c_);
+		var e_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a();
+		var f_ = context.Operators.Not((bool?)(e_ is null));
+		var g_ = context.Operators.And(d_, f_);
+		var h_ = this.Most_Recent_PSA_Test_Result_is_Low();
+		var i_ = context.Operators.And(g_, h_);
+		var j_ = this.Most_Recent_Gleason_Score_is_Low();
+		var k_ = context.Operators.And(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+}

--- a/Demo/Measures-cms/SevereObstetricComplicationsFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/SevereObstetricComplicationsFHIR-0.1.000.g.cs
@@ -1,0 +1,2175 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("SevereObstetricComplicationsFHIR", "0.1.000")]
+public class SevereObstetricComplicationsFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> ___20_to_42_Plus_Weeks_Gestation;
+    internal Lazy<CqlValueSet> __Acute_or_Persistent_Asthma;
+    internal Lazy<CqlValueSet> __Anemia;
+    internal Lazy<CqlValueSet> __Autoimmune_Disease;
+    internal Lazy<CqlValueSet> __Bariatric_Surgery;
+    internal Lazy<CqlValueSet> __Bleeding_Disorder;
+    internal Lazy<CqlValueSet> __Blood_Transfusion;
+    internal Lazy<CqlValueSet> __Cardiac_Disease;
+    internal Lazy<CqlValueSet> __COVID_19_Confirmed;
+    internal Lazy<CqlValueSet> __Delivery_Procedures;
+    internal Lazy<CqlValueSet> __Economic_Housing_Instability;
+    internal Lazy<CqlValueSet> __ED_Visit_and_OB_Triage;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Gastrointestinal_Disease;
+    internal Lazy<CqlValueSet> __Gestational_Diabetes;
+    internal Lazy<CqlValueSet> __Hematocrit_lab_test;
+    internal Lazy<CqlValueSet> __HIV_in_Pregnancy_Childbirth_and_Puerperium;
+    internal Lazy<CqlValueSet> __Hypertension;
+    internal Lazy<CqlValueSet> __Long_Term_Anticoagulant_Use;
+    internal Lazy<CqlValueSet> __Mental_Health_Disorder;
+    internal Lazy<CqlValueSet> __Mild_or_Moderate_Preeclampsia;
+    internal Lazy<CqlValueSet> __Morbid_or_Severe_Obesity;
+    internal Lazy<CqlValueSet> __Multiple_Pregnancy;
+    internal Lazy<CqlValueSet> __Neuromuscular_Disease;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlValueSet> __Patient_Expired;
+    internal Lazy<CqlValueSet> __Placenta_Previa;
+    internal Lazy<CqlValueSet> __Placental_Abruption;
+    internal Lazy<CqlValueSet> __Placental_Accreta_Spectrum;
+    internal Lazy<CqlValueSet> __Preexisting_Diabetes;
+    internal Lazy<CqlValueSet> __Present_on_Admission_is_No_or_Unable_To_Determine;
+    internal Lazy<CqlValueSet> __Present_On_Admission_is_Yes_or_Exempt;
+    internal Lazy<CqlValueSet> __Preterm_Birth;
+    internal Lazy<CqlValueSet> __Previous_Cesarean;
+    internal Lazy<CqlValueSet> __Pulmonary_Hypertension;
+    internal Lazy<CqlValueSet> __Renal_Disease;
+    internal Lazy<CqlValueSet> __Respiratory_Conditions_Related_to_COVID_19;
+    internal Lazy<CqlValueSet> __Respiratory_Support_Procedures_Related_to_COVID_19;
+    internal Lazy<CqlValueSet> __Severe_Maternal_Morbidity_Diagnoses;
+    internal Lazy<CqlValueSet> __Severe_Maternal_Morbidity_Procedures;
+    internal Lazy<CqlValueSet> __Severe_Preeclampsia;
+    internal Lazy<CqlValueSet> __Substance_Abuse;
+    internal Lazy<CqlValueSet> __Thyrotoxicosis;
+    internal Lazy<CqlValueSet> __Venous_Thromboembolism_in_Pregnancy;
+    internal Lazy<CqlValueSet> __White_blood_cells_count_lab_test;
+    internal Lazy<CqlCode> __Heart_rate;
+    internal Lazy<CqlCode> __Systolic_blood_pressure;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_with_Expiration;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_with_Blood_Transfusion;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_with_Severe_Obstetric_Complications;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exclusion;
+    internal Lazy<IEnumerable<Encounter>> __Stratification_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions;
+    internal Lazy<IEnumerable<Encounter>> __Stratum_1;
+    internal Lazy<IEnumerable<Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM>> __Variable_Calculated_Gestational_Age;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Anemia;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Asthma;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Autoimmune_Disease;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Bariatric_Surgery;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Bleeding_Disorder;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Morbid_Obesity;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Cardiac_Disease;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Economic_Housing_Instability;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Gastrointestinal_Disease;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Gestational_Diabetes;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_HIV;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Hypertension;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Long_Term_Anticoagulant_Use;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Mental_Health_Disorder;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Multiple_Pregnancy;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Neuromuscular;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Obstetrical_VTE;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Placenta_Previa;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Placental_Abruption;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Placental_Accreta_Spectrum;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Preexisting_Diabetes;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Previous_Cesarean;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Pulmonary_Hypertension;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Renal_Disease;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Severe_Preeclampsia;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Substance_Abuse;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Thyrotoxicosis;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Other_Preeclampsia;
+    internal Lazy<IEnumerable<Encounter>> __Risk_Variable_Preterm_Birth;
+    internal Lazy<IEnumerable<Tuples.Tuple_BUSccGEhJLedCLcPKRPjDcPjV>> __Risk_Variable_First_Hematocrit_Lab_Test;
+    internal Lazy<IEnumerable<Tuples.Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA>> __Risk_Variable_First_White_Blood_Cell_Count_Lab_Test;
+    internal Lazy<IEnumerable<Tuples.Tuple_CYVVSdgZbMfXHMiBHjISgejQI>> __Risk_Variable_Heart_Rate;
+    internal Lazy<IEnumerable<Tuples.Tuple_DBZhWNcHciGGJUSXZKiOPXJYf>> __Risk_Variable_Systolic_Blood_Pressure;
+
+    #endregion
+    public SevereObstetricComplicationsFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        PCMaternal_5_16_000 = new PCMaternal_5_16_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+
+        ___20_to_42_Plus_Weeks_Gestation = new Lazy<CqlValueSet>(this._20_to_42_Plus_Weeks_Gestation_Value);
+        __Acute_or_Persistent_Asthma = new Lazy<CqlValueSet>(this.Acute_or_Persistent_Asthma_Value);
+        __Anemia = new Lazy<CqlValueSet>(this.Anemia_Value);
+        __Autoimmune_Disease = new Lazy<CqlValueSet>(this.Autoimmune_Disease_Value);
+        __Bariatric_Surgery = new Lazy<CqlValueSet>(this.Bariatric_Surgery_Value);
+        __Bleeding_Disorder = new Lazy<CqlValueSet>(this.Bleeding_Disorder_Value);
+        __Blood_Transfusion = new Lazy<CqlValueSet>(this.Blood_Transfusion_Value);
+        __Cardiac_Disease = new Lazy<CqlValueSet>(this.Cardiac_Disease_Value);
+        __COVID_19_Confirmed = new Lazy<CqlValueSet>(this.COVID_19_Confirmed_Value);
+        __Delivery_Procedures = new Lazy<CqlValueSet>(this.Delivery_Procedures_Value);
+        __Economic_Housing_Instability = new Lazy<CqlValueSet>(this.Economic_Housing_Instability_Value);
+        __ED_Visit_and_OB_Triage = new Lazy<CqlValueSet>(this.ED_Visit_and_OB_Triage_Value);
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value);
+        __Gastrointestinal_Disease = new Lazy<CqlValueSet>(this.Gastrointestinal_Disease_Value);
+        __Gestational_Diabetes = new Lazy<CqlValueSet>(this.Gestational_Diabetes_Value);
+        __Hematocrit_lab_test = new Lazy<CqlValueSet>(this.Hematocrit_lab_test_Value);
+        __HIV_in_Pregnancy_Childbirth_and_Puerperium = new Lazy<CqlValueSet>(this.HIV_in_Pregnancy_Childbirth_and_Puerperium_Value);
+        __Hypertension = new Lazy<CqlValueSet>(this.Hypertension_Value);
+        __Long_Term_Anticoagulant_Use = new Lazy<CqlValueSet>(this.Long_Term_Anticoagulant_Use_Value);
+        __Mental_Health_Disorder = new Lazy<CqlValueSet>(this.Mental_Health_Disorder_Value);
+        __Mild_or_Moderate_Preeclampsia = new Lazy<CqlValueSet>(this.Mild_or_Moderate_Preeclampsia_Value);
+        __Morbid_or_Severe_Obesity = new Lazy<CqlValueSet>(this.Morbid_or_Severe_Obesity_Value);
+        __Multiple_Pregnancy = new Lazy<CqlValueSet>(this.Multiple_Pregnancy_Value);
+        __Neuromuscular_Disease = new Lazy<CqlValueSet>(this.Neuromuscular_Disease_Value);
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value);
+        __Patient_Expired = new Lazy<CqlValueSet>(this.Patient_Expired_Value);
+        __Placenta_Previa = new Lazy<CqlValueSet>(this.Placenta_Previa_Value);
+        __Placental_Abruption = new Lazy<CqlValueSet>(this.Placental_Abruption_Value);
+        __Placental_Accreta_Spectrum = new Lazy<CqlValueSet>(this.Placental_Accreta_Spectrum_Value);
+        __Preexisting_Diabetes = new Lazy<CqlValueSet>(this.Preexisting_Diabetes_Value);
+        __Present_on_Admission_is_No_or_Unable_To_Determine = new Lazy<CqlValueSet>(this.Present_on_Admission_is_No_or_Unable_To_Determine_Value);
+        __Present_On_Admission_is_Yes_or_Exempt = new Lazy<CqlValueSet>(this.Present_On_Admission_is_Yes_or_Exempt_Value);
+        __Preterm_Birth = new Lazy<CqlValueSet>(this.Preterm_Birth_Value);
+        __Previous_Cesarean = new Lazy<CqlValueSet>(this.Previous_Cesarean_Value);
+        __Pulmonary_Hypertension = new Lazy<CqlValueSet>(this.Pulmonary_Hypertension_Value);
+        __Renal_Disease = new Lazy<CqlValueSet>(this.Renal_Disease_Value);
+        __Respiratory_Conditions_Related_to_COVID_19 = new Lazy<CqlValueSet>(this.Respiratory_Conditions_Related_to_COVID_19_Value);
+        __Respiratory_Support_Procedures_Related_to_COVID_19 = new Lazy<CqlValueSet>(this.Respiratory_Support_Procedures_Related_to_COVID_19_Value);
+        __Severe_Maternal_Morbidity_Diagnoses = new Lazy<CqlValueSet>(this.Severe_Maternal_Morbidity_Diagnoses_Value);
+        __Severe_Maternal_Morbidity_Procedures = new Lazy<CqlValueSet>(this.Severe_Maternal_Morbidity_Procedures_Value);
+        __Severe_Preeclampsia = new Lazy<CqlValueSet>(this.Severe_Preeclampsia_Value);
+        __Substance_Abuse = new Lazy<CqlValueSet>(this.Substance_Abuse_Value);
+        __Thyrotoxicosis = new Lazy<CqlValueSet>(this.Thyrotoxicosis_Value);
+        __Venous_Thromboembolism_in_Pregnancy = new Lazy<CqlValueSet>(this.Venous_Thromboembolism_in_Pregnancy_Value);
+        __White_blood_cells_count_lab_test = new Lazy<CqlValueSet>(this.White_blood_cells_count_lab_test_Value);
+        __Heart_rate = new Lazy<CqlCode>(this.Heart_rate_Value);
+        __Systolic_blood_pressure = new Lazy<CqlCode>(this.Systolic_blood_pressure_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Value);
+        __Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks_Value);
+        __Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding_Value);
+        __Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation_Value);
+        __Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion_Value);
+        __Delivery_Encounters_with_Expiration = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_with_Expiration_Value);
+        __Delivery_Encounters_with_Blood_Transfusion = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_with_Blood_Transfusion_Value);
+        __Delivery_Encounters_with_Severe_Obstetric_Complications = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_with_Severe_Obstetric_Complications_Value);
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value);
+        __Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure_Value);
+        __Denominator_Exclusion = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exclusion_Value);
+        __Stratification_Encounter = new Lazy<IEnumerable<Encounter>>(this.Stratification_Encounter_Value);
+        __Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions = new Lazy<IEnumerable<Encounter>>(this.Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions_Value);
+        __Stratum_1 = new Lazy<IEnumerable<Encounter>>(this.Stratum_1_Value);
+        __Variable_Calculated_Gestational_Age = new Lazy<IEnumerable<Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM>>(this.Variable_Calculated_Gestational_Age_Value);
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value);
+        __Risk_Variable_Anemia = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Anemia_Value);
+        __Risk_Variable_Asthma = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Asthma_Value);
+        __Risk_Variable_Autoimmune_Disease = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Autoimmune_Disease_Value);
+        __Risk_Variable_Bariatric_Surgery = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Bariatric_Surgery_Value);
+        __Risk_Variable_Bleeding_Disorder = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Bleeding_Disorder_Value);
+        __Risk_Variable_Morbid_Obesity = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Morbid_Obesity_Value);
+        __Risk_Variable_Cardiac_Disease = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Cardiac_Disease_Value);
+        __Risk_Variable_Economic_Housing_Instability = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Economic_Housing_Instability_Value);
+        __Risk_Variable_Gastrointestinal_Disease = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Gastrointestinal_Disease_Value);
+        __Risk_Variable_Gestational_Diabetes = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Gestational_Diabetes_Value);
+        __Risk_Variable_HIV = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_HIV_Value);
+        __Risk_Variable_Hypertension = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Hypertension_Value);
+        __Risk_Variable_Long_Term_Anticoagulant_Use = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Long_Term_Anticoagulant_Use_Value);
+        __Risk_Variable_Mental_Health_Disorder = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Mental_Health_Disorder_Value);
+        __Risk_Variable_Multiple_Pregnancy = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Multiple_Pregnancy_Value);
+        __Risk_Variable_Neuromuscular = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Neuromuscular_Value);
+        __Risk_Variable_Obstetrical_VTE = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Obstetrical_VTE_Value);
+        __Risk_Variable_Placenta_Previa = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Placenta_Previa_Value);
+        __Risk_Variable_Placental_Abruption = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Placental_Abruption_Value);
+        __Risk_Variable_Placental_Accreta_Spectrum = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Placental_Accreta_Spectrum_Value);
+        __Risk_Variable_Preexisting_Diabetes = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Preexisting_Diabetes_Value);
+        __Risk_Variable_Previous_Cesarean = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Previous_Cesarean_Value);
+        __Risk_Variable_Pulmonary_Hypertension = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Pulmonary_Hypertension_Value);
+        __Risk_Variable_Renal_Disease = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Renal_Disease_Value);
+        __Risk_Variable_Severe_Preeclampsia = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Severe_Preeclampsia_Value);
+        __Risk_Variable_Substance_Abuse = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Substance_Abuse_Value);
+        __Risk_Variable_Thyrotoxicosis = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Thyrotoxicosis_Value);
+        __Risk_Variable_Other_Preeclampsia = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Other_Preeclampsia_Value);
+        __Risk_Variable_Preterm_Birth = new Lazy<IEnumerable<Encounter>>(this.Risk_Variable_Preterm_Birth_Value);
+        __Risk_Variable_First_Hematocrit_Lab_Test = new Lazy<IEnumerable<Tuples.Tuple_BUSccGEhJLedCLcPKRPjDcPjV>>(this.Risk_Variable_First_Hematocrit_Lab_Test_Value);
+        __Risk_Variable_First_White_Blood_Cell_Count_Lab_Test = new Lazy<IEnumerable<Tuples.Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA>>(this.Risk_Variable_First_White_Blood_Cell_Count_Lab_Test_Value);
+        __Risk_Variable_Heart_Rate = new Lazy<IEnumerable<Tuples.Tuple_CYVVSdgZbMfXHMiBHjISgejQI>>(this.Risk_Variable_Heart_Rate_Value);
+        __Risk_Variable_Systolic_Blood_Pressure = new Lazy<IEnumerable<Tuples.Tuple_DBZhWNcHciGGJUSXZKiOPXJYf>>(this.Risk_Variable_Systolic_Blood_Pressure_Value);
+    }
+    #region Dependencies
+
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public PCMaternal_5_16_000 PCMaternal_5_16_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet _20_to_42_Plus_Weeks_Gestation_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67", null);
+
+    [CqlDeclaration("20 to 42 Plus Weeks Gestation")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67")]
+	public CqlValueSet _20_to_42_Plus_Weeks_Gestation() => 
+		___20_to_42_Plus_Weeks_Gestation.Value;
+
+	private CqlValueSet Acute_or_Persistent_Asthma_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271", null);
+
+    [CqlDeclaration("Acute or Persistent Asthma")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271")]
+	public CqlValueSet Acute_or_Persistent_Asthma() => 
+		__Acute_or_Persistent_Asthma.Value;
+
+	private CqlValueSet Anemia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323", null);
+
+    [CqlDeclaration("Anemia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323")]
+	public CqlValueSet Anemia() => 
+		__Anemia.Value;
+
+	private CqlValueSet Autoimmune_Disease_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311", null);
+
+    [CqlDeclaration("Autoimmune Disease")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311")]
+	public CqlValueSet Autoimmune_Disease() => 
+		__Autoimmune_Disease.Value;
+
+	private CqlValueSet Bariatric_Surgery_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317", null);
+
+    [CqlDeclaration("Bariatric Surgery")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317")]
+	public CqlValueSet Bariatric_Surgery() => 
+		__Bariatric_Surgery.Value;
+
+	private CqlValueSet Bleeding_Disorder_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287", null);
+
+    [CqlDeclaration("Bleeding Disorder")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287")]
+	public CqlValueSet Bleeding_Disorder() => 
+		__Bleeding_Disorder.Value;
+
+	private CqlValueSet Blood_Transfusion_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213", null);
+
+    [CqlDeclaration("Blood Transfusion")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213")]
+	public CqlValueSet Blood_Transfusion() => 
+		__Blood_Transfusion.Value;
+
+	private CqlValueSet Cardiac_Disease_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341", null);
+
+    [CqlDeclaration("Cardiac Disease")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341")]
+	public CqlValueSet Cardiac_Disease() => 
+		__Cardiac_Disease.Value;
+
+	private CqlValueSet COVID_19_Confirmed_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373", null);
+
+    [CqlDeclaration("COVID 19 Confirmed")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373")]
+	public CqlValueSet COVID_19_Confirmed() => 
+		__COVID_19_Confirmed.Value;
+
+	private CqlValueSet Delivery_Procedures_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", null);
+
+    [CqlDeclaration("Delivery Procedures")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
+	public CqlValueSet Delivery_Procedures() => 
+		__Delivery_Procedures.Value;
+
+	private CqlValueSet Economic_Housing_Instability_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292", null);
+
+    [CqlDeclaration("Economic Housing Instability")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292")]
+	public CqlValueSet Economic_Housing_Instability() => 
+		__Economic_Housing_Instability.Value;
+
+	private CqlValueSet ED_Visit_and_OB_Triage_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", null);
+
+    [CqlDeclaration("ED Visit and OB Triage")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369")]
+	public CqlValueSet ED_Visit_and_OB_Triage() => 
+		__ED_Visit_and_OB_Triage.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+
+    [CqlDeclaration("Emergency Department Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit.Value;
+
+	private CqlValueSet Gastrointestinal_Disease_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338", null);
+
+    [CqlDeclaration("Gastrointestinal Disease")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338")]
+	public CqlValueSet Gastrointestinal_Disease() => 
+		__Gastrointestinal_Disease.Value;
+
+	private CqlValueSet Gestational_Diabetes_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269", null);
+
+    [CqlDeclaration("Gestational Diabetes")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269")]
+	public CqlValueSet Gestational_Diabetes() => 
+		__Gestational_Diabetes.Value;
+
+	private CqlValueSet Hematocrit_lab_test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
+
+    [CqlDeclaration("Hematocrit lab test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
+	public CqlValueSet Hematocrit_lab_test() => 
+		__Hematocrit_lab_test.Value;
+
+	private CqlValueSet HIV_in_Pregnancy_Childbirth_and_Puerperium_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272", null);
+
+    [CqlDeclaration("HIV in Pregnancy Childbirth and Puerperium")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272")]
+	public CqlValueSet HIV_in_Pregnancy_Childbirth_and_Puerperium() => 
+		__HIV_in_Pregnancy_Childbirth_and_Puerperium.Value;
+
+	private CqlValueSet Hypertension_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332", null);
+
+    [CqlDeclaration("Hypertension")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332")]
+	public CqlValueSet Hypertension() => 
+		__Hypertension.Value;
+
+	private CqlValueSet Long_Term_Anticoagulant_Use_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366", null);
+
+    [CqlDeclaration("Long Term Anticoagulant Use")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366")]
+	public CqlValueSet Long_Term_Anticoagulant_Use() => 
+		__Long_Term_Anticoagulant_Use.Value;
+
+	private CqlValueSet Mental_Health_Disorder_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314", null);
+
+    [CqlDeclaration("Mental Health Disorder")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314")]
+	public CqlValueSet Mental_Health_Disorder() => 
+		__Mental_Health_Disorder.Value;
+
+	private CqlValueSet Mild_or_Moderate_Preeclampsia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329", null);
+
+    [CqlDeclaration("Mild or Moderate Preeclampsia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329")]
+	public CqlValueSet Mild_or_Moderate_Preeclampsia() => 
+		__Mild_or_Moderate_Preeclampsia.Value;
+
+	private CqlValueSet Morbid_or_Severe_Obesity_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290", null);
+
+    [CqlDeclaration("Morbid or Severe Obesity")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290")]
+	public CqlValueSet Morbid_or_Severe_Obesity() => 
+		__Morbid_or_Severe_Obesity.Value;
+
+	private CqlValueSet Multiple_Pregnancy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284", null);
+
+    [CqlDeclaration("Multiple Pregnancy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284")]
+	public CqlValueSet Multiple_Pregnancy() => 
+		__Multiple_Pregnancy.Value;
+
+	private CqlValueSet Neuromuscular_Disease_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308", null);
+
+    [CqlDeclaration("Neuromuscular Disease")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308")]
+	public CqlValueSet Neuromuscular_Disease() => 
+		__Neuromuscular_Disease.Value;
+
+	private CqlValueSet Observation_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+
+    [CqlDeclaration("Observation Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services.Value;
+
+	private CqlValueSet Patient_Expired_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+
+    [CqlDeclaration("Patient Expired")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
+	public CqlValueSet Patient_Expired() => 
+		__Patient_Expired.Value;
+
+	private CqlValueSet Placenta_Previa_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35", null);
+
+    [CqlDeclaration("Placenta Previa")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35")]
+	public CqlValueSet Placenta_Previa() => 
+		__Placenta_Previa.Value;
+
+	private CqlValueSet Placental_Abruption_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305", null);
+
+    [CqlDeclaration("Placental Abruption")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305")]
+	public CqlValueSet Placental_Abruption() => 
+		__Placental_Abruption.Value;
+
+	private CqlValueSet Placental_Accreta_Spectrum_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302", null);
+
+    [CqlDeclaration("Placental Accreta Spectrum")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302")]
+	public CqlValueSet Placental_Accreta_Spectrum() => 
+		__Placental_Accreta_Spectrum.Value;
+
+	private CqlValueSet Preexisting_Diabetes_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275", null);
+
+    [CqlDeclaration("Preexisting Diabetes")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275")]
+	public CqlValueSet Preexisting_Diabetes() => 
+		__Preexisting_Diabetes.Value;
+
+	private CqlValueSet Present_on_Admission_is_No_or_Unable_To_Determine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370", null);
+
+    [CqlDeclaration("Present on Admission is No or Unable To Determine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370")]
+	public CqlValueSet Present_on_Admission_is_No_or_Unable_To_Determine() => 
+		__Present_on_Admission_is_No_or_Unable_To_Determine.Value;
+
+	private CqlValueSet Present_On_Admission_is_Yes_or_Exempt_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63", null);
+
+    [CqlDeclaration("Present On Admission is Yes or Exempt")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63")]
+	public CqlValueSet Present_On_Admission_is_Yes_or_Exempt() => 
+		__Present_On_Admission_is_Yes_or_Exempt.Value;
+
+	private CqlValueSet Preterm_Birth_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299", null);
+
+    [CqlDeclaration("Preterm Birth")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299")]
+	public CqlValueSet Preterm_Birth() => 
+		__Preterm_Birth.Value;
+
+	private CqlValueSet Previous_Cesarean_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278", null);
+
+    [CqlDeclaration("Previous Cesarean")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278")]
+	public CqlValueSet Previous_Cesarean() => 
+		__Previous_Cesarean.Value;
+
+	private CqlValueSet Pulmonary_Hypertension_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281", null);
+
+    [CqlDeclaration("Pulmonary Hypertension")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281")]
+	public CqlValueSet Pulmonary_Hypertension() => 
+		__Pulmonary_Hypertension.Value;
+
+	private CqlValueSet Renal_Disease_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335", null);
+
+    [CqlDeclaration("Renal Disease")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335")]
+	public CqlValueSet Renal_Disease() => 
+		__Renal_Disease.Value;
+
+	private CqlValueSet Respiratory_Conditions_Related_to_COVID_19_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376", null);
+
+    [CqlDeclaration("Respiratory Conditions Related to COVID 19")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376")]
+	public CqlValueSet Respiratory_Conditions_Related_to_COVID_19() => 
+		__Respiratory_Conditions_Related_to_COVID_19.Value;
+
+	private CqlValueSet Respiratory_Support_Procedures_Related_to_COVID_19_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379", null);
+
+    [CqlDeclaration("Respiratory Support Procedures Related to COVID 19")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379")]
+	public CqlValueSet Respiratory_Support_Procedures_Related_to_COVID_19() => 
+		__Respiratory_Support_Procedures_Related_to_COVID_19.Value;
+
+	private CqlValueSet Severe_Maternal_Morbidity_Diagnoses_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255", null);
+
+    [CqlDeclaration("Severe Maternal Morbidity Diagnoses")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255")]
+	public CqlValueSet Severe_Maternal_Morbidity_Diagnoses() => 
+		__Severe_Maternal_Morbidity_Diagnoses.Value;
+
+	private CqlValueSet Severe_Maternal_Morbidity_Procedures_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256", null);
+
+    [CqlDeclaration("Severe Maternal Morbidity Procedures")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256")]
+	public CqlValueSet Severe_Maternal_Morbidity_Procedures() => 
+		__Severe_Maternal_Morbidity_Procedures.Value;
+
+	private CqlValueSet Severe_Preeclampsia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327", null);
+
+    [CqlDeclaration("Severe Preeclampsia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327")]
+	public CqlValueSet Severe_Preeclampsia() => 
+		__Severe_Preeclampsia.Value;
+
+	private CqlValueSet Substance_Abuse_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320", null);
+
+    [CqlDeclaration("Substance Abuse")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320")]
+	public CqlValueSet Substance_Abuse() => 
+		__Substance_Abuse.Value;
+
+	private CqlValueSet Thyrotoxicosis_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296", null);
+
+    [CqlDeclaration("Thyrotoxicosis")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296")]
+	public CqlValueSet Thyrotoxicosis() => 
+		__Thyrotoxicosis.Value;
+
+	private CqlValueSet Venous_Thromboembolism_in_Pregnancy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363", null);
+
+    [CqlDeclaration("Venous Thromboembolism in Pregnancy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363")]
+	public CqlValueSet Venous_Thromboembolism_in_Pregnancy() => 
+		__Venous_Thromboembolism_in_Pregnancy.Value;
+
+	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
+
+    [CqlDeclaration("White blood cells count lab test")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
+	public CqlValueSet White_blood_cells_count_lab_test() => 
+		__White_blood_cells_count_lab_test.Value;
+
+	private CqlCode Heart_rate_Value() => 
+		new CqlCode("8867-4", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Heart rate")]
+	public CqlCode Heart_rate() => 
+		__Heart_rate.Value;
+
+	private CqlCode Systolic_blood_pressure_Value() => 
+		new CqlCode("8480-6", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Systolic blood pressure")]
+	public CqlCode Systolic_blood_pressure() => 
+		__Systolic_blood_pressure.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("8867-4", "http://loinc.org", null, null),
+			new CqlCode("8480-6", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] SNOMEDCT_Value()
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("SevereObstetricComplicationsFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Value()
+	{
+		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		bool? b_(Encounter DeliveryEncounter)
+		{
+			var d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			var e_ = context.Operators.GreaterOrEqual(d_, (int?)20);
+
+			return e_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Delivery Encounters with Calculated Gestational Age Greater than or Equal to 20 Weeks")]
+	public IEnumerable<Encounter> Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks() => 
+		__Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks_Value()
+	{
+		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		bool? b_(Encounter DeliveryEncounter)
+		{
+			var d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			var e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			var f_ = context.Operators.Quantity(20m, "weeks");
+			var g_ = context.Operators.GreaterOrEqual(e_, f_);
+			var h_ = context.Operators.And((bool?)(d_ is null), g_);
+
+			return h_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Delivery Encounters with Estimated Gestational Age Assessment Greater than or Equal to 20 Weeks")]
+	public IEnumerable<Encounter> Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks() => 
+		__Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding_Value()
+	{
+		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		bool? b_(Encounter DeliveryEncounter)
+		{
+			var d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			var e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			var f_ = context.Operators.And((bool?)(d_ is null), (bool?)(e_ is null));
+			var g_ = CQMCommon_2_0_000.encounterDiagnosis(DeliveryEncounter);
+			bool? h_(Condition EncounterDiagnosis)
+			{
+				var l_ = FHIRHelpers_4_3_000.ToConcept(EncounterDiagnosis?.Code);
+				var m_ = this._20_to_42_Plus_Weeks_Gestation();
+				var n_ = context.Operators.ConceptInValueSet(l_, m_);
+
+				return n_;
+			};
+			var i_ = context.Operators.WhereOrNull<Condition>(g_, h_);
+			var j_ = context.Operators.ExistsInList<Condition>(i_);
+			var k_ = context.Operators.And(f_, j_);
+
+			return k_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Delivery Encounters with Gestational Age Greater than or Equal to 20 Weeks Based on Coding")]
+	public IEnumerable<Encounter> Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding() => 
+		__Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation_Value()
+	{
+		var a_ = this.Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks();
+		var b_ = this.Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+		var d_ = this.Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding();
+		var e_ = context.Operators.ListUnion<Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Delivery Encounters At Greater than or Equal to 20 Weeks Gestation")]
+	public IEnumerable<Encounter> Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation() => 
+		__Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			bool? d_(Encounter.DiagnosisComponent EncounterDiagnoses)
+			{
+				var m_ = CQMCommon_2_0_000.getCondition(EncounterDiagnoses?.Condition);
+				var n_ = FHIRHelpers_4_3_000.ToConcept(m_?.Code);
+				var o_ = this.Severe_Maternal_Morbidity_Diagnoses();
+				var p_ = context.Operators.ConceptInValueSet(n_, o_);
+				bool? q_(Extension @this)
+				{
+					var aa_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+
+					return aa_;
+				};
+				var r_ = context.Operators.WhereOrNull<Extension>(((EncounterDiagnoses is Element)
+						? ((EncounterDiagnoses as Element).Extension)
+						: null), q_);
+				DataType s_(Extension @this) => 
+					@this?.Value;
+				var t_ = context.Operators.SelectOrNull<Extension, DataType>(r_, s_);
+				var u_ = context.Operators.SingleOrNull<DataType>(t_);
+				var v_ = context.Operators.Convert<CodeableConcept>(u_);
+				var w_ = FHIRHelpers_4_3_000.ToConcept(v_);
+				var x_ = this.Present_on_Admission_is_No_or_Unable_To_Determine();
+				var y_ = context.Operators.ConceptInValueSet(w_, x_);
+				var z_ = context.Operators.And(p_, y_);
+
+				return z_;
+			};
+			var e_ = context.Operators.WhereOrNull<Encounter.DiagnosisComponent>((TwentyWeeksPlusEncounter?.Diagnosis as IEnumerable<Encounter.DiagnosisComponent>), d_);
+			var f_ = context.Operators.ExistsInList<Encounter.DiagnosisComponent>(e_);
+			var g_ = this.Severe_Maternal_Morbidity_Procedures();
+			var h_ = context.Operators.RetrieveByValueSet<Procedure>(g_, null);
+			bool? i_(Procedure EncounterSMMProcedures)
+			{
+				var ab_ = context.Operators.EnumEqualsString(EncounterSMMProcedures?.StatusElement?.Value, "completed");
+				var ac_ = FHIRHelpers_4_3_000.ToValue(EncounterSMMProcedures?.Performed);
+				var ad_ = QICoreCommon_2_0_000.toInterval(ac_);
+				var ae_ = context.Operators.Start(ad_);
+				var af_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var ag_ = context.Operators.ElementInInterval<CqlDateTime>(ae_, af_, "day");
+				var ah_ = context.Operators.And(ab_, ag_);
+
+				return ah_;
+			};
+			var j_ = context.Operators.WhereOrNull<Procedure>(h_, i_);
+			var k_ = context.Operators.ExistsInList<Procedure>(j_);
+			var l_ = context.Operators.Or(f_, k_);
+
+			return l_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Delivery Encounters with Severe Obstetric Complications Diagnosis or Procedure Excluding Blood Transfusion")]
+	public IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion() => 
+		__Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_with_Expiration_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = FHIRHelpers_4_3_000.ToConcept(TwentyWeeksPlusEncounter?.Hospitalization?.DischargeDisposition);
+			var e_ = this.Patient_Expired();
+			var f_ = context.Operators.ConceptInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Delivery Encounters with Expiration")]
+	public IEnumerable<Encounter> Delivery_Encounters_with_Expiration() => 
+		__Delivery_Encounters_with_Expiration.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_with_Blood_Transfusion_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.Blood_Transfusion();
+			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			bool? f_(Procedure BloodTransfusion)
+			{
+				var j_ = context.Operators.EnumEqualsString(BloodTransfusion?.StatusElement?.Value, "completed");
+				var k_ = FHIRHelpers_4_3_000.ToValue(BloodTransfusion?.Performed);
+				var l_ = QICoreCommon_2_0_000.toInterval(k_);
+				var m_ = context.Operators.Start(l_);
+				var n_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, "day");
+				var p_ = context.Operators.And(j_, o_);
+
+				return p_;
+			};
+			var g_ = context.Operators.WhereOrNull<Procedure>(e_, f_);
+			Encounter h_(Procedure BloodTransfusion) => 
+				TwentyWeeksPlusEncounter;
+			var i_ = context.Operators.SelectOrNull<Procedure, Encounter>(g_, h_);
+
+			return i_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Delivery Encounters with Blood Transfusion")]
+	public IEnumerable<Encounter> Delivery_Encounters_with_Blood_Transfusion() => 
+		__Delivery_Encounters_with_Blood_Transfusion.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Value()
+	{
+		var a_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion();
+		var b_ = this.Delivery_Encounters_with_Expiration();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+		var d_ = this.Delivery_Encounters_with_Blood_Transfusion();
+		var e_ = context.Operators.ListUnion<Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Delivery Encounters with Severe Obstetric Complications")]
+	public IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications() => 
+		__Delivery_Encounters_with_Severe_Obstetric_Complications.Value;
+
+	private IEnumerable<Encounter> Numerator_Value()
+	{
+		var a_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = CQMCommon_2_0_000.encounterDiagnosis(TwentyWeeksPlusEncounter);
+			bool? e_(Condition EncounterDiagnosis)
+			{
+				var s_ = FHIRHelpers_4_3_000.ToConcept(EncounterDiagnosis?.Code);
+				var t_ = this.COVID_19_Confirmed();
+				var u_ = context.Operators.ConceptInValueSet(s_, t_);
+
+				return u_;
+			};
+			var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+			var g_ = context.Operators.ExistsInList<Condition>(f_);
+			bool? i_(Condition EncounterDiagnosis)
+			{
+				var v_ = FHIRHelpers_4_3_000.ToConcept(EncounterDiagnosis?.Code);
+				var w_ = this.Respiratory_Conditions_Related_to_COVID_19();
+				var x_ = context.Operators.ConceptInValueSet(v_, w_);
+
+				return x_;
+			};
+			var j_ = context.Operators.WhereOrNull<Condition>(d_, i_);
+			var k_ = context.Operators.ExistsInList<Condition>(j_);
+			var l_ = this.Respiratory_Support_Procedures_Related_to_COVID_19();
+			var m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, null);
+			bool? n_(Procedure COVIDRespiratoryProcedure)
+			{
+				var y_ = context.Operators.EnumEqualsString(COVIDRespiratoryProcedure?.StatusElement?.Value, "completed");
+				var z_ = FHIRHelpers_4_3_000.ToValue(COVIDRespiratoryProcedure?.Performed);
+				var aa_ = QICoreCommon_2_0_000.toInterval(z_);
+				var ab_ = context.Operators.Start(aa_);
+				var ac_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var ad_ = context.Operators.ElementInInterval<CqlDateTime>(ab_, ac_, "day");
+				var ae_ = context.Operators.And(y_, ad_);
+
+				return ae_;
+			};
+			var o_ = context.Operators.WhereOrNull<Procedure>(m_, n_);
+			var p_ = context.Operators.ExistsInList<Procedure>(o_);
+			var q_ = context.Operators.Or(k_, p_);
+			var r_ = context.Operators.And(g_, q_);
+
+			return r_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Delivery Encounters with COVID and Respiratory Condition or Procedure")]
+	public IEnumerable<Encounter> Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure() => 
+		__Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure.Value;
+
+	private IEnumerable<Encounter> Denominator_Exclusion_Value()
+	{
+		var a_ = this.Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator Exclusion")]
+	public IEnumerable<Encounter> Denominator_Exclusion() => 
+		__Denominator_Exclusion.Value;
+
+	private IEnumerable<Encounter> Stratification_Encounter_Value()
+	{
+		var a_ = this.Numerator();
+		var b_ = this.Denominator_Exclusion();
+		var c_ = context.Operators.ListExcept<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Stratification Encounter")]
+	public IEnumerable<Encounter> Stratification_Encounter() => 
+		__Stratification_Encounter.Value;
+
+	private IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions_Value()
+	{
+		var a_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion();
+		var b_ = this.Delivery_Encounters_with_Expiration();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Delivery Encounters with Severe Obstetric Complications Excluding Blood Transfusions")]
+	public IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions() => 
+		__Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions.Value;
+
+	private IEnumerable<Encounter> Stratum_1_Value()
+	{
+		var a_ = this.Stratification_Encounter();
+		var b_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions();
+		var c_ = context.Operators.ListIntersect<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Stratum 1")]
+	public IEnumerable<Encounter> Stratum_1() => 
+		__Stratum_1.Value;
+
+	private IEnumerable<Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM> Variable_Calculated_Gestational_Age_Value()
+	{
+		var a_ = PCMaternal_5_16_000.Variable_Calculated_Gestational_Age();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Variable Calculated Gestational Age")]
+	public IEnumerable<Tuples.Tuple_CDQdAjUGdePbWTVfePeZUXKFM> Variable_Calculated_Gestational_Age() => 
+		__Variable_Calculated_Gestational_Age.Value;
+
+	private IEnumerable<Encounter> Denominator_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator.Value;
+
+    [CqlDeclaration("pOAIsYesOrExempt")]
+	public IEnumerable<CqlConcept> pOAIsYesOrExempt(Encounter TheEncounter)
+	{
+		bool? a_(Encounter.DiagnosisComponent EncounterDiagnoses)
+		{
+			bool? e_(Extension @this)
+			{
+				var n_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+
+				return n_;
+			};
+			var f_ = context.Operators.WhereOrNull<Extension>(((EncounterDiagnoses is Element)
+					? ((EncounterDiagnoses as Element).Extension)
+					: null), e_);
+			DataType g_(Extension @this) => 
+				@this?.Value;
+			var h_ = context.Operators.SelectOrNull<Extension, DataType>(f_, g_);
+			var i_ = context.Operators.SingleOrNull<DataType>(h_);
+			var j_ = context.Operators.Convert<CodeableConcept>(i_);
+			var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
+			var l_ = this.Present_On_Admission_is_Yes_or_Exempt();
+			var m_ = context.Operators.ConceptInValueSet(k_, l_);
+
+			return m_;
+		};
+		var b_ = context.Operators.WhereOrNull<Encounter.DiagnosisComponent>((TheEncounter?.Diagnosis as IEnumerable<Encounter.DiagnosisComponent>), a_);
+		CqlConcept c_(Encounter.DiagnosisComponent EncounterDiagnoses)
+		{
+			var o_ = CQMCommon_2_0_000.getCondition(EncounterDiagnoses?.Condition);
+			var p_ = FHIRHelpers_4_3_000.ToConcept(o_?.Code);
+
+			return p_;
+		};
+		var d_ = context.Operators.SelectOrNull<Encounter.DiagnosisComponent, CqlConcept>(b_, c_);
+
+		return d_;
+	}
+
+	private IEnumerable<Encounter> Risk_Variable_Anemia_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Anemia();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Anemia")]
+	public IEnumerable<Encounter> Risk_Variable_Anemia() => 
+		__Risk_Variable_Anemia.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Asthma_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Acute_or_Persistent_Asthma();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Asthma")]
+	public IEnumerable<Encounter> Risk_Variable_Asthma() => 
+		__Risk_Variable_Asthma.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Autoimmune_Disease_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Autoimmune_Disease();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Autoimmune Disease")]
+	public IEnumerable<Encounter> Risk_Variable_Autoimmune_Disease() => 
+		__Risk_Variable_Autoimmune_Disease.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Bariatric_Surgery_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Bariatric_Surgery();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Bariatric Surgery")]
+	public IEnumerable<Encounter> Risk_Variable_Bariatric_Surgery() => 
+		__Risk_Variable_Bariatric_Surgery.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Bleeding_Disorder_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Bleeding_Disorder();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Bleeding Disorder")]
+	public IEnumerable<Encounter> Risk_Variable_Bleeding_Disorder() => 
+		__Risk_Variable_Bleeding_Disorder.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Morbid_Obesity_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Morbid_or_Severe_Obesity();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Morbid Obesity")]
+	public IEnumerable<Encounter> Risk_Variable_Morbid_Obesity() => 
+		__Risk_Variable_Morbid_Obesity.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Cardiac_Disease_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Cardiac_Disease();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Cardiac Disease")]
+	public IEnumerable<Encounter> Risk_Variable_Cardiac_Disease() => 
+		__Risk_Variable_Cardiac_Disease.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Economic_Housing_Instability_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Economic_Housing_Instability();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Economic Housing Instability")]
+	public IEnumerable<Encounter> Risk_Variable_Economic_Housing_Instability() => 
+		__Risk_Variable_Economic_Housing_Instability.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Gastrointestinal_Disease_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Gastrointestinal_Disease();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Gastrointestinal Disease")]
+	public IEnumerable<Encounter> Risk_Variable_Gastrointestinal_Disease() => 
+		__Risk_Variable_Gastrointestinal_Disease.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Gestational_Diabetes_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Gestational_Diabetes();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Gestational Diabetes")]
+	public IEnumerable<Encounter> Risk_Variable_Gestational_Diabetes() => 
+		__Risk_Variable_Gestational_Diabetes.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_HIV_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.HIV_in_Pregnancy_Childbirth_and_Puerperium();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable HIV")]
+	public IEnumerable<Encounter> Risk_Variable_HIV() => 
+		__Risk_Variable_HIV.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Hypertension_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Hypertension();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Hypertension")]
+	public IEnumerable<Encounter> Risk_Variable_Hypertension() => 
+		__Risk_Variable_Hypertension.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Long_Term_Anticoagulant_Use_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Long_Term_Anticoagulant_Use();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Long Term Anticoagulant Use")]
+	public IEnumerable<Encounter> Risk_Variable_Long_Term_Anticoagulant_Use() => 
+		__Risk_Variable_Long_Term_Anticoagulant_Use.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Mental_Health_Disorder_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Mental_Health_Disorder();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Mental Health Disorder")]
+	public IEnumerable<Encounter> Risk_Variable_Mental_Health_Disorder() => 
+		__Risk_Variable_Mental_Health_Disorder.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Multiple_Pregnancy_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Multiple_Pregnancy();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Multiple Pregnancy")]
+	public IEnumerable<Encounter> Risk_Variable_Multiple_Pregnancy() => 
+		__Risk_Variable_Multiple_Pregnancy.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Neuromuscular_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Neuromuscular_Disease();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Neuromuscular")]
+	public IEnumerable<Encounter> Risk_Variable_Neuromuscular() => 
+		__Risk_Variable_Neuromuscular.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Obstetrical_VTE_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Venous_Thromboembolism_in_Pregnancy();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Obstetrical VTE")]
+	public IEnumerable<Encounter> Risk_Variable_Obstetrical_VTE() => 
+		__Risk_Variable_Obstetrical_VTE.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Placenta_Previa_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Placenta_Previa();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Placenta Previa")]
+	public IEnumerable<Encounter> Risk_Variable_Placenta_Previa() => 
+		__Risk_Variable_Placenta_Previa.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Placental_Abruption_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Placental_Abruption();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Placental Abruption")]
+	public IEnumerable<Encounter> Risk_Variable_Placental_Abruption() => 
+		__Risk_Variable_Placental_Abruption.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Placental_Accreta_Spectrum_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Placental_Accreta_Spectrum();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Placental Accreta Spectrum")]
+	public IEnumerable<Encounter> Risk_Variable_Placental_Accreta_Spectrum() => 
+		__Risk_Variable_Placental_Accreta_Spectrum.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Preexisting_Diabetes_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Preexisting_Diabetes();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Preexisting Diabetes")]
+	public IEnumerable<Encounter> Risk_Variable_Preexisting_Diabetes() => 
+		__Risk_Variable_Preexisting_Diabetes.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Previous_Cesarean_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Previous_Cesarean();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Previous Cesarean")]
+	public IEnumerable<Encounter> Risk_Variable_Previous_Cesarean() => 
+		__Risk_Variable_Previous_Cesarean.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Pulmonary_Hypertension_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Pulmonary_Hypertension();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Pulmonary Hypertension")]
+	public IEnumerable<Encounter> Risk_Variable_Pulmonary_Hypertension() => 
+		__Risk_Variable_Pulmonary_Hypertension.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Renal_Disease_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Renal_Disease();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Renal Disease")]
+	public IEnumerable<Encounter> Risk_Variable_Renal_Disease() => 
+		__Risk_Variable_Renal_Disease.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Severe_Preeclampsia_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Severe_Preeclampsia();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Severe Preeclampsia")]
+	public IEnumerable<Encounter> Risk_Variable_Severe_Preeclampsia() => 
+		__Risk_Variable_Severe_Preeclampsia.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Substance_Abuse_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Substance_Abuse();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Substance Abuse")]
+	public IEnumerable<Encounter> Risk_Variable_Substance_Abuse() => 
+		__Risk_Variable_Substance_Abuse.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Thyrotoxicosis_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Thyrotoxicosis();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Thyrotoxicosis")]
+	public IEnumerable<Encounter> Risk_Variable_Thyrotoxicosis() => 
+		__Risk_Variable_Thyrotoxicosis.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Other_Preeclampsia_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		bool? b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			var e_ = this.Mild_or_Moderate_Preeclampsia();
+			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+
+			return f_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Other Preeclampsia")]
+	public IEnumerable<Encounter> Risk_Variable_Other_Preeclampsia() => 
+		__Risk_Variable_Other_Preeclampsia.Value;
+
+	private IEnumerable<Encounter> Risk_Variable_Preterm_Birth_Value()
+	{
+		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		bool? b_(Encounter DeliveryEncounter)
+		{
+			var h_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			var i_ = context.Operators.Interval((int?)20, (int?)36, true, true);
+			var j_ = context.Operators.ElementInInterval<int?>(h_, i_, null);
+			var l_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			var m_ = context.Operators.Quantity(20m, "weeks");
+			var n_ = context.Operators.GreaterOrEqual(l_, m_);
+			var p_ = context.Operators.Quantity(36m, "weeks");
+			var q_ = context.Operators.LessOrEqual(l_, p_);
+			var r_ = context.Operators.And(n_, q_);
+			var s_ = context.Operators.And((bool?)(h_ is null), r_);
+			var t_ = context.Operators.Or(j_, s_);
+
+			return t_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		bool? e_(Encounter DeliveryEncounter)
+		{
+			var u_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			var v_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			var w_ = context.Operators.And((bool?)(u_ is null), (bool?)(v_ is null));
+			var x_ = this.pOAIsYesOrExempt(DeliveryEncounter);
+			var y_ = this.Preterm_Birth();
+			var z_ = context.Operators.ConceptsInValueSet(x_, y_);
+			var aa_ = context.Operators.And(w_, z_);
+
+			return aa_;
+		};
+		var f_ = context.Operators.WhereOrNull<Encounter>(a_, e_);
+		var g_ = context.Operators.ListUnion<Encounter>(c_, f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("Risk Variable Preterm Birth")]
+	public IEnumerable<Encounter> Risk_Variable_Preterm_Birth() => 
+		__Risk_Variable_Preterm_Birth.Value;
+
+	private IEnumerable<Tuples.Tuple_BUSccGEhJLedCLcPKRPjDcPjV> Risk_Variable_First_Hematocrit_Lab_Test_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		Tuples.Tuple_BUSccGEhJLedCLcPKRPjDcPjV b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.Hematocrit_lab_test();
+			var e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			bool? f_(Observation Hematocrit)
+			{
+				var u_ = context.Operators.Convert<CqlDateTime>(Hematocrit?.IssuedElement?.Value);
+				var v_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var w_ = context.Operators.Start(v_);
+				var x_ = context.Operators.Quantity(1440m, "minutes");
+				var y_ = context.Operators.Subtract(w_, x_);
+				var z_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				var aa_ = context.Operators.Interval(y_, z_, true, false);
+				var ab_ = context.Operators.ElementInInterval<CqlDateTime>(u_, aa_, null);
+				var ac_ = context.Operators.Convert<string>(Hematocrit?.StatusElement?.Value);
+				var ad_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var ae_ = context.Operators.InList<string>(ac_, (ad_ as IEnumerable<string>));
+				var af_ = context.Operators.And(ab_, ae_);
+				var ag_ = FHIRHelpers_4_3_000.ToValue(Hematocrit?.Value);
+				var ah_ = context.Operators.Not((bool?)(ag_ is null));
+				var ai_ = context.Operators.And(af_, ah_);
+
+				return ai_;
+			};
+			var g_ = context.Operators.WhereOrNull<Observation>(e_, f_);
+			object h_(Observation @this)
+			{
+				var aj_ = context.Operators.Convert<CqlDateTime>(@this?.IssuedElement?.Value);
+				var ak_ = QICoreCommon_2_0_000.earliest((aj_ as object));
+
+				return ak_;
+			};
+			var i_ = context.Operators.ListSortBy<Observation>(g_, h_, System.ComponentModel.ListSortDirection.Ascending);
+			var j_ = context.Operators.FirstOfList<Observation>(i_);
+			var k_ = FHIRHelpers_4_3_000.ToValue(j_?.Value);
+			var m_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			bool? n_(Observation Hematocrit)
+			{
+				var al_ = context.Operators.Convert<CqlDateTime>(Hematocrit?.IssuedElement?.Value);
+				var am_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var an_ = context.Operators.Start(am_);
+				var ao_ = context.Operators.Quantity(1440m, "minutes");
+				var ap_ = context.Operators.Subtract(an_, ao_);
+				var aq_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				var ar_ = context.Operators.Interval(ap_, aq_, true, false);
+				var as_ = context.Operators.ElementInInterval<CqlDateTime>(al_, ar_, null);
+				var at_ = context.Operators.Convert<string>(Hematocrit?.StatusElement?.Value);
+				var au_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var av_ = context.Operators.InList<string>(at_, (au_ as IEnumerable<string>));
+				var aw_ = context.Operators.And(as_, av_);
+				var ax_ = FHIRHelpers_4_3_000.ToValue(Hematocrit?.Value);
+				var ay_ = context.Operators.Not((bool?)(ax_ is null));
+				var az_ = context.Operators.And(aw_, ay_);
+
+				return az_;
+			};
+			var o_ = context.Operators.WhereOrNull<Observation>(m_, n_);
+			object p_(Observation @this)
+			{
+				var ba_ = context.Operators.Convert<CqlDateTime>(@this?.IssuedElement?.Value);
+				var bb_ = QICoreCommon_2_0_000.earliest((ba_ as object));
+
+				return bb_;
+			};
+			var q_ = context.Operators.ListSortBy<Observation>(o_, p_, System.ComponentModel.ListSortDirection.Ascending);
+			var r_ = context.Operators.FirstOfList<Observation>(q_);
+			var s_ = context.Operators.Convert<CqlDateTime>(r_?.IssuedElement?.Value);
+			var t_ = new Tuples.Tuple_BUSccGEhJLedCLcPKRPjDcPjV
+			{
+				EncounterId = TwentyWeeksPlusEncounter?.IdElement?.Value,
+				FirstHematocritResult = (k_ as CqlQuantity),
+				Timing = s_,
+			};
+
+			return t_;
+		};
+		var c_ = context.Operators.SelectOrNull<Encounter, Tuples.Tuple_BUSccGEhJLedCLcPKRPjDcPjV>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable First Hematocrit Lab Test")]
+	public IEnumerable<Tuples.Tuple_BUSccGEhJLedCLcPKRPjDcPjV> Risk_Variable_First_Hematocrit_Lab_Test() => 
+		__Risk_Variable_First_Hematocrit_Lab_Test.Value;
+
+	private IEnumerable<Tuples.Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA> Risk_Variable_First_White_Blood_Cell_Count_Lab_Test_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		Tuples.Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = this.White_blood_cells_count_lab_test();
+			var e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			bool? f_(Observation WBC)
+			{
+				var u_ = context.Operators.Convert<CqlDateTime>(WBC?.IssuedElement?.Value);
+				var v_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var w_ = context.Operators.Start(v_);
+				var x_ = context.Operators.Quantity(1440m, "minutes");
+				var y_ = context.Operators.Subtract(w_, x_);
+				var z_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				var aa_ = context.Operators.Interval(y_, z_, true, false);
+				var ab_ = context.Operators.ElementInInterval<CqlDateTime>(u_, aa_, null);
+				var ac_ = context.Operators.Convert<string>(WBC?.StatusElement?.Value);
+				var ad_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var ae_ = context.Operators.InList<string>(ac_, (ad_ as IEnumerable<string>));
+				var af_ = context.Operators.And(ab_, ae_);
+				var ag_ = FHIRHelpers_4_3_000.ToValue(WBC?.Value);
+				var ah_ = context.Operators.Not((bool?)(ag_ is null));
+				var ai_ = context.Operators.And(af_, ah_);
+
+				return ai_;
+			};
+			var g_ = context.Operators.WhereOrNull<Observation>(e_, f_);
+			object h_(Observation @this)
+			{
+				var aj_ = context.Operators.Convert<CqlDateTime>(@this?.IssuedElement?.Value);
+				var ak_ = QICoreCommon_2_0_000.earliest((aj_ as object));
+
+				return ak_;
+			};
+			var i_ = context.Operators.ListSortBy<Observation>(g_, h_, System.ComponentModel.ListSortDirection.Ascending);
+			var j_ = context.Operators.FirstOfList<Observation>(i_);
+			var k_ = FHIRHelpers_4_3_000.ToValue(j_?.Value);
+			var m_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			bool? n_(Observation WBC)
+			{
+				var al_ = context.Operators.Convert<CqlDateTime>(WBC?.IssuedElement?.Value);
+				var am_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var an_ = context.Operators.Start(am_);
+				var ao_ = context.Operators.Quantity(1440m, "minutes");
+				var ap_ = context.Operators.Subtract(an_, ao_);
+				var aq_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				var ar_ = context.Operators.Interval(ap_, aq_, true, false);
+				var as_ = context.Operators.ElementInInterval<CqlDateTime>(al_, ar_, null);
+				var at_ = context.Operators.Convert<string>(WBC?.StatusElement?.Value);
+				var au_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var av_ = context.Operators.InList<string>(at_, (au_ as IEnumerable<string>));
+				var aw_ = context.Operators.And(as_, av_);
+				var ax_ = FHIRHelpers_4_3_000.ToValue(WBC?.Value);
+				var ay_ = context.Operators.Not((bool?)(ax_ is null));
+				var az_ = context.Operators.And(aw_, ay_);
+
+				return az_;
+			};
+			var o_ = context.Operators.WhereOrNull<Observation>(m_, n_);
+			object p_(Observation @this)
+			{
+				var ba_ = context.Operators.Convert<CqlDateTime>(@this?.IssuedElement?.Value);
+				var bb_ = QICoreCommon_2_0_000.earliest((ba_ as object));
+
+				return bb_;
+			};
+			var q_ = context.Operators.ListSortBy<Observation>(o_, p_, System.ComponentModel.ListSortDirection.Ascending);
+			var r_ = context.Operators.FirstOfList<Observation>(q_);
+			var s_ = context.Operators.Convert<CqlDateTime>(r_?.IssuedElement?.Value);
+			var t_ = new Tuples.Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA
+			{
+				EncounterId = TwentyWeeksPlusEncounter?.IdElement?.Value,
+				FirstWBCResult = (k_ as CqlQuantity),
+				Timing = s_,
+			};
+
+			return t_;
+		};
+		var c_ = context.Operators.SelectOrNull<Encounter, Tuples.Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable First White Blood Cell Count Lab Test")]
+	public IEnumerable<Tuples.Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA> Risk_Variable_First_White_Blood_Cell_Count_Lab_Test() => 
+		__Risk_Variable_First_White_Blood_Cell_Count_Lab_Test.Value;
+
+	private IEnumerable<Tuples.Tuple_CYVVSdgZbMfXHMiBHjISgejQI> Risk_Variable_Heart_Rate_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		Tuples.Tuple_CYVVSdgZbMfXHMiBHjISgejQI b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? e_(Observation HeartRate)
+			{
+				var u_ = FHIRHelpers_4_3_000.ToValue(HeartRate?.Effective);
+				var v_ = QICoreCommon_2_0_000.earliest(u_);
+				var w_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var x_ = context.Operators.Start(w_);
+				var y_ = context.Operators.Quantity(1440m, "minutes");
+				var z_ = context.Operators.Subtract(x_, y_);
+				var aa_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				var ab_ = context.Operators.Interval(z_, aa_, true, false);
+				var ac_ = context.Operators.ElementInInterval<CqlDateTime>(v_, ab_, null);
+				var ad_ = context.Operators.Convert<string>(HeartRate?.StatusElement?.Value);
+				var ae_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var af_ = context.Operators.InList<string>(ad_, (ae_ as IEnumerable<string>));
+				var ag_ = context.Operators.And(ac_, af_);
+
+				return ag_;
+			};
+			var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+			object g_(Observation @this)
+			{
+				var ah_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var ai_ = QICoreCommon_2_0_000.earliest(ah_);
+
+				return ai_;
+			};
+			var h_ = context.Operators.ListSortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			var i_ = context.Operators.FirstOfList<Observation>(h_);
+			var j_ = context.Operators.Convert<Quantity>(i_?.Value);
+			var k_ = FHIRHelpers_4_3_000.ToQuantity(j_);
+			bool? m_(Observation HeartRate)
+			{
+				var aj_ = FHIRHelpers_4_3_000.ToValue(HeartRate?.Effective);
+				var ak_ = QICoreCommon_2_0_000.earliest(aj_);
+				var al_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var am_ = context.Operators.Start(al_);
+				var an_ = context.Operators.Quantity(1440m, "minutes");
+				var ao_ = context.Operators.Subtract(am_, an_);
+				var ap_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				var aq_ = context.Operators.Interval(ao_, ap_, true, false);
+				var ar_ = context.Operators.ElementInInterval<CqlDateTime>(ak_, aq_, null);
+				var as_ = context.Operators.Convert<string>(HeartRate?.StatusElement?.Value);
+				var at_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var au_ = context.Operators.InList<string>(as_, (at_ as IEnumerable<string>));
+				var av_ = context.Operators.And(ar_, au_);
+
+				return av_;
+			};
+			var n_ = context.Operators.WhereOrNull<Observation>(d_, m_);
+			object o_(Observation @this)
+			{
+				var aw_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var ax_ = QICoreCommon_2_0_000.earliest(aw_);
+
+				return ax_;
+			};
+			var p_ = context.Operators.ListSortBy<Observation>(n_, o_, System.ComponentModel.ListSortDirection.Ascending);
+			var q_ = context.Operators.FirstOfList<Observation>(p_);
+			var r_ = FHIRHelpers_4_3_000.ToValue(q_?.Effective);
+			var s_ = QICoreCommon_2_0_000.earliest(r_);
+			var t_ = new Tuples.Tuple_CYVVSdgZbMfXHMiBHjISgejQI
+			{
+				EncounterId = TwentyWeeksPlusEncounter?.IdElement?.Value,
+				FirstHRResult = (k_ as CqlQuantity),
+				Timing = s_,
+			};
+
+			return t_;
+		};
+		var c_ = context.Operators.SelectOrNull<Encounter, Tuples.Tuple_CYVVSdgZbMfXHMiBHjISgejQI>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Heart Rate")]
+	public IEnumerable<Tuples.Tuple_CYVVSdgZbMfXHMiBHjISgejQI> Risk_Variable_Heart_Rate() => 
+		__Risk_Variable_Heart_Rate.Value;
+
+	private IEnumerable<Tuples.Tuple_DBZhWNcHciGGJUSXZKiOPXJYf> Risk_Variable_Systolic_Blood_Pressure_Value()
+	{
+		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		Tuples.Tuple_DBZhWNcHciGGJUSXZKiOPXJYf b_(Encounter TwentyWeeksPlusEncounter)
+		{
+			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? e_(Observation BP)
+			{
+				var w_ = FHIRHelpers_4_3_000.ToValue(BP?.Effective);
+				var x_ = QICoreCommon_2_0_000.earliest(w_);
+				var y_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var z_ = context.Operators.Start(y_);
+				var aa_ = context.Operators.Quantity(1440m, "minutes");
+				var ab_ = context.Operators.Subtract(z_, aa_);
+				var ac_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				var ad_ = context.Operators.Interval(ab_, ac_, true, false);
+				var ae_ = context.Operators.ElementInInterval<CqlDateTime>(x_, ad_, null);
+				var af_ = context.Operators.Convert<string>(BP?.StatusElement?.Value);
+				var ag_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var ah_ = context.Operators.InList<string>(af_, (ag_ as IEnumerable<string>));
+				var ai_ = context.Operators.And(ae_, ah_);
+
+				return ai_;
+			};
+			var f_ = context.Operators.WhereOrNull<Observation>(d_, e_);
+			object g_(Observation @this)
+			{
+				var aj_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var ak_ = QICoreCommon_2_0_000.earliest(aj_);
+
+				return ak_;
+			};
+			var h_ = context.Operators.ListSortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			var i_ = context.Operators.FirstOfList<Observation>(h_);
+			bool? j_(Observation.ComponentComponent C)
+			{
+				var al_ = FHIRHelpers_4_3_000.ToConcept(C?.Code);
+				var am_ = this.Systolic_blood_pressure();
+				var an_ = context.Operators.ConvertCodeToConcept(am_);
+				var ao_ = context.Operators.Equivalent(al_, an_);
+
+				return ao_;
+			};
+			var k_ = context.Operators.WhereOrNull<Observation.ComponentComponent>((i_?.Component as IEnumerable<Observation.ComponentComponent>), j_);
+			CqlQuantity l_(Observation.ComponentComponent C)
+			{
+				var ap_ = FHIRHelpers_4_3_000.ToValue(C?.Value);
+
+				return (ap_ as CqlQuantity);
+			};
+			var m_ = context.Operators.SelectOrNull<Observation.ComponentComponent, CqlQuantity>(k_, l_);
+			bool? o_(Observation BP)
+			{
+				var aq_ = FHIRHelpers_4_3_000.ToValue(BP?.Effective);
+				var ar_ = QICoreCommon_2_0_000.earliest(aq_);
+				var as_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				var at_ = context.Operators.Start(as_);
+				var au_ = context.Operators.Quantity(1440m, "minutes");
+				var av_ = context.Operators.Subtract(at_, au_);
+				var aw_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				var ax_ = context.Operators.Interval(av_, aw_, true, false);
+				var ay_ = context.Operators.ElementInInterval<CqlDateTime>(ar_, ax_, null);
+				var az_ = context.Operators.Convert<string>(BP?.StatusElement?.Value);
+				var ba_ = new string[]
+				{
+					"final",
+					"amended",
+					"corrected",
+				};
+				var bb_ = context.Operators.InList<string>(az_, (ba_ as IEnumerable<string>));
+				var bc_ = context.Operators.And(ay_, bb_);
+
+				return bc_;
+			};
+			var p_ = context.Operators.WhereOrNull<Observation>(d_, o_);
+			object q_(Observation @this)
+			{
+				var bd_ = FHIRHelpers_4_3_000.ToValue(@this?.Effective);
+				var be_ = QICoreCommon_2_0_000.earliest(bd_);
+
+				return be_;
+			};
+			var r_ = context.Operators.ListSortBy<Observation>(p_, q_, System.ComponentModel.ListSortDirection.Ascending);
+			var s_ = context.Operators.FirstOfList<Observation>(r_);
+			var t_ = FHIRHelpers_4_3_000.ToValue(s_?.Effective);
+			var u_ = QICoreCommon_2_0_000.earliest(t_);
+			var v_ = new Tuples.Tuple_DBZhWNcHciGGJUSXZKiOPXJYf
+			{
+				EncounterId = TwentyWeeksPlusEncounter?.IdElement?.Value,
+				FirstSBPResult = m_,
+				Timing = u_,
+			};
+
+			return v_;
+		};
+		var c_ = context.Operators.SelectOrNull<Encounter, Tuples.Tuple_DBZhWNcHciGGJUSXZKiOPXJYf>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Risk Variable Systolic Blood Pressure")]
+	public IEnumerable<Tuples.Tuple_DBZhWNcHciGGJUSXZKiOPXJYf> Risk_Variable_Systolic_Blood_Pressure() => 
+		__Risk_Variable_Systolic_Blood_Pressure.Value;
+
+    [CqlDeclaration("pOAIsNoOrUTD")]
+	public IEnumerable<CqlConcept> pOAIsNoOrUTD(Encounter TheEncounter)
+	{
+		bool? a_(Encounter.DiagnosisComponent EncounterDiagnoses)
+		{
+			bool? e_(Extension @this)
+			{
+				var n_ = context.Operators.Equal(@this?.Url, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+
+				return n_;
+			};
+			var f_ = context.Operators.WhereOrNull<Extension>(((EncounterDiagnoses is Element)
+					? ((EncounterDiagnoses as Element).Extension)
+					: null), e_);
+			DataType g_(Extension @this) => 
+				@this?.Value;
+			var h_ = context.Operators.SelectOrNull<Extension, DataType>(f_, g_);
+			var i_ = context.Operators.SingleOrNull<DataType>(h_);
+			var j_ = context.Operators.Convert<CodeableConcept>(i_);
+			var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
+			var l_ = this.Present_on_Admission_is_No_or_Unable_To_Determine();
+			var m_ = context.Operators.ConceptInValueSet(k_, l_);
+
+			return m_;
+		};
+		var b_ = context.Operators.WhereOrNull<Encounter.DiagnosisComponent>((TheEncounter?.Diagnosis as IEnumerable<Encounter.DiagnosisComponent>), a_);
+		CqlConcept c_(Encounter.DiagnosisComponent EncounterDiagnoses)
+		{
+			var o_ = CQMCommon_2_0_000.getCondition(EncounterDiagnoses?.Condition);
+			var p_ = FHIRHelpers_4_3_000.ToConcept(o_?.Code);
+
+			return p_;
+		};
+		var d_ = context.Operators.SelectOrNull<Encounter.DiagnosisComponent, CqlConcept>(b_, c_);
+
+		return d_;
+	}
+
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BGiOaDWjFAVaAFWAKdFWJcFOg: TupleBaseType
+    {
+        [CqlDeclaration("HepatitisBVaccination1")]
+        public CqlDate HepatitisBVaccination1 { get; set; }
+        [CqlDeclaration("HepatitisBVaccination2")]
+        public CqlDate HepatitisBVaccination2 { get; set; }
+        [CqlDeclaration("HepatitisBVaccination3")]
+        public CqlDate HepatitisBVaccination3 { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BJTSgXESaFEOLbMHHiDMHCcdP.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BJTSgXESaFEOLbMHHiDMHCcdP.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BJTSgXESaFEOLbMHHiDMHCcdP: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstTemperatureResult")]
+        public CqlQuantity FirstTemperatureResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BLYNRWKJOdUDPHZXcaNNjjGLE.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BLYNRWKJOdUDPHZXcaNNjjGLE.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BLYNRWKJOdUDPHZXcaNNjjGLE: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstSodiumResult")]
+        public CqlQuantity FirstSodiumResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BQRHOWGHNMjBJPPZJZXVMjCPK: TupleBaseType
+    {
+        [CqlDeclaration("ID")]
+        public string ID { get; set; }
+        [CqlDeclaration("AuthorDate")]
+        public CqlDateTime AuthorDate { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BUSccGEhJLedCLcPKRPjDcPjV.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BUSccGEhJLedCLcPKRPjDcPjV.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BUSccGEhJLedCLcPKRPjDcPjV: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstHematocritResult")]
+        public CqlQuantity FirstHematocritResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BVCGRhSDCRLNScbMJUKidNAJh.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BVCGRhSDCRLNScbMJUKidNAJh.g.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BVCGRhSDCRLNScbMJUKidNAJh: TupleBaseType
+    {
+        [CqlDeclaration("PneumococcalVaccination1")]
+        public CqlDate PneumococcalVaccination1 { get; set; }
+        [CqlDeclaration("PneumococcalVaccination2")]
+        public CqlDate PneumococcalVaccination2 { get; set; }
+        [CqlDeclaration("PneumococcalVaccination3")]
+        public CqlDate PneumococcalVaccination3 { get; set; }
+        [CqlDeclaration("PneumococcalVaccination4")]
+        public CqlDate PneumococcalVaccination4 { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BXadXcWUgfMHAjQNVhdOPQXSG.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BXadXcWUgfMHAjQNVhdOPQXSG.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BXadXcWUgfMHAjQNVhdOPQXSG: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstResult")]
+        public CqlQuantity FirstResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BaPOXCdQPieFFFdPRAYQHJVMK.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BaPOXCdQPieFFFdPRAYQHJVMK.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BaPOXCdQPieFFFdPRAYQHJVMK: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialPROMIS10Date")]
+        public CqlDate InitialPROMIS10Date { get; set; }
+        [CqlDeclaration("FollowupPROMIS10Date")]
+        public CqlDate FollowupPROMIS10Date { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BbghRjaMVeQThBCTRUcdHSBQH.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BbghRjaMVeQThBCTRUcdHSBQH.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BbghRjaMVeQThBCTRUcdHSBQH: TupleBaseType
+    {
+        [CqlDeclaration("HepatitisBVaccination1")]
+        public CqlDate HepatitisBVaccination1 { get; set; }
+        [CqlDeclaration("HepatitisBVaccination2")]
+        public CqlDate HepatitisBVaccination2 { get; set; }
+        [CqlDeclaration("NewBornVaccine3")]
+        public CqlDate NewBornVaccine3 { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV.g.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BbiPKFIYFfdQCLCHPcXKDaFMV: TupleBaseType
+    {
+        [CqlDeclaration("KCCQLifeQuality")]
+        public Observation KCCQLifeQuality { get; set; }
+        [CqlDeclaration("KCCQSymptomStability")]
+        public Observation KCCQSymptomStability { get; set; }
+        [CqlDeclaration("KCCQSelfEfficacy")]
+        public Observation KCCQSelfEfficacy { get; set; }
+        [CqlDeclaration("KCCQSymptoms")]
+        public Observation KCCQSymptoms { get; set; }
+        [CqlDeclaration("KCCQPhysicalLimits")]
+        public Observation KCCQPhysicalLimits { get; set; }
+        [CqlDeclaration("KCCQSocialLimits")]
+        public Observation KCCQSocialLimits { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_BdOfeUSQKMfBEYcULSQYBIjjC.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_BdOfeUSQKMfBEYcULSQYBIjjC.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_BdOfeUSQKMfBEYcULSQYBIjjC: TupleBaseType
+    {
+        [CqlDeclaration("QualifyingEncounter")]
+        public Encounter QualifyingEncounter { get; set; }
+        [CqlDeclaration("HospitalDietitianReferral")]
+        public Procedure HospitalDietitianReferral { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_CBaKLCFRCUhXghPfCScgCAfHU.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_CBaKLCFRCUhXghPfCScgCAfHU.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_CBaKLCFRCUhXghPfCScgCAfHU: TupleBaseType
+    {
+        [CqlDeclaration("MLHFQPhysical")]
+        public Observation MLHFQPhysical { get; set; }
+        [CqlDeclaration("MLHFQEmotional")]
+        public Observation MLHFQEmotional { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_CDQdAjUGdePbWTVfePeZUXKFM.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_CDQdAjUGdePbWTVfePeZUXKFM.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_CDQdAjUGdePbWTVfePeZUXKFM: TupleBaseType
+    {
+        [CqlDeclaration("EncounterID")]
+        public string EncounterID { get; set; }
+        [CqlDeclaration("CalculatedCGA")]
+        public int? CalculatedCGA { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_CLQMhWLiXMcEdgLhhFRZWUeU.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_CLQMhWLiXMcEdgLhhFRZWUeU.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_CLQMhWLiXMcEdgLhhFRZWUeU: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstSystolicBP")]
+        public CqlQuantity FirstSystolicBP { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_CLQRPFFCjgiFZUVDVEDIIKeXW: TupleBaseType
+    {
+        [CqlDeclaration("QualifyingEncounters")]
+        public Encounter QualifyingEncounters { get; set; }
+        [CqlDeclaration("URI")]
+        public Condition URI { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_CQTbBRGObHbJhTLCMKYTEOihZ.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_CQTbBRGObHbJhTLCMKYTEOihZ.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_CQTbBRGObHbJhTLCMKYTEOihZ: TupleBaseType
+    {
+        [CqlDeclaration("QualifyingEncounter")]
+        public Encounter QualifyingEncounter { get; set; }
+        [CqlDeclaration("LowGlucoseTest")]
+        public Observation LowGlucoseTest { get; set; }
+        [CqlDeclaration("FollowupGlucoseTest")]
+        public Observation FollowupGlucoseTest { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_CSQNXjbdUJCRVLSGAJQOISbPM.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_CSQNXjbdUJCRVLSGAJQOISbPM.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_CSQNXjbdUJCRVLSGAJQOISbPM: TupleBaseType
+    {
+        [CqlDeclaration("PROMIS10MentalScore")]
+        public Observation PROMIS10MentalScore { get; set; }
+        [CqlDeclaration("PROMIS10PhysicalScore")]
+        public Observation PROMIS10PhysicalScore { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_CYVVSdgZbMfXHMiBHjISgejQI.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_CYVVSdgZbMfXHMiBHjISgejQI.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_CYVVSdgZbMfXHMiBHjISgejQI: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstHRResult")]
+        public CqlQuantity FirstHRResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DAGCHJJjDfWYJVbiHKMLJjYRS: TupleBaseType
+    {
+        [CqlDeclaration("period")]
+        public CqlInterval<CqlDate> period { get; set; }
+        [CqlDeclaration("periodStart")]
+        public CqlDate periodStart { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DBZhWNcHciGGJUSXZKiOPXJYf.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DBZhWNcHciGGJUSXZKiOPXJYf.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DBZhWNcHciGGJUSXZKiOPXJYf: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstSBPResult")]
+        public IEnumerable<CqlQuantity> FirstSBPResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DKOWLZZJefTKbjLjeXPNieaFS.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DKOWLZZJefTKbjLjeXPNieaFS.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DKOWLZZJefTKbjLjeXPNieaFS: TupleBaseType
+    {
+        [CqlDeclaration("QualifyingEncounter")]
+        public Encounter QualifyingEncounter { get; set; }
+        [CqlDeclaration("HypoglycemicEvent")]
+        public Observation HypoglycemicEvent { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DNZcZTNIZUQfFfijaYDWagbfi.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DNZcZTNIZUQfFfijaYDWagbfi.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DNZcZTNIZUQfFfijaYDWagbfi: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialKCCQ12Date")]
+        public CqlDate InitialKCCQ12Date { get; set; }
+        [CqlDeclaration("FollowupKCCQ12Date")]
+        public CqlDate FollowupKCCQ12Date { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DPdLURgGeOHhHAcheMAZcWfbT.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DPdLURgGeOHhHAcheMAZcWfbT.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DPdLURgGeOHhHAcheMAZcWfbT: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstHeartRateResult")]
+        public CqlQuantity FirstHeartRateResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DSFJBiLfcBVJWbYSgXHdjCKIZ: TupleBaseType
+    {
+        [CqlDeclaration("QualifyingEncounter")]
+        public Encounter QualifyingEncounter { get; set; }
+        [CqlDeclaration("HypoglycemicMedication")]
+        public MedicationAdministration HypoglycemicMedication { get; set; }
+        [CqlDeclaration("GlucoseTest")]
+        public Observation GlucoseTest { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DSdKcfQMUMBjegQCVVeYhPYdf.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DSdKcfQMUMBjegQCVVeYhPYdf.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DSdKcfQMUMBjegQCVVeYhPYdf: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialKCCQTotalScore")]
+        public CqlDate InitialKCCQTotalScore { get; set; }
+        [CqlDeclaration("FollowupKCCQTotalScore")]
+        public CqlDate FollowupKCCQTotalScore { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DTggaXNYbDKaGBeEeceXhUMKb.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DTggaXNYbDKaGBeEeceXhUMKb.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DTggaXNYbDKaGBeEeceXhUMKb: TupleBaseType
+    {
+        [CqlDeclaration("QualifyingEncounter")]
+        public Encounter QualifyingEncounter { get; set; }
+        [CqlDeclaration("MalnutritionDiagnosis")]
+        public Condition MalnutritionDiagnosis { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DaTHNXWGHIVRYGRfGdXJYJKRZ: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialVR12OrthogonalDate")]
+        public CqlDate InitialVR12OrthogonalDate { get; set; }
+        [CqlDeclaration("FollowupVR12OrthogonalDate")]
+        public CqlDate FollowupVR12OrthogonalDate { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DcgYAFMUGiITLMLBigQTHXaba.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DcgYAFMUGiITLMLBigQTHXaba.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DcgYAFMUGiITLMLBigQTHXaba: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialPROMIS29Date")]
+        public CqlDate InitialPROMIS29Date { get; set; }
+        [CqlDeclaration("FollowupPROMIS29Date")]
+        public CqlDate FollowupPROMIS29Date { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DfAYaANhHDiVRPdSaKCNbKVfZ.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DfAYaANhHDiVRPdSaKCNbKVfZ.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DfAYaANhHDiVRPdSaKCNbKVfZ: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstPlateletResult")]
+        public CqlQuantity FirstPlateletResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_DgNBKfGfRHaWDZaDFPZKifXLi.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_DgNBKfGfRHaWDZaDFPZKifXLi.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_DgNBKfGfRHaWDZaDFPZKifXLi: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialMLHFQDate")]
+        public CqlDate InitialMLHFQDate { get; set; }
+        [CqlDeclaration("FollowupMLHFQDate")]
+        public CqlDate FollowupMLHFQDate { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_EAccDaIgTNOHbEQUMLJiXWIJO.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_EAccDaIgTNOHbEQUMLJiXWIJO.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_EAccDaIgTNOHbEQUMLJiXWIJO: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstRespRateResult")]
+        public CqlQuantity FirstRespRateResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_EDFAENKgHPZdhfZCdMcGebfcS.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_EDFAENKgHPZdhfZCdMcGebfcS.g.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_EDFAENKgHPZdhfZCdMcGebfcS: TupleBaseType
+    {
+        [CqlDeclaration("DTaPVaccination1")]
+        public CqlDate DTaPVaccination1 { get; set; }
+        [CqlDeclaration("DTaPVaccination2")]
+        public CqlDate DTaPVaccination2 { get; set; }
+        [CqlDeclaration("DTaPVaccination3")]
+        public CqlDate DTaPVaccination3 { get; set; }
+        [CqlDeclaration("DTaPVaccination4")]
+        public CqlDate DTaPVaccination4 { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_EHBXDbaEhdOYNSIVBgQCYjWfV.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_EHBXDbaEhdOYNSIVBgQCYjWfV.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_EHBXDbaEhdOYNSIVBgQCYjWfV: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstWhiteBloodCellResult")]
+        public CqlQuantity FirstWhiteBloodCellResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_EPUbUfihDVTJZfYVTHGLFUeUf.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_EPUbUfihDVTJZfYVTHGLFUeUf.g.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_EPUbUfihDVTJZfYVTHGLFUeUf: TupleBaseType
+    {
+        [CqlDeclaration("HOOSLifeQuality")]
+        public Observation HOOSLifeQuality { get; set; }
+        [CqlDeclaration("HOOSSport")]
+        public Observation HOOSSport { get; set; }
+        [CqlDeclaration("HOOSActivityScore")]
+        public Observation HOOSActivityScore { get; set; }
+        [CqlDeclaration("HOOSSymptoms")]
+        public Observation HOOSSymptoms { get; set; }
+        [CqlDeclaration("HOOSPain")]
+        public Observation HOOSPain { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_ESUAOONTBOMCFNSgVCeZOQUbj.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_ESUAOONTBOMCFNSgVCeZOQUbj.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_ESUAOONTBOMCFNSgVCeZOQUbj: TupleBaseType
+    {
+        [CqlDeclaration("FluVaccination1")]
+        public CqlDate FluVaccination1 { get; set; }
+        [CqlDeclaration("FluVaccination2")]
+        public CqlDate FluVaccination2 { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_EUPiSWiDDKENbbAiXeEcRBcdI.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_EUPiSWiDDKENbbAiXeEcRBcdI.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_EUPiSWiDDKENbbAiXeEcRBcdI: TupleBaseType
+    {
+        [CqlDeclaration("OpioidAntagonistGiven")]
+        public MedicationAdministration OpioidAntagonistGiven { get; set; }
+        [CqlDeclaration("OpioidGiven")]
+        public MedicationAdministration OpioidGiven { get; set; }
+        [CqlDeclaration("EncounterWithQualifyingAge")]
+        public Encounter EncounterWithQualifyingAge { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_EbSJTAdMHbBibBKjAIBeBhcjh.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_EbSJTAdMHbBibBKjAIBeBhcjh.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_EbSJTAdMHbBibBKjAIBeBhcjh: TupleBaseType
+    {
+        [CqlDeclaration("VR36MentalAssessment")]
+        public Observation VR36MentalAssessment { get; set; }
+        [CqlDeclaration("VR36PhysicalAssessment")]
+        public Observation VR36PhysicalAssessment { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_EbcGgjOhJFXiKXEMDPcAXPAhA: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstWBCResult")]
+        public CqlQuantity FirstWBCResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_EhGfQcQTPMaVGfjeRNgbDIGOU: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialVR12ObliqueDate")]
+        public CqlDate InitialVR12ObliqueDate { get; set; }
+        [CqlDeclaration("FollowupVR12ObliqueDate")]
+        public CqlDate FollowupVR12ObliqueDate { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_FFJNYaMQHZAOFYMNSKAHAUdLF: TupleBaseType
+    {
+        [CqlDeclaration("KCCQ12Item")]
+        public Observation KCCQ12Item { get; set; }
+        [CqlDeclaration("KCCQ12Summary")]
+        public Observation KCCQ12Summary { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_FGYJHhbRRZTDGeEKJQJIIbGUe: TupleBaseType
+    {
+        [CqlDeclaration("OfficeVisit1")]
+        public Encounter OfficeVisit1 { get; set; }
+        [CqlDeclaration("OfficeVisit2")]
+        public Encounter OfficeVisit2 { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_FNbCKKYcLGcBUjDdFESQQgGfh.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_FNbCKKYcLGcBUjDdFESQQgGfh.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_FNbCKKYcLGcBUjDdFESQQgGfh: TupleBaseType
+    {
+        [CqlDeclaration("QualifyingEncounter")]
+        public Encounter QualifyingEncounter { get; set; }
+        [CqlDeclaration("NutritionAssessment")]
+        public Observation NutritionAssessment { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_FZFeLiXHKPLAfNDgWDMeScIDi.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_FZFeLiXHKPLAfNDgWDMeScIDi.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_FZFeLiXHKPLAfNDgWDMeScIDi: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialVR36OrthogonalDate")]
+        public CqlDate InitialVR36OrthogonalDate { get; set; }
+        [CqlDeclaration("FollowupVR36OrthogonalDate")]
+        public CqlDate FollowupVR36OrthogonalDate { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_FeRJiKQTQgCPbSYWQKEAbBEeV: TupleBaseType
+    {
+        [CqlDeclaration("GroupAStreptococcusTest")]
+        public Observation GroupAStreptococcusTest { get; set; }
+        [CqlDeclaration("EncounterWithPharyngitis")]
+        public Encounter EncounterWithPharyngitis { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_FfUejBAXZfEABRILhFReePdGS.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_FfUejBAXZfEABRILhFReePdGS.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_FfUejBAXZfEABRILhFReePdGS: TupleBaseType
+    {
+        [CqlDeclaration("QualifyingEncounter")]
+        public Encounter QualifyingEncounter { get; set; }
+        [CqlDeclaration("MalnutritionRiskScreening")]
+        public Observation MalnutritionRiskScreening { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_FgYDjIJBhiXdBHJjiISjVeOjV.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_FgYDjIJBhiXdBHJjiISjVeOjV.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_FgYDjIJBhiXdBHJjiISjVeOjV: TupleBaseType
+    {
+        [CqlDeclaration("HeartRate")]
+        public Observation HeartRate { get; set; }
+        [CqlDeclaration("ModerateOrSevereLVSDHFOutpatientEncounter")]
+        public Encounter ModerateOrSevereLVSDHFOutpatientEncounter { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_GCVGMbOiaNAaiRPIPICSbUPeC.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_GCVGMbOiaNAaiRPIPICSbUPeC.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_GCVGMbOiaNAaiRPIPICSbUPeC: TupleBaseType
+    {
+        [CqlDeclaration("VisitWithAntibiotic")]
+        public Encounter VisitWithAntibiotic { get; set; }
+        [CqlDeclaration("AcutePharyngitisTonsillitis")]
+        public Condition AcutePharyngitisTonsillitis { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_GOXKBgTPjADgQhXfdgXgTMIJS.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_GOXKBgTPjADgQhXfdgXgTMIJS.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_GOXKBgTPjADgQhXfdgXgTMIJS: TupleBaseType
+    {
+        [CqlDeclaration("PolioVaccination1")]
+        public CqlDate PolioVaccination1 { get; set; }
+        [CqlDeclaration("PolioVaccination2")]
+        public CqlDate PolioVaccination2 { get; set; }
+        [CqlDeclaration("PolioVaccination3")]
+        public CqlDate PolioVaccination3 { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_GPTRiSLQJWYOPEAYVPRhQCIiV.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_GPTRiSLQJWYOPEAYVPRhQCIiV.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_GPTRiSLQJWYOPEAYVPRhQCIiV: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstCreatinineResult")]
+        public CqlQuantity FirstCreatinineResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_GWOGLWjZWOZYMaEJIOWOEZNOO.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_GWOGLWjZWOZYMaEJIOWOEZNOO.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_GWOGLWjZWOZYMaEJIOWOEZNOO: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstOxygenSatResult")]
+        public CqlQuantity FirstOxygenSatResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_GechMKfhePFUbfJYJeVegQTRC.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_GechMKfhePFUbfJYJeVegQTRC.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_GechMKfhePFUbfJYJeVegQTRC: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialKCCQAssessmentDate")]
+        public CqlDate InitialKCCQAssessmentDate { get; set; }
+        [CqlDeclaration("FollowupKCCQAssessmentDate")]
+        public CqlDate FollowupKCCQAssessmentDate { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_GgbdNTdhNeafRfiEMSgeHDMdE.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_GgbdNTdhNeafRfiEMSgeHDMdE.g.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_GgbdNTdhNeafRfiEMSgeHDMdE: TupleBaseType
+    {
+        [CqlDeclaration("startDate")]
+        public CqlDate startDate { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_HEhDGGHAahjZgibAaAMLGaSGT.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_HEhDGGHAahjZgibAaAMLGaSGT.g.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_HEhDGGHAahjZgibAaAMLGaSGT: TupleBaseType
+    {
+        [CqlDeclaration("FaceToFaceOrTelehealthEncounter")]
+        public Encounter FaceToFaceOrTelehealthEncounter { get; set; }
+        [CqlDeclaration("ChemoBeforeEncounter")]
+        public Procedure ChemoBeforeEncounter { get; set; }
+        [CqlDeclaration("ChemoAfterEncounter")]
+        public Procedure ChemoAfterEncounter { get; set; }
+        [CqlDeclaration("Cancer")]
+        public Condition Cancer { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_HNUZSEJfeiQXIhXGUDXLiWidi.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_HNUZSEJfeiQXIhXGUDXLiWidi.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_HNUZSEJfeiQXIhXGUDXLiWidi: TupleBaseType
+    {
+        [CqlDeclaration("ValidEncounters")]
+        public Encounter ValidEncounters { get; set; }
+        [CqlDeclaration("InitialVR36ObliqueDate")]
+        public CqlDate InitialVR36ObliqueDate { get; set; }
+        [CqlDeclaration("FollowupVR36ObliqueDate")]
+        public CqlDate FollowupVR36ObliqueDate { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_HPafMBLgKMTIEMRRLfcfNHQBV.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_HPafMBLgKMTIEMRRLfcfNHQBV.g.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_HPafMBLgKMTIEMRRLfcfNHQBV: TupleBaseType
+    {
+        [CqlDeclaration("EncounterId")]
+        public string EncounterId { get; set; }
+        [CqlDeclaration("FirstBicarbonateResult")]
+        public CqlQuantity FirstBicarbonateResult { get; set; }
+        [CqlDeclaration("Timing")]
+        public CqlDateTime Timing { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_ITZjeBeBSEgNiFGcLhJYIJNb.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_ITZjeBeBSEgNiFGcLhJYIJNb.g.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_ITZjeBeBSEgNiFGcLhJYIJNb: TupleBaseType
+    {
+        [CqlDeclaration("Promis29Sleep")]
+        public Observation Promis29Sleep { get; set; }
+        [CqlDeclaration("Promis29SocialRoles")]
+        public Observation Promis29SocialRoles { get; set; }
+        [CqlDeclaration("Promis29Physical")]
+        public Observation Promis29Physical { get; set; }
+        [CqlDeclaration("Promis29Pain")]
+        public Observation Promis29Pain { get; set; }
+        [CqlDeclaration("Promis29Fatigue")]
+        public Observation Promis29Fatigue { get; set; }
+        [CqlDeclaration("Promis29Depression")]
+        public Observation Promis29Depression { get; set; }
+        [CqlDeclaration("Promis29Anxiety")]
+        public Observation Promis29Anxiety { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_aWLEFJMGFWIGJKOEOKKQfQiJ: TupleBaseType
+    {
+        [CqlDeclaration("VR12MentalAssessment")]
+        public Observation VR12MentalAssessment { get; set; }
+        [CqlDeclaration("VR12PhysicalAssessment")]
+        public Observation VR12PhysicalAssessment { get; set; }
+    }
+}

--- a/Demo/Measures-cms/Tuples/Tuple_cTMBKgNETPhcWPSTMVcRebEg.g.cs
+++ b/Demo/Measures-cms/Tuples/Tuple_cTMBKgNETPhcWPSTMVcRebEg.g.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+namespace Tuples
+{
+    [System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+    public class Tuple_cTMBKgNETPhcWPSTMVcRebEg: TupleBaseType
+    {
+        [CqlDeclaration("QualifyingEncounter")]
+        public Encounter QualifyingEncounter { get; set; }
+        [CqlDeclaration("NutritionCarePlan")]
+        public Procedure NutritionCarePlan { get; set; }
+    }
+}

--- a/Demo/Measures-cms/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
@@ -1,0 +1,1548 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("UseofHighRiskMedicationsintheElderlyFHIR", "0.1.000")]
+public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Alcohol_Withdrawal;
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Anti_Infectives__other;
+    internal Lazy<CqlValueSet> __Anticholinergics__anti_Parkinson_agents;
+    internal Lazy<CqlValueSet> __Anticholinergics__first_generation_antihistamines;
+    internal Lazy<CqlValueSet> __Antipsychotic;
+    internal Lazy<CqlValueSet> __Antispasmodics;
+    internal Lazy<CqlValueSet> __Antithrombotic;
+    internal Lazy<CqlValueSet> __Benzodiazepine_Withdrawal;
+    internal Lazy<CqlValueSet> __Benzodiazepine;
+    internal Lazy<CqlValueSet> __Bipolar_Disorder;
+    internal Lazy<CqlValueSet> __Cardiovascular__alpha_agonists__central;
+    internal Lazy<CqlValueSet> __Cardiovascular__other;
+    internal Lazy<CqlValueSet> __Care_Services_in_Long_Term_Residential_Facility;
+    internal Lazy<CqlValueSet> __Central_nervous_system__antidepressants;
+    internal Lazy<CqlValueSet> __Central_nervous_system__barbiturates;
+    internal Lazy<CqlValueSet> __Central_nervous_system__other;
+    internal Lazy<CqlValueSet> __Central_nervous_system__vasodilators;
+    internal Lazy<CqlValueSet> __Digoxin;
+    internal Lazy<CqlValueSet> __Discharge_Services_Nursing_Facility;
+    internal Lazy<CqlValueSet> __Doxepin;
+    internal Lazy<CqlValueSet> __Endocrine_system__estrogens_with_or_without_progestins;
+    internal Lazy<CqlValueSet> __Endocrine_system__other;
+    internal Lazy<CqlValueSet> __Endocrine_system__sulfonylureas__long_duration;
+    internal Lazy<CqlValueSet> __Generalized_Anxiety_Disorder;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Nonbenzodiazepine_hypnotics;
+    internal Lazy<CqlValueSet> __Nursing_Facility_Visit;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Ophthalmologic_Services;
+    internal Lazy<CqlValueSet> __Pain_medications__other;
+    internal Lazy<CqlValueSet> __Pain_medications__skeletal_muscle_relaxants;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __REM_Sleep_Behavior_Disorder;
+    internal Lazy<CqlValueSet> __Reserpine;
+    internal Lazy<CqlValueSet> __Schizophrenia;
+    internal Lazy<CqlValueSet> __Seizure_Disorder;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlCode> ___1_ML_digoxin_0_1_MG_ML_Injection;
+    internal Lazy<CqlCode> ___2_ML_digoxin_0_25_MG_ML_Injection;
+    internal Lazy<CqlCode> __digoxin_0_05_MG_ML_Oral_Solution;
+    internal Lazy<CqlCode> __digoxin_0_0625_MG_Oral_Tablet;
+    internal Lazy<CqlCode> __digoxin_0_125_MG_Oral_Tablet;
+    internal Lazy<CqlCode> __digoxin_0_1875_MG_Oral_Tablet;
+    internal Lazy<CqlCode> __digoxin_0_25_MG_Oral_Tablet;
+    internal Lazy<CqlCode> __doxepin_3_MG_Oral_Tablet;
+    internal Lazy<CqlCode> __doxepin_6_MG_Oral_Tablet;
+    internal Lazy<CqlCode> __doxepin_hydrochloride_10_MG_Oral_Capsule;
+    internal Lazy<CqlCode> __doxepin_hydrochloride_10_MG_ML_Oral_Solution;
+    internal Lazy<CqlCode> __doxepin_hydrochloride_100_MG_Oral_Capsule;
+    internal Lazy<CqlCode> __doxepin_hydrochloride_150_MG_Oral_Capsule;
+    internal Lazy<CqlCode> __doxepin_hydrochloride_25_MG_Oral_Capsule;
+    internal Lazy<CqlCode> __doxepin_hydrochloride_50_MG_Oral_Capsule;
+    internal Lazy<CqlCode> __doxepin_hydrochloride_75_MG_Oral_Capsule;
+    internal Lazy<CqlCode> __Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_;
+    internal Lazy<CqlCode> __reserpine_0_1_MG_Oral_Tablet;
+    internal Lazy<CqlCode> __reserpine_0_25_MG_Oral_Tablet;
+    internal Lazy<CqlCode[]> __RXNORM;
+    internal Lazy<CqlCode[]> __CPT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<MedicationRequest>> __Same_High_Risk_Medications_Ordered_on_Different_Days;
+    internal Lazy<bool?> __Two_High_Risk_Medications_with_Prolonged_Duration;
+    internal Lazy<bool?> __High_Risk_Medications_with_Average_Daily_Dose_Criteria;
+    internal Lazy<bool?> __Numerator_1;
+    internal Lazy<bool?> __More_than_One_Antipsychotic_Order;
+    internal Lazy<CqlDateTime> __Antipsychotic_Index_Prescription_Start_Date;
+    internal Lazy<bool?> __More_than_One_Benzodiazepine_Order;
+    internal Lazy<CqlDateTime> __Benzodiazepine_Index_Prescription_Start_Date;
+    internal Lazy<bool?> __Numerator_2;
+    internal Lazy<bool?> __Numerator_3;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public UseofHighRiskMedicationsintheElderlyFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        PalliativeCare_1_9_000 = new PalliativeCare_1_9_000(context);
+        CumulativeMedicationDuration_4_0_000 = new CumulativeMedicationDuration_4_0_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+
+        __Alcohol_Withdrawal = new Lazy<CqlValueSet>(this.Alcohol_Withdrawal_Value);
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value);
+        __Anti_Infectives__other = new Lazy<CqlValueSet>(this.Anti_Infectives__other_Value);
+        __Anticholinergics__anti_Parkinson_agents = new Lazy<CqlValueSet>(this.Anticholinergics__anti_Parkinson_agents_Value);
+        __Anticholinergics__first_generation_antihistamines = new Lazy<CqlValueSet>(this.Anticholinergics__first_generation_antihistamines_Value);
+        __Antipsychotic = new Lazy<CqlValueSet>(this.Antipsychotic_Value);
+        __Antispasmodics = new Lazy<CqlValueSet>(this.Antispasmodics_Value);
+        __Antithrombotic = new Lazy<CqlValueSet>(this.Antithrombotic_Value);
+        __Benzodiazepine_Withdrawal = new Lazy<CqlValueSet>(this.Benzodiazepine_Withdrawal_Value);
+        __Benzodiazepine = new Lazy<CqlValueSet>(this.Benzodiazepine_Value);
+        __Bipolar_Disorder = new Lazy<CqlValueSet>(this.Bipolar_Disorder_Value);
+        __Cardiovascular__alpha_agonists__central = new Lazy<CqlValueSet>(this.Cardiovascular__alpha_agonists__central_Value);
+        __Cardiovascular__other = new Lazy<CqlValueSet>(this.Cardiovascular__other_Value);
+        __Care_Services_in_Long_Term_Residential_Facility = new Lazy<CqlValueSet>(this.Care_Services_in_Long_Term_Residential_Facility_Value);
+        __Central_nervous_system__antidepressants = new Lazy<CqlValueSet>(this.Central_nervous_system__antidepressants_Value);
+        __Central_nervous_system__barbiturates = new Lazy<CqlValueSet>(this.Central_nervous_system__barbiturates_Value);
+        __Central_nervous_system__other = new Lazy<CqlValueSet>(this.Central_nervous_system__other_Value);
+        __Central_nervous_system__vasodilators = new Lazy<CqlValueSet>(this.Central_nervous_system__vasodilators_Value);
+        __Digoxin = new Lazy<CqlValueSet>(this.Digoxin_Value);
+        __Discharge_Services_Nursing_Facility = new Lazy<CqlValueSet>(this.Discharge_Services_Nursing_Facility_Value);
+        __Doxepin = new Lazy<CqlValueSet>(this.Doxepin_Value);
+        __Endocrine_system__estrogens_with_or_without_progestins = new Lazy<CqlValueSet>(this.Endocrine_system__estrogens_with_or_without_progestins_Value);
+        __Endocrine_system__other = new Lazy<CqlValueSet>(this.Endocrine_system__other_Value);
+        __Endocrine_system__sulfonylureas__long_duration = new Lazy<CqlValueSet>(this.Endocrine_system__sulfonylureas__long_duration_Value);
+        __Generalized_Anxiety_Disorder = new Lazy<CqlValueSet>(this.Generalized_Anxiety_Disorder_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Nonbenzodiazepine_hypnotics = new Lazy<CqlValueSet>(this.Nonbenzodiazepine_hypnotics_Value);
+        __Nursing_Facility_Visit = new Lazy<CqlValueSet>(this.Nursing_Facility_Visit_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value);
+        __Ophthalmologic_Services = new Lazy<CqlValueSet>(this.Ophthalmologic_Services_Value);
+        __Pain_medications__other = new Lazy<CqlValueSet>(this.Pain_medications__other_Value);
+        __Pain_medications__skeletal_muscle_relaxants = new Lazy<CqlValueSet>(this.Pain_medications__skeletal_muscle_relaxants_Value);
+        __Preventive_Care_Services_Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value);
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value);
+        __REM_Sleep_Behavior_Disorder = new Lazy<CqlValueSet>(this.REM_Sleep_Behavior_Disorder_Value);
+        __Reserpine = new Lazy<CqlValueSet>(this.Reserpine_Value);
+        __Schizophrenia = new Lazy<CqlValueSet>(this.Schizophrenia_Value);
+        __Seizure_Disorder = new Lazy<CqlValueSet>(this.Seizure_Disorder_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        ___1_ML_digoxin_0_1_MG_ML_Injection = new Lazy<CqlCode>(this._1_ML_digoxin_0_1_MG_ML_Injection_Value);
+        ___2_ML_digoxin_0_25_MG_ML_Injection = new Lazy<CqlCode>(this._2_ML_digoxin_0_25_MG_ML_Injection_Value);
+        __digoxin_0_05_MG_ML_Oral_Solution = new Lazy<CqlCode>(this.digoxin_0_05_MG_ML_Oral_Solution_Value);
+        __digoxin_0_0625_MG_Oral_Tablet = new Lazy<CqlCode>(this.digoxin_0_0625_MG_Oral_Tablet_Value);
+        __digoxin_0_125_MG_Oral_Tablet = new Lazy<CqlCode>(this.digoxin_0_125_MG_Oral_Tablet_Value);
+        __digoxin_0_1875_MG_Oral_Tablet = new Lazy<CqlCode>(this.digoxin_0_1875_MG_Oral_Tablet_Value);
+        __digoxin_0_25_MG_Oral_Tablet = new Lazy<CqlCode>(this.digoxin_0_25_MG_Oral_Tablet_Value);
+        __doxepin_3_MG_Oral_Tablet = new Lazy<CqlCode>(this.doxepin_3_MG_Oral_Tablet_Value);
+        __doxepin_6_MG_Oral_Tablet = new Lazy<CqlCode>(this.doxepin_6_MG_Oral_Tablet_Value);
+        __doxepin_hydrochloride_10_MG_Oral_Capsule = new Lazy<CqlCode>(this.doxepin_hydrochloride_10_MG_Oral_Capsule_Value);
+        __doxepin_hydrochloride_10_MG_ML_Oral_Solution = new Lazy<CqlCode>(this.doxepin_hydrochloride_10_MG_ML_Oral_Solution_Value);
+        __doxepin_hydrochloride_100_MG_Oral_Capsule = new Lazy<CqlCode>(this.doxepin_hydrochloride_100_MG_Oral_Capsule_Value);
+        __doxepin_hydrochloride_150_MG_Oral_Capsule = new Lazy<CqlCode>(this.doxepin_hydrochloride_150_MG_Oral_Capsule_Value);
+        __doxepin_hydrochloride_25_MG_Oral_Capsule = new Lazy<CqlCode>(this.doxepin_hydrochloride_25_MG_Oral_Capsule_Value);
+        __doxepin_hydrochloride_50_MG_Oral_Capsule = new Lazy<CqlCode>(this.doxepin_hydrochloride_50_MG_Oral_Capsule_Value);
+        __doxepin_hydrochloride_75_MG_Oral_Capsule = new Lazy<CqlCode>(this.doxepin_hydrochloride_75_MG_Oral_Capsule_Value);
+        __Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_ = new Lazy<CqlCode>(this.Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal__Value);
+        __reserpine_0_1_MG_Oral_Tablet = new Lazy<CqlCode>(this.reserpine_0_1_MG_Oral_Tablet_Value);
+        __reserpine_0_25_MG_Oral_Tablet = new Lazy<CqlCode>(this.reserpine_0_25_MG_Oral_Tablet_Value);
+        __RXNORM = new Lazy<CqlCode[]>(this.RXNORM_Value);
+        __CPT = new Lazy<CqlCode[]>(this.CPT_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __Same_High_Risk_Medications_Ordered_on_Different_Days = new Lazy<IEnumerable<MedicationRequest>>(this.Same_High_Risk_Medications_Ordered_on_Different_Days_Value);
+        __Two_High_Risk_Medications_with_Prolonged_Duration = new Lazy<bool?>(this.Two_High_Risk_Medications_with_Prolonged_Duration_Value);
+        __High_Risk_Medications_with_Average_Daily_Dose_Criteria = new Lazy<bool?>(this.High_Risk_Medications_with_Average_Daily_Dose_Criteria_Value);
+        __Numerator_1 = new Lazy<bool?>(this.Numerator_1_Value);
+        __More_than_One_Antipsychotic_Order = new Lazy<bool?>(this.More_than_One_Antipsychotic_Order_Value);
+        __Antipsychotic_Index_Prescription_Start_Date = new Lazy<CqlDateTime>(this.Antipsychotic_Index_Prescription_Start_Date_Value);
+        __More_than_One_Benzodiazepine_Order = new Lazy<bool?>(this.More_than_One_Benzodiazepine_Order_Value);
+        __Benzodiazepine_Index_Prescription_Start_Date = new Lazy<CqlDateTime>(this.Benzodiazepine_Index_Prescription_Start_Date_Value);
+        __Numerator_2 = new Lazy<bool?>(this.Numerator_2_Value);
+        __Numerator_3 = new Lazy<bool?>(this.Numerator_3_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public PalliativeCare_1_9_000 PalliativeCare_1_9_000 { get; }
+    public CumulativeMedicationDuration_4_0_000 CumulativeMedicationDuration_4_0_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Alcohol_Withdrawal_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209", null);
+
+    [CqlDeclaration("Alcohol Withdrawal")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209")]
+	public CqlValueSet Alcohol_Withdrawal() => 
+		__Alcohol_Withdrawal.Value;
+
+	private CqlValueSet Annual_Wellness_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+
+    [CqlDeclaration("Annual Wellness Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit.Value;
+
+	private CqlValueSet Anti_Infectives__other_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481", null);
+
+    [CqlDeclaration("Anti Infectives, other")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481")]
+	public CqlValueSet Anti_Infectives__other() => 
+		__Anti_Infectives__other.Value;
+
+	private CqlValueSet Anticholinergics__anti_Parkinson_agents_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049", null);
+
+    [CqlDeclaration("Anticholinergics, anti Parkinson agents")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049")]
+	public CqlValueSet Anticholinergics__anti_Parkinson_agents() => 
+		__Anticholinergics__anti_Parkinson_agents.Value;
+
+	private CqlValueSet Anticholinergics__first_generation_antihistamines_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043", null);
+
+    [CqlDeclaration("Anticholinergics, first generation antihistamines")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043")]
+	public CqlValueSet Anticholinergics__first_generation_antihistamines() => 
+		__Anticholinergics__first_generation_antihistamines.Value;
+
+	private CqlValueSet Antipsychotic_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523", null);
+
+    [CqlDeclaration("Antipsychotic")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523")]
+	public CqlValueSet Antipsychotic() => 
+		__Antipsychotic.Value;
+
+	private CqlValueSet Antispasmodics_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050", null);
+
+    [CqlDeclaration("Antispasmodics")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050")]
+	public CqlValueSet Antispasmodics() => 
+		__Antispasmodics.Value;
+
+	private CqlValueSet Antithrombotic_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051", null);
+
+    [CqlDeclaration("Antithrombotic")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051")]
+	public CqlValueSet Antithrombotic() => 
+		__Antithrombotic.Value;
+
+	private CqlValueSet Benzodiazepine_Withdrawal_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208", null);
+
+    [CqlDeclaration("Benzodiazepine Withdrawal")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208")]
+	public CqlValueSet Benzodiazepine_Withdrawal() => 
+		__Benzodiazepine_Withdrawal.Value;
+
+	private CqlValueSet Benzodiazepine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522", null);
+
+    [CqlDeclaration("Benzodiazepine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522")]
+	public CqlValueSet Benzodiazepine() => 
+		__Benzodiazepine.Value;
+
+	private CqlValueSet Bipolar_Disorder_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157", null);
+
+    [CqlDeclaration("Bipolar Disorder")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157")]
+	public CqlValueSet Bipolar_Disorder() => 
+		__Bipolar_Disorder.Value;
+
+	private CqlValueSet Cardiovascular__alpha_agonists__central_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052", null);
+
+    [CqlDeclaration("Cardiovascular, alpha agonists, central")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052")]
+	public CqlValueSet Cardiovascular__alpha_agonists__central() => 
+		__Cardiovascular__alpha_agonists__central.Value;
+
+	private CqlValueSet Cardiovascular__other_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053", null);
+
+    [CqlDeclaration("Cardiovascular, other")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053")]
+	public CqlValueSet Cardiovascular__other() => 
+		__Cardiovascular__other.Value;
+
+	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+
+    [CqlDeclaration("Care Services in Long Term Residential Facility")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
+	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
+		__Care_Services_in_Long_Term_Residential_Facility.Value;
+
+	private CqlValueSet Central_nervous_system__antidepressants_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054", null);
+
+    [CqlDeclaration("Central nervous system, antidepressants")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054")]
+	public CqlValueSet Central_nervous_system__antidepressants() => 
+		__Central_nervous_system__antidepressants.Value;
+
+	private CqlValueSet Central_nervous_system__barbiturates_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055", null);
+
+    [CqlDeclaration("Central nervous system, barbiturates")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055")]
+	public CqlValueSet Central_nervous_system__barbiturates() => 
+		__Central_nervous_system__barbiturates.Value;
+
+	private CqlValueSet Central_nervous_system__other_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057", null);
+
+    [CqlDeclaration("Central nervous system, other")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057")]
+	public CqlValueSet Central_nervous_system__other() => 
+		__Central_nervous_system__other.Value;
+
+	private CqlValueSet Central_nervous_system__vasodilators_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056", null);
+
+    [CqlDeclaration("Central nervous system, vasodilators")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056")]
+	public CqlValueSet Central_nervous_system__vasodilators() => 
+		__Central_nervous_system__vasodilators.Value;
+
+	private CqlValueSet Digoxin_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065", null);
+
+    [CqlDeclaration("Digoxin")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065")]
+	public CqlValueSet Digoxin() => 
+		__Digoxin.Value;
+
+	private CqlValueSet Discharge_Services_Nursing_Facility_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", null);
+
+    [CqlDeclaration("Discharge Services Nursing Facility")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013")]
+	public CqlValueSet Discharge_Services_Nursing_Facility() => 
+		__Discharge_Services_Nursing_Facility.Value;
+
+	private CqlValueSet Doxepin_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067", null);
+
+    [CqlDeclaration("Doxepin")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067")]
+	public CqlValueSet Doxepin() => 
+		__Doxepin.Value;
+
+	private CqlValueSet Endocrine_system__estrogens_with_or_without_progestins_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058", null);
+
+    [CqlDeclaration("Endocrine system, estrogens with or without progestins")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058")]
+	public CqlValueSet Endocrine_system__estrogens_with_or_without_progestins() => 
+		__Endocrine_system__estrogens_with_or_without_progestins.Value;
+
+	private CqlValueSet Endocrine_system__other_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060", null);
+
+    [CqlDeclaration("Endocrine system, other")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060")]
+	public CqlValueSet Endocrine_system__other() => 
+		__Endocrine_system__other.Value;
+
+	private CqlValueSet Endocrine_system__sulfonylureas__long_duration_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059", null);
+
+    [CqlDeclaration("Endocrine system, sulfonylureas, long duration")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059")]
+	public CqlValueSet Endocrine_system__sulfonylureas__long_duration() => 
+		__Endocrine_system__sulfonylureas__long_duration.Value;
+
+	private CqlValueSet Generalized_Anxiety_Disorder_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210", null);
+
+    [CqlDeclaration("Generalized Anxiety Disorder")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210")]
+	public CqlValueSet Generalized_Anxiety_Disorder() => 
+		__Generalized_Anxiety_Disorder.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Nonbenzodiazepine_hypnotics_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480", null);
+
+    [CqlDeclaration("Nonbenzodiazepine hypnotics")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480")]
+	public CqlValueSet Nonbenzodiazepine_hypnotics() => 
+		__Nonbenzodiazepine_hypnotics.Value;
+
+	private CqlValueSet Nursing_Facility_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+
+    [CqlDeclaration("Nursing Facility Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
+	public CqlValueSet Nursing_Facility_Visit() => 
+		__Nursing_Facility_Visit.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Online_Assessments_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+
+    [CqlDeclaration("Online Assessments")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments.Value;
+
+	private CqlValueSet Ophthalmologic_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206", null);
+
+    [CqlDeclaration("Ophthalmologic Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206")]
+	public CqlValueSet Ophthalmologic_Services() => 
+		__Ophthalmologic_Services.Value;
+
+	private CqlValueSet Pain_medications__other_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063", null);
+
+    [CqlDeclaration("Pain medications, other")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063")]
+	public CqlValueSet Pain_medications__other() => 
+		__Pain_medications__other.Value;
+
+	private CqlValueSet Pain_medications__skeletal_muscle_relaxants_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062", null);
+
+    [CqlDeclaration("Pain medications, skeletal muscle relaxants")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062")]
+	public CqlValueSet Pain_medications__skeletal_muscle_relaxants() => 
+		__Pain_medications__skeletal_muscle_relaxants.Value;
+
+	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+
+    [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
+	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+
+    [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
+
+	private CqlValueSet REM_Sleep_Behavior_Disorder_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207", null);
+
+    [CqlDeclaration("REM Sleep Behavior Disorder")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207")]
+	public CqlValueSet REM_Sleep_Behavior_Disorder() => 
+		__REM_Sleep_Behavior_Disorder.Value;
+
+	private CqlValueSet Reserpine_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044", null);
+
+    [CqlDeclaration("Reserpine")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044")]
+	public CqlValueSet Reserpine() => 
+		__Reserpine.Value;
+
+	private CqlValueSet Schizophrenia_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205", null);
+
+    [CqlDeclaration("Schizophrenia")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205")]
+	public CqlValueSet Schizophrenia() => 
+		__Schizophrenia.Value;
+
+	private CqlValueSet Seizure_Disorder_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206", null);
+
+    [CqlDeclaration("Seizure Disorder")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206")]
+	public CqlValueSet Seizure_Disorder() => 
+		__Seizure_Disorder.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlCode _1_ML_digoxin_0_1_MG_ML_Injection_Value() => 
+		new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("1 ML digoxin 0.1 MG/ML Injection")]
+	public CqlCode _1_ML_digoxin_0_1_MG_ML_Injection() => 
+		___1_ML_digoxin_0_1_MG_ML_Injection.Value;
+
+	private CqlCode _2_ML_digoxin_0_25_MG_ML_Injection_Value() => 
+		new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("2 ML digoxin 0.25 MG/ML Injection")]
+	public CqlCode _2_ML_digoxin_0_25_MG_ML_Injection() => 
+		___2_ML_digoxin_0_25_MG_ML_Injection.Value;
+
+	private CqlCode digoxin_0_05_MG_ML_Oral_Solution_Value() => 
+		new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("digoxin 0.05 MG/ML Oral Solution")]
+	public CqlCode digoxin_0_05_MG_ML_Oral_Solution() => 
+		__digoxin_0_05_MG_ML_Oral_Solution.Value;
+
+	private CqlCode digoxin_0_0625_MG_Oral_Tablet_Value() => 
+		new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("digoxin 0.0625 MG Oral Tablet")]
+	public CqlCode digoxin_0_0625_MG_Oral_Tablet() => 
+		__digoxin_0_0625_MG_Oral_Tablet.Value;
+
+	private CqlCode digoxin_0_125_MG_Oral_Tablet_Value() => 
+		new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("digoxin 0.125 MG Oral Tablet")]
+	public CqlCode digoxin_0_125_MG_Oral_Tablet() => 
+		__digoxin_0_125_MG_Oral_Tablet.Value;
+
+	private CqlCode digoxin_0_1875_MG_Oral_Tablet_Value() => 
+		new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("digoxin 0.1875 MG Oral Tablet")]
+	public CqlCode digoxin_0_1875_MG_Oral_Tablet() => 
+		__digoxin_0_1875_MG_Oral_Tablet.Value;
+
+	private CqlCode digoxin_0_25_MG_Oral_Tablet_Value() => 
+		new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("digoxin 0.25 MG Oral Tablet")]
+	public CqlCode digoxin_0_25_MG_Oral_Tablet() => 
+		__digoxin_0_25_MG_Oral_Tablet.Value;
+
+	private CqlCode doxepin_3_MG_Oral_Tablet_Value() => 
+		new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("doxepin 3 MG Oral Tablet")]
+	public CqlCode doxepin_3_MG_Oral_Tablet() => 
+		__doxepin_3_MG_Oral_Tablet.Value;
+
+	private CqlCode doxepin_6_MG_Oral_Tablet_Value() => 
+		new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("doxepin 6 MG Oral Tablet")]
+	public CqlCode doxepin_6_MG_Oral_Tablet() => 
+		__doxepin_6_MG_Oral_Tablet.Value;
+
+	private CqlCode doxepin_hydrochloride_10_MG_Oral_Capsule_Value() => 
+		new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("doxepin hydrochloride 10 MG Oral Capsule")]
+	public CqlCode doxepin_hydrochloride_10_MG_Oral_Capsule() => 
+		__doxepin_hydrochloride_10_MG_Oral_Capsule.Value;
+
+	private CqlCode doxepin_hydrochloride_10_MG_ML_Oral_Solution_Value() => 
+		new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("doxepin hydrochloride 10 MG/ML Oral Solution")]
+	public CqlCode doxepin_hydrochloride_10_MG_ML_Oral_Solution() => 
+		__doxepin_hydrochloride_10_MG_ML_Oral_Solution.Value;
+
+	private CqlCode doxepin_hydrochloride_100_MG_Oral_Capsule_Value() => 
+		new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("doxepin hydrochloride 100 MG Oral Capsule")]
+	public CqlCode doxepin_hydrochloride_100_MG_Oral_Capsule() => 
+		__doxepin_hydrochloride_100_MG_Oral_Capsule.Value;
+
+	private CqlCode doxepin_hydrochloride_150_MG_Oral_Capsule_Value() => 
+		new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("doxepin hydrochloride 150 MG Oral Capsule")]
+	public CqlCode doxepin_hydrochloride_150_MG_Oral_Capsule() => 
+		__doxepin_hydrochloride_150_MG_Oral_Capsule.Value;
+
+	private CqlCode doxepin_hydrochloride_25_MG_Oral_Capsule_Value() => 
+		new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("doxepin hydrochloride 25 MG Oral Capsule")]
+	public CqlCode doxepin_hydrochloride_25_MG_Oral_Capsule() => 
+		__doxepin_hydrochloride_25_MG_Oral_Capsule.Value;
+
+	private CqlCode doxepin_hydrochloride_50_MG_Oral_Capsule_Value() => 
+		new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("doxepin hydrochloride 50 MG Oral Capsule")]
+	public CqlCode doxepin_hydrochloride_50_MG_Oral_Capsule() => 
+		__doxepin_hydrochloride_50_MG_Oral_Capsule.Value;
+
+	private CqlCode doxepin_hydrochloride_75_MG_Oral_Capsule_Value() => 
+		new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("doxepin hydrochloride 75 MG Oral Capsule")]
+	public CqlCode doxepin_hydrochloride_75_MG_Oral_Capsule() => 
+		__doxepin_hydrochloride_75_MG_Oral_Capsule.Value;
+
+	private CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal__Value() => 
+		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null);
+
+    [CqlDeclaration("Office or other outpatient visit for the evaluation and management of an established patient, that may not require the presence of a physician or other qualified health care professional. Usually, the presenting problem(s) are minimal.")]
+	public CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_() => 
+		__Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_.Value;
+
+	private CqlCode reserpine_0_1_MG_Oral_Tablet_Value() => 
+		new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("reserpine 0.1 MG Oral Tablet")]
+	public CqlCode reserpine_0_1_MG_Oral_Tablet() => 
+		__reserpine_0_1_MG_Oral_Tablet.Value;
+
+	private CqlCode reserpine_0_25_MG_Oral_Tablet_Value() => 
+		new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+
+    [CqlDeclaration("reserpine 0.25 MG Oral Tablet")]
+	public CqlCode reserpine_0_25_MG_Oral_Tablet() => 
+		__reserpine_0_25_MG_Oral_Tablet.Value;
+
+	private CqlCode[] RXNORM_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("RXNORM")]
+	public CqlCode[] RXNORM() => 
+		__RXNORM.Value;
+
+	private CqlCode[] CPT_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("CPT")]
+	public CqlCode[] CPT() => 
+		__CPT.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("UseofHighRiskMedicationsintheElderlyFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Ophthalmologic_Services();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Discharge_Services_Nursing_Facility();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Nursing_Facility_Visit();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = this.Annual_Wellness_Visit();
+		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
+		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
+		var x_ = this.Home_Healthcare_Services();
+		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		var z_ = this.Telephone_Visits();
+		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		var ab_ = context.Operators.ListUnion<Encounter>(y_, aa_);
+		var ac_ = context.Operators.ListUnion<Encounter>(w_, ab_);
+		var ad_ = this.Online_Assessments();
+		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		var af_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		bool? ag_(Encounter E)
+		{
+			CqlConcept am_(CodeableConcept @this)
+			{
+				var ar_ = FHIRHelpers_4_3_000.ToConcept(@this);
+
+				return ar_;
+			};
+			var an_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>(E?.Type, am_);
+			bool? ao_(CqlConcept T)
+			{
+				var as_ = this.Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_();
+				var at_ = context.Operators.ConvertCodeToConcept(as_);
+				var au_ = context.Operators.Equivalent(T, at_);
+
+				return au_;
+			};
+			var ap_ = context.Operators.WhereOrNull<CqlConcept>(an_, ao_);
+			var aq_ = context.Operators.ExistsInList<CqlConcept>(ap_);
+
+			return aq_;
+		};
+		var ah_ = context.Operators.WhereOrNull<Encounter>(af_, ag_);
+		var ai_ = context.Operators.ListUnion<Encounter>(ae_, ah_);
+		var aj_ = context.Operators.ListUnion<Encounter>(ac_, ai_);
+		bool? ak_(Encounter ValidEncounters)
+		{
+			var av_ = this.Measurement_Period();
+			var aw_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounters?.Period);
+			var ax_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(av_, aw_, null);
+
+			return ax_;
+		};
+		var al_ = context.Operators.WhereOrNull<Encounter>(aj_, ak_);
+
+		return al_;
+	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.GreaterOrEqual(f_, (int?)65);
+		var h_ = this.Qualifying_Encounters();
+		var i_ = context.Operators.ExistsInList<Encounter>(h_);
+		var j_ = context.Operators.And(g_, i_);
+
+		return j_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		var c_ = context.Operators.Or(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+    [CqlDeclaration("More Than One Order")]
+	public IEnumerable<MedicationRequest> More_Than_One_Order(IEnumerable<MedicationRequest> Medication)
+	{
+		var a_ = Status_1_6_000.Active_or_Completed_Medication_Request(Medication);
+		IEnumerable<MedicationRequest> b_(MedicationRequest OrderMedication1)
+		{
+			var f_ = Status_1_6_000.Active_or_Completed_Medication_Request(Medication);
+			bool? g_(MedicationRequest OrderMedication2)
+			{
+				var k_ = context.Operators.Convert<CqlDateTime>(OrderMedication1?.AuthoredOnElement);
+				var l_ = this.Measurement_Period();
+				var m_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, null);
+				var n_ = context.Operators.GreaterOrEqual(OrderMedication1?.DispenseRequest?.NumberOfRepeatsAllowedElement?.Value, (int?)1);
+				var o_ = context.Operators.And(m_, n_);
+				var q_ = context.Operators.DateFrom(k_);
+				var r_ = context.Operators.Convert<CqlDateTime>(OrderMedication2?.AuthoredOnElement);
+				var s_ = context.Operators.DateFrom(r_);
+				var t_ = context.Operators.Equivalent(q_, s_);
+				var u_ = context.Operators.Not(t_);
+				var x_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, null);
+				var y_ = context.Operators.And(u_, x_);
+				var ab_ = context.Operators.ElementInInterval<CqlDateTime>(r_, l_, null);
+				var ac_ = context.Operators.And(y_, ab_);
+				var ad_ = context.Operators.Or(o_, ac_);
+				var af_ = context.Operators.DateFrom(k_);
+				var ah_ = context.Operators.DateFrom(r_);
+				var ai_ = context.Operators.Equivalent(af_, ah_);
+				var al_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, null);
+				var am_ = context.Operators.And(ai_, al_);
+				var an_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OrderMedication1);
+				var ao_ = context.Operators.Start(an_);
+				var ap_ = context.Operators.ConvertDateToDateTime(ao_);
+				var aq_ = context.Operators.DateFrom(ap_);
+				var ar_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OrderMedication2);
+				var as_ = context.Operators.Start(ar_);
+				var at_ = context.Operators.ConvertDateToDateTime(as_);
+				var au_ = context.Operators.DateFrom(at_);
+				var av_ = context.Operators.Equivalent(aq_, au_);
+				var aw_ = context.Operators.Not(av_);
+				var ax_ = context.Operators.And(am_, aw_);
+				var az_ = context.Operators.Start(an_);
+				var ba_ = context.Operators.ConvertDateToDateTime(az_);
+				var bc_ = context.Operators.ElementInInterval<CqlDateTime>(ba_, l_, null);
+				var bd_ = context.Operators.And(ax_, bc_);
+				var bf_ = context.Operators.Start(ar_);
+				var bg_ = context.Operators.ConvertDateToDateTime(bf_);
+				var bi_ = context.Operators.ElementInInterval<CqlDateTime>(bg_, l_, null);
+				var bj_ = context.Operators.And(bd_, bi_);
+				var bk_ = context.Operators.Or(ad_, bj_);
+
+				return bk_;
+			};
+			var h_ = context.Operators.WhereOrNull<MedicationRequest>(f_, g_);
+			MedicationRequest i_(MedicationRequest OrderMedication2) => 
+				OrderMedication1;
+			var j_ = context.Operators.SelectOrNull<MedicationRequest, MedicationRequest>(h_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.SelectManyOrNull<MedicationRequest, MedicationRequest>(a_, b_);
+		MedicationRequest d_(MedicationRequest OrderMedication1) => 
+			OrderMedication1;
+		var e_ = context.Operators.SelectOrNull<MedicationRequest, MedicationRequest>(c_, d_);
+
+		return e_;
+	}
+
+	private IEnumerable<MedicationRequest> Same_High_Risk_Medications_Ordered_on_Different_Days_Value()
+	{
+		var a_ = this.Anticholinergics__first_generation_antihistamines();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = this.More_Than_One_Order(e_);
+		var g_ = this.Anticholinergics__anti_Parkinson_agents();
+		var h_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, null);
+		var j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, null);
+		var k_ = context.Operators.ListUnion<MedicationRequest>(h_, j_);
+		var l_ = this.More_Than_One_Order(k_);
+		var m_ = context.Operators.ListUnion<MedicationRequest>(f_, l_);
+		var n_ = this.Antispasmodics();
+		var o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		var q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		var r_ = context.Operators.ListUnion<MedicationRequest>(o_, q_);
+		var s_ = this.More_Than_One_Order(r_);
+		var t_ = this.Antithrombotic();
+		var u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		var w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		var x_ = context.Operators.ListUnion<MedicationRequest>(u_, w_);
+		var y_ = this.More_Than_One_Order(x_);
+		var z_ = context.Operators.ListUnion<MedicationRequest>(s_, y_);
+		var aa_ = context.Operators.ListUnion<MedicationRequest>(m_, z_);
+		var ab_ = this.Cardiovascular__alpha_agonists__central();
+		var ac_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, null);
+		var ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, null);
+		var af_ = context.Operators.ListUnion<MedicationRequest>(ac_, ae_);
+		var ag_ = this.More_Than_One_Order(af_);
+		var ah_ = this.Cardiovascular__other();
+		var ai_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, null);
+		var ak_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, null);
+		var al_ = context.Operators.ListUnion<MedicationRequest>(ai_, ak_);
+		var am_ = this.More_Than_One_Order(al_);
+		var an_ = context.Operators.ListUnion<MedicationRequest>(ag_, am_);
+		var ao_ = context.Operators.ListUnion<MedicationRequest>(aa_, an_);
+		var ap_ = this.Central_nervous_system__antidepressants();
+		var aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
+		var as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
+		var at_ = context.Operators.ListUnion<MedicationRequest>(aq_, as_);
+		var au_ = this.More_Than_One_Order(at_);
+		var av_ = this.Central_nervous_system__barbiturates();
+		var aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
+		var ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
+		var az_ = context.Operators.ListUnion<MedicationRequest>(aw_, ay_);
+		var ba_ = this.More_Than_One_Order(az_);
+		var bb_ = context.Operators.ListUnion<MedicationRequest>(au_, ba_);
+		var bc_ = context.Operators.ListUnion<MedicationRequest>(ao_, bb_);
+		var bd_ = this.Central_nervous_system__vasodilators();
+		var be_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, null);
+		var bg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, null);
+		var bh_ = context.Operators.ListUnion<MedicationRequest>(be_, bg_);
+		var bi_ = this.More_Than_One_Order(bh_);
+		var bj_ = this.Central_nervous_system__other();
+		var bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, null);
+		var bm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, null);
+		var bn_ = context.Operators.ListUnion<MedicationRequest>(bk_, bm_);
+		var bo_ = this.More_Than_One_Order(bn_);
+		var bp_ = context.Operators.ListUnion<MedicationRequest>(bi_, bo_);
+		var bq_ = context.Operators.ListUnion<MedicationRequest>(bc_, bp_);
+		var br_ = this.Endocrine_system__estrogens_with_or_without_progestins();
+		var bs_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, null);
+		var bu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, null);
+		var bv_ = context.Operators.ListUnion<MedicationRequest>(bs_, bu_);
+		var bw_ = this.More_Than_One_Order(bv_);
+		var bx_ = this.Endocrine_system__sulfonylureas__long_duration();
+		var by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, null);
+		var ca_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, null);
+		var cb_ = context.Operators.ListUnion<MedicationRequest>(by_, ca_);
+		var cc_ = this.More_Than_One_Order(cb_);
+		var cd_ = context.Operators.ListUnion<MedicationRequest>(bw_, cc_);
+		var ce_ = context.Operators.ListUnion<MedicationRequest>(bq_, cd_);
+		var cf_ = this.Endocrine_system__other();
+		var cg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, null);
+		var ci_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, null);
+		var cj_ = context.Operators.ListUnion<MedicationRequest>(cg_, ci_);
+		var ck_ = this.More_Than_One_Order(cj_);
+		var cl_ = this.Nonbenzodiazepine_hypnotics();
+		var cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		var co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		var cp_ = context.Operators.ListUnion<MedicationRequest>(cm_, co_);
+		var cq_ = this.More_Than_One_Order(cp_);
+		var cr_ = context.Operators.ListUnion<MedicationRequest>(ck_, cq_);
+		var cs_ = context.Operators.ListUnion<MedicationRequest>(ce_, cr_);
+		var ct_ = this.Pain_medications__skeletal_muscle_relaxants();
+		var cu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, null);
+		var cw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, null);
+		var cx_ = context.Operators.ListUnion<MedicationRequest>(cu_, cw_);
+		var cy_ = this.More_Than_One_Order(cx_);
+		var cz_ = this.Pain_medications__other();
+		var da_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, null);
+		var dc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, null);
+		var dd_ = context.Operators.ListUnion<MedicationRequest>(da_, dc_);
+		var de_ = this.More_Than_One_Order(dd_);
+		var df_ = context.Operators.ListUnion<MedicationRequest>(cy_, de_);
+		var dg_ = context.Operators.ListUnion<MedicationRequest>(cs_, df_);
+
+		return dg_;
+	}
+
+    [CqlDeclaration("Same High Risk Medications Ordered on Different Days")]
+	public IEnumerable<MedicationRequest> Same_High_Risk_Medications_Ordered_on_Different_Days() => 
+		__Same_High_Risk_Medications_Ordered_on_Different_Days.Value;
+
+    [CqlDeclaration("MedicationRequestPeriodInDays")]
+	public decimal? MedicationRequestPeriodInDays(MedicationRequest Request)
+	{
+		var a_ = new MedicationRequest[]
+		{
+			Request,
+		};
+		decimal? b_(MedicationRequest R)
+		{
+			var e_ = FHIRHelpers_4_3_000.ToQuantity((R?.DispenseRequest?.ExpectedSupplyDuration as Quantity));
+			var f_ = context.Operators.ConvertQuantity(e_, "d");
+			var g_ = FHIRHelpers_4_3_000.ToQuantity(R?.DispenseRequest?.Quantity);
+			var h_ = context.Operators.SingleOrNull<Dosage>((R?.DosageInstruction as IEnumerable<Dosage>));
+			var i_ = context.Operators.SingleOrNull<Dosage.DoseAndRateComponent>((h_?.DoseAndRate as IEnumerable<Dosage.DoseAndRateComponent>));
+			var j_ = FHIRHelpers_4_3_000.ToValue(i_?.Dose);
+			var k_ = context.Operators.End((j_ as CqlInterval<CqlQuantity>));
+			var m_ = context.Operators.SingleOrNull<Dosage.DoseAndRateComponent>((h_?.DoseAndRate as IEnumerable<Dosage.DoseAndRateComponent>));
+			var n_ = FHIRHelpers_4_3_000.ToValue(m_?.Dose);
+			var s_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(h_?.Timing?.Repeat?.PeriodUnitElement?.Value);
+			var t_ = context.Operators.Convert<string>(s_);
+			var u_ = CumulativeMedicationDuration_4_0_000.Quantity(h_?.Timing?.Repeat?.PeriodElement?.Value, t_);
+			var v_ = CumulativeMedicationDuration_4_0_000.ToDaily((h_?.Timing?.Repeat?.FrequencyMaxElement?.Value ?? h_?.Timing?.Repeat?.FrequencyElement?.Value), u_);
+			var x_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(h_?.Timing?.Repeat?.TimeOfDayElement, "value");
+			var y_ = context.Operators.CountOrNull<CqlTime>(x_);
+			var z_ = context.Operators.ConvertIntegerToDecimal(y_);
+			var aa_ = context.Operators.Multiply((k_ ?? (n_ as CqlQuantity))?.value, ((v_ ?? z_) ?? (decimal?)1.0m));
+			var ab_ = context.Operators.Divide(g_?.value, aa_);
+			var ac_ = context.Operators.Add((int?)1, (R?.DispenseRequest?.NumberOfRepeatsAllowedElement?.Value ?? (int?)0));
+			var ad_ = context.Operators.ConvertIntegerToDecimal(ac_);
+			var ae_ = context.Operators.Multiply((f_?.value ?? ab_), ad_);
+
+			return ae_;
+		};
+		var c_ = context.Operators.SelectOrNull<MedicationRequest, decimal?>(a_, b_);
+		var d_ = context.Operators.SingleOrNull<decimal?>(c_);
+
+		return d_;
+	}
+
+	private bool? Two_High_Risk_Medications_with_Prolonged_Duration_Value()
+	{
+		var a_ = this.Anti_Infectives__other();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = this.More_Than_One_Order(e_);
+		decimal? g_(MedicationRequest AntiInfectives)
+		{
+			var l_ = this.MedicationRequestPeriodInDays(AntiInfectives);
+
+			return l_;
+		};
+		var h_ = context.Operators.SelectOrNull<MedicationRequest, decimal?>(f_, g_);
+		var i_ = context.Operators.Sum(h_);
+		var j_ = context.Operators.ConvertIntegerToDecimal((int?)90);
+		var k_ = context.Operators.Greater(i_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Two High Risk Medications with Prolonged Duration")]
+	public bool? Two_High_Risk_Medications_with_Prolonged_Duration() => 
+		__Two_High_Risk_Medications_with_Prolonged_Duration.Value;
+
+    [CqlDeclaration("MedicationStrengthPerUnit")]
+	public CqlQuantity MedicationStrengthPerUnit(CqlConcept Strength)
+	{
+		CqlQuantity a_()
+		{
+			if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.reserpine_0_1_MG_Oral_Tablet())) ?? false))
+			{
+				var b_ = context.Operators.Quantity(0.1m, "mg");
+
+				return b_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.reserpine_0_25_MG_Oral_Tablet())) ?? false))
+			{
+				var c_ = context.Operators.Quantity(0.25m, "mg");
+
+				return c_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.digoxin_0_05_MG_ML_Oral_Solution())) ?? false))
+			{
+				var d_ = context.Operators.Quantity(0.05m, "mg/mL");
+
+				return d_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.digoxin_0_0625_MG_Oral_Tablet())) ?? false))
+			{
+				var e_ = context.Operators.Quantity(0.0625m, "mg");
+
+				return e_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this._1_ML_digoxin_0_1_MG_ML_Injection())) ?? false))
+			{
+				var f_ = context.Operators.Quantity(0.1m, "mg/mL");
+
+				return f_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.digoxin_0_125_MG_Oral_Tablet())) ?? false))
+			{
+				var g_ = context.Operators.Quantity(0.125m, "mg");
+
+				return g_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.digoxin_0_1875_MG_Oral_Tablet())) ?? false))
+			{
+				var h_ = context.Operators.Quantity(0.1875m, "mg");
+
+				return h_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.digoxin_0_25_MG_Oral_Tablet())) ?? false))
+			{
+				var i_ = context.Operators.Quantity(0.25m, "mg");
+
+				return i_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this._2_ML_digoxin_0_25_MG_ML_Injection())) ?? false))
+			{
+				var j_ = context.Operators.Quantity(0.25m, "mg/mL");
+
+				return j_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.doxepin_3_MG_Oral_Tablet())) ?? false))
+			{
+				var k_ = context.Operators.Quantity(3m, "mg");
+
+				return k_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.doxepin_6_MG_Oral_Tablet())) ?? false))
+			{
+				var l_ = context.Operators.Quantity(6m, "mg");
+
+				return l_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.doxepin_hydrochloride_10_MG_Oral_Capsule())) ?? false))
+			{
+				var m_ = context.Operators.Quantity(10m, "mg");
+
+				return m_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.doxepin_hydrochloride_10_MG_ML_Oral_Solution())) ?? false))
+			{
+				var n_ = context.Operators.Quantity(10m, "mg/mL");
+
+				return n_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.doxepin_hydrochloride_25_MG_Oral_Capsule())) ?? false))
+			{
+				var o_ = context.Operators.Quantity(25m, "mg");
+
+				return o_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.doxepin_hydrochloride_50_MG_Oral_Capsule())) ?? false))
+			{
+				var p_ = context.Operators.Quantity(50m, "mg");
+
+				return p_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.doxepin_hydrochloride_75_MG_Oral_Capsule())) ?? false))
+			{
+				var q_ = context.Operators.Quantity(75m, "mg");
+
+				return q_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.doxepin_hydrochloride_100_MG_Oral_Capsule())) ?? false))
+			{
+				var r_ = context.Operators.Quantity(100m, "mg");
+
+				return r_;
+			}
+			else if ((context.Operators.Equivalent(Strength, context.Operators.ConvertCodeToConcept(this.doxepin_hydrochloride_150_MG_Oral_Capsule())) ?? false))
+			{
+				var s_ = context.Operators.Quantity(150m, "mg");
+
+				return s_;
+			}
+			else
+			{
+				return null;
+			};
+		};
+
+		return a_();
+	}
+
+    [CqlDeclaration("Average Daily Dose")]
+	public CqlQuantity Average_Daily_Dose(MedicationRequest MedicationRequest)
+	{
+		var a_ = new MedicationRequest[]
+		{
+			MedicationRequest,
+		};
+		CqlQuantity b_(MedicationRequest Order)
+		{
+			CqlQuantity e_()
+			{
+				if ((context.Operators.And(context.Operators.Not((bool?)(this.MedicationRequestPeriodInDays(Order) is null)), context.Operators.Or(context.Operators.Equal(this.MedicationStrengthPerUnit(CQMCommon_2_0_000.getMedicationCode(Order))?.unit, "mg"), context.Operators.And(context.Operators.Equal(this.MedicationStrengthPerUnit(CQMCommon_2_0_000.getMedicationCode(Order))?.unit, "mg/mL"), context.Operators.Equal(FHIRHelpers_4_3_000.ToQuantity(Order?.DispenseRequest?.Quantity)?.unit, "mL")))) ?? false))
+				{
+					var f_ = FHIRHelpers_4_3_000.ToQuantity(Order?.DispenseRequest?.Quantity);
+					var g_ = CQMCommon_2_0_000.getMedicationCode(Order);
+					var h_ = this.MedicationStrengthPerUnit(g_);
+					var i_ = context.Operators.Multiply(f_, h_);
+					var j_ = this.MedicationRequestPeriodInDays(Order);
+					var k_ = context.Operators.Divide(i_, new CqlQuantity(j_, "d"));
+
+					return k_;
+				}
+				else
+				{
+					return null;
+				};
+			};
+
+			return e_();
+		};
+		var c_ = context.Operators.SelectOrNull<MedicationRequest, CqlQuantity>(a_, b_);
+		var d_ = context.Operators.SingleOrNull<CqlQuantity>(c_);
+
+		return d_;
+	}
+
+	private bool? High_Risk_Medications_with_Average_Daily_Dose_Criteria_Value()
+	{
+		var a_ = this.Reserpine();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		bool? f_(MedicationRequest ReserpineOrdered)
+		{
+			var ad_ = this.Average_Daily_Dose(ReserpineOrdered);
+			var ae_ = context.Operators.Quantity(0.1m, "mg/d");
+			var af_ = context.Operators.Greater(ad_, ae_);
+
+			return af_;
+		};
+		var g_ = context.Operators.WhereOrNull<MedicationRequest>(e_, f_);
+		var h_ = this.More_Than_One_Order(g_);
+		var i_ = context.Operators.ExistsInList<MedicationRequest>(h_);
+		var j_ = this.Digoxin();
+		var k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
+		var m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
+		var n_ = context.Operators.ListUnion<MedicationRequest>(k_, m_);
+		bool? o_(MedicationRequest DigoxinOrdered)
+		{
+			var ag_ = this.Average_Daily_Dose(DigoxinOrdered);
+			var ah_ = context.Operators.Quantity(0.125m, "mg/d");
+			var ai_ = context.Operators.Greater(ag_, ah_);
+
+			return ai_;
+		};
+		var p_ = context.Operators.WhereOrNull<MedicationRequest>(n_, o_);
+		var q_ = this.More_Than_One_Order(p_);
+		var r_ = context.Operators.ExistsInList<MedicationRequest>(q_);
+		var s_ = context.Operators.Or(i_, r_);
+		var t_ = this.Doxepin();
+		var u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		var w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		var x_ = context.Operators.ListUnion<MedicationRequest>(u_, w_);
+		bool? y_(MedicationRequest DoxepinOrdered)
+		{
+			var aj_ = this.Average_Daily_Dose(DoxepinOrdered);
+			var ak_ = context.Operators.Quantity(6m, "mg/d");
+			var al_ = context.Operators.Greater(aj_, ak_);
+
+			return al_;
+		};
+		var z_ = context.Operators.WhereOrNull<MedicationRequest>(x_, y_);
+		var aa_ = this.More_Than_One_Order(z_);
+		var ab_ = context.Operators.ExistsInList<MedicationRequest>(aa_);
+		var ac_ = context.Operators.Or(s_, ab_);
+
+		return ac_;
+	}
+
+    [CqlDeclaration("High Risk Medications with Average Daily Dose Criteria")]
+	public bool? High_Risk_Medications_with_Average_Daily_Dose_Criteria() => 
+		__High_Risk_Medications_with_Average_Daily_Dose_Criteria.Value;
+
+	private bool? Numerator_1_Value()
+	{
+		var a_ = this.Same_High_Risk_Medications_Ordered_on_Different_Days();
+		var b_ = context.Operators.ExistsInList<MedicationRequest>(a_);
+		var c_ = this.Two_High_Risk_Medications_with_Prolonged_Duration();
+		var d_ = context.Operators.Or(b_, c_);
+		var e_ = this.High_Risk_Medications_with_Average_Daily_Dose_Criteria();
+		var f_ = context.Operators.Or(d_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Numerator 1")]
+	public bool? Numerator_1() => 
+		__Numerator_1.Value;
+
+	private bool? More_than_One_Antipsychotic_Order_Value()
+	{
+		var a_ = this.Antipsychotic();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = this.More_Than_One_Order(e_);
+		var g_ = context.Operators.ExistsInList<MedicationRequest>(f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("More than One Antipsychotic Order")]
+	public bool? More_than_One_Antipsychotic_Order() => 
+		__More_than_One_Antipsychotic_Order.Value;
+
+	private CqlDateTime Antipsychotic_Index_Prescription_Start_Date_Value()
+	{
+		var a_ = this.Antipsychotic();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
+		bool? g_(MedicationRequest AntipsychoticMedication)
+		{
+			var m_ = context.Operators.Convert<CqlDateTime>(AntipsychoticMedication?.AuthoredOnElement);
+			var n_ = this.Measurement_Period();
+			var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, null);
+
+			return o_;
+		};
+		var h_ = context.Operators.WhereOrNull<MedicationRequest>(f_, g_);
+		CqlDateTime i_(MedicationRequest AntipsychoticMedication)
+		{
+			var p_ = context.Operators.Convert<CqlDateTime>(AntipsychoticMedication?.AuthoredOnElement);
+
+			return p_;
+		};
+		var j_ = context.Operators.SelectOrNull<MedicationRequest, CqlDateTime>(h_, i_);
+		var k_ = context.Operators.ListSort<CqlDateTime>(j_, System.ComponentModel.ListSortDirection.Ascending);
+		var l_ = context.Operators.FirstOfList<CqlDateTime>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Antipsychotic Index Prescription Start Date")]
+	public CqlDateTime Antipsychotic_Index_Prescription_Start_Date() => 
+		__Antipsychotic_Index_Prescription_Start_Date.Value;
+
+	private bool? More_than_One_Benzodiazepine_Order_Value()
+	{
+		var a_ = this.Benzodiazepine();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = this.More_Than_One_Order(e_);
+		var g_ = context.Operators.ExistsInList<MedicationRequest>(f_);
+
+		return g_;
+	}
+
+    [CqlDeclaration("More than One Benzodiazepine Order")]
+	public bool? More_than_One_Benzodiazepine_Order() => 
+		__More_than_One_Benzodiazepine_Order.Value;
+
+	private CqlDateTime Benzodiazepine_Index_Prescription_Start_Date_Value()
+	{
+		var a_ = this.Benzodiazepine();
+		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
+		var f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
+		bool? g_(MedicationRequest BenzodiazepineMedication)
+		{
+			var m_ = context.Operators.Convert<CqlDateTime>(BenzodiazepineMedication?.AuthoredOnElement);
+			var n_ = this.Measurement_Period();
+			var o_ = context.Operators.ElementInInterval<CqlDateTime>(m_, n_, null);
+
+			return o_;
+		};
+		var h_ = context.Operators.WhereOrNull<MedicationRequest>(f_, g_);
+		CqlDateTime i_(MedicationRequest BenzodiazepineMedication)
+		{
+			var p_ = context.Operators.Convert<CqlDateTime>(BenzodiazepineMedication?.AuthoredOnElement);
+
+			return p_;
+		};
+		var j_ = context.Operators.SelectOrNull<MedicationRequest, CqlDateTime>(h_, i_);
+		var k_ = context.Operators.ListSort<CqlDateTime>(j_, System.ComponentModel.ListSortDirection.Ascending);
+		var l_ = context.Operators.FirstOfList<CqlDateTime>(k_);
+
+		return l_;
+	}
+
+    [CqlDeclaration("Benzodiazepine Index Prescription Start Date")]
+	public CqlDateTime Benzodiazepine_Index_Prescription_Start_Date() => 
+		__Benzodiazepine_Index_Prescription_Start_Date.Value;
+
+	private bool? Numerator_2_Value()
+	{
+		var a_ = this.More_than_One_Antipsychotic_Order();
+		var b_ = this.Schizophrenia();
+		var c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		var d_ = this.Bipolar_Disorder();
+		var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+		var f_ = context.Operators.ListUnion<Condition>(c_, e_);
+		bool? g_(Condition AntipsychoticTreatedDiagnoses)
+		{
+			var ag_ = QICoreCommon_2_0_000.ToPrevalenceInterval(AntipsychoticTreatedDiagnoses);
+			var ah_ = this.Measurement_Period();
+			var ai_ = context.Operators.Start(ah_);
+			var aj_ = context.Operators.Quantity(1m, "year");
+			var ak_ = context.Operators.Subtract(ai_, aj_);
+			var al_ = this.Antipsychotic_Index_Prescription_Start_Date();
+			var am_ = context.Operators.Interval(ak_, al_, true, true);
+			var an_ = context.Operators.Overlaps(ag_, am_, null);
+
+			return an_;
+		};
+		var h_ = context.Operators.WhereOrNull<Condition>(f_, g_);
+		var i_ = context.Operators.ExistsInList<Condition>(h_);
+		var j_ = context.Operators.Not(i_);
+		var k_ = context.Operators.And(a_, j_);
+		var l_ = this.More_than_One_Benzodiazepine_Order();
+		var m_ = this.Seizure_Disorder();
+		var n_ = context.Operators.RetrieveByValueSet<Condition>(m_, null);
+		var o_ = this.REM_Sleep_Behavior_Disorder();
+		var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		var q_ = context.Operators.ListUnion<Condition>(n_, p_);
+		var r_ = this.Benzodiazepine_Withdrawal();
+		var s_ = context.Operators.RetrieveByValueSet<Condition>(r_, null);
+		var t_ = this.Alcohol_Withdrawal();
+		var u_ = context.Operators.RetrieveByValueSet<Condition>(t_, null);
+		var v_ = context.Operators.ListUnion<Condition>(s_, u_);
+		var w_ = context.Operators.ListUnion<Condition>(q_, v_);
+		var x_ = this.Generalized_Anxiety_Disorder();
+		var y_ = context.Operators.RetrieveByValueSet<Condition>(x_, null);
+		var z_ = context.Operators.ListUnion<Condition>(w_, y_);
+		bool? aa_(Condition BenzodiazepineTreatedDiagnoses)
+		{
+			var ao_ = QICoreCommon_2_0_000.ToPrevalenceInterval(BenzodiazepineTreatedDiagnoses);
+			var ap_ = this.Measurement_Period();
+			var aq_ = context.Operators.Start(ap_);
+			var ar_ = context.Operators.Quantity(1m, "year");
+			var as_ = context.Operators.Subtract(aq_, ar_);
+			var at_ = this.Benzodiazepine_Index_Prescription_Start_Date();
+			var au_ = context.Operators.Interval(as_, at_, true, true);
+			var av_ = context.Operators.Overlaps(ao_, au_, null);
+
+			return av_;
+		};
+		var ab_ = context.Operators.WhereOrNull<Condition>(z_, aa_);
+		var ac_ = context.Operators.ExistsInList<Condition>(ab_);
+		var ad_ = context.Operators.Not(ac_);
+		var ae_ = context.Operators.And(l_, ad_);
+		var af_ = context.Operators.Or(k_, ae_);
+
+		return af_;
+	}
+
+    [CqlDeclaration("Numerator 2")]
+	public bool? Numerator_2() => 
+		__Numerator_2.Value;
+
+	private bool? Numerator_3_Value()
+	{
+		var a_ = this.Numerator_2();
+		var b_ = this.Numerator_1();
+		var d_ = context.Operators.Not(a_);
+		var e_ = context.Operators.And(b_, d_);
+		var f_ = context.Operators.Or(a_, e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Numerator 3")]
+	public bool? Numerator_3() => 
+		__Numerator_3.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+}

--- a/Demo/Measures-cms/VTE-8.6.000.g.cs
+++ b/Demo/Measures-cms/VTE-8.6.000.g.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("VTE", "8.6.000")]
+public class VTE_8_6_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Obstetrical_or_Pregnancy_Related_Conditions;
+    internal Lazy<CqlValueSet> __Obstetrics_VTE;
+    internal Lazy<CqlValueSet> __Venous_Thromboembolism;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Admission_without_VTE_or_Obstetrical_Conditions;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+
+    #endregion
+    public VTE_8_6_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        CQMCommon_2_0_000 = new CQMCommon_2_0_000(context);
+
+        __Obstetrical_or_Pregnancy_Related_Conditions = new Lazy<CqlValueSet>(this.Obstetrical_or_Pregnancy_Related_Conditions_Value);
+        __Obstetrics_VTE = new Lazy<CqlValueSet>(this.Obstetrics_VTE_Value);
+        __Venous_Thromboembolism = new Lazy<CqlValueSet>(this.Venous_Thromboembolism_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Admission_without_VTE_or_Obstetrical_Conditions = new Lazy<IEnumerable<Encounter>>(this.Admission_without_VTE_or_Obstetrical_Conditions_Value);
+        __Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions_Value);
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public CQMCommon_2_0_000 CQMCommon_2_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Obstetrical_or_Pregnancy_Related_Conditions_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263", null);
+
+    [CqlDeclaration("Obstetrical or Pregnancy Related Conditions")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263")]
+	public CqlValueSet Obstetrical_or_Pregnancy_Related_Conditions() => 
+		__Obstetrical_or_Pregnancy_Related_Conditions.Value;
+
+	private CqlValueSet Obstetrics_VTE_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264", null);
+
+    [CqlDeclaration("Obstetrics VTE")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264")]
+	public CqlValueSet Obstetrics_VTE() => 
+		__Obstetrics_VTE.Value;
+
+	private CqlValueSet Venous_Thromboembolism_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279", null);
+
+    [CqlDeclaration("Venous Thromboembolism")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279")]
+	public CqlValueSet Venous_Thromboembolism() => 
+		__Venous_Thromboembolism.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.ResolveParameter("VTE-8.6.000", "Measurement Period", null);
+
+		return (CqlInterval<CqlDateTime>)a_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private IEnumerable<Encounter> Admission_without_VTE_or_Obstetrical_Conditions_Value()
+	{
+		var a_ = CQMCommon_2_0_000.Inpatient_Encounter();
+		bool? b_(Encounter InpatientEncounter)
+		{
+			var d_ = CQMCommon_2_0_000.encounterDiagnosis(InpatientEncounter);
+			bool? e_(Condition EncDx)
+			{
+				var i_ = FHIRHelpers_4_3_000.ToConcept(EncDx?.Code);
+				var j_ = this.Obstetrical_or_Pregnancy_Related_Conditions();
+				var k_ = context.Operators.ConceptInValueSet(i_, j_);
+				var m_ = this.Venous_Thromboembolism();
+				var n_ = context.Operators.ConceptInValueSet(i_, m_);
+				var o_ = context.Operators.Or(k_, n_);
+				var q_ = this.Obstetrics_VTE();
+				var r_ = context.Operators.ConceptInValueSet(i_, q_);
+				var s_ = context.Operators.Or(o_, r_);
+
+				return s_;
+			};
+			var f_ = context.Operators.WhereOrNull<Condition>(d_, e_);
+			var g_ = context.Operators.ExistsInList<Condition>(f_);
+			var h_ = context.Operators.Not(g_);
+
+			return h_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Admission without VTE or Obstetrical Conditions")]
+	public IEnumerable<Encounter> Admission_without_VTE_or_Obstetrical_Conditions() => 
+		__Admission_without_VTE_or_Obstetrical_Conditions.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions_Value()
+	{
+		var a_ = CQMCommon_2_0_000.Inpatient_Encounter();
+		bool? b_(Encounter InpatientEncounter)
+		{
+			var f_ = this.Patient();
+			var g_ = context.Operators.Convert<CqlDate>(f_?.BirthDateElement?.Value);
+			var h_ = FHIRHelpers_4_3_000.ToInterval(InpatientEncounter?.Period);
+			var i_ = context.Operators.Start(h_);
+			var j_ = context.Operators.DateFrom(i_);
+			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			var l_ = context.Operators.GreaterOrEqual(k_, (int?)18);
+
+			return l_;
+		};
+		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
+		var d_ = this.Admission_without_VTE_or_Obstetrical_Conditions();
+		var e_ = context.Operators.ListIntersect<Encounter>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Encounter with Age Range and without VTE Diagnosis or Obstetrical Conditions")]
+	public IEnumerable<Encounter> Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions() => 
+		__Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value()
+	{
+		var a_ = this.Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population.Value;
+
+    [CqlDeclaration("FromDayOfStartOfHospitalizationToDayAfterAdmission")]
+	public CqlInterval<CqlDate> FromDayOfStartOfHospitalizationToDayAfterAdmission(Encounter Encounter)
+	{
+		var a_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
+		var b_ = context.Operators.Start(a_);
+		var c_ = context.Operators.DateFrom(b_);
+		var d_ = FHIRHelpers_4_3_000.ToInterval(Encounter?.Period);
+		var e_ = context.Operators.Start(d_);
+		var f_ = context.Operators.DateFrom(e_);
+		var g_ = context.Operators.Quantity(1m, "days");
+		var h_ = context.Operators.Add(f_, g_);
+		var i_ = context.Operators.Interval(c_, h_, true, true);
+
+		return i_;
+	}
+
+    [CqlDeclaration("StartOfFirstICU")]
+	public CqlDateTime StartOfFirstICU(Encounter Encounter)
+	{
+		var a_ = CQMCommon_2_0_000.firstInpatientIntensiveCareUnit(Encounter);
+		var b_ = FHIRHelpers_4_3_000.ToInterval(a_?.Period);
+		var c_ = context.Operators.Start(b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("FromDayOfStartOfHospitalizationToDayAfterFirstICU")]
+	public CqlInterval<CqlDate> FromDayOfStartOfHospitalizationToDayAfterFirstICU(Encounter Encounter)
+	{
+		var a_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
+		var b_ = context.Operators.Start(a_);
+		var c_ = context.Operators.DateFrom(b_);
+		var d_ = this.StartOfFirstICU(Encounter);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.Quantity(1m, "day");
+		var g_ = context.Operators.Add(e_, f_);
+		var h_ = context.Operators.Interval(c_, g_, true, true);
+
+		return h_;
+	}
+
+}

--- a/Demo/Measures-cms/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
+++ b/Demo/Measures-cms/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
@@ -1,0 +1,768 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.0.0")]
+[CqlLibrary("WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR", "0.1.000")]
+public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR_0_1_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __BMI_percentile;
+    internal Lazy<CqlValueSet> __Counseling_for_Nutrition;
+    internal Lazy<CqlValueSet> __Counseling_for_Physical_Activity;
+    internal Lazy<CqlValueSet> __Discharged_to_Health_Care_Facility_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Discharged_to_Home_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Height;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Hospice_care_ambulatory;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Pregnancy;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Group_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Individual_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care__Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Weight;
+    internal Lazy<CqlCode> ___in_i_;
+    internal Lazy<CqlCode> ___lb_av_;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode> __Body_height;
+    internal Lazy<CqlCode> __Body_mass_index__BMI___Ratio_;
+    internal Lazy<CqlCode> __Body_weight;
+    internal Lazy<CqlCode> __cm;
+    internal Lazy<CqlCode> __exam;
+    internal Lazy<CqlCode> __g;
+    internal Lazy<CqlCode> __kg;
+    internal Lazy<CqlCode> __vital_signs;
+    internal Lazy<CqlCode[]> __UCUM;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __ObservationCategoryCodes;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>> __SDE_Payer;
+    internal Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Condition>> __Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Observation>> __BMI_Percentile_in_Measurement_Period;
+    internal Lazy<IEnumerable<Observation>> __Height_in_Measurement_Period;
+    internal Lazy<IEnumerable<Observation>> __Weight_in_Measurement_Period;
+    internal Lazy<bool?> __Numerator_1;
+    internal Lazy<bool?> __Numerator_2;
+    internal Lazy<bool?> __Numerator_3;
+    internal Lazy<bool?> __Stratifaction_1;
+    internal Lazy<bool?> __Stratifaction_2;
+
+    #endregion
+    public WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR_0_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_3_000 = new FHIRHelpers_4_3_000(context);
+        QICoreCommon_2_0_000 = new QICoreCommon_2_0_000(context);
+        SupplementalDataElements_3_4_000 = new SupplementalDataElements_3_4_000(context);
+        Hospice_6_9_000 = new Hospice_6_9_000(context);
+        Status_1_6_000 = new Status_1_6_000(context);
+
+        __BMI_percentile = new Lazy<CqlValueSet>(this.BMI_percentile_Value);
+        __Counseling_for_Nutrition = new Lazy<CqlValueSet>(this.Counseling_for_Nutrition_Value);
+        __Counseling_for_Physical_Activity = new Lazy<CqlValueSet>(this.Counseling_for_Physical_Activity_Value);
+        __Discharged_to_Health_Care_Facility_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Health_Care_Facility_for_Hospice_Care_Value);
+        __Discharged_to_Home_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Home_for_Hospice_Care_Value);
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value);
+        __Height = new Lazy<CqlValueSet>(this.Height_Value);
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value);
+        __Hospice_care_ambulatory = new Lazy<CqlValueSet>(this.Hospice_care_ambulatory_Value);
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value);
+        __Pregnancy = new Lazy<CqlValueSet>(this.Pregnancy_Value);
+        __Preventive_Care_Services___Group_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Group_Counseling_Value);
+        __Preventive_Care_Services__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value);
+        __Preventive_Care_Services_Individual_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Individual_Counseling_Value);
+        __Preventive_Care__Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Established_Office_Visit__0_to_17_Value);
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value);
+        __Weight = new Lazy<CqlValueSet>(this.Weight_Value);
+        ___in_i_ = new Lazy<CqlCode>(this._in_i__Value);
+        ___lb_av_ = new Lazy<CqlCode>(this._lb_av__Value);
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value);
+        __Body_height = new Lazy<CqlCode>(this.Body_height_Value);
+        __Body_mass_index__BMI___Ratio_ = new Lazy<CqlCode>(this.Body_mass_index__BMI___Ratio__Value);
+        __Body_weight = new Lazy<CqlCode>(this.Body_weight_Value);
+        __cm = new Lazy<CqlCode>(this.cm_Value);
+        __exam = new Lazy<CqlCode>(this.exam_Value);
+        __g = new Lazy<CqlCode>(this.g_Value);
+        __kg = new Lazy<CqlCode>(this.kg_Value);
+        __vital_signs = new Lazy<CqlCode>(this.vital_signs_Value);
+        __UCUM = new Lazy<CqlCode[]>(this.UCUM_Value);
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value);
+        __ObservationCategoryCodes = new Lazy<CqlCode[]>(this.ObservationCategoryCodes_Value);
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __SDE_Ethnicity = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Ethnicity_Value);
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX>>(this.SDE_Payer_Value);
+        __SDE_Race = new Lazy<Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB>(this.SDE_Race_Value);
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value);
+        __Qualifying_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_Value);
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value);
+        __Denominator = new Lazy<bool?>(this.Denominator_Value);
+        __Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period = new Lazy<IEnumerable<Condition>>(this.Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period_Value);
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value);
+        __BMI_Percentile_in_Measurement_Period = new Lazy<IEnumerable<Observation>>(this.BMI_Percentile_in_Measurement_Period_Value);
+        __Height_in_Measurement_Period = new Lazy<IEnumerable<Observation>>(this.Height_in_Measurement_Period_Value);
+        __Weight_in_Measurement_Period = new Lazy<IEnumerable<Observation>>(this.Weight_in_Measurement_Period_Value);
+        __Numerator_1 = new Lazy<bool?>(this.Numerator_1_Value);
+        __Numerator_2 = new Lazy<bool?>(this.Numerator_2_Value);
+        __Numerator_3 = new Lazy<bool?>(this.Numerator_3_Value);
+        __Stratifaction_1 = new Lazy<bool?>(this.Stratifaction_1_Value);
+        __Stratifaction_2 = new Lazy<bool?>(this.Stratifaction_2_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_3_000 FHIRHelpers_4_3_000 { get; }
+    public QICoreCommon_2_0_000 QICoreCommon_2_0_000 { get; }
+    public SupplementalDataElements_3_4_000 SupplementalDataElements_3_4_000 { get; }
+    public Hospice_6_9_000 Hospice_6_9_000 { get; }
+    public Status_1_6_000 Status_1_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet BMI_percentile_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012", null);
+
+    [CqlDeclaration("BMI percentile")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012")]
+	public CqlValueSet BMI_percentile() => 
+		__BMI_percentile.Value;
+
+	private CqlValueSet Counseling_for_Nutrition_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003", null);
+
+    [CqlDeclaration("Counseling for Nutrition")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003")]
+	public CqlValueSet Counseling_for_Nutrition() => 
+		__Counseling_for_Nutrition.Value;
+
+	private CqlValueSet Counseling_for_Physical_Activity_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035", null);
+
+    [CqlDeclaration("Counseling for Physical Activity")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035")]
+	public CqlValueSet Counseling_for_Physical_Activity() => 
+		__Counseling_for_Physical_Activity.Value;
+
+	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+
+    [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
+	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
+		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
+
+	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+
+    [CqlDeclaration("Discharged to Home for Hospice Care")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
+	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
+		__Discharged_to_Home_for_Hospice_Care.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlDeclaration("Encounter Inpatient")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient.Value;
+
+	private CqlValueSet Height_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014", null);
+
+    [CqlDeclaration("Height")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014")]
+	public CqlValueSet Height() => 
+		__Height.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlDeclaration("Home Healthcare Services")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services.Value;
+
+	private CqlValueSet Hospice_care_ambulatory_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+
+    [CqlDeclaration("Hospice care ambulatory")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
+	public CqlValueSet Hospice_care_ambulatory() => 
+		__Hospice_care_ambulatory.Value;
+
+	private CqlValueSet Office_Visit_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlDeclaration("Office Visit")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit.Value;
+
+	private CqlValueSet Pregnancy_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378", null);
+
+    [CqlDeclaration("Pregnancy")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378")]
+	public CqlValueSet Pregnancy() => 
+		__Pregnancy.Value;
+
+	private CqlValueSet Preventive_Care_Services___Group_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+
+    [CqlDeclaration("Preventive Care Services - Group Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
+	public CqlValueSet Preventive_Care_Services___Group_Counseling() => 
+		__Preventive_Care_Services___Group_Counseling.Value;
+
+	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+
+    [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
+	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+
+    [CqlDeclaration("Preventive Care Services-Individual Counseling")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
+	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
+		__Preventive_Care_Services_Individual_Counseling.Value;
+
+	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+
+    [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
+	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
+		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
+
+	private CqlValueSet Telephone_Visits_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    [CqlDeclaration("Telephone Visits")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits.Value;
+
+	private CqlValueSet Weight_Value() => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015", null);
+
+    [CqlDeclaration("Weight")]
+    [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015")]
+	public CqlValueSet Weight() => 
+		__Weight.Value;
+
+	private CqlCode _in_i__Value() => 
+		new CqlCode("[in_i]", "http://unitsofmeasure.org", null, null);
+
+    [CqlDeclaration("[in_i]")]
+	public CqlCode _in_i_() => 
+		___in_i_.Value;
+
+	private CqlCode _lb_av__Value() => 
+		new CqlCode("[lb_av]", "http://unitsofmeasure.org", null, null);
+
+    [CqlDeclaration("[lb_av]")]
+	public CqlCode _lb_av_() => 
+		___lb_av_.Value;
+
+	private CqlCode Birth_date_Value() => 
+		new CqlCode("21112-8", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date.Value;
+
+	private CqlCode Body_height_Value() => 
+		new CqlCode("8302-2", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Body height")]
+	public CqlCode Body_height() => 
+		__Body_height.Value;
+
+	private CqlCode Body_mass_index__BMI___Ratio__Value() => 
+		new CqlCode("39156-5", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Body mass index (BMI) [Ratio]")]
+	public CqlCode Body_mass_index__BMI___Ratio_() => 
+		__Body_mass_index__BMI___Ratio_.Value;
+
+	private CqlCode Body_weight_Value() => 
+		new CqlCode("29463-7", "http://loinc.org", null, null);
+
+    [CqlDeclaration("Body weight")]
+	public CqlCode Body_weight() => 
+		__Body_weight.Value;
+
+	private CqlCode cm_Value() => 
+		new CqlCode("cm", "http://unitsofmeasure.org", null, null);
+
+    [CqlDeclaration("cm")]
+	public CqlCode cm() => 
+		__cm.Value;
+
+	private CqlCode exam_Value() => 
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+
+    [CqlDeclaration("exam")]
+	public CqlCode exam() => 
+		__exam.Value;
+
+	private CqlCode g_Value() => 
+		new CqlCode("g", "http://unitsofmeasure.org", null, null);
+
+    [CqlDeclaration("g")]
+	public CqlCode g() => 
+		__g.Value;
+
+	private CqlCode kg_Value() => 
+		new CqlCode("kg", "http://unitsofmeasure.org", null, null);
+
+    [CqlDeclaration("kg")]
+	public CqlCode kg() => 
+		__kg.Value;
+
+	private CqlCode vital_signs_Value() => 
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+
+    [CqlDeclaration("vital-signs")]
+	public CqlCode vital_signs() => 
+		__vital_signs.Value;
+
+	private CqlCode[] UCUM_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("[in_i]", "http://unitsofmeasure.org", null, null),
+			new CqlCode("[lb_av]", "http://unitsofmeasure.org", null, null),
+			new CqlCode("cm", "http://unitsofmeasure.org", null, null),
+			new CqlCode("g", "http://unitsofmeasure.org", null, null),
+			new CqlCode("kg", "http://unitsofmeasure.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("UCUM")]
+	public CqlCode[] UCUM() => 
+		__UCUM.Value;
+
+	private CqlCode[] LOINC_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("8302-2", "http://loinc.org", null, null),
+			new CqlCode("39156-5", "http://loinc.org", null, null),
+			new CqlCode("29463-7", "http://loinc.org", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC.Value;
+
+	private CqlCode[] ObservationCategoryCodes_Value()
+	{
+		var a_ = new CqlCode[]
+		{
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+		};
+
+		return a_;
+	}
+
+    [CqlDeclaration("ObservationCategoryCodes")]
+	public CqlCode[] ObservationCategoryCodes() => 
+		__ObservationCategoryCodes.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value()
+	{
+		var a_ = context.Operators.ConvertIntegerToDecimal(default);
+		var b_ = context.Operators.DateTime((int?)2025, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var d_ = context.Operators.DateTime((int?)2026, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
+		var e_ = context.Operators.Interval(b_, d_, true, false);
+		var f_ = context.ResolveParameter("WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000", "Measurement Period", e_);
+
+		return (CqlInterval<CqlDateTime>)f_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		var b_ = context.Operators.SingleOrNull<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Ethnicity() => 
+		__SDE_Ethnicity.Value;
+
+	private IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_GDKRbfOIHhLGieQSVDEMIaDPX> SDE_Payer() => 
+		__SDE_Payer.Value;
+
+	private Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Race")]
+	public Tuples.Tuple_DMgHTLENEHBHWJISQgKZGZVMB SDE_Race() => 
+		__SDE_Race.Value;
+
+	private CqlCode SDE_Sex_Value()
+	{
+		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_Value()
+	{
+		var a_ = this.Office_Visit();
+		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		var c_ = this.Preventive_Care_Services_Individual_Counseling();
+		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
+		var f_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		var h_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
+		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
+		var l_ = this.Preventive_Care_Services___Group_Counseling();
+		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		var n_ = this.Home_Healthcare_Services();
+		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
+		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
+		var r_ = this.Telephone_Visits();
+		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		var t_ = context.Operators.ListUnion<Encounter>(q_, s_);
+		var u_ = Status_1_6_000.Finished_Encounter(t_);
+		bool? v_(Encounter ValidEncounters)
+		{
+			var x_ = this.Measurement_Period();
+			var y_ = FHIRHelpers_4_3_000.ToInterval(ValidEncounters?.Period);
+			var z_ = QICoreCommon_2_0_000.ToInterval((y_ as object));
+			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, null);
+
+			return aa_;
+		};
+		var w_ = context.Operators.WhereOrNull<Encounter>(u_, v_);
+
+		return w_;
+	}
+
+    [CqlDeclaration("Qualifying Encounter")]
+	public IEnumerable<Encounter> Qualifying_Encounter() => 
+		__Qualifying_Encounter.Value;
+
+	private bool? Initial_Population_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)3, (int?)17, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+		var i_ = this.Qualifying_Encounter();
+		var j_ = context.Operators.ExistsInList<Encounter>(i_);
+		var k_ = context.Operators.And(h_, j_);
+
+		return k_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+	private bool? Denominator_Value()
+	{
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+	private IEnumerable<Condition> Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period_Value()
+	{
+		var a_ = this.Pregnancy();
+		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		var c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition Pregnancy)
+		{
+			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Pregnancy);
+			var g_ = this.Measurement_Period();
+			var h_ = context.Operators.Overlaps(f_, g_, null);
+
+			return h_;
+		};
+		var e_ = context.Operators.WhereOrNull<Condition>(c_, d_);
+
+		return e_;
+	}
+
+    [CqlDeclaration("Pregnancy Diagnosis Which Overlaps Measurement Period")]
+	public IEnumerable<Condition> Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period() => 
+		__Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period.Value;
+
+	private bool? Denominator_Exclusions_Value()
+	{
+		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		var b_ = this.Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period();
+		var c_ = context.Operators.ExistsInList<Condition>(b_);
+		var d_ = context.Operators.Or(a_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+	private IEnumerable<Observation> BMI_Percentile_in_Measurement_Period_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		var b_ = Status_1_6_000.BMI(a_);
+		bool? c_(Observation BMIPercentile)
+		{
+			var e_ = this.Measurement_Period();
+			var f_ = FHIRHelpers_4_3_000.ToValue(BMIPercentile?.Effective);
+			var g_ = QICoreCommon_2_0_000.ToInterval(f_);
+			var h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
+			var i_ = context.Operators.Convert<Quantity>(BMIPercentile?.Value);
+			var j_ = FHIRHelpers_4_3_000.ToQuantity(i_);
+			var k_ = context.Operators.Not((bool?)(j_ is null));
+			var l_ = context.Operators.And(h_, k_);
+
+			return l_;
+		};
+		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("BMI Percentile in Measurement Period")]
+	public IEnumerable<Observation> BMI_Percentile_in_Measurement_Period() => 
+		__BMI_Percentile_in_Measurement_Period.Value;
+
+	private IEnumerable<Observation> Height_in_Measurement_Period_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		var b_ = Status_1_6_000.BodyHeight(a_);
+		bool? c_(Observation Height)
+		{
+			var e_ = this.Measurement_Period();
+			var f_ = FHIRHelpers_4_3_000.ToValue(Height?.Effective);
+			var g_ = QICoreCommon_2_0_000.ToInterval(f_);
+			var h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
+			var i_ = context.Operators.Convert<Quantity>(Height?.Value);
+			var j_ = FHIRHelpers_4_3_000.ToQuantity(i_);
+			var k_ = context.Operators.Not((bool?)(j_ is null));
+			var l_ = context.Operators.And(h_, k_);
+
+			return l_;
+		};
+		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Height in Measurement Period")]
+	public IEnumerable<Observation> Height_in_Measurement_Period() => 
+		__Height_in_Measurement_Period.Value;
+
+	private IEnumerable<Observation> Weight_in_Measurement_Period_Value()
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		var b_ = Status_1_6_000.BodyWeight(a_);
+		bool? c_(Observation Weight)
+		{
+			var e_ = this.Measurement_Period();
+			var f_ = FHIRHelpers_4_3_000.ToValue(Weight?.Effective);
+			var g_ = QICoreCommon_2_0_000.ToInterval(f_);
+			var h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
+			var i_ = context.Operators.Convert<Quantity>(Weight?.Value);
+			var j_ = FHIRHelpers_4_3_000.ToQuantity(i_);
+			var k_ = context.Operators.Not((bool?)(j_ is null));
+			var l_ = context.Operators.And(h_, k_);
+
+			return l_;
+		};
+		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Weight in Measurement Period")]
+	public IEnumerable<Observation> Weight_in_Measurement_Period() => 
+		__Weight_in_Measurement_Period.Value;
+
+	private bool? Numerator_1_Value()
+	{
+		var a_ = this.BMI_Percentile_in_Measurement_Period();
+		var b_ = context.Operators.ExistsInList<Observation>(a_);
+		var c_ = this.Height_in_Measurement_Period();
+		var d_ = context.Operators.ExistsInList<Observation>(c_);
+		var e_ = context.Operators.And(b_, d_);
+		var f_ = this.Weight_in_Measurement_Period();
+		var g_ = context.Operators.ExistsInList<Observation>(f_);
+		var h_ = context.Operators.And(e_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Numerator 1")]
+	public bool? Numerator_1() => 
+		__Numerator_1.Value;
+
+	private bool? Numerator_2_Value()
+	{
+		var a_ = this.Counseling_for_Nutrition();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		bool? d_(Procedure NutritionCounseling)
+		{
+			var g_ = this.Measurement_Period();
+			var h_ = FHIRHelpers_4_3_000.ToValue(NutritionCounseling?.Performed);
+			var i_ = QICoreCommon_2_0_000.ToInterval(h_);
+			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, "day");
+
+			return j_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Procedure>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Numerator 2")]
+	public bool? Numerator_2() => 
+		__Numerator_2.Value;
+
+	private bool? Numerator_3_Value()
+	{
+		var a_ = this.Counseling_for_Physical_Activity();
+		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		bool? d_(Procedure ActivityCounseling)
+		{
+			var g_ = this.Measurement_Period();
+			var h_ = FHIRHelpers_4_3_000.ToValue(ActivityCounseling?.Performed);
+			var i_ = QICoreCommon_2_0_000.ToInterval(h_);
+			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, "day");
+
+			return j_;
+		};
+		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
+		var f_ = context.Operators.ExistsInList<Procedure>(e_);
+
+		return f_;
+	}
+
+    [CqlDeclaration("Numerator 3")]
+	public bool? Numerator_3() => 
+		__Numerator_3.Value;
+
+	private bool? Stratifaction_1_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)3, (int?)11, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Stratifaction 1")]
+	public bool? Stratifaction_1() => 
+		__Stratifaction_1.Value;
+
+	private bool? Stratifaction_2_Value()
+	{
+		var a_ = this.Patient();
+		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
+		var c_ = this.Measurement_Period();
+		var d_ = context.Operators.End(c_);
+		var e_ = context.Operators.DateFrom(d_);
+		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
+		var g_ = context.Operators.Interval((int?)12, (int?)17, true, true);
+		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Stratifaction 2")]
+	public bool? Stratifaction_2() => 
+		__Stratifaction_2.Value;
+
+}


### PR DESCRIPTION
* Added a list of hard-coded filenames for now that don't compile - so we can at least continue and work in parrallel.
* Fixed the situation where we need to navigate into a property where the ELM does not specify the type, but our own POCO model does have information.
* Added a correction for one more unresolved QICore datatype.