### PR TITLE
2.0/259 use stackable scopes  in expression builder

### DIFF
--- a/Cql/Cql.Abstractions/Infrastructure/EnumerableExtensions.cs
+++ b/Cql/Cql.Abstractions/Infrastructure/EnumerableExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Hl7.Cql.Abstractions.Infrastructure;
@@ -53,5 +54,19 @@ internal static class EnumerableExtensions
             throw new ArgumentException($"Source array must have '{sourceLength}' element(s), but has '{i}'.");
 
         return array;
+    }
+
+    public static bool TryPeek<T>(
+        this IImmutableStack<T> stack,
+        out T value)
+    {
+        if (stack.IsEmpty)
+        {
+            value = default;
+            return false;
+        }
+
+        value = stack.Peek();
+        return true;
     }
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.BuilderNode.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.BuilderNode.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using Hl7.Cql.Abstractions.Infrastructure;

--- a/Cql/Cql.Compiler/ExpressionBuilder.BuilderNode.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.BuilderNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using Hl7.Cql.Abstractions.Infrastructure;
 
 namespace Hl7.Cql.Compiler;
 
@@ -35,7 +36,7 @@ partial class ExpressionBuilder : IBuilderNode
 
     private IPopToken PushElement(Elm.Element element)
     {
-        Elm.Element? previous = _elementStack.IsEmpty ? null : _elementStack.Peek();
+        _elementStack.TryPeek(out var previous);
         if (previous == element) return EmptyDisposable.Instance;
 
         _elementStack = _elementStack.Push(element);

--- a/Cql/Cql.Compiler/ExpressionBuilder.BuilderNode.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.BuilderNode.cs
@@ -12,7 +12,7 @@ partial class ExpressionBuilder : IBuilderNode
     private IBuilderNode CreateBuilderNode() => new ExpressionBuilderNode()
     {
         LibraryExpressionBuilder = _libraryContext,
-        ElementStackList = _elementStack.ToList(),
+        ElementStackList = [.. _elementStack],
         ElementStackPosition = 0,
     };
 
@@ -36,7 +36,7 @@ partial class ExpressionBuilder : IBuilderNode
     private IPopToken PushElement(Elm.Element element)
     {
         Elm.Element? previous = _elementStack.IsEmpty ? null : _elementStack.Peek();
-        if (previous == element) return new EmptyDisposable();
+        if (previous == element) return EmptyDisposable.Instance;
 
         _elementStack = _elementStack.Push(element);
         return new PopElementToken(this, previous);
@@ -55,11 +55,6 @@ partial class ExpressionBuilder : IBuilderNode
         public BuilderDebuggerInfo? BuilderDebuggerInfo => ElementStackPosition >= 0
             ? Hl7.Cql.Compiler.BuilderDebuggerInfo.FromElement(ElementStackList[ElementStackPosition])
             : null!;
-    }
-
-    protected interface IPopToken : IDisposable
-    {
-        void Pop();
     }
 
     private readonly record struct PopElementToken : IPopToken
@@ -83,17 +78,6 @@ partial class ExpressionBuilder : IBuilderNode
                 throw new InvalidOperationException("Popping should be called in the correct reverse order.");
 
             _owner._elementStack = _owner._elementStack.Pop();
-        }
-    }
-
-    private readonly record struct EmptyDisposable : IPopToken
-    {
-        void IDisposable.Dispose()
-        {
-        }
-
-        void IPopToken.Pop()
-        {
         }
     }
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.BuilderNode.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.BuilderNode.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 
@@ -11,8 +12,8 @@ partial class ExpressionBuilder : IBuilderNode
     private IBuilderNode CreateBuilderNode() => new ExpressionBuilderNode()
     {
         LibraryExpressionBuilder = _libraryContext,
-        ElementStackList = _elementStack.Reverse().ToList(),
-        ElementStackPosition = _elementStack.Count - 1
+        ElementStackList = _elementStack.ToList(),
+        ElementStackPosition = 0,
     };
 
     IBuilderNode? IBuilderNode.OuterBuilder =>
@@ -34,21 +35,21 @@ partial class ExpressionBuilder : IBuilderNode
 
     private IPopToken PushElement(Elm.Element element)
     {
-        Elm.Element? previous = _elementStack.Any() ? _elementStack.Peek() : null;
+        Elm.Element? previous = _elementStack.IsEmpty ? null : _elementStack.Peek();
         if (previous == element) return new EmptyDisposable();
 
-        _elementStack.Push(element);
+        _elementStack = _elementStack.Push(element);
         return new PopElementToken(this, previous);
     }
 
     private readonly record struct ExpressionBuilderNode : IBuilderNode
     {
         public LibraryExpressionBuilder LibraryExpressionBuilder { get; init; }
-        public List<Elm.Element> ElementStackList { get; init; }
+        public IReadOnlyList<Elm.Element> ElementStackList { get; init; }
         public int ElementStackPosition { get; init; }
 
-        public IBuilderNode? OuterBuilder => ElementStackPosition > 0
-            ? this with { ElementStackPosition = ElementStackPosition - 1 }
+        public IBuilderNode? OuterBuilder => ElementStackPosition < ElementStackList.Count - 1
+            ? this with { ElementStackPosition = ElementStackPosition + 1 }
             : LibraryExpressionBuilder;
 
         public BuilderDebuggerInfo? BuilderDebuggerInfo => ElementStackPosition >= 0
@@ -76,11 +77,12 @@ partial class ExpressionBuilder : IBuilderNode
 
         public void Pop()
         {
-            var expectedPreviousElement = _owner._elementStack.Count > 1 ? _owner._elementStack.ElementAt(1) : null;
+            var expectedPreviousElement = _owner._elementStack.ElementAtOrDefault(1);
+
             if (_previousElement != expectedPreviousElement)
                 throw new InvalidOperationException("Popping should be called in the correct reverse order.");
 
-            _ = _owner._elementStack.Pop();
+            _owner._elementStack = _owner._elementStack.Pop();
         }
     }
 

--- a/Cql/Cql.Compiler/ExpressionBuilder.Context.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.Context.cs
@@ -85,14 +85,5 @@ namespace Hl7.Cql.Compiler
             var subContext = WithScopes(aliasName, new KeyValuePair<string, (Expression, Elm.Element)>(aliasName, (linqExpression, elmExpression)));
             return subContext;
         }
-
-        public Expression? Mutate(Elm.Element op, Expression? expression)
-        {
-            foreach (var visitor in _expressionMutators)
-            {
-                expression = visitor.Mutate(expression!, op, this);
-            }
-            return expression;
-        }
     }
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.LibraryDefs.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.LibraryDefs.cs
@@ -166,7 +166,7 @@ partial class ExpressionBuilder
                     parameters = parameters
                         .Concat(_operands.Values)
                         .ToArray();
-                    if (TryGetCustomImplementationByExpressionKey(expressionKey, out var factory))
+                    if (_customImplementations.TryGetValue(expressionKey, out var factory))
                     {
                         var customLambda = factory(parameters);
                         _libraryContext.LibraryDefinitions.Add(_libraryContext.LibraryKey, expressionDef.name,

--- a/Cql/Cql.Compiler/ExpressionBuilder.LibraryDefs.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.LibraryDefs.cs
@@ -225,7 +225,7 @@ partial class ExpressionBuilder
                         }
                     }
 
-                    Type[] signature = functionParameterTypes ?? Array.Empty<Type>();
+                    Type[] signature = functionParameterTypes ?? [];
                     _libraryContext.LibraryDefinitions.Add(_libraryContext.LibraryKey, expressionDef.name, signature,
                         lambda);
                 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.Query.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.Query.cs
@@ -23,7 +23,7 @@ internal partial class ExpressionBuilder
     {
         QueryDumpDebugInfoToLog(query);
 
-        using PopTokenCleanupStack cleanupScopes = new();
+        using PopTokenCleanupStack scopesStack = new();
 
         var sources = query.source;
         if (sources.Length == 0)
@@ -38,7 +38,7 @@ internal partial class ExpressionBuilder
             var source0 = sources[0];
             var sourceParameterName = NormalizeIdentifier(source0.alias);
             scopeParameter = Expression.Parameter(returnElementType, sourceParameterName);
-            cleanupScopes.PushForCleanup(PushScopes(ImpliedAlias, KeyValuePair.Create(source0.alias, ((Expression)scopeParameter, (Element)source0.expression))));
+            scopesStack.Register(PushScopes(ImpliedAlias, KeyValuePair.Create(source0.alias, ((Expression)scopeParameter, (Element)source0.expression))));
         }
         else
         {
@@ -51,7 +51,7 @@ internal partial class ExpressionBuilder
                     select new ExpressionElementPairForIdentifier(property.Name, (propertyAccess, query))
                 )
                 .ToArray();
-            cleanupScopes.PushForCleanup(PushScopes(ImpliedAlias, scopes));
+            scopesStack.Register(PushScopes(ImpliedAlias, scopes));
         }
 
         if (query.let != null)
@@ -59,7 +59,7 @@ internal partial class ExpressionBuilder
             foreach (var let in query.let)
             {
                 var expression = TranslateExpression(let.expression!);
-                cleanupScopes.PushForCleanup(PushScopes(ImpliedAlias, KeyValuePair.Create(let.identifier!, (expression, (Element)let.expression!))));
+                scopesStack.Register(PushScopes(ImpliedAlias, KeyValuePair.Create(let.identifier!, (expression, (Element)let.expression!))));
             }
         }
 

--- a/Cql/Cql.Compiler/ExpressionBuilder.Query.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.Query.cs
@@ -23,12 +23,15 @@ internal partial class ExpressionBuilder
     {
         QueryDumpDebugInfoToLog(query);
 
-        Action popScopes = null!;
+        Action popTokens = null!;
 
         void PushScopes(
             string? alias = null,
-            params ExpressionElementPairForIdentifier[] kvps) =>
-            popScopes = (() => this.PushScopes(alias, kvps)) + popScopes;
+            params ExpressionElementPairForIdentifier[] kvps)
+        {
+            var popToken = this.PushScopes(alias, kvps);
+            popTokens = (() => popToken.Pop()) + popTokens;
+        }
 
         try
         {
@@ -194,7 +197,7 @@ internal partial class ExpressionBuilder
         }
         finally
         {
-            popScopes?.Invoke();
+            popTokens?.Invoke();
         }
     }
 

--- a/Cql/Cql.Compiler/ExpressionBuilder.Scopes.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.Scopes.cs
@@ -6,42 +6,38 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
-using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Hl7.Cql.Compiler
 {
     internal partial class ExpressionBuilder
     {
-        public bool TryGetCustomImplementationByExpressionKey(
-            string expressionKey,
-            [NotNullWhen(true)] out Func<ParameterExpression[], LambdaExpression>? factory) =>
-            _customImplementations.TryGetValue(expressionKey, out factory);
-
-        internal Expression GetScopeExpression(string elmAlias)
+        protected Expression GetScopeExpression(string elmAlias)
         {
             var normalized = NormalizeIdentifier(elmAlias!)!;
-            if (_scopes.TryGetValue(normalized, out var expression))
-                return expression.Item1;
-            else throw this.NewExpressionBuildingException($"The scope alias {elmAlias}, normalized to {normalized}, is not present in the scopes dictionary.");
+            if (!_scopes.TryGetValue(normalized, out var expression))
+                throw this.NewExpressionBuildingException(
+                    $"The scope alias {elmAlias}, normalized to {normalized}, is not present in the scopes dictionary.");
+
+            return expression.Item1;
         }
 
-        internal (Expression, Elm.Element) GetScope(string elmAlias)
+        protected (Expression, Elm.Element) GetScope(string elmAlias)
         {
             var normalized = NormalizeIdentifier(elmAlias!)!;
-            if (_scopes.TryGetValue(normalized, out var expression))
-                return expression;
-            else throw this.NewExpressionBuildingException($"The scope alias {elmAlias}, normalized to {normalized}, is not present in the scopes dictionary.");
+            if (!_scopes.TryGetValue(normalized, out var expression))
+                throw this.NewExpressionBuildingException(
+                    $"The scope alias {elmAlias}, normalized to {normalized}, is not present in the scopes dictionary.");
+            return expression;
         }
 
-        internal bool HasScope(string elmAlias) => _scopes.ContainsKey(elmAlias);
+        protected bool HasScope(string elmAlias) => _scopes.ContainsKey(elmAlias);
 
-        internal ExpressionBuilder WithScope(string alias, Expression expr, Elm.Element element) =>
+        protected ExpressionBuilder WithScope(string alias, Expression expr, Elm.Element element) =>
             WithScopes(KeyValuePair.Create(alias, (expr, element)));
 
-        internal ExpressionBuilder WithScopes(string? alias, params KeyValuePair<string, (Expression, Elm.Element)>[] kvps)
+        protected ExpressionBuilder WithScopes(string? alias, params KeyValuePair<string, (Expression, Elm.Element)>[] kvps)
         {
             var scopes = new Dictionary<string, (Expression, Elm.Element)>(_scopes);
             if (_libraryDefinitionBuilderSettings.AllowScopeRedefinition)
@@ -76,11 +72,10 @@ namespace Hl7.Cql.Compiler
         /// <summary>
         /// Creates a copy with the scopes provided.
         /// </summary>
-        internal ExpressionBuilder
-            WithScopes(params KeyValuePair<string, (Expression, Elm.Element)>[] kvps) =>
+        protected ExpressionBuilder WithScopes(params KeyValuePair<string, (Expression, Elm.Element)>[] kvps) =>
             WithScopes(_impliedAlias, kvps);
 
-        internal ExpressionBuilder WithImpliedAlias(string aliasName, Expression linqExpression, Elm.Element elmExpression)
+        protected ExpressionBuilder WithImpliedAlias(string aliasName, Expression linqExpression, Elm.Element elmExpression)
         {
             var subContext = WithScopes(aliasName, new KeyValuePair<string, (Expression, Elm.Element)>(aliasName, (linqExpression, elmExpression)));
             return subContext;

--- a/Cql/Cql.Compiler/ExpressionBuilder.Scopes.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.Scopes.cs
@@ -13,6 +13,8 @@ using System.Linq;
 using Hl7.Cql.Abstractions.Infrastructure;
 using Expression = System.Linq.Expressions.Expression;
 
+using ExpressionElementPairForIdentifier = System.Collections.Generic.KeyValuePair<string, (System.Linq.Expressions.Expression, Hl7.Cql.Elm.Element)>;
+
 namespace Hl7.Cql.Compiler
 {
     internal partial class ExpressionBuilder
@@ -65,7 +67,7 @@ namespace Hl7.Cql.Compiler
 
         protected IPopToken PushScopes(
             string? alias = null,
-            params KeyValuePair<string, (Expression, Elm.Element)>[] kvps)
+            params ExpressionElementPairForIdentifier[] kvps)
         {
             _impliedAliasAndScopesStack.TryPeek(out var peek);
 

--- a/Cql/Cql.Compiler/ExpressionBuilder.Scopes.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.Scopes.cs
@@ -6,79 +6,119 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
+using System.Collections.ObjectModel;
+using Hl7.Cql.Elm;
+using Expression = System.Linq.Expressions.Expression;
 
 namespace Hl7.Cql.Compiler
 {
     internal partial class ExpressionBuilder
     {
+        private IReadOnlyDictionary<string, (Expression expr, Elm.Element element)> Scopes =>
+            _scopesStack.IsEmpty
+                ? ReadOnlyDictionary<string, (Expression expr, Elm.Element element)>.Empty
+                : _scopesStack.Peek().scopes;
+
+        /// <summary>
+        /// In dodgy sort expressions where the properties are named using the undocumented IdentifierRef expression type,
+        /// this value is the implied alias name that should qualify it, e.g. from DRR-E 2022:
+        /// <code>
+        ///     "PHQ-9 Assessments" PHQ
+        ///      where ...
+        ///      sort by date from start of FHIRBase."Normalize Interval"(effective) asc
+        /// </code>
+        /// The use of "effective" here is unqualified and is implied to be PHQ.effective
+        /// No idea how this is supposed to work with queries with multiple sources (e.g., with let statements)
+        /// </summary>
+        private string? ImpliedAlias =>
+            _scopesStack.IsEmpty
+                ? null
+                : _scopesStack.Peek().impliedAlias;
+
+
         protected Expression GetScopeExpression(string elmAlias)
         {
             var normalized = NormalizeIdentifier(elmAlias!)!;
-            if (!_scopes.TryGetValue(normalized, out var expression))
+            if (!Scopes.TryGetValue(normalized, out var kv))
                 throw this.NewExpressionBuildingException(
                     $"The scope alias {elmAlias}, normalized to {normalized}, is not present in the scopes dictionary.");
 
-            return expression.Item1;
+            return kv.expr;
         }
 
         protected (Expression, Elm.Element) GetScope(string elmAlias)
         {
             var normalized = NormalizeIdentifier(elmAlias!)!;
-            if (!_scopes.TryGetValue(normalized, out var expression))
+            if (!Scopes.TryGetValue(normalized, out var kv))
                 throw this.NewExpressionBuildingException(
                     $"The scope alias {elmAlias}, normalized to {normalized}, is not present in the scopes dictionary.");
-            return expression;
+            return kv;
         }
 
-        protected bool HasScope(string elmAlias) => _scopes.ContainsKey(elmAlias);
+        protected bool HasScope(string elmAlias) => Scopes.ContainsKey(elmAlias);
 
-        protected ExpressionBuilder WithScope(string alias, Expression expr, Elm.Element element) =>
-            WithScopes(KeyValuePair.Create(alias, (expr, element)));
-
-        protected ExpressionBuilder WithScopes(string? alias, params KeyValuePair<string, (Expression, Elm.Element)>[] kvps)
+        protected IPopToken PushScopes(
+            string? alias,
+            params KeyValuePair<string, (Expression, Elm.Element)>[] kvps)
         {
-            var scopes = new Dictionary<string, (Expression, Elm.Element)>(_scopes);
+            var scopes = new Dictionary<string, (Expression, Elm.Element)>(Scopes);
             if (_libraryDefinitionBuilderSettings.AllowScopeRedefinition)
             {
-                foreach (var kvp in kvps)
+                foreach (var (expr, element) in kvps)
                 {
-                    string? normalizedIdentifier = NormalizeIdentifier(kvp.Key);
+                    string? normalizedIdentifier = NormalizeIdentifier(expr);
                     if (string.IsNullOrWhiteSpace(normalizedIdentifier))
                         throw this.NewExpressionBuildingException("The normalized identifier is not available.");
 
-                    scopes[normalizedIdentifier] = kvp.Value;
+                    scopes[normalizedIdentifier] = element;
                 }
             }
             else
             {
-                foreach (var kvp in kvps)
+                foreach (var (expr, element) in kvps)
                 {
-                    string? normalizedIdentifier = NormalizeIdentifier(kvp.Key);
+                    string? normalizedIdentifier = NormalizeIdentifier(expr);
                     if (string.IsNullOrWhiteSpace(normalizedIdentifier))
                         throw this.NewExpressionBuildingException("The normalize identifier is not available.");
 
-                    if (scopes.ContainsKey(normalizedIdentifier))
+                    if (!scopes.TryAdd(normalizedIdentifier, element))
                         throw this.NewExpressionBuildingException(
-                            $"Scope {kvp.Key}, normalized to {NormalizeIdentifier(kvp.Key)}, is already defined and this builder does not allow scope redefinition.  Check the CQL source, or set {nameof(_libraryDefinitionBuilderSettings.AllowScopeRedefinition)} to true");
-                    scopes.Add(normalizedIdentifier, kvp.Value);
+                            $"Scope {expr}, normalized to {NormalizeIdentifier(expr)}, is already defined and this builder does not allow scope redefinition.  Check the CQL source, or set {nameof(_libraryDefinitionBuilderSettings.AllowScopeRedefinition)} to true");
                 }
             }
-            var subContext = new ExpressionBuilder(this, impliedAlias:alias, scopes: scopes);
-            return subContext;
+
+            _scopesStack = _scopesStack.Push((alias, scopes));
+            return new PopScopesToken(this);
         }
 
-        /// <summary>
-        /// Creates a copy with the scopes provided.
-        /// </summary>
-        protected ExpressionBuilder WithScopes(params KeyValuePair<string, (Expression, Elm.Element)>[] kvps) =>
-            WithScopes(_impliedAlias, kvps);
 
-        protected ExpressionBuilder WithImpliedAlias(string aliasName, Expression linqExpression, Elm.Element elmExpression)
+
+        private readonly record struct PopScopesToken : IPopToken
         {
-            var subContext = WithScopes(aliasName, new KeyValuePair<string, (Expression, Elm.Element)>(aliasName, (linqExpression, elmExpression)));
-            return subContext;
+            private readonly ExpressionBuilder _owner;/*
+            private readonly Elm.Element? _previousElement;*/
+
+            public PopScopesToken(
+                ExpressionBuilder owner/*,
+                Elm.Element? previousElement*/)
+            {
+                _owner = owner;/*
+                _previousElement = previousElement;*/
+            }
+
+            void IDisposable.Dispose() => Pop();
+
+            public void Pop()
+            {
+                /*var expectedPreviousElement = _owner._elementStack.ElementAtOrDefault(1);
+
+                if (_previousElement != expectedPreviousElement)
+                    throw new InvalidOperationException("Popping should be called in the correct reverse order.");*/
+
+                _owner._scopesStack = _owner._scopesStack.Pop();
+            }
         }
     }
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
@@ -250,22 +250,4 @@ partial class ExpressionBuilder
         {
         }
     }
-
-    private readonly record struct PopTokenCleanupStack() : IPopToken
-    {
-        private readonly Stack<IPopToken> _stack = new();
-
-        /// <summary>
-        /// Registers a pop token which will be popped later when this stack is popped.
-        /// </summary>
-        public void Register(IPopToken popToken) => _stack.Push(popToken);
-
-        void IDisposable.Dispose() => Pop();
-
-        public void Pop()
-        {
-            while (_stack.TryPop(out var next))
-                next.Pop();
-        }
-    }
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
@@ -255,8 +255,13 @@ partial class ExpressionBuilder
     {
         private readonly Stack<IPopToken> _stack = new();
 
-        public void PushForCleanup(IPopToken popToken) => _stack.Push(popToken);
+        /// <summary>
+        /// Registers a pop token which will be popped later when this stack is popped.
+        /// </summary>
+        public void Register(IPopToken popToken) => _stack.Push(popToken);
+
         void IDisposable.Dispose() => Pop();
+
         public void Pop()
         {
             while (_stack.TryPop(out var next))

--- a/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
@@ -233,5 +233,22 @@ partial class ExpressionBuilder
         return false;
     }
 
+    
+    protected interface IPopToken : IDisposable
+    {
+        void Pop();
+    }
 
+    private readonly record struct EmptyDisposable : IPopToken
+    {
+        public static readonly EmptyDisposable Instance = new();
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        void IPopToken.Pop()
+        {
+        }
+    }
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Hl7.Cql.Abstractions;
 using Hl7.Cql.Compiler.Infrastructure;
 using Hl7.Cql.Elm;
+using Hl7.Cql.Model;
 using Hl7.Cql.Operators;
 using Hl7.Cql.Primitives;
 using Hl7.Cql.Runtime;
@@ -18,6 +19,9 @@ namespace Hl7.Cql.Compiler;
 
 partial class ExpressionBuilder
 {
+    // Yeah, hardwired to FHIR 4.0.1 for now.
+    private static readonly IDictionary<string, ClassInfo> ModelMapping = Models.ClassesById(Models.Fhir401);
+
 
     private static readonly Dictionary<(Type, Type), Type> KnownErrors = new()
     {

--- a/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.StaticHelpers.cs
@@ -233,7 +233,6 @@ partial class ExpressionBuilder
         return false;
     }
 
-    
     protected interface IPopToken : IDisposable
     {
         void Pop();
@@ -249,6 +248,19 @@ partial class ExpressionBuilder
 
         void IPopToken.Pop()
         {
+        }
+    }
+
+    private readonly record struct PopTokenCleanupStack() : IPopToken
+    {
+        private readonly Stack<IPopToken> _stack = new();
+
+        public void PushForCleanup(IPopToken popToken) => _stack.Push(popToken);
+        void IDisposable.Dispose() => Pop();
+        public void Pop()
+        {
+            while (_stack.TryPop(out var next))
+                next.Pop();
         }
     }
 }

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -48,7 +48,7 @@ namespace Hl7.Cql.Compiler
         /// <summary>
         /// Contains query aliases and let declarations, and any other symbol that is now "in scope"
         /// </summary>
-        private ImmutableStack<(string? impliedAlias, IReadOnlyDictionary<string, (Expression expr, Element element)> scopes)> _scopesStack;
+        private ImmutableStack<(string? impliedAlias, IReadOnlyDictionary<string, (Expression expr, Element element)> scopes)> _impliedAliasAndScopesStack;
 
         /// <summary>
         /// Parameters for function definitions.
@@ -90,7 +90,7 @@ namespace Hl7.Cql.Compiler
             _elementStack = ImmutableStack<Element>.Empty;
             _operands = new Dictionary<string, ParameterExpression>();
             _libraries = new Dictionary<string, DefinitionDictionary<LambdaExpression>>();
-            _scopesStack = ImmutableStack<(string? impliedAlias, IReadOnlyDictionary<string, (Expression expr, Element element)> scopes)>.Empty;
+            _impliedAliasAndScopesStack = ImmutableStack<(string? impliedAlias, IReadOnlyDictionary<string, (Expression expr, Element element)> scopes)>.Empty;
             _expressionMutators = new List<IExpressionMutator>();
             _customImplementations = new Dictionary<string, Func<ParameterExpression[], LambdaExpression>>();
         }

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -321,7 +321,6 @@ namespace Hl7.Cql.Compiler
                             Substring e                => Substring(e),
                             Starts starts              => Starts(starts),
                             Time time                  => Time(time),
-
                             Elm.Tuple tu               => Tuple(tu),
                             Union ue                   => Union(ue),
                             ValueSetRef vsre           => ValueSetRef(vsre),

--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -15,6 +15,7 @@ using Hl7.Cql.Runtime;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -39,7 +40,7 @@ namespace Hl7.Cql.Compiler
         private readonly TypeConverter _typeConverter;
         private readonly TypeResolver _typeResolver;
 
-        private readonly Stack<Element> _elementStack;
+        private ImmutableStack<Element> _elementStack;
         private readonly LibraryDefinitionBuilderSettings _libraryDefinitionBuilderSettings;
         private readonly LibraryExpressionBuilder _libraryContext;
         private readonly Dictionary<string, DefinitionDictionary<LambdaExpression>> _libraries;
@@ -99,7 +100,7 @@ namespace Hl7.Cql.Compiler
             _libraryContext = libContext;
 
             // Internal State
-            _elementStack = new Stack<Element>();
+            _elementStack = ImmutableStack<Element>.Empty;
             _impliedAlias = null;
             _operands = new Dictionary<string, ParameterExpression>();
             _libraries = new Dictionary<string, DefinitionDictionary<LambdaExpression>>();
@@ -111,7 +112,7 @@ namespace Hl7.Cql.Compiler
         private ExpressionBuilder(
             ExpressionBuilder source)
         {
-            _elementStack = new Stack<Element>(source._elementStack);
+            _elementStack = source._elementStack;
             _libraryDefinitionBuilderSettings = source._libraryDefinitionBuilderSettings;
             _operatorBinding = source._operatorBinding;
             _impliedAlias = source._impliedAlias;

--- a/Cql/Cql.Compiler/IExpressionMutator.cs
+++ b/Cql/Cql.Compiler/IExpressionMutator.cs
@@ -27,7 +27,7 @@ namespace Hl7.Cql.Compiler
         /// </summary>
         /// <param name="linqExpression">The source expression.</param>
         /// <param name="elmExpression">The corresponding ELM expression.</param>
-        /// <param name="ctx">The build context.  Be careful modifying this value as it can have unexpected side effects (e.g., removing key from <see cref="ExpressionBuilder._scopes"/> could break the builder.).</param>
+        /// <param name="ctx">The build context.  Be careful modifying this value as it can have unexpected side effects (e.g., removing key from <see cref="ExpressionBuilder.Scopes"/> could break the builder.).</param>
         public System.Linq.Expressions.Expression Mutate(
             System.Linq.Expressions.Expression linqExpression,
             Elm.Element elmExpression,


### PR DESCRIPTION
⚠️Before reviewing, previous PR #286 to be merged first
ℹ️Work for issue #259 


* Push `ImpliedAlias` with `Scopes` into a stack, the same was as elements are pushed onto an existing `ExpressionBuilder`, without having to clone the `ExpressionBuilder`.
* Use `ImmutableStack<>` instead of `Stack<>`