### PR TITLE
1.0/Make ExpressionBuilder.Lambda obsolete.

### DIFF
--- a/Cql/Cql.Compiler/ExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilder.cs
@@ -1,8 +1,8 @@
 ﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-/* 
+/*
  * Copyright (c) 2023, NCQA and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
@@ -405,6 +405,7 @@ namespace Hl7.Cql.Compiler
         /// <param name="expression">The ELM expression to convert</param>
         /// <param name="lambdas">Existing lambdas, required if <paramref name="expression"/> contains any references to other ELM definitions</param>
         /// <param name="ctx">If <paramref name="expression"/> requires contextual scope, provide it via an <see cref="ExpressionBuilderContext"/>.</param>
+        [Obsolete("This will not be available in future versions of the SDK.")]
         public LambdaExpression Lambda(elm.Expression expression,
             DefinitionDictionary<LambdaExpression>? lambdas = null,
             ExpressionBuilderContext? ctx = null)
@@ -418,7 +419,7 @@ namespace Hl7.Cql.Compiler
             return lambda;
         }
 
-        protected Expression TranslateExpression(elm.Element op, ExpressionBuilderContext ctx)
+        protected internal Expression TranslateExpression(elm.Element op, ExpressionBuilderContext ctx)
         {
             ctx = ctx.Deeper(op);
             Expression? expression;
@@ -2036,7 +2037,7 @@ namespace Hl7.Cql.Compiler
             //Func<Bundle, Context, IEnumerable<Encounter>> x = (bundle, ctx) =>
             //    bundle.Entry.ByResourceType<Encounter>()
             //    .SelectMany(E =>
-            //        bundle.Entry.ByResourceType<Condition>() // <-- 
+            //        bundle.Entry.ByResourceType<Condition>() // <--
             //            .Where(P => true) // such that goes here
             //            .Select(P => E));
             var selectManyParameter = Expression.Parameter(outerElementType, outerScope);
@@ -2098,8 +2099,8 @@ namespace Hl7.Cql.Compiler
             //  IEnumerable<Tuple1> source = <cross join expression>;
             //
             //  source
-            //    .SelectMany(T => 
-            //        bundle.Entry.ByResourceType<Condition>() // <-- 
+            //    .SelectMany(T =>
+            //        bundle.Entry.ByResourceType<Condition>() // <--
             //            .Where(P => true) // such that goes here, in place of "true"
             //            .Select(P => E));
 
@@ -2222,7 +2223,7 @@ namespace Hl7.Cql.Compiler
                     return call;
                 }
                 var propogate = PropogateNull(scopeExpression, pathMemberInfo, ctx);
-                // This is only necessary for Firely b/c it always initializes colleciton members even if they are 
+                // This is only necessary for Firely b/c it always initializes colleciton members even if they are
                 // not included in the FHIR, and this makes it impossible for CQL to differentiate [] from null
                 //
                 //if (typeof(Resource).IsAssignableFrom(scopeExpression.Type)
@@ -2311,7 +2312,7 @@ namespace Hl7.Cql.Compiler
                 var propogateNull = PropogateNull(source, pathMemberInfo, ctx);
                 result = propogateNull;
             }
-                
+
             if (expectedType != null && expectedType != result.Type)
             {
                 if (expectedType == typeof(string))
@@ -2794,7 +2795,7 @@ namespace Hl7.Cql.Compiler
             //var lambda = (LambdaExpression)makeLambda.Invoke(null, new object[] { @throw, parameters });
             return lambda;
         }
-        
+
         protected static bool IsEnum(Type type)
         {
             if (type.IsEnum)

--- a/Cql/Cql.Packaging/ElmLibraryExtensions.cs
+++ b/Cql/Cql.Packaging/ElmLibraryExtensions.cs
@@ -1,8 +1,10 @@
-﻿using Hl7.Cql.Compiler;
+﻿using System.Linq.Expressions;
+using Hl7.Cql.Compiler;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Runtime;
 using Hl7.Fhir.Model;
 using Microsoft.Extensions.Logging;
+using Expression = System.Linq.Expressions.Expression;
 using Library = Hl7.Cql.Elm.Library;
 
 namespace Hl7.Cql.Packaging
@@ -28,7 +30,14 @@ namespace Hl7.Cql.Packaging
                 new CqlOperatorsBinding(typeResolver, FhirTypeConverter.Create(ModelInfo.ModelInspector)),
                 new TypeManager(typeResolver),
                 library!, builderLogger, new(false));
-            var lambda = builder.Lambda(expression);
+            DefinitionDictionary<LambdaExpression>? lambdas = null;
+            ExpressionBuilderContext? ctx = null;
+            var parameter = Expression.Parameter(typeof(CqlContext), "rtx");
+            lambdas ??= new DefinitionDictionary<LambdaExpression>();
+            ctx ??= new ExpressionBuilderContext(builder, parameter, lambdas, new Dictionary<string, string>());
+            lambdas = new DefinitionDictionary<LambdaExpression>();
+            var translated = builder.TranslateExpression(expression, ctx);
+            var lambda = Expression.Lambda(translated, parameter);
             var func = lambda.Compile();
             return func.DynamicInvoke(context);
         }

--- a/Cql/Cql.Packaging/ElmLibraryExtensions.cs
+++ b/Cql/Cql.Packaging/ElmLibraryExtensions.cs
@@ -30,12 +30,9 @@ namespace Hl7.Cql.Packaging
                 new CqlOperatorsBinding(typeResolver, FhirTypeConverter.Create(ModelInfo.ModelInspector)),
                 new TypeManager(typeResolver),
                 library!, builderLogger, new(false));
-            DefinitionDictionary<LambdaExpression>? lambdas = null;
-            ExpressionBuilderContext? ctx = null;
+            DefinitionDictionary<LambdaExpression> lambdas = new DefinitionDictionary<LambdaExpression>();
             var parameter = Expression.Parameter(typeof(CqlContext), "rtx");
-            lambdas ??= new DefinitionDictionary<LambdaExpression>();
-            ctx ??= new ExpressionBuilderContext(builder, parameter, lambdas, new Dictionary<string, string>());
-            lambdas = new DefinitionDictionary<LambdaExpression>();
+            ExpressionBuilderContext? ctx = new ExpressionBuilderContext(builder, parameter, lambdas, new Dictionary<string, string>());
             var translated = builder.TranslateExpression(expression, ctx);
             var lambda = Expression.Lambda(translated, parameter);
             var func = lambda.Compile();

--- a/Cql/Cql.Packaging/LibraryPackager.cs
+++ b/Cql/Cql.Packaging/LibraryPackager.cs
@@ -1,8 +1,8 @@
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-/* 
+/*
  * Copyright (c) 2023, NCQA and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
@@ -149,7 +149,7 @@ namespace Hl7.Cql.Packaging
                 .Select(node => node.Properties?[elm.Library.LibraryNodeProperty] as elm.Library)
                 .OfType<elm.Library>()
                 // Processing this deterministically to reduce different exceptions when running this repeatedly
-                .OrderBy(lib => lib.NameAndVersion) 
+                .OrderBy(lib => lib.NameAndVersion)
                 .ToArray();
 
             var all = new DefinitionDictionary<LambdaExpression>();

--- a/Demo/Measures/FHIRHelpers-4.0.001.cs
+++ b/Demo/Measures/FHIRHelpers-4.0.001.cs
@@ -59,8 +59,8 @@ public class FHIRHelpers_4_0_001
 			}
 			else
 			{
-				var c_ = context.Operators.ConvertStringToDateTime(period?.StartElement?.Value);
-				var d_ = context.Operators.ConvertStringToDateTime(period?.EndElement?.Value);
+				var c_ = context.Operators.Convert<CqlDateTime>(period?.StartElement);
+				var d_ = context.Operators.Convert<CqlDateTime>(period?.EndElement);
 				var e_ = context.Operators.Interval(c_, d_, true, true);
 
 				return e_;
@@ -1044,7 +1044,7 @@ public class FHIRHelpers_4_0_001
     [CqlDeclaration("ToDateTime")]
 	public CqlDateTime ToDateTime(FhirDateTime value)
 	{
-		var a_ = context.Operators.ConvertStringToDateTime(value?.Value);
+		var a_ = context.Operators.Convert<CqlDateTime>(value);
 
 		return a_;
 	}

--- a/Demo/Measures/NCQAFHIRBase-1.0.0.cs
+++ b/Demo/Measures/NCQAFHIRBase-1.0.0.cs
@@ -63,9 +63,9 @@ public class NCQAFHIRBase_1_0_0
 			else if (onset is Period)
 			{
 				var e_ = context.Operators.LateBoundProperty<FhirDateTime>(onset, "start");
-				var f_ = context.Operators.ConvertStringToDateTime(e_?.Value);
+				var f_ = context.Operators.Convert<CqlDateTime>(e_);
 				var g_ = context.Operators.LateBoundProperty<FhirDateTime>(onset, "end");
-				var h_ = context.Operators.ConvertStringToDateTime(g_?.Value);
+				var h_ = context.Operators.Convert<CqlDateTime>(g_);
 				var i_ = context.Operators.Interval(f_, h_, true, true);
 
 				return i_;
@@ -257,9 +257,9 @@ public class NCQAFHIRBase_1_0_0
 			else if (abatement is Period)
 			{
 				var e_ = context.Operators.LateBoundProperty<FhirDateTime>(abatement, "start");
-				var f_ = context.Operators.ConvertStringToDateTime(e_?.Value);
+				var f_ = context.Operators.Convert<CqlDateTime>(e_);
 				var g_ = context.Operators.LateBoundProperty<FhirDateTime>(abatement, "end");
-				var h_ = context.Operators.ConvertStringToDateTime(g_?.Value);
+				var h_ = context.Operators.Convert<CqlDateTime>(g_);
 				var i_ = context.Operators.Interval(f_, h_, true, true);
 
 				return i_;
@@ -472,9 +472,9 @@ public class NCQAFHIRBase_1_0_0
 			else if (choice is Period)
 			{
 				var j_ = context.Operators.LateBoundProperty<FhirDateTime>(choice, "start");
-				var k_ = context.Operators.ConvertStringToDateTime(j_?.Value);
+				var k_ = context.Operators.Convert<CqlDateTime>(j_);
 				var l_ = context.Operators.LateBoundProperty<FhirDateTime>(choice, "end");
-				var m_ = context.Operators.ConvertStringToDateTime(l_?.Value);
+				var m_ = context.Operators.Convert<CqlDateTime>(l_);
 				var n_ = context.Operators.Interval(k_, m_, true, true);
 
 				return n_;


### PR DESCRIPTION
ℹ️Work for issue #264

Making ExpressionBuilder.Lambda obsolete in 1.0. Will be removed in 2.0 and another way will be used to dynamically invoke cql.

Two generated c# files changed during the build process and are included in this PR, however, the changes are not as a result of the work done in this PR.