### PR TITLE
Fix missing url on library resource

### DIFF
--- a/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
+++ b/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
@@ -111,11 +111,12 @@ internal class CqlToResourcePackagingPipeline
         }
     }
 
-    protected virtual IReadOnlyCollection<Resource> PackageResources(IReadOnlyDictionary<string, AssemblyData> assembliesByLibraryName, LibrarySet librarySet) =>
-        _resourcePackager.PackageResources(
+    protected virtual IReadOnlyCollection<Resource> PackageResources(IReadOnlyDictionary<string, AssemblyData> assembliesByLibraryName, LibrarySet librarySet) => _resourcePackager.PackageResources(
             _options.ElmDirectory,
             _options.CqlDirectory,
-            _options.CanonicalRootUrl?.ToString(), librarySet, assembliesByLibraryName);
+            _options.CanonicalRootUrl?.ToString(),
+            librarySet,
+            assembliesByLibraryName);
 
     protected virtual IReadOnlyDictionary<string, AssemblyData> CompileExpressions(LibrarySet librarySet, DefinitionDictionary<LambdaExpression> definitions) =>
         _assemblyCompiler.Compile(librarySet, definitions);

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -12,6 +12,7 @@ using Hl7.Fhir.Model;
 using FhirLibrary = Hl7.Fhir.Model.Library;
 using Annotation = Hl7.Cql.Elm.Annotation;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
+using Library = Hl7.Cql.Elm.Library;
 
 namespace Hl7.Cql.Packaging;
 
@@ -98,7 +99,7 @@ internal class ResourcePackager
                 if (library.NameAndVersion() is null)
                     throw new InvalidOperationException("Library NameAndVersion should not be null.");
 
-                var fhirLibrary = CreateLibraryResource(elmFile, cqlFile, asmData, typeCrosswalk, library);
+                var fhirLibrary = CreateLibraryResource(elmFile, cqlFile, resourceCanonicalRootUrl, asmData, typeCrosswalk, library);
                 librariesByNameAndVersion.Add(library.NameAndVersion()!, fhirLibrary);
                 OnResourceCreated(fhirLibrary);
             }
@@ -133,27 +134,7 @@ internal class ResourcePackager
                     && !string.IsNullOrWhiteSpace(yearAnnotation.value)
                     && int.TryParse(yearAnnotation.value, out var measureYear))
                 {
-                    var measure = new Measure();
-                    measure.Name = measureAnnotation.value;
-                    measure.Id = library.identifier?.id!;
-                    measure.Version = library.identifier?.version!;
-                    measure.Status = PublicationStatus.Active;
-                    measure.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, DateTimePrecision.Millisecond)
-                        .ToString();
-                    measure.EffectivePeriod = new Period
-                    {
-                        Start = new DateTimeIso8601(measureYear, 1, 1, 0, 0, 0, 0, 0, 0).ToString(),
-                        End = new DateTimeIso8601(measureYear, 12, 31, 23, 59, 59, 999, 0, 0).ToString(),
-                    };
-                    measure.Group = new List<Measure.GroupComponent>();
-                    measure.Url = measure.CanonicalUri(resourceCanonicalRootUrl);
-                    if (library.NameAndVersion() is null)
-                        throw new InvalidOperationException("Library NameAndVersion should not be null.");
-
-                    if (!librariesByNameAndVersion.TryGetValue(library.NameAndVersion()!, out var libForMeasure))
-                        throw new InvalidOperationException(
-                            $"We didn't create a measure for library {libForMeasure}");
-                    measure.Library = new List<string> { libForMeasure!.Url };
+                    Measure measure = CreateMeasureResource(elmFile, resourceCanonicalRootUrl, measureAnnotation, measureYear, librariesByNameAndVersion, library);
                     OnResourceCreated(measure);
                 }
             }
@@ -162,9 +143,42 @@ internal class ResourcePackager
         return resources;
     }
 
+    private static Measure CreateMeasureResource(
+        FileInfo elmFile,
+        string? resourceCanonicalRootUrl,
+        Tag measureAnnotation,
+        int measureYear,
+        Dictionary<string, FhirLibrary> librariesByNameAndVersion,
+        Elm.Library elmLibrary)
+    {
+        var measure = new Measure();
+        measure.Name = measureAnnotation.value;
+        measure.Id = elmLibrary.identifier?.id!;
+        measure.Version = elmLibrary.identifier?.version!;
+        measure.Status = PublicationStatus.Active;
+        measure.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, DateTimePrecision.Millisecond)
+            .ToString();
+        measure.EffectivePeriod = new Period
+        {
+            Start = new DateTimeIso8601(measureYear, 1, 1, 0, 0, 0, 0, 0, 0).ToString(),
+            End = new DateTimeIso8601(measureYear, 12, 31, 23, 59, 59, 999, 0, 0).ToString(),
+        };
+        measure.Group = new List<Measure.GroupComponent>();
+        measure.Url = measure.CanonicalUri(resourceCanonicalRootUrl);
+        if (elmLibrary.NameAndVersion() is null)
+            throw new InvalidOperationException("Library NameAndVersion should not be null.");
+
+        if (!librariesByNameAndVersion.TryGetValue(elmLibrary.NameAndVersion()!, out var libForMeasure))
+            throw new InvalidOperationException(
+                $"We didn't create a measure for library {libForMeasure}");
+        measure.Library = new List<string> { libForMeasure!.Url };
+        return measure;
+    }
+
     private static FhirLibrary CreateLibraryResource(
         FileInfo elmFile,
         FileInfo? cqlFile,
+        string? resourceCanonicalRootUrl,
         AssemblyData assembly,
         CqlTypeToFhirTypeMapper typeCrosswalk,
         Elm.Library? elmLibrary = null)
@@ -195,6 +209,7 @@ internal class ResourcePackager
         library.Name = elmLibrary!.identifier?.id!;
         library.Status = PublicationStatus.Active;
         library.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, Iso8601.DateTimePrecision.Millisecond).ToString();
+        library.Url = library.CanonicalUri(resourceCanonicalRootUrl);
         var parameters = new List<ParameterDefinition>();
         var inParams = elmLibrary.parameters?
             .Select(pd => ElmParameterToFhir(pd, typeCrosswalk));


### PR DESCRIPTION
ℹ️Fix for bug #309 

Somehow writing out the url for a library resource got deleted at some point in the 2.0 branch. Added it back.
Also, extracted the code to create a measure into its own method, just like library has its own method