### PR TITLE
Develop 2.0 fix 309 Reintroduce library resource url

### DIFF
--- a/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
+++ b/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
@@ -110,11 +110,12 @@ internal class CqlToResourcePackagingPipeline
         }
     }
 
-    protected virtual IReadOnlyCollection<Resource> PackageResources(IReadOnlyDictionary<string, AssemblyData> assembliesByLibraryName, LibrarySet librarySet) =>
-        _resourcePackager.PackageResources(
+    protected virtual IReadOnlyCollection<Resource> PackageResources(IReadOnlyDictionary<string, AssemblyData> assembliesByLibraryName, LibrarySet librarySet) => _resourcePackager.PackageResources(
             _options.ElmDirectory,
             _options.CqlDirectory,
-            _options.CanonicalRootUrl?.ToString(), librarySet, assembliesByLibraryName);
+            _options.CanonicalRootUrl?.ToString(),
+            librarySet,
+            assembliesByLibraryName);
 
     protected virtual IReadOnlyDictionary<string, AssemblyData> CompileExpressions(LibrarySet librarySet, DefinitionDictionary<LambdaExpression> definitions) =>
         _assemblyCompiler.Compile(librarySet, definitions);

--- a/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
+++ b/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
@@ -110,7 +110,8 @@ internal class CqlToResourcePackagingPipeline
         }
     }
 
-    protected virtual IReadOnlyCollection<Resource> PackageResources(IReadOnlyDictionary<string, AssemblyData> assembliesByLibraryName, LibrarySet librarySet) => _resourcePackager.PackageResources(
+    protected virtual IReadOnlyCollection<Resource> PackageResources(IReadOnlyDictionary<string, AssemblyData> assembliesByLibraryName, LibrarySet librarySet) =>
+        _resourcePackager.PackageResources(
             _options.ElmDirectory,
             _options.CqlDirectory,
             _options.CanonicalRootUrl?.ToString(),

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -9,6 +9,7 @@ using Hl7.Fhir.Model;
 using FhirLibrary = Hl7.Fhir.Model.Library;
 using Annotation = Hl7.Cql.Elm.Annotation;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
+using Library = Hl7.Cql.Elm.Library;
 
 namespace Hl7.Cql.Packaging;
 
@@ -95,7 +96,7 @@ internal class ResourcePackager
                 if (library.NameAndVersion() is null)
                     throw new InvalidOperationException("Library NameAndVersion should not be null.");
 
-                var fhirLibrary = CreateLibraryResource(elmFile, cqlFile, asmData, typeCrosswalk, library);
+                var fhirLibrary = CreateLibraryResource(elmFile, cqlFile, resourceCanonicalRootUrl, asmData, typeCrosswalk, library);
                 librariesByNameAndVersion.Add(library.NameAndVersion()!, fhirLibrary);
                 OnResourceCreated(fhirLibrary);
             }
@@ -130,27 +131,7 @@ internal class ResourcePackager
                     && !string.IsNullOrWhiteSpace(yearAnnotation.value)
                     && int.TryParse(yearAnnotation.value, out var measureYear))
                 {
-                    var measure = new Measure();
-                    measure.Name = measureAnnotation.value;
-                    measure.Id = library.identifier?.id!;
-                    measure.Version = library.identifier?.version!;
-                    measure.Status = PublicationStatus.Active;
-                    measure.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, DateTimePrecision.Millisecond)
-                        .ToString();
-                    measure.EffectivePeriod = new Period
-                    {
-                        Start = new DateTimeIso8601(measureYear, 1, 1, 0, 0, 0, 0, 0, 0).ToString(),
-                        End = new DateTimeIso8601(measureYear, 12, 31, 23, 59, 59, 999, 0, 0).ToString(),
-                    };
-                    measure.Group = [];
-                    measure.Url = measure.CanonicalUri(resourceCanonicalRootUrl);
-                    if (library.NameAndVersion() is null)
-                        throw new InvalidOperationException("Library NameAndVersion should not be null.");
-
-                    if (!librariesByNameAndVersion.TryGetValue(library.NameAndVersion()!, out var libForMeasure))
-                        throw new InvalidOperationException(
-                            $"We didn't create a measure for library {libForMeasure}");
-                    measure.Library = new List<string> { libForMeasure!.Url };
+                    Measure measure = CreateMeasureResource(elmFile, resourceCanonicalRootUrl, measureAnnotation, measureYear, librariesByNameAndVersion, library);
                     OnResourceCreated(measure);
                 }
             }
@@ -159,9 +140,42 @@ internal class ResourcePackager
         return resources;
     }
 
+    private static Measure CreateMeasureResource(
+        FileInfo elmFile,
+        string? resourceCanonicalRootUrl,
+        Tag measureAnnotation,
+        int measureYear,
+        Dictionary<string, FhirLibrary> librariesByNameAndVersion,
+        Elm.Library elmLibrary)
+    {
+        var measure = new Measure();
+        measure.Name = measureAnnotation.value;
+        measure.Id = elmLibrary.identifier?.id!;
+        measure.Version = elmLibrary.identifier?.version!;
+        measure.Status = PublicationStatus.Active;
+        measure.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, DateTimePrecision.Millisecond)
+            .ToString();
+        measure.EffectivePeriod = new Period
+        {
+            Start = new DateTimeIso8601(measureYear, 1, 1, 0, 0, 0, 0, 0, 0).ToString(),
+            End = new DateTimeIso8601(measureYear, 12, 31, 23, 59, 59, 999, 0, 0).ToString(),
+        };
+        measure.Group = [];
+        measure.Url = measure.CanonicalUri(resourceCanonicalRootUrl);
+        if (elmLibrary.NameAndVersion() is null)
+            throw new InvalidOperationException("Library NameAndVersion should not be null.");
+
+        if (!librariesByNameAndVersion.TryGetValue(elmLibrary.NameAndVersion()!, out var libForMeasure))
+            throw new InvalidOperationException(
+                $"We didn't create a measure for library {libForMeasure}");
+        measure.Library = new List<string> { libForMeasure!.Url };
+        return measure;
+    }
+
     private static FhirLibrary CreateLibraryResource(
         FileInfo elmFile,
         FileInfo? cqlFile,
+        string? resourceCanonicalRootUrl,
         AssemblyData assembly,
         CqlTypeToFhirTypeMapper typeCrosswalk,
         Elm.Library? elmLibrary = null)
@@ -192,6 +206,7 @@ internal class ResourcePackager
         library.Name = elmLibrary!.identifier?.id!;
         library.Status = PublicationStatus.Active;
         library.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, Iso8601.DateTimePrecision.Millisecond).ToString();
+        library.Url = library.CanonicalUri(resourceCanonicalRootUrl);
         var parameters = new List<ParameterDefinition>();
         var inParams = elmLibrary.parameters?
             .Select(pd => ElmParameterToFhir(pd, typeCrosswalk));

--- a/Demo/Measures-cms/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures-cms/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
@@ -552,7 +552,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var i_ = context.Operators.LastOfList<Observation>(h_);
 			bool? j_(Observation.ComponentComponent @this)
 			{
-				var as_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var as_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var at_ = context.Operators.Convert<string>(as_?.SystemElement);
 				var au_ = context.Operators.Equal(at_, "http://loinc.org");
 				var aw_ = context.Operators.Convert<string>(as_?.CodeElement);
@@ -600,7 +600,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var w_ = context.Operators.LastOfList<Observation>(v_);
 			bool? x_(Observation.ComponentComponent @this)
 			{
-				var bl_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var bl_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var bm_ = context.Operators.Convert<string>(bl_?.SystemElement);
 				var bn_ = context.Operators.Equal(bm_, "http://loinc.org");
 				var bp_ = context.Operators.Convert<string>(bl_?.CodeElement);
@@ -666,7 +666,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var i_ = context.Operators.LastOfList<Observation>(h_);
 			bool? j_(Observation.ComponentComponent @this)
 			{
-				var as_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var as_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var at_ = context.Operators.Convert<string>(as_?.SystemElement);
 				var au_ = context.Operators.Equal(at_, "http://loinc.org");
 				var aw_ = context.Operators.Convert<string>(as_?.CodeElement);
@@ -714,7 +714,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var w_ = context.Operators.LastOfList<Observation>(v_);
 			bool? x_(Observation.ComponentComponent @this)
 			{
-				var bl_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var bl_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var bm_ = context.Operators.Convert<string>(bl_?.SystemElement);
 				var bn_ = context.Operators.Equal(bm_, "http://loinc.org");
 				var bp_ = context.Operators.Convert<string>(bl_?.CodeElement);
@@ -945,7 +945,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var i_ = context.Operators.LastOfList<Observation>(h_);
 			bool? j_(Observation.ComponentComponent @this)
 			{
-				var by_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var by_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var bz_ = context.Operators.Convert<string>(by_?.SystemElement);
 				var ca_ = context.Operators.Equal(bz_, "http://loinc.org");
 				var cc_ = context.Operators.Convert<string>(by_?.CodeElement);
@@ -999,7 +999,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var u_ = context.Operators.LastOfList<Observation>(t_);
 			bool? v_(Observation.ComponentComponent @this)
 			{
-				var db_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var db_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var dc_ = context.Operators.Convert<string>(db_?.SystemElement);
 				var dd_ = context.Operators.Equal(dc_, "http://loinc.org");
 				var df_ = context.Operators.Convert<string>(db_?.CodeElement);
@@ -1053,7 +1053,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var ah_ = context.Operators.LastOfList<Observation>(ag_);
 			bool? ai_(Observation.ComponentComponent @this)
 			{
-				var ee_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var ee_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var ef_ = context.Operators.Convert<string>(ee_?.SystemElement);
 				var eg_ = context.Operators.Equal(ef_, "http://loinc.org");
 				var ei_ = context.Operators.Convert<string>(ee_?.CodeElement);
@@ -1107,7 +1107,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var at_ = context.Operators.LastOfList<Observation>(as_);
 			bool? au_(Observation.ComponentComponent @this)
 			{
-				var fh_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var fh_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var fi_ = context.Operators.Convert<string>(fh_?.SystemElement);
 				var fj_ = context.Operators.Equal(fi_, "http://loinc.org");
 				var fl_ = context.Operators.Convert<string>(fh_?.CodeElement);
@@ -1164,7 +1164,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var k_ = context.Operators.LastOfList<Observation>(j_);
 			bool? l_(Observation.ComponentComponent @this)
 			{
-				var bm_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var bm_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var bn_ = context.Operators.Convert<string>(bm_?.SystemElement);
 				var bo_ = context.Operators.Equal(bn_, "http://loinc.org");
 				var bq_ = context.Operators.Convert<string>(bm_?.CodeElement);
@@ -1201,7 +1201,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var w_ = context.Operators.LastOfList<Observation>(v_);
 			bool? x_(Observation.ComponentComponent @this)
 			{
-				var cb_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var cb_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var cc_ = context.Operators.Convert<string>(cb_?.SystemElement);
 				var cd_ = context.Operators.Equal(cc_, "http://loinc.org");
 				var cf_ = context.Operators.Convert<string>(cb_?.CodeElement);
@@ -1238,7 +1238,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var aj_ = context.Operators.LastOfList<Observation>(ai_);
 			bool? ak_(Observation.ComponentComponent @this)
 			{
-				var cq_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var cq_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var cr_ = context.Operators.Convert<string>(cq_?.SystemElement);
 				var cs_ = context.Operators.Equal(cr_, "http://loinc.org");
 				var cu_ = context.Operators.Convert<string>(cq_?.CodeElement);
@@ -1275,7 +1275,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var av_ = context.Operators.LastOfList<Observation>(au_);
 			bool? aw_(Observation.ComponentComponent @this)
 			{
-				var df_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var df_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var dg_ = context.Operators.Convert<string>(df_?.SystemElement);
 				var dh_ = context.Operators.Equal(dg_, "http://loinc.org");
 				var dj_ = context.Operators.Convert<string>(df_?.CodeElement);
@@ -1412,7 +1412,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var i_ = context.Operators.LastOfList<Observation>(h_);
 			bool? j_(Observation.ComponentComponent @this)
 			{
-				var bw_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var bw_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var bx_ = context.Operators.Convert<string>(bw_?.SystemElement);
 				var by_ = context.Operators.Equal(bx_, "http://loinc.org");
 				var ca_ = context.Operators.Convert<string>(bw_?.CodeElement);
@@ -1460,7 +1460,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var w_ = context.Operators.LastOfList<Observation>(v_);
 			bool? x_(Observation.ComponentComponent @this)
 			{
-				var cp_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var cp_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var cq_ = context.Operators.Convert<string>(cp_?.SystemElement);
 				var cr_ = context.Operators.Equal(cq_, "http://loinc.org");
 				var ct_ = context.Operators.Convert<string>(cp_?.CodeElement);
@@ -1509,7 +1509,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var al_ = context.Operators.LastOfList<Observation>(ak_);
 			bool? am_(Observation.ComponentComponent @this)
 			{
-				var di_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var di_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var dj_ = context.Operators.Convert<string>(di_?.SystemElement);
 				var dk_ = context.Operators.Equal(dj_, "http://loinc.org");
 				var dm_ = context.Operators.Convert<string>(di_?.CodeElement);
@@ -1555,7 +1555,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var ax_ = context.Operators.LastOfList<Observation>(aw_);
 			bool? ay_(Observation.ComponentComponent @this)
 			{
-				var eb_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var eb_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var ec_ = context.Operators.Convert<string>(eb_?.SystemElement);
 				var ed_ = context.Operators.Equal(ec_, "http://loinc.org");
 				var ef_ = context.Operators.Convert<string>(eb_?.CodeElement);
@@ -1755,7 +1755,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var i_ = context.Operators.LastOfList<Observation>(h_);
 			bool? j_(Observation.ComponentComponent @this)
 			{
-				var br_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var br_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var bs_ = context.Operators.Convert<string>(br_?.SystemElement);
 				var bt_ = context.Operators.Equal(bs_, "http://loinc.org");
 				var bv_ = context.Operators.Convert<string>(br_?.CodeElement);
@@ -1801,7 +1801,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var u_ = context.Operators.LastOfList<Observation>(t_);
 			bool? v_(Observation.ComponentComponent @this)
 			{
-				var ck_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var ck_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var cl_ = context.Operators.Convert<string>(ck_?.SystemElement);
 				var cm_ = context.Operators.Equal(cl_, "http://loinc.org");
 				var co_ = context.Operators.Convert<string>(ck_?.CodeElement);
@@ -1847,7 +1847,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var ah_ = context.Operators.LastOfList<Observation>(ag_);
 			bool? ai_(Observation.ComponentComponent @this)
 			{
-				var dd_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var dd_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var de_ = context.Operators.Convert<string>(dd_?.SystemElement);
 				var df_ = context.Operators.Equal(de_, "http://loinc.org");
 				var dh_ = context.Operators.Convert<string>(dd_?.CodeElement);
@@ -1893,7 +1893,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			var at_ = context.Operators.LastOfList<Observation>(as_);
 			bool? au_(Observation.ComponentComponent @this)
 			{
-				var dw_ = context.Operators.FirstOfList<Coding>((@this?.Code?.Coding as IEnumerable<Coding>));
+				var dw_ = context.Operators.FirstOfList<Coding>(@this?.Code?.Coding);
 				var dx_ = context.Operators.Convert<string>(dw_?.SystemElement);
 				var dy_ = context.Operators.Equal(dx_, "http://loinc.org");
 				var ea_ = context.Operators.Convert<string>(dw_?.CodeElement);


### PR DESCRIPTION
ℹ️Fix for bug #309 

Somehow writing out the url for a library resource got deleted at some point in the 2.0 branch. Added it back.
Also, extracted the code to create a measure into its own method, just like library has its own method