### PR TITLE
Develop 2.0 setup for pom upgrades

### DIFF
--- a/Demo/Cql/Build/Cql.Targets.xml
+++ b/Demo/Cql/Build/Cql.Targets.xml
@@ -25,8 +25,8 @@
 	        DependsOnTargets="Download CQL to ELM CLI via Maven"
 	        AfterTargets="Build">
 		<Message Text="Converting CQL to ELM"/>
-		<Exec Command='java -classpath "$(MSBuildProjectDirectory)\Build\target\dependency\*" org.cqframework.cql.cql2elm.cli.Main -input "$(SolutionDir)\LibrarySets\Demo\Cql" -f JSON -output "$(SolutionDir)\LibrarySets\Demo\Elm" -locators true -result-types true -signatures All'/>
-		<Exec Command='java -classpath "$(MSBuildProjectDirectory)\Build\target\dependency\*" org.cqframework.cql.cql2elm.cli.Main -input "$(SolutionDir)\LibrarySets\CMS\Cql" -f JSON -output "$(SolutionDir)\LibrarySets\CMS\Elm" -locators true -result-types true -signatures All'/>
+		<Exec Command='java -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persistence.jaxb.XMLBindingContextFactory -classpath "$(MSBuildProjectDirectory)\Build\target\dependency\*" org.cqframework.cql.cql2elm.cli.Main -input "$(SolutionDir)\LibrarySets\Demo\Cql" -f JSON -output "$(SolutionDir)\LibrarySets\Demo\Elm" -locators true -result-types true -signatures All'/>
+		<Exec Command='java -Djakarta.xml.bind.JAXBContextFactory=org.eclipse.persistence.jaxb.XMLBindingContextFactory -classpath "$(MSBuildProjectDirectory)\Build\target\dependency\*" org.cqframework.cql.cql2elm.cli.Main -input "$(SolutionDir)\LibrarySets\CMS\Cql" -f JSON -output "$(SolutionDir)\LibrarySets\CMS\Elm" -locators true -result-types true -signatures All'/>
 	</Target>
 
 	<Target Name="Delete JAR Dependencies" AfterTargets="Clean">

--- a/Demo/Cql/Build/pom.xml
+++ b/Demo/Cql/Build/pom.xml
@@ -7,7 +7,10 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>firely.cql</groupId>
 	<artifactId>demo</artifactId>
-	<version>1</version>
+	<version>1.0</version>
+	<properties>
+		<cql.version>3.1.0</cql.version>
+	</properties>
 	<repositories>
 		<repository>
 			<id>sonatype-public</id>
@@ -20,12 +23,12 @@
 		<dependency>
 			<groupId>info.cqframework</groupId>
 			<artifactId>cql-to-elm-cli</artifactId>
-			<version>3.1.0</version>
+			<version>${cql.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>info.cqframework</groupId>
 			<artifactId>elm-fhir</artifactId>
-			<version>3.1.0</version>
+			<version>${cql.version}</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
eclipse retired some backward compatibility so you have to set the binding factory manually. This is not working in the java sourcecode so I will open a ticket with them too.