### PR TITLE
2.0/Command line arg to chooce type format in generated C# code

### DIFF
--- a/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
+++ b/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
@@ -20,6 +20,12 @@ public class CSharpCodeWriterOptions
     public DirectoryInfo? OutDirectory { get; set; }
 
     internal const string ArgNameOutDirectory = "--cs";
+    internal const string ArgNamePreferVar = "--cs-prefervar";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to prefer 'var' over explicit types.
+    /// </summary>
+    public bool PreferVar { get; set; }
 
     /// <summary>
     /// Binds the configuration values to the CSharpResourceWriterOptions object.

--- a/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
+++ b/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
@@ -20,6 +20,12 @@ public class CSharpCodeWriterOptions
     public DirectoryInfo? OutDirectory { get; set; }
 
     internal const string ArgNameOutDirectory = "--cs";
+    internal const string ArgNameTypeFormat = "--cs-typeformat";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to prefer 'var' over explicit types.
+    /// </summary>
+    public CSharpCodeWriterTypeFormat TypeFormat { get; set; }
 
     /// <summary>
     /// Binds the configuration values to the CSharpResourceWriterOptions object.
@@ -40,4 +46,20 @@ public class CSharpCodeWriterOptions
             return string.IsNullOrWhiteSpace(path) ? null : new DirectoryInfo(Path.GetFullPath(path));
         }
     }
+}
+
+/// <summary>
+/// How to format types in C# output
+/// </summary>
+public enum CSharpCodeWriterTypeFormat
+{
+    /// <summary>
+    /// Use 'var' over explicit types.
+    /// </summary>
+    Var,
+
+    /// <summary>
+    /// Use explicit types.
+    /// </summary>
+    Explicit
 }

--- a/Cql/CodeGeneration.NET/CSharpLibrarySetToStreamsWriter.cs
+++ b/Cql/CodeGeneration.NET/CSharpLibrarySetToStreamsWriter.cs
@@ -21,6 +21,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using Hl7.Cql.Compiler;
+using Microsoft.Extensions.Options;
 
 namespace Hl7.Cql.CodeGeneration.NET
 {
@@ -31,17 +32,21 @@ namespace Hl7.Cql.CodeGeneration.NET
     {
         private const string TuplesNamespace = "Tuples";
         private readonly ILogger<CSharpLibrarySetToStreamsWriter> _logger;
+        private readonly CSharpCodeWriterOptions _options;
 
         /// <summary>
         /// Creates an instance.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger{TCategoryName}"/> to report output.</param>
+        /// <param name="options">The options <see cref="CSharpCodeWriterOptions"/></param>
         /// <param name="typeResolver">The <see cref="TypeResolver"/> to use to include namespaces and aliases from.</param>
         public CSharpLibrarySetToStreamsWriter(
             ILogger<CSharpLibrarySetToStreamsWriter> logger,
+            IOptions<CSharpCodeWriterOptions> options,
             TypeResolver typeResolver)
         {
             _logger = logger;
+            _options = options.Value;
             _contextAccessModifier = AccessModifier.Internal;
             _definesAccessModifier = AccessModifier.Internal;
             _usings = BuildUsings(typeResolver);
@@ -449,7 +454,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 new LocalVariableDeduper()
             );
 
-            var expressionConverter = new ExpressionConverter(libraryName);
+            var expressionConverter = new ExpressionConverter(libraryName, _options.PreferVar);
 
             // Skip CqlContext
             var parameters = overload.Parameters.Skip(1);

--- a/Cql/CodeGeneration.NET/CSharpLibrarySetToStreamsWriter.cs
+++ b/Cql/CodeGeneration.NET/CSharpLibrarySetToStreamsWriter.cs
@@ -21,6 +21,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using Hl7.Cql.Compiler;
+using Microsoft.Extensions.Options;
 
 namespace Hl7.Cql.CodeGeneration.NET
 {
@@ -31,17 +32,21 @@ namespace Hl7.Cql.CodeGeneration.NET
     {
         private const string TuplesNamespace = "Tuples";
         private readonly ILogger<CSharpLibrarySetToStreamsWriter> _logger;
+        private readonly CSharpCodeWriterOptions _options;
 
         /// <summary>
         /// Creates an instance.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger{TCategoryName}"/> to report output.</param>
+        /// <param name="options">The options <see cref="CSharpCodeWriterOptions"/></param>
         /// <param name="typeResolver">The <see cref="TypeResolver"/> to use to include namespaces and aliases from.</param>
         public CSharpLibrarySetToStreamsWriter(
             ILogger<CSharpLibrarySetToStreamsWriter> logger,
+            IOptions<CSharpCodeWriterOptions> options,
             TypeResolver typeResolver)
         {
             _logger = logger;
+            _options = options.Value;
             _contextAccessModifier = AccessModifier.Internal;
             _definesAccessModifier = AccessModifier.Internal;
             _usings = BuildUsings(typeResolver);
@@ -449,7 +454,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 new LocalVariableDeduper()
             );
 
-            var expressionConverter = new ExpressionConverter(libraryName);
+            var expressionConverter = new ExpressionConverter(libraryName, _options.TypeFormat);
 
             // Skip CqlContext
             var parameters = overload.Parameters.Skip(1);

--- a/Cql/CodeGeneration.NET/ExpressionConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionConverter.cs
@@ -20,10 +20,10 @@ using Hl7.Cql.Abstractions.Infrastructure;
 
 namespace Hl7.Cql.CodeGeneration.NET
 {
-    internal class ExpressionConverter(string libraryName)
+    internal class ExpressionConverter(
+        string libraryName,
+        bool preferVar)
     {
-        private static readonly bool PreferVar = false;
-
         public string ConvertExpression(int indent, Expression expression, bool leadingIndent = true)
         {
             try
@@ -565,7 +565,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 var rightCode = ConvertExpression(indent, right, false);
 
                 string typeDeclaration = "var";
-                if (!PreferVar || rightCode is "null" or "default")
+                if (!preferVar || rightCode is "null" or "default")
                     typeDeclaration = PrettyTypeName(left.Type);
 
                 var assignment = $"{leadingIndentString}{typeDeclaration} {ParamName(parameter)} = {rightCode}";

--- a/Cql/CodeGeneration.NET/ExpressionConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionConverter.cs
@@ -20,10 +20,10 @@ using Hl7.Cql.Abstractions.Infrastructure;
 
 namespace Hl7.Cql.CodeGeneration.NET
 {
-    internal class ExpressionConverter(string libraryName)
+    internal class ExpressionConverter(
+        string libraryName,
+        CSharpCodeWriterTypeFormat typeFormat)
     {
-        private static readonly bool PreferVar = true;
-
         public string ConvertExpression(int indent, Expression expression, bool leadingIndent = true)
         {
             try
@@ -565,7 +565,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 var rightCode = ConvertExpression(indent, right, false);
 
                 string typeDeclaration = "var";
-                if (!PreferVar || rightCode is "null" or "default")
+                if (typeFormat is CSharpCodeWriterTypeFormat.Explicit || rightCode is "null" or "default")
                     typeDeclaration = PrettyTypeName(left.Type);
 
                 var assignment = $"{leadingIndentString}{typeDeclaration} {ParamName(parameter)} = {rightCode}";

--- a/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
+++ b/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
@@ -3,4 +3,9 @@ Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.CSharpCodeWriterOptions() -> void
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.OutDirectory.get -> System.IO.DirectoryInfo?
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.OutDirectory.set -> void
+Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.TypeFormat.get -> Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
+Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.TypeFormat.set -> void
+Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
+Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat.Explicit = 1 -> Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
+Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat.Var = 0 -> Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
 static Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.BindConfig(Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions! opt, Microsoft.Extensions.Configuration.IConfiguration! config) -> void

--- a/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
+++ b/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
@@ -3,4 +3,6 @@ Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.CSharpCodeWriterOptions() -> void
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.OutDirectory.get -> System.IO.DirectoryInfo?
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.OutDirectory.set -> void
+Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.PreferVar.get -> bool
+Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.PreferVar.set -> void
 static Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.BindConfig(Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions! opt, Microsoft.Extensions.Configuration.IConfiguration! config) -> void

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -3390,7 +3390,7 @@ namespace CoreTests
             var isDone = false;
             writer.ProcessDefinitions(
                 definitions,
-                librarySet, 
+                librarySet,
                 Factory.TypeManager.TupleTypes,
                 callbacks:new(onAfterStep: step =>
                 {
@@ -3401,7 +3401,7 @@ namespace CoreTests
                             break;
                     }
                 }));
-            Assert.IsTrue(isDone); 
+            Assert.IsTrue(isDone);
         }
 
         [TestMethod]
@@ -3423,7 +3423,7 @@ namespace CoreTests
             Assert.IsNotNull(meets);
             Assert.IsTrue(meets ?? false);
 
-            // Interval[null, 2022-12-31] meets Interval[2024-01-01, null] returns false 
+            // Interval[null, 2022-12-31] meets Interval[2024-01-01, null] returns false
             meets = rtx.Operators.Meets(
                 new CqlInterval<CqlDate>(null, new CqlDate(2022, 12, 31), true, true),
                 new CqlInterval<CqlDate>(new CqlDate(2023, 7, 1), null, true, true),

--- a/Cql/Cql.Packaging/CqlPackagingPipelineOptions.cs
+++ b/Cql/Cql.Packaging/CqlPackagingPipelineOptions.cs
@@ -14,7 +14,7 @@ internal partial class CqlToResourcePackagingOptions
     public bool Debug { get; set; }
 
     public const string ArgNameForce = "--f";
-    public bool Force { get; set; }
+    public bool Force { get; set; } // TODO: There are no usages for this, Remove or implement!
 
     public const string ArgNameCanonicalRootUrl = "--canonical-root-url";
     public Uri? CanonicalRootUrl { get; set; }

--- a/Cql/Cql.Packaging/ResourcePackagerFactory.cs
+++ b/Cql/Cql.Packaging/ResourcePackagerFactory.cs
@@ -33,13 +33,17 @@ internal class CqlPackagerFactory : CqlCompilerFactory
     protected virtual CqlTypeToFhirTypeMapper NewCqlTypeToFhirTypeMapper() => new(TypeResolver);
 
     public virtual CSharpLibrarySetToStreamsWriter CSharpLibrarySetToStreamsWriter => Singleton(NewCSharpLibrarySetToStreamsWriter);
-    protected virtual CSharpLibrarySetToStreamsWriter NewCSharpLibrarySetToStreamsWriter() => new(Logger<CSharpLibrarySetToStreamsWriter>(), TypeResolver);
+    protected virtual CSharpLibrarySetToStreamsWriter NewCSharpLibrarySetToStreamsWriter() => new(
+        Logger<CSharpLibrarySetToStreamsWriter>(),
+        Options(CSharpCodeWriterOptions ?? throw new ArgumentNullException(nameof(CSharpCodeWriterOptions))),
+        TypeResolver);
 
     public virtual CSharpCodeStreamPostProcessor? CSharpCodeStreamPostProcessor => Singleton(NewCSharpCodeStreamPostProcessorOrNull);
     protected virtual CSharpCodeStreamPostProcessor? NewCSharpCodeStreamPostProcessorOrNull() =>
         CSharpCodeWriterOptions is { OutDirectory: { } } opt
             ? NewWriteToFileCSharpCodeStreamPostProcessor(opt)
             : default(CSharpCodeStreamPostProcessor);
+
     protected virtual WriteToFileCSharpCodeStreamPostProcessor NewWriteToFileCSharpCodeStreamPostProcessor(
         CSharpCodeWriterOptions opt) =>
         new(Options(opt), Logger<WriteToFileCSharpCodeStreamPostProcessor>());

--- a/Cql/Cql.Packaging/ResourcePackagerFactory.cs
+++ b/Cql/Cql.Packaging/ResourcePackagerFactory.cs
@@ -14,8 +14,8 @@ namespace Hl7.Cql.Packaging;
 internal class CqlPackagerFactory : CqlCompilerFactory
 {
     public CqlToResourcePackagingOptions CqlToResourcePackagingOptions { get; }
-    public CSharpCodeWriterOptions? CSharpCodeWriterOptions { get; }
-    public FhirResourceWriterOptions? FhirResourceWriterOptions { get; }
+    public CSharpCodeWriterOptions CSharpCodeWriterOptions { get; }
+    public FhirResourceWriterOptions FhirResourceWriterOptions { get; }
 
     public CqlPackagerFactory(
         ILoggerFactory loggerFactory,
@@ -25,8 +25,8 @@ internal class CqlPackagerFactory : CqlCompilerFactory
         FhirResourceWriterOptions? fhirResourceWriterOptions = default) : base(loggerFactory, cacheSize)
     {
         CqlToResourcePackagingOptions = cqlToResourcePackagingOptions ?? new();
-        CSharpCodeWriterOptions = cSharpCodeWriterOptions;
-        FhirResourceWriterOptions = fhirResourceWriterOptions;
+        CSharpCodeWriterOptions = cSharpCodeWriterOptions ?? new();
+        FhirResourceWriterOptions = fhirResourceWriterOptions ?? new();
     }
 
     public virtual CqlTypeToFhirTypeMapper CqlTypeToFhirTypeMapper => Singleton(NewCqlTypeToFhirTypeMapper);
@@ -35,7 +35,7 @@ internal class CqlPackagerFactory : CqlCompilerFactory
     public virtual CSharpLibrarySetToStreamsWriter CSharpLibrarySetToStreamsWriter => Singleton(NewCSharpLibrarySetToStreamsWriter);
     protected virtual CSharpLibrarySetToStreamsWriter NewCSharpLibrarySetToStreamsWriter() => new(
         Logger<CSharpLibrarySetToStreamsWriter>(),
-        Options(CSharpCodeWriterOptions ?? throw new ArgumentNullException(nameof(CSharpCodeWriterOptions))),
+        Options(CSharpCodeWriterOptions),
         TypeResolver);
 
     public virtual CSharpCodeStreamPostProcessor? CSharpCodeStreamPostProcessor => Singleton(NewCSharpCodeStreamPostProcessorOrNull);

--- a/Cql/PackagerCLI/OptionsConsoleDumper.cs
+++ b/Cql/PackagerCLI/OptionsConsoleDumper.cs
@@ -1,23 +1,27 @@
 ﻿using Microsoft.Extensions.Options;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Hl7.Cql.CodeGeneration.NET;
 using Hl7.Cql.Packaging;
-using static System.Console;
 using Hl7.Cql.Packaging.PostProcessors;
+using Microsoft.Extensions.Logging;
 
 namespace Hl7.Cql.Packager;
 
 internal class OptionsConsoleDumper
 {
+    private readonly ILogger<OptionsConsoleDumper> _logger;
     private readonly CqlToResourcePackagingOptions _options;
     private readonly FhirResourceWriterOptions _fhirResourceWriterOptions;
     private readonly CSharpCodeWriterOptions _csharpCodeWriterOptions;
 
     public OptionsConsoleDumper(
+        ILogger<OptionsConsoleDumper> logger,
         IOptions<CqlToResourcePackagingOptions> packagerOptions,
         IOptions<FhirResourceWriterOptions> fhirResourceWriterOptions,
         IOptions<CSharpCodeWriterOptions> csharpResourceWriterOptions)
     {
+        _logger = logger;
         _options = packagerOptions.Value;
         _fhirResourceWriterOptions = fhirResourceWriterOptions.Value;
         _csharpCodeWriterOptions = csharpResourceWriterOptions.Value;
@@ -25,25 +29,37 @@ internal class OptionsConsoleDumper
 
     public void DumpToConsole()
     {
+        StringBuilder? sb = _logger.IsEnabled(LogLevel.Information) ? new() : null;
+
         WriteLine("PackageCLI");
         WriteLine("- Environment -----------------------------------");
-        WriteLine("{0,-20} : {1}", "Current Directory", Environment.CurrentDirectory);
+        WriteLine($"{"Current Directory",-38} : {Environment.CurrentDirectory}");
         WriteLine("- Arguments Provided ----------------------------");
         (string name, object? value)[] values = new[]
         {
-            ArgFor(_options.CqlDirectory),
-            ArgFor(_options.ElmDirectory),
-            ArgFor(_options.CanonicalRootUrl),
             ArgFor(_options.Force),
             ArgFor(_options.Debug),
-            ArgFor("Fhir", _fhirResourceWriterOptions.OutDirectory),
-            ArgFor("Fhir", _fhirResourceWriterOptions.OverrideDate),
-            ArgFor("CSharp", _csharpCodeWriterOptions.OutDirectory),
+            ArgFor("Resource, CanonicalRootUrl", _options.CanonicalRootUrl),
+            ArgFor("Cql, InDirectory", _options.CqlDirectory),
+            ArgFor("Elm, InDirectory", _options.ElmDirectory),
+            ArgFor("Fhir, OutDirectory", _fhirResourceWriterOptions.OutDirectory),
+            ArgFor("Fhir, OverrideDate", _fhirResourceWriterOptions.OverrideDate),
+            ArgFor("CSharp, OutDirectory", _csharpCodeWriterOptions.OutDirectory),
+            ArgFor("CSharp, TypeFormat", _csharpCodeWriterOptions.TypeFormat),
         }.Where(t => t.value is not null)
         .ToArray();
 
-        foreach (var (name, value) in values) 
-            WriteLine($"{name,-20} : {value}");
+        foreach (var (name, value) in values)
+            WriteLine($"{name,-38} : {value}");
+
+        if (sb is not null)
+            _logger.LogInformation("{options}", sb.ToString());
+
+        void WriteLine(string s)
+        {
+            sb?.AppendLine(s);
+            Console.WriteLine(s);
+        }
     }
 
     static (string name, object? value) ArgFor(object? value, [CallerArgumentExpression(nameof(value))] string name = "") => (name.Split('.').Last(), value);

--- a/Cql/PackagerCLI/OptionsConsoleDumper.cs
+++ b/Cql/PackagerCLI/OptionsConsoleDumper.cs
@@ -1,23 +1,27 @@
 ﻿using Microsoft.Extensions.Options;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Hl7.Cql.CodeGeneration.NET;
 using Hl7.Cql.Packaging;
-using static System.Console;
 using Hl7.Cql.Packaging.PostProcessors;
+using Microsoft.Extensions.Logging;
 
 namespace Hl7.Cql.Packager;
 
 internal class OptionsConsoleDumper
 {
+    private readonly ILogger<OptionsConsoleDumper> _logger;
     private readonly CqlToResourcePackagingOptions _options;
     private readonly FhirResourceWriterOptions _fhirResourceWriterOptions;
     private readonly CSharpCodeWriterOptions _csharpCodeWriterOptions;
 
     public OptionsConsoleDumper(
+        ILogger<OptionsConsoleDumper> logger,
         IOptions<CqlToResourcePackagingOptions> packagerOptions,
         IOptions<FhirResourceWriterOptions> fhirResourceWriterOptions,
         IOptions<CSharpCodeWriterOptions> csharpResourceWriterOptions)
     {
+        _logger = logger;
         _options = packagerOptions.Value;
         _fhirResourceWriterOptions = fhirResourceWriterOptions.Value;
         _csharpCodeWriterOptions = csharpResourceWriterOptions.Value;
@@ -25,25 +29,37 @@ internal class OptionsConsoleDumper
 
     public void DumpToConsole()
     {
+        StringBuilder? sb = _logger.IsEnabled(LogLevel.Information) ? new() : null;
+
         WriteLine("PackageCLI");
         WriteLine("- Environment -----------------------------------");
-        WriteLine("{0,-20} : {1}", "Current Directory", Environment.CurrentDirectory);
+        WriteLine($"{"Current Directory",-38} : {Environment.CurrentDirectory}");
         WriteLine("- Arguments Provided ----------------------------");
         (string name, object? value)[] values = new[]
         {
-            ArgFor(_options.CqlDirectory),
-            ArgFor(_options.ElmDirectory),
-            ArgFor(_options.CanonicalRootUrl),
             ArgFor(_options.Force),
             ArgFor(_options.Debug),
-            ArgFor("Fhir", _fhirResourceWriterOptions.OutDirectory),
-            ArgFor("Fhir", _fhirResourceWriterOptions.OverrideDate),
-            ArgFor("CSharp", _csharpCodeWriterOptions.OutDirectory),
+            ArgFor("Resource, CanonicalRootUrl", _options.CanonicalRootUrl),
+            ArgFor("Cql, InDirectory", _options.CqlDirectory),
+            ArgFor("Elm, InDirectory", _options.ElmDirectory),
+            ArgFor("Fhir, OutDirectory", _fhirResourceWriterOptions.OutDirectory),
+            ArgFor("Fhir, OverrideDate", _fhirResourceWriterOptions.OverrideDate),
+            ArgFor("CSharp, OutDirectory", _csharpCodeWriterOptions.OutDirectory),
+            ArgFor("CSharp, PreferVar", _csharpCodeWriterOptions.PreferVar),
         }.Where(t => t.value is not null)
         .ToArray();
 
-        foreach (var (name, value) in values) 
-            WriteLine($"{name,-20} : {value}");
+        foreach (var (name, value) in values)
+            WriteLine($"{name,-38} : {value}");
+
+        if (sb is not null)
+            _logger.LogInformation("{options}", sb.ToString());
+
+        void WriteLine(string s)
+        {
+            sb?.AppendLine(s);
+            Console.WriteLine(s);
+        }
     }
 
     static (string name, object? value) ArgFor(object? value, [CallerArgumentExpression(nameof(value))] string name = "") => (name.Split('.').Last(), value);

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -69,6 +69,7 @@ public class Program
             [CqlToResourcePackagingOptions.ArgNameCanonicalRootUrl] = PackageSection + nameof(CqlToResourcePackagingOptions.CanonicalRootUrl),
 
             [CSharpCodeWriterOptions.ArgNameOutDirectory]           = CSharpResourceWriterSection + nameof(CSharpCodeWriterOptions.OutDirectory),
+            [CSharpCodeWriterOptions.ArgNameTypeFormat]             = CSharpResourceWriterSection + nameof(CSharpCodeWriterOptions.TypeFormat),
 
             [FhirResourceWriterOptions.ArgNameOutDirectory]         = FhirResourceWriterSection + nameof(FhirResourceWriterOptions.OutDirectory),
             [FhirResourceWriterOptions.ArgNameOverrideDate]         = FhirResourceWriterSection + nameof(FhirResourceWriterOptions.OverrideDate),
@@ -76,24 +77,30 @@ public class Program
         };
     }
 
-    private const string Usage =
-        """
-        Packager CLI Usage:
+    private static string Usage { get; }
 
-            -?|-h|-help                                Show this help
+    static Program()
+    {
+        Usage = $"""
+                 Packager CLI Usage:
 
-            --elm                  <directory>         Library root directory
-            --cql                  <directory>         CQL root directory
-            [--fhir]               <file|directory>    Resource location, either file name or directory
-            [--cs]                 <file|directory>    C# output location, either file name or directory
-            [--d]                  <true|false>        Produce as a debug assembly
-            [--f]                  <true|false>        Force an overwrite even if the output file already exists
-            [--canonical-root-url] <url>               The root url used for the resource canonical.
-                                                       If omitted a '#' will be used.
-            [--fhir-override-date] <ISO8601-date-time> The UTC date to override in the generated FHIR resource libraries.
-                                                       (example: 2000-12-31T23:59:59.99Z)
-                                                       If omitted the current date time will be used.
-        """;
+                     {"-?|-h|-help", -26} Show this help
+
+                     {CqlToResourcePackagingOptions.ArgNameElmDirectory,-26} {"<directory>", -19} Library root directory
+                     {CqlToResourcePackagingOptions.ArgNameCqlDirectory,-26} {"<directory>", -19} CQL root directory
+                     {Optional(FhirResourceWriterOptions.ArgNameOutDirectory),-26} {"<file|directory>", -19} Resource location, either file name or directory
+                     {Optional(CSharpCodeWriterOptions.ArgNameOutDirectory),-26} {"<file|directory>",-19} C# output location, either file name or directory
+                     {Optional(CSharpCodeWriterOptions.ArgNameTypeFormat),-26} {"<var|explicit>",-19} Whether to use var or explicit types in the C# output
+                     {Optional(CqlToResourcePackagingOptions.ArgNameDebug),-26} {"<true|false>",-19} Produce as a debug assembly
+                     {Optional(CqlToResourcePackagingOptions.ArgNameForce),-26} {"<true|false>",-19} Force an overwrite even if the output file already exists
+                     {Optional(CqlToResourcePackagingOptions.ArgNameCanonicalRootUrl),-26} {"<url>",-19} The root url used for the resource canonical.
+                     {"", -26-19-1} If omitted a '#' will be used.
+                     {Optional(FhirResourceWriterOptions.ArgNameOverrideDate),-26} {"<ISO8601-date-time>",-19} The UTC date to override in the generated FHIR resource libraries.
+                     {"", -26-19-1} (example: 2000-12-31T23:59:59.99Z)
+                     {"", -26-19-1} If omitted the current date time will be used.
+                 """;
+        static string Optional(string s) => $"[{s}]";
+    }
 
 
     private static void ConfigureAppConfiguration(IConfigurationBuilder config, string[] args)
@@ -106,7 +113,8 @@ public class Program
     {
         logging.ClearProviders();
 
-        var minLogLevel = Debugger.IsAttached ? LogLevel.Trace : LogLevel.Information;
+        var minLogLevel = Debugger.IsAttached ? LogLevel.Trace : LogLevel.Information;// TODO: We should base this on the configuration for the 'Debug' flag
+
         logging.AddFilter(level => level >= minLogLevel);
 
         logging.AddCleanConsole(opt =>

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -69,6 +69,7 @@ public class Program
             [CqlToResourcePackagingOptions.ArgNameCanonicalRootUrl] = PackageSection + nameof(CqlToResourcePackagingOptions.CanonicalRootUrl),
 
             [CSharpCodeWriterOptions.ArgNameOutDirectory]           = CSharpResourceWriterSection + nameof(CSharpCodeWriterOptions.OutDirectory),
+            [CSharpCodeWriterOptions.ArgNamePreferVar]              = CSharpResourceWriterSection + nameof(CSharpCodeWriterOptions.PreferVar),
 
             [FhirResourceWriterOptions.ArgNameOutDirectory]         = FhirResourceWriterSection + nameof(FhirResourceWriterOptions.OutDirectory),
             [FhirResourceWriterOptions.ArgNameOverrideDate]         = FhirResourceWriterSection + nameof(FhirResourceWriterOptions.OverrideDate),
@@ -76,24 +77,30 @@ public class Program
         };
     }
 
-    private const string Usage =
-        """
-        Packager CLI Usage:
+    private static string Usage { get; }
 
-            -?|-h|-help                                Show this help
+    static Program()
+    {
+        Usage = $"""
+                 Packager CLI Usage:
 
-            --elm                  <directory>         Library root directory
-            --cql                  <directory>         CQL root directory
-            [--fhir]               <file|directory>    Resource location, either file name or directory
-            [--cs]                 <file|directory>    C# output location, either file name or directory
-            [--d]                  <true|false>        Produce as a debug assembly
-            [--f]                  <true|false>        Force an overwrite even if the output file already exists
-            [--canonical-root-url] <url>               The root url used for the resource canonical.
-                                                       If omitted a '#' will be used.
-            [--fhir-override-date] <ISO8601-date-time> The UTC date to override in the generated FHIR resource libraries.
-                                                       (example: 2000-12-31T23:59:59.99Z)
-                                                       If omitted the current date time will be used.
-        """;
+                     {"-?|-h|-help", -26} Show this help
+
+                     {CqlToResourcePackagingOptions.ArgNameElmDirectory,-26} {"<directory>", -19} Library root directory
+                     {CqlToResourcePackagingOptions.ArgNameCqlDirectory,-26} {"<directory>", -19} CQL root directory
+                     {Optional(FhirResourceWriterOptions.ArgNameOutDirectory),-26} {"<file|directory>", -19} Resource location, either file name or directory
+                     {Optional(CSharpCodeWriterOptions.ArgNameOutDirectory),-26} {"<file|directory>",-19} C# output location, either file name or directory
+                     {Optional(CSharpCodeWriterOptions.ArgNamePreferVar),-26} {"<true|false>",-19} Whether to use var over explicit types in the C# output
+                     {Optional(CqlToResourcePackagingOptions.ArgNameDebug),-26} {"<true|false>",-19} Produce as a debug assembly
+                     {Optional(CqlToResourcePackagingOptions.ArgNameForce),-26} {"<true|false>",-19} Force an overwrite even if the output file already exists
+                     {Optional(CqlToResourcePackagingOptions.ArgNameCanonicalRootUrl),-26} {"<url>",-19} The root url used for the resource canonical.
+                     {"", -26-19-1} If omitted a '#' will be used.
+                     {Optional(FhirResourceWriterOptions.ArgNameOverrideDate),-26} {"<ISO8601-date-time>",-19} The UTC date to override in the generated FHIR resource libraries.
+                     {"", -26-19-1} (example: 2000-12-31T23:59:59.99Z)
+                     {"", -26-19-1} If omitted the current date time will be used.
+                 """;
+        static string Optional(string s) => $"[{s}]";
+    }
 
 
     private static void ConfigureAppConfiguration(IConfigurationBuilder config, string[] args)
@@ -106,7 +113,8 @@ public class Program
     {
         logging.ClearProviders();
 
-        var minLogLevel = Debugger.IsAttached ? LogLevel.Trace : LogLevel.Information;
+        var minLogLevel = Debugger.IsAttached ? LogLevel.Trace : LogLevel.Information;// TODO: We should base this on the configuration for the 'Debug' flag
+
         logging.AddFilter(level => level >= minLogLevel);
 
         logging.AddCleanConsole(opt =>

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -2,11 +2,11 @@
   "profiles": {
     "PackageCLI (Demo LibrarySet)": {
       "commandName": "Project",
-      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Demo/Elm\" --cql \"$(SolutionDir)/LibrarySets/Demo/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Demo/Resources\" --cs \"$(SolutionDir)/Demo/Measures\" --f true"
+      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Demo/Elm\" --cql \"$(SolutionDir)/LibrarySets/Demo/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Demo/Resources\" --cs \"$(SolutionDir)/Demo/Measures\" --cs-typeformat var --f true"
     },
     "PackageCLI (CMS Measures LibrarySet)": {
       "commandName": "Project",
-      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Cms/Elm\" --cql \"$(SolutionDir)/LibrarySets/Cms/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Cms/Resources\" --cs \"$(SolutionDir)/Demo/Measures-cms\" --f true"
+      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Cms/Elm\" --cql \"$(SolutionDir)/LibrarySets/Cms/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Cms/Resources\" --cs \"$(SolutionDir)/Demo/Measures-cms\" --cs-typeformat var --f true"
     }
   }
 }


### PR DESCRIPTION
ℹ️Work for issue #318
⏮️ PR #308
⏭️ PR #322

Make it possible to choose type format in generated c# from command line `--cs-typeformat  <var|explicit>`. Default is `var`