### PR TITLE
Develop 2.0 PackageCLI add optional option to write out assemblies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,4 @@ VSCodeExtension/ncqa-cql-engine-workspace/test/*/*/results/*.json
 
 # We don't include Resources, because compiling the same C# code does not generate a deterministic binary, so it becomes very noise when they are included in the Resources
 /LibrarySets/**/Resources/*.*
+*.dat

--- a/Cql/CodeGeneration.NET/AssemblyCompiler.cs
+++ b/Cql/CodeGeneration.NET/AssemblyCompiler.cs
@@ -10,7 +10,6 @@
 using Hl7.Cql.Abstractions;
 using Hl7.Cql.CodeGeneration.NET.PostProcessors;
 using Hl7.Cql.Compiler;
-using Hl7.Cql.Elm;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.ValueSets;
 using Microsoft.CodeAnalysis;

--- a/Cql/CodeGeneration.NET/AssemblyCompiler.cs
+++ b/Cql/CodeGeneration.NET/AssemblyCompiler.cs
@@ -10,6 +10,7 @@
 using Hl7.Cql.Abstractions;
 using Hl7.Cql.CodeGeneration.NET.PostProcessors;
 using Hl7.Cql.Compiler;
+using Hl7.Cql.Elm;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.ValueSets;
 using Microsoft.CodeAnalysis;
@@ -100,6 +101,11 @@ namespace Hl7.Cql.CodeGeneration.NET
                         break;
 
                     case NET.CSharpSourceCodeStep.OnDone:
+                        if (_assemblyDataPostProcessor != null)
+                            foreach (var referenceAssembly in _referencesLazy.Value)
+                                _assemblyDataPostProcessor.ProcessReferenceAssembly(referenceAssembly);
+
+
                         // Compile Tuples
                         var tupleStreams =
                             items
@@ -107,7 +113,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                                 .Select(item => (item.libraryName, item.stream));
                         var tupleAssembly = CompileTuples(tupleStreams, _referencesLazy.Value);
                         results.Add("TupleTypes", tupleAssembly);
-                        _assemblyDataPostProcessor?.ProcessAssemblyData("TupleTypes", tupleAssembly);
+                        _assemblyDataPostProcessor?.ProcessAssemblyData("Tuples", tupleAssembly);
                         AssemblyData[] additionalReferences = [tupleAssembly];
 
                         // Compile Libraries

--- a/Cql/CodeGeneration.NET/AssemblyDataWriterOptions.cs
+++ b/Cql/CodeGeneration.NET/AssemblyDataWriterOptions.cs
@@ -1,10 +1,10 @@
-﻿// /*
-//  * Copyright (c) 2024, NCQA and contributors
-//  * See the file CONTRIBUTORS for details.
-//  *
-//  * This file is licensed under the BSD 3-Clause license
-//  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
-//  */
+﻿/*
+ * Copyright (c) 2024, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
 
 using System.IO;
 using Hl7.Cql.CodeGeneration.NET.PostProcessors;

--- a/Cql/CodeGeneration.NET/AssemblyDataWriterOptions.cs
+++ b/Cql/CodeGeneration.NET/AssemblyDataWriterOptions.cs
@@ -1,0 +1,51 @@
+﻿// /*
+//  * Copyright (c) 2024, NCQA and contributors
+//  * See the file CONTRIBUTORS for details.
+//  *
+//  * This file is licensed under the BSD 3-Clause license
+//  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+//  */
+
+using System.IO;
+using Hl7.Cql.CodeGeneration.NET.PostProcessors;
+using Microsoft.Extensions.Configuration;
+
+namespace Hl7.Cql.CodeGeneration.NET;
+
+/// <summary>
+/// Represents the options for the <see cref="AssemblyDataPostProcessor"/>.
+/// </summary>
+public class AssemblyDataWriterOptions
+{
+    /// <summary>
+    /// The name of the config setting.
+    /// </summary>
+    internal const string ConfigSection = "AssemblyDataWriter";
+
+    /// <summary>
+    /// Gets or sets the output directory.
+    /// </summary>
+    public DirectoryInfo? OutDirectory { get; set; }
+
+    internal const string ArgNameOutDirectory = "--dll";
+
+    /// <summary>
+    /// Binds the configuration values to the <see cref="AssemblyDataWriterOptions"/> object.
+    /// </summary>
+    /// <param name="opt">The <see cref="AssemblyDataWriterOptions"/> object to bind the configuration values to.</param>
+    /// <param name="config">The <see cref="IConfiguration"/> object containing the configuration values.</param>
+    public static void BindConfig(AssemblyDataWriterOptions opt, IConfiguration config)
+    {
+        var section = config.GetSection(ConfigSection);
+        section.Bind(opt);
+
+        // DirectoryInfos cannot be bound directly from IConfiguration, so we do it manually.
+        opt.OutDirectory = GetDirectoryInfo(nameof(OutDirectory))!;
+
+        DirectoryInfo? GetDirectoryInfo(string key)
+        {
+            var path = section[key];
+            return string.IsNullOrWhiteSpace(path) ? null : new DirectoryInfo(Path.GetFullPath(path));
+        }
+    }
+}

--- a/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
+++ b/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
@@ -6,12 +6,13 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 using System.IO;
+using Hl7.Cql.CodeGeneration.NET.PostProcessors;
 using Microsoft.Extensions.Configuration;
 
 namespace Hl7.Cql.CodeGeneration.NET;
 
 /// <summary>
-/// Represents the options for the CSharpResourceWriter.
+/// Represents the options for the <see cref="CSharpCodeStreamPostProcessor"/>.
 /// </summary>
 public class CSharpCodeWriterOptions
 
@@ -19,7 +20,7 @@ public class CSharpCodeWriterOptions
     /// <summary>
     /// The name of the config setting.
     /// </summary>
-    internal const string ConfigSection = "CSharpResourceWriter";
+    internal const string ConfigSection = "CSharpCodeWriter";
 
     /// <summary>
     /// Gets or sets the output directory.
@@ -35,10 +36,10 @@ public class CSharpCodeWriterOptions
     public CSharpCodeWriterTypeFormat TypeFormat { get; set; }
 
     /// <summary>
-    /// Binds the configuration values to the CSharpResourceWriterOptions object.
+    /// Binds the configuration values to the <see cref="CSharpCodeWriterOptions"/> object.
     /// </summary>
-    /// <param name="opt">The CSharpResourceWriterOptions object to bind the configuration values to.</param>
-    /// <param name="config">The IConfiguration object containing the configuration values.</param>
+    /// <param name="opt">The <see cref="CSharpCodeWriterOptions"/> object to bind the configuration values to.</param>
+    /// <param name="config">The <see cref="IConfiguration"/> object containing the configuration values.</param>
     public static void BindConfig(CSharpCodeWriterOptions opt, IConfiguration config)
     {
         var section = config.GetSection(ConfigSection);

--- a/Cql/CodeGeneration.NET/PostProcessors/AssemblyDataPostProcessor.cs
+++ b/Cql/CodeGeneration.NET/PostProcessors/AssemblyDataPostProcessor.cs
@@ -1,0 +1,14 @@
+﻿/*
+ * Copyright (c) 2024, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+namespace Hl7.Cql.CodeGeneration.NET.PostProcessors;
+
+internal abstract class AssemblyDataPostProcessor
+{
+    public abstract void ProcessAssemblyData(string name, AssemblyData assemblyData);
+}

--- a/Cql/CodeGeneration.NET/PostProcessors/AssemblyDataPostProcessor.cs
+++ b/Cql/CodeGeneration.NET/PostProcessors/AssemblyDataPostProcessor.cs
@@ -6,9 +6,12 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using System.Reflection;
+
 namespace Hl7.Cql.CodeGeneration.NET.PostProcessors;
 
 internal abstract class AssemblyDataPostProcessor
 {
     public abstract void ProcessAssemblyData(string name, AssemblyData assemblyData);
+    public abstract void ProcessReferenceAssembly(Assembly referenceAssembly);
 }

--- a/Cql/CodeGeneration.NET/PostProcessors/WriteToFileAssemblyDataPostProcessor.cs
+++ b/Cql/CodeGeneration.NET/PostProcessors/WriteToFileAssemblyDataPostProcessor.cs
@@ -7,6 +7,7 @@
  */
 
 using System.IO;
+using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -31,8 +32,16 @@ internal class WriteToFileAssemblyDataPostProcessor : AssemblyDataPostProcessor
         _logger.LogInformation("Writing Assembly file: '{file}'", file.FullName);
 
         file.Directory!.Create();
-        using var streamOut = file.OpenWrite();
-        streamOut.SetLength(0); // Clears out previous contents
-        streamOut.Write(assemblyData.Binary, 0, assemblyData.Binary.Length);
+        File.WriteAllBytes(file.FullName, assemblyData.Binary);
+    }
+
+    public override void ProcessReferenceAssembly(Assembly referenceAssembly)
+    {
+        _ = referenceAssembly;
+        // var file = new FileInfo($"{Path.Combine(_assemblyDataWriterOptions.OutDirectory!.FullName, referenceAssembly.GetName().Name!)}.dll");
+        // _logger.LogInformation("Writing Reference Assembly file: '{file}'", file.FullName);
+        //
+        // file.Directory!.Create();
+        // File.Copy(referenceAssembly.Location, file.FullName, true);
     }
 }

--- a/Cql/CodeGeneration.NET/PostProcessors/WriteToFileAssemblyDataPostProcessor.cs
+++ b/Cql/CodeGeneration.NET/PostProcessors/WriteToFileAssemblyDataPostProcessor.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright (c) 2024, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Hl7.Cql.CodeGeneration.NET.PostProcessors;
+
+internal class WriteToFileAssemblyDataPostProcessor : AssemblyDataPostProcessor
+{
+    private readonly AssemblyDataWriterOptions _assemblyDataWriterOptions;
+    private readonly ILogger<WriteToFileAssemblyDataPostProcessor> _logger;
+
+    public WriteToFileAssemblyDataPostProcessor(
+        IOptions<AssemblyDataWriterOptions> assemblyDataWriterOptions,
+        ILogger<WriteToFileAssemblyDataPostProcessor> logger)
+    {
+        _logger = logger;
+        _assemblyDataWriterOptions = assemblyDataWriterOptions.Value;
+    }
+
+    public override void ProcessAssemblyData(string name, AssemblyData assemblyData)
+    {
+        var file = new FileInfo($"{Path.Combine(_assemblyDataWriterOptions.OutDirectory!.FullName, name)}.dll");
+        _logger.LogInformation("Writing Assembly file: '{file}'", file.FullName);
+
+        file.Directory!.Create();
+        using var streamOut = file.OpenWrite();
+        streamOut.SetLength(0); // Clears out previous contents
+        streamOut.Write(assemblyData.Binary, 0, assemblyData.Binary.Length);
+    }
+}

--- a/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
+++ b/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 ﻿#nullable enable
+Hl7.Cql.CodeGeneration.NET.AssemblyDataWriterOptions
+Hl7.Cql.CodeGeneration.NET.AssemblyDataWriterOptions.AssemblyDataWriterOptions() -> void
+Hl7.Cql.CodeGeneration.NET.AssemblyDataWriterOptions.OutDirectory.get -> System.IO.DirectoryInfo?
+Hl7.Cql.CodeGeneration.NET.AssemblyDataWriterOptions.OutDirectory.set -> void
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.CSharpCodeWriterOptions() -> void
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.OutDirectory.get -> System.IO.DirectoryInfo?
@@ -8,4 +12,5 @@ Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.TypeFormat.set -> void
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat.Explicit = 1 -> Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat.Var = 0 -> Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
+static Hl7.Cql.CodeGeneration.NET.AssemblyDataWriterOptions.BindConfig(Hl7.Cql.CodeGeneration.NET.AssemblyDataWriterOptions! opt, Microsoft.Extensions.Configuration.IConfiguration! config) -> void
 static Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.BindConfig(Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions! opt, Microsoft.Extensions.Configuration.IConfiguration! config) -> void

--- a/Cql/CoreTests/LibrarySetsDirs.cs
+++ b/Cql/CoreTests/LibrarySetsDirs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Hl7.Cql.Abstractions.Infrastructure;
 
 namespace CoreTests;
 
@@ -31,22 +32,8 @@ internal static class LibrarySetsDirs
         }
 
         var solDir = new DirectoryInfo(Directory.GetCurrentDirectory())
-                         .Enumerate(d => d.Parent)
-                         .TakeWhile(d => d is not null)
-                         .LastOrDefault(d => d.EnumerateFiles("*.sln", SearchOption.TopDirectoryOnly).Any())
-                     ?? throw new InvalidOperationException("Could not find an ancestor directory containing a solution file.");
+                         .FindParentDirectoryContaining("*.sln")
+                     ?? throw new InvalidOperationException("Could not find an parent directory containing a solution file.");
         return solDir;
-    }
-
-    private static IEnumerable<T> Enumerate<T>(
-        this T seed,
-        Func<T, T> getNext)
-    {
-        var current = seed;
-        while (true)
-        {
-            yield return current;
-            current = getNext(current);
-        }
     }
 }

--- a/Cql/CoreTests/LibrarySetsDirs.cs
+++ b/Cql/CoreTests/LibrarySetsDirs.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Hl7.Cql.Abstractions.Infrastructure;
 
 namespace CoreTests;

--- a/Cql/Cql.Abstractions/Infrastructure/DirectoryInfoExtensions.cs
+++ b/Cql/Cql.Abstractions/Infrastructure/DirectoryInfoExtensions.cs
@@ -1,10 +1,10 @@
-// /*
-//  * Copyright (c) 2024, NCQA and contributors
-//  * See the file CONTRIBUTORS for details.
-//  *
-//  * This file is licensed under the BSD 3-Clause license
-//  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
-//  */
+/*
+ * Copyright (c) 2024, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
 
 using System.Collections.Generic;
 using System.IO;

--- a/Cql/Cql.Abstractions/Infrastructure/DirectoryInfoExtensions.cs
+++ b/Cql/Cql.Abstractions/Infrastructure/DirectoryInfoExtensions.cs
@@ -1,0 +1,34 @@
+// /*
+//  * Copyright (c) 2024, NCQA and contributors
+//  * See the file CONTRIBUTORS for details.
+//  *
+//  * This file is licensed under the BSD 3-Clause license
+//  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+//  */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Hl7.Cql.Abstractions.Infrastructure;
+
+internal static class DirectoryInfoExtensions
+{
+    public static IEnumerable<DirectoryInfo> SelfAndParents(
+        this DirectoryInfo dir)
+    {
+        var current = dir;
+        while (current != null)
+        {
+            yield return current;
+            current = current.Parent;
+        }
+    }
+
+    public static DirectoryInfo? FindParentDirectoryContaining(
+        this DirectoryInfo dir,
+        string searchPattern,
+        SearchOption searchOption = SearchOption.TopDirectoryOnly) =>
+        dir.SelfAndParents()
+           .FirstOrDefault(d => d.EnumerateFiles(searchPattern, searchOption).Any());
+}

--- a/Cql/Cql.Firely/FhirModelBindingSetup.cs
+++ b/Cql/Cql.Firely/FhirModelBindingSetup.cs
@@ -38,9 +38,12 @@ namespace Hl7.Cql.Fhir
             _options = options ?? FhirModelBindingOptions.Default;
 
             Comparers = new CqlComparers();
+
+            var typeConverter = FhirTypeConverter.Create(ModelInfo.ModelInspector, _options.LRUCacheSize);
+
             Operators = CqlOperators.Create(
                     TypeResolver,
-                    FhirTypeConverter.Create(ModelInfo.ModelInspector, _options.LRUCacheSize),
+                    typeConverter,
                     dataSource,
                     Comparers,
                     valuesets,

--- a/Cql/Cql.Firely/FhirTypeConverter.cs
+++ b/Cql/Cql.Firely/FhirTypeConverter.cs
@@ -395,27 +395,26 @@ namespace Hl7.Cql.Fhir
 
             void addEnumConversion(Type enumType)
             {
-                var codeType = typeof(M.Code<>).MakeGenericType(enumType);
+                var codeOfEnumType = typeof(M.Code<>).MakeGenericType(enumType);
                 var nullableEnumType = typeof(Nullable<>).MakeGenericType(enumType);
 
-                //converter.AddConversion(codeType, typeof(CqlCode), (code) =>
-                //{
-                //    var systemAndCode = (M.ISystemAndCode)code;
-                //    return new CqlCode(systemAndCode.Code, systemAndCode.System);
-                //});
-                //converter.AddConversion(codeType, nullableEnumType, (code) => code.GetType().GetProperty("ObjectValue")!.GetValue(code)!);
-                //converter.AddConversion(enumType, codeType, enumValue => Activator.CreateInstance(codeType, enumValue)!);
-
-                converter.AddConversion(nullableEnumType, codeType, enumValue => Activator.CreateInstance(codeType, enumValue)!);
-
-                converter.AddConversion(codeType, typeof(string), (code) =>
+                converter.AddConversion(codeOfEnumType, typeof(CqlCode), (code) =>
+                {
+                    var systemAndCode = (M.ISystemAndCode)code;
+                    return new CqlCode(systemAndCode.Code, systemAndCode.System);
+                });
+                converter.AddConversion(codeOfEnumType, nullableEnumType, (code) => code.GetType().GetProperty("ObjectValue")!.GetValue(code)!);
+                converter.AddConversion(codeOfEnumType, typeof(string), (code) =>
                 {
                     var systemAndCode = (M.ISystemAndCode)code;
                     return systemAndCode.Code;
                 });
 
-                converter.AddConversion(nullableEnumType, typeof(string), (@enum) =>
-                    Enum.GetName(nullableEnumType, @enum) ?? throw new InvalidOperationException($"Did not find enum member {@enum} on type {nullableEnumType}."));
+
+                converter.AddConversion(nullableEnumType, codeOfEnumType, enumValue => Activator.CreateInstance(codeOfEnumType, enumValue)!);
+                converter.AddConversion(nullableEnumType, typeof(string), (@enum) => Enum.GetName(nullableEnumType, @enum) ?? throw new InvalidOperationException($"Did not find enum member {@enum} on type {nullableEnumType}."));
+
+                converter.AddConversion(enumType, codeOfEnumType, enumValue => Activator.CreateInstance(codeOfEnumType, enumValue)!);
             }
             return converter;
         }

--- a/Cql/Cql.Firely/StreamExtensions.cs
+++ b/Cql/Cql.Firely/StreamExtensions.cs
@@ -25,7 +25,7 @@ namespace Hl7.Cql.Fhir
             return o;
         }
 
-        public static T ParseFhir<T>(this Stream stream) => JsonSerializer.Deserialize<T>(stream, Options)
-                                                            ?? throw new ArgumentException($"Unable to deserialize this stream as {typeof(T).Name}");
+        public static T ParseFhir<T>(this Stream stream) =>
+            JsonSerializer.Deserialize<T>(stream, Options) ?? throw new ArgumentException($"Unable to deserialize this stream as {typeof(T).Name}");
     }
 }

--- a/Cql/Cql.Packaging/AssemblyLoadContextExtensions.cs
+++ b/Cql/Cql.Packaging/AssemblyLoadContextExtensions.cs
@@ -1,7 +1,7 @@
-﻿/* 
+﻿/*
  * Copyright (c) 2023, NCQA and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */

--- a/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
+++ b/Cql/Cql.Packaging/CqlToResourcePackagingPipeline.cs
@@ -67,6 +67,13 @@ internal class CqlToResourcePackagingPipeline
         try
         {
             BuildExpressions(librarySet, definitions);
+
+            // Important: Do not enumerate the libraryset by getting its Count until after processing.
+            if (librarySet.Count == 0)
+            {
+                _logger.LogWarning("Nothing to do, since no ELM libraries were found.");
+                return Array.Empty<Resource>();
+            }
         }
         catch (Exception e)
         {

--- a/Cql/Cql.Packaging/LibraryPackageCallbacks.cs
+++ b/Cql/Cql.Packaging/LibraryPackageCallbacks.cs
@@ -23,7 +23,7 @@ internal readonly record struct LibraryPackageCallbacks
     private readonly Action<Resource>? _afterPackageMutator;
     private readonly Func<Resource, string>? _buildUrlFromResource;
 
-    public string BuildUrlFromResource(Resource resource) => 
+    public string BuildUrlFromResource(Resource resource) =>
         _buildUrlFromResource?.Invoke(resource) ?? "#";
 
     public void MutateResource(Resource resource) =>

--- a/Cql/Cql.Packaging/PostProcessors/FhirResourcePostProcessor.cs
+++ b/Cql/Cql.Packaging/PostProcessors/FhirResourcePostProcessor.cs
@@ -1,4 +1,11 @@
-﻿using Hl7.Fhir.Model;
+﻿/*
+ * Copyright (c) 2024, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+using Hl7.Fhir.Model;
 
 namespace Hl7.Cql.Packaging.PostProcessors;
 

--- a/Cql/Cql.Packaging/PostProcessors/FhirResourceWriterOptions.cs
+++ b/Cql/Cql.Packaging/PostProcessors/FhirResourceWriterOptions.cs
@@ -1,4 +1,11 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿/*
+ * Copyright (c) 2024, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+using Microsoft.Extensions.Configuration;
 
 namespace Hl7.Cql.Packaging.PostProcessors;
 

--- a/Cql/Cql.Packaging/PostProcessors/WriteToFileFhirResourcePostProcessor.cs
+++ b/Cql/Cql.Packaging/PostProcessors/WriteToFileFhirResourcePostProcessor.cs
@@ -1,4 +1,11 @@
-﻿using System.Text.Json;
+﻿/*
+ * Copyright (c) 2024, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+using System.Text.Json;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using Microsoft.Extensions.Logging;

--- a/Cql/Cql.Packaging/ResourcePackagerFactory.cs
+++ b/Cql/Cql.Packaging/ResourcePackagerFactory.cs
@@ -27,12 +27,12 @@ internal class CqlPackagerFactory : CqlCompilerFactory
 
     public CqlPackagerFactory(
         ILoggerFactory loggerFactory,
-        CancellationToken cancellationToken = default,
         int cacheSize = 0,
         CqlToResourcePackagingOptions? cqlToResourcePackagingOptions = default,
         CSharpCodeWriterOptions? cSharpCodeWriterOptions = default,
         FhirResourceWriterOptions? fhirResourceWriterOptions = default,
-        AssemblyDataWriterOptions? assemblyDataWriterOptions = default)
+        AssemblyDataWriterOptions? assemblyDataWriterOptions = default,
+        CancellationToken cancellationToken = default)
         : base(loggerFactory, cancellationToken, cacheSize)
     {
         AssemblyDataWriterOptions = assemblyDataWriterOptions;

--- a/Cql/Cql.Packaging/ResourcePackagerFactory.cs
+++ b/Cql/Cql.Packaging/ResourcePackagerFactory.cs
@@ -20,6 +20,7 @@ namespace Hl7.Cql.Packaging;
 /// </summary>
 internal class CqlPackagerFactory : CqlCompilerFactory
 {
+    public AssemblyDataWriterOptions? AssemblyDataWriterOptions { get; }
     public CqlToResourcePackagingOptions CqlToResourcePackagingOptions { get; }
     public CSharpCodeWriterOptions CSharpCodeWriterOptions { get; }
     public FhirResourceWriterOptions FhirResourceWriterOptions { get; }
@@ -30,9 +31,11 @@ internal class CqlPackagerFactory : CqlCompilerFactory
         int cacheSize = 0,
         CqlToResourcePackagingOptions? cqlToResourcePackagingOptions = default,
         CSharpCodeWriterOptions? cSharpCodeWriterOptions = default,
-        FhirResourceWriterOptions? fhirResourceWriterOptions = default)
+        FhirResourceWriterOptions? fhirResourceWriterOptions = default,
+        AssemblyDataWriterOptions? assemblyDataWriterOptions = default)
         : base(loggerFactory, cancellationToken, cacheSize)
     {
+        AssemblyDataWriterOptions = assemblyDataWriterOptions;
         CqlToResourcePackagingOptions = cqlToResourcePackagingOptions ?? new();
         CSharpCodeWriterOptions = cSharpCodeWriterOptions ?? new();
         FhirResourceWriterOptions = fhirResourceWriterOptions ?? new();
@@ -59,6 +62,18 @@ internal class CqlPackagerFactory : CqlCompilerFactory
             Options(opt),
             Logger<WriteToFileCSharpCodeStreamPostProcessor>());
 
+    public virtual AssemblyDataPostProcessor? AssemblyDataPostProcessor => Singleton(NewAssemblyDataPostProcessorOrNull);
+    protected virtual AssemblyDataPostProcessor? NewAssemblyDataPostProcessorOrNull() =>
+        AssemblyDataWriterOptions is { OutDirectory: { } } opt
+            ? NewWriteToFileAssemblyDataPostProcessor(opt)
+            : default(AssemblyDataPostProcessor);
+
+    protected virtual WriteToFileAssemblyDataPostProcessor NewWriteToFileAssemblyDataPostProcessor(
+        AssemblyDataWriterOptions opt) =>
+        new WriteToFileAssemblyDataPostProcessor(
+            Options(opt),
+            Logger<WriteToFileAssemblyDataPostProcessor>());
+
     public virtual FhirResourcePostProcessor? FhirResourcePostProcessor => Singleton(NewFhirResourcePostProcessorOrNull);
     protected virtual FhirResourcePostProcessor? NewFhirResourcePostProcessorOrNull() =>
         FhirResourceWriterOptions is { OutDirectory: {} } opt
@@ -77,7 +92,8 @@ internal class CqlPackagerFactory : CqlCompilerFactory
         new AssemblyCompiler(
             CSharpLibrarySetToStreamsWriter,
             TypeManager,
-            CSharpCodeStreamPostProcessor);
+            CSharpCodeStreamPostProcessor,
+            AssemblyDataPostProcessor);
 
     public ResourcePackager ResourcePackager => Singleton(NewResourcePackager);
     protected virtual ResourcePackager NewResourcePackager() =>

--- a/Cql/Cql.Runtime/DefinitionDictionary.cs
+++ b/Cql/Cql.Runtime/DefinitionDictionary.cs
@@ -258,7 +258,7 @@ public class DefinitionDictionary<T> where T : class
     /// <summary>
     /// Gets the libraries defined in this dictionary.
     /// </summary>
-    public IEnumerable<string> Libraries => ExpressionsByLibrary.Keys;
+    public IReadOnlyCollection<string> Libraries => ExpressionsByLibrary.Keys;
 
     /// <summary>
     /// Gets key-value pairs of definitions and their values.
@@ -266,14 +266,12 @@ public class DefinitionDictionary<T> where T : class
     /// <param name="libraryName">The name of the library.</param>
     /// <returns>Key-value pairs of definitions and their values.</returns>
     /// <exception cref="ArgumentException">If <paramref name="libraryName"/> does not exist in the dictionary.</exception>
-    public IEnumerable<KeyValuePair<string, List<(Type[] Signature, T T)>>> DefinitionsForLibrary(string? libraryName)
+    public IReadOnlyDictionary<string, List<(Type[] Signature, T T)>> DefinitionsForLibrary(string? libraryName)
     {
         libraryName ??= string.Empty;
-        if (ExpressionsByLibrary.TryGetValue(libraryName, out var library))
-        {
-            return library;
-        }
-        else throw new ArgumentException($"No library {libraryName} exists", nameof(libraryName));
+        return ExpressionsByLibrary.TryGetValue(libraryName, out var library)
+                   ? library
+                   : throw new ArgumentException($"No library {libraryName} exists", nameof(libraryName));
     }
 
     /// <summary>

--- a/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
@@ -21,8 +21,8 @@ Hl7.Cql.Runtime.DefinitionDictionary<T>.ContainsKey(string? libraryName, string!
 Hl7.Cql.Runtime.DefinitionDictionary<T>.ContainsKey(string? libraryName, string! definition, System.Type![]! signature) -> bool
 Hl7.Cql.Runtime.DefinitionDictionary<T>.ContainsLibrary(string! libraryName) -> bool
 Hl7.Cql.Runtime.DefinitionDictionary<T>.DefinitionDictionary() -> void
-Hl7.Cql.Runtime.DefinitionDictionary<T>.DefinitionsForLibrary(string? libraryName) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, System.Collections.Generic.List<(System.Type![]! Signature, T! T)>!>>!
-Hl7.Cql.Runtime.DefinitionDictionary<T>.Libraries.get -> System.Collections.Generic.IEnumerable<string!>!
+Hl7.Cql.Runtime.DefinitionDictionary<T>.DefinitionsForLibrary(string? libraryName) -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.List<(System.Type![]! Signature, T! T)>!>!
+Hl7.Cql.Runtime.DefinitionDictionary<T>.Libraries.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
 Hl7.Cql.Runtime.DefinitionDictionary<T>.Merge(params Hl7.Cql.Runtime.DefinitionDictionary<T!>![]! dictionaries) -> void
 Hl7.Cql.Runtime.DefinitionDictionary<T>.Merge(string! libKey, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, System.Collections.Generic.List<(System.Type![]!, T!)>!>>! expressions) -> void
 Hl7.Cql.Runtime.DefinitionDictionary<T>.this[string? libraryName, string! definition, params System.Type![]! signature].get -> T!

--- a/Cql/MultiPackagerCLI/Program.cs
+++ b/Cql/MultiPackagerCLI/Program.cs
@@ -25,6 +25,7 @@ foreach ((string librarySetSubDir, string measuresSubDir) in iteration)
                         --elm "{solutionDir}/LibrarySets/{librarySetSubDir}/Elm"
                         --cql "{solutionDir}/LibrarySets/{librarySetSubDir}/Cql"
                         --fhir "{solutionDir}/LibrarySets/{librarySetSubDir}/Resources"
+                        --dll "{solutionDir}/LibrarySets/{librarySetSubDir}/Assemblies"
                         --cs "{solutionDir}/Demo/{measuresSubDir}"
                         --cs-typeformat {csTypeFormat}
                         --f true

--- a/Cql/MultiPackagerCLI/Program.cs
+++ b/Cql/MultiPackagerCLI/Program.cs
@@ -1,11 +1,11 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
+using Hl7.Cql.Abstractions.Infrastructure;
 using Hl7.Cql.CodeGeneration.NET;
 using Microsoft.CodeAnalysis;
 
-var solutionDir = new DirectoryInfo(Environment.CurrentDirectory);
-while (!File.Exists(Path.Combine(solutionDir!.FullName, "CqlAndDemo.sln")))
-    solutionDir = solutionDir.Parent;
+var solutionDir = new DirectoryInfo(Environment.CurrentDirectory)
+    .FindParentDirectoryContaining("CqlAndDemo.sln")!;
 
 CSharpCodeWriterTypeFormat csTypeFormat = CSharpCodeWriterTypeFormat.Var;
 (string subDir, string measureSubDir)[] iteration = [

--- a/Cql/PackagerCLI/PackagerCliProgram.cs
+++ b/Cql/PackagerCLI/PackagerCliProgram.cs
@@ -65,8 +65,15 @@ internal class ProgramCqlPackagerFactory : CqlPackagerFactory
         IHostApplicationLifetime hostLifetime,
         IOptions<CqlToResourcePackagingOptions> cqlToResourcePackagingOptions,
         IOptions<CSharpCodeWriterOptions> cSharpCodeWriterOptions,
-        IOptions<FhirResourceWriterOptions> fhirResourceWriterOptions)
-        : base(loggerFactory, hostLifetime.ApplicationStopping, 0, cqlToResourcePackagingOptions.Value, cSharpCodeWriterOptions.Value, fhirResourceWriterOptions.Value)
+        IOptions<FhirResourceWriterOptions> fhirResourceWriterOptions,
+        IOptions<AssemblyDataWriterOptions> assemblyDataWriterOptions)
+        : base(loggerFactory,
+               hostLifetime.ApplicationStopping,
+               cacheSize: 0,
+               cqlToResourcePackagingOptions.Value,
+               cSharpCodeWriterOptions.Value,
+               fhirResourceWriterOptions.Value,
+               assemblyDataWriterOptions.Value)
     {
     }
 }

--- a/Cql/PackagerCLI/PackagerCliProgram.cs
+++ b/Cql/PackagerCLI/PackagerCliProgram.cs
@@ -68,12 +68,12 @@ internal class ProgramCqlPackagerFactory : CqlPackagerFactory
         IOptions<FhirResourceWriterOptions> fhirResourceWriterOptions,
         IOptions<AssemblyDataWriterOptions> assemblyDataWriterOptions)
         : base(loggerFactory,
-               hostLifetime.ApplicationStopping,
                cacheSize: 0,
-               cqlToResourcePackagingOptions.Value,
-               cSharpCodeWriterOptions.Value,
-               fhirResourceWriterOptions.Value,
-               assemblyDataWriterOptions.Value)
+               cqlToResourcePackagingOptions: cqlToResourcePackagingOptions.Value,
+               cSharpCodeWriterOptions: cSharpCodeWriterOptions.Value,
+               fhirResourceWriterOptions: fhirResourceWriterOptions.Value,
+               assemblyDataWriterOptions: assemblyDataWriterOptions.Value,
+               cancellationToken: hostLifetime.ApplicationStopping)
     {
     }
 }

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -2,19 +2,19 @@
   "profiles": {
     "PackageCLI (Demo LibrarySet, typeformat=var)": {
       "commandName": "Project",
-      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Demo/Elm\" --cql \"$(SolutionDir)/LibrarySets/Demo/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Demo/Resources\" --cs \"$(SolutionDir)/Demo/Measures\" --cs-typeformat var --f true"
+      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Demo/Elm\" --cql \"$(SolutionDir)/LibrarySets/Demo/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Demo/Resources\" --dll \"$(SolutionDir)/LibrarySets/Demo/Assemblies\" --cs \"$(SolutionDir)/Demo/Measures\" --cs-typeformat var --f true"
     },
     "PackageCLI (CMS Measures LibrarySet, typeformat=var)": {
       "commandName": "Project",
-      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Cms/Elm\" --cql \"$(SolutionDir)/LibrarySets/Cms/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Cms/Resources\" --cs \"$(SolutionDir)/Demo/Measures-cms\" --cs-typeformat var --f true"
+      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Cms/Elm\" --cql \"$(SolutionDir)/LibrarySets/Cms/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Cms/Resources\" --dll \"$(SolutionDir)/LibrarySets/Cms/Assemblies\" --cs \"$(SolutionDir)/Demo/Measures-cms\" --cs-typeformat var --f true"
     },
     "PackageCLI (Demo LibrarySet, typeformat=explicit)": {
       "commandName": "Project",
-      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Demo/Elm\" --cql \"$(SolutionDir)/LibrarySets/Demo/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Demo/Resources\" --cs \"$(SolutionDir)/Demo/Measures\" --cs-typeformat explicit --f true"
+      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Demo/Elm\" --cql \"$(SolutionDir)/LibrarySets/Demo/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Demo/Resources\" --dll \"$(SolutionDir)/LibrarySets/Demo/Assemblies\" --cs \"$(SolutionDir)/Demo/Measures\" --cs-typeformat explicit --f true"
     },
     "PackageCLI (CMS Measures LibrarySet, typeformat=explicit)": {
       "commandName": "Project",
-      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Cms/Elm\" --cql \"$(SolutionDir)/LibrarySets/Cms/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Cms/Resources\" --cs \"$(SolutionDir)/Demo/Measures-cms\" --cs-typeformat explicit --f true"
+      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(SolutionDir)/LibrarySets/Cms/Elm\" --cql \"$(SolutionDir)/LibrarySets/Cms/Cql\" --fhir \"$(SolutionDir)/LibrarySets/Cms/Resources\" --dll \"$(SolutionDir)/LibrarySets/Cms/Assemblies\" --cs \"$(SolutionDir)/Demo/Measures-cms\" --cs-typeformat explicit --f true"
     }
 
   }

--- a/Demo/CLI-cms/CLI-cms.csproj
+++ b/Demo/CLI-cms/CLI-cms.csproj
@@ -9,8 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Cql\Cql.Abstractions\Infrastructure\DirectoryInfoExtensions.cs" Link="Helpers\DirectoryInfoExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Dumpify" Version="0.6.5"  />
+    <PackageReference Include="Dumpify" Version="0.6.5" />
   </ItemGroup>
 
 

--- a/Demo/CLI-cms/Helpers/CommandLineOptions.cs
+++ b/Demo/CLI-cms/Helpers/CommandLineOptions.cs
@@ -8,6 +8,7 @@
 
 using CommandLine;
 using Dumpify;
+using Hl7.Cql.Abstractions.Infrastructure;
 
 namespace CLI_cms.Helpers;
 internal class CommandLineOptions
@@ -22,8 +23,14 @@ internal class CommandLineOptions
 
     public string LibraryName => Library.Split('-')[0];
     public string LibraryVersion => Library.Split('-')[1];
-    public string TestRootDirectory => Path.Join(AppContext.BaseDirectory, "Measures");
-    public string ValueSetDirectory => Path.Join(TestRootDirectory, Library, "ValueSet");
+    private static DirectoryInfo FindProjectDirectory() =>
+        new DirectoryInfo(Directory.GetCurrentDirectory())
+            .FindParentDirectoryContaining("*.csproj")
+        ?? throw new DirectoryNotFoundException("Cannot find the parent directory containing the project file.");
+
+    public string TestRootDirectory => Path.Join(FindProjectDirectory().FullName, "Measures");
+
+    public string ValueSetsDirectory => Path.Join(TestRootDirectory, Library, "ValueSets");
 
     [Option('r', "resourceDirectory", HelpText = "The directory where the library resources are stored.")]
     public string ResourceDirectory
@@ -56,7 +63,7 @@ internal class CommandLineOptions
 
         foreach (var directory in new string[] {
             options.TestRootDirectory,
-            options.ValueSetDirectory,
+            options.ValueSetsDirectory,
             options.ResourceDirectory,
             options.TestCaseDirectory })
         {
@@ -91,7 +98,7 @@ internal class CommandLineOptions
             AssemblySource,
             TestCaseDirectory,
             ResourceDirectory,
-            ValueSetDirectory
+            ValueSetDirectory = ValueSetsDirectory
         }.DumpConsole("Options");
     }
 }

--- a/Demo/CLI-cms/LibraryRunner.cs
+++ b/Demo/CLI-cms/LibraryRunner.cs
@@ -88,7 +88,7 @@ internal static class LibraryRunner
         Type libraryType = ResolveLibraryType(opt, assembly) ?? throw new ArgumentException($"Uknown library: {opt.Library}");
 
         Console.WriteLine("Loading value sets");
-        IValueSetDictionary valueSets = ResourceHelper.LoadValueSets(new DirectoryInfo(opt.ValueSetDirectory));
+        IValueSetDictionary valueSets = ResourceHelper.LoadValueSets(new DirectoryInfo(opt.ValueSetsDirectory));
 
         Console.WriteLine("Loading test case bundle");
         Bundle patientBundle = ResourceHelper.LoadBundle(opt.TestCaseBundleFile);

--- a/Demo/Test/LibraryExtensions.cs
+++ b/Demo/Test/LibraryExtensions.cs
@@ -65,7 +65,7 @@ namespace Hl7.Cql.Packaging
                 {
                     if (node.Value.Properties != null)
                     {
-                        if (node.Value.Properties.TryGetValue(libraryProperty, out object libObject)
+                        if (node.Value.Properties.TryGetValue(libraryProperty, out object? libObject)
                             && libObject is FhirLibrary library)
                         {
                             yield return library;
@@ -81,7 +81,7 @@ namespace Hl7.Cql.Packaging
 
         [UsedImplicitly]
         public static DirectedGraph GetDependencies(
-            this FhirLibrary library, 
+            this FhirLibrary library,
             DirectoryInfo directory) =>
             library.GetDependencies(id =>
             {

--- a/Demo/Test/MeasuresTest.cs
+++ b/Demo/Test/MeasuresTest.cs
@@ -42,7 +42,7 @@ namespace Test
         {
             var lib = "BCSEHEDISMY2022";
             var version = "1.0.0";
-            var dir = LibrarySetsDirs.Demo.ResourcesDir;// new DirectoryInfo("Resources");
+            var dir = LibrarySetsDirs.Demo.ResourcesDir;
             var asmContext = LoadResources(dir, lib, version);
 
             var patientEverything = new Bundle();   // Add data

--- a/Demo/Test/MeasuresTest.cs
+++ b/Demo/Test/MeasuresTest.cs
@@ -146,9 +146,10 @@ namespace Test
             ILoggerFactory logFactory,
             int cacheSize)
         {
+            using var cts = new CancellationTokenSource();
             LibrarySet librarySet = new();
             librarySet.LoadLibraryAndDependencies(elmDirectory, lib, version);
-            CqlPackagerFactory factory = new CqlPackagerFactory(logFactory, cacheSize);
+            CqlPackagerFactory factory = new CqlPackagerFactory(logFactory, cacheSize, cancellationToken:cts.Token);
             var definitions = factory.LibrarySetExpressionBuilder.ProcessLibrarySet(librarySet);
             var assemblyData = factory.AssemblyCompiler.Compile(librarySet, definitions);
             var asmContext = new AssemblyLoadContext($"{lib}-{version}");

--- a/Demo/Test/Test.csproj
+++ b/Demo/Test/Test.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\Cql\CoreTests\LibrarySetsDirs.cs" Link="LibrarySetsDirs.cs" />
+    <Compile Include="..\..\Cql\Cql.Abstractions\Infrastructure\DirectoryInfoExtensions.cs" Link="DirectoryInfoExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Demo/cql-demo.props
+++ b/Demo/cql-demo.props
@@ -8,6 +8,23 @@
 		<FirelySdkVersion>5.7.0</FirelySdkVersion>
 	</PropertyGroup>
 
+	<!-- Solution-wide properties for NuGet packaging -->
+	<PropertyGroup>
+		<VersionPrefix>2.0.0</VersionPrefix>
+		<VersionSuffix>alpha</VersionSuffix>
+		<Authors>NCQA, Firely (info@fire.ly) and contributors</Authors>
+		<Copyright>Copyright 2013-2024 NCQA, Firely. Contains materials (C) HL7 International</Copyright>
+		<PackageProjectUrl>https://github.com/FirelyTeam/firely-cql-sdk</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/FirelyTeam/firely-cql-sdk</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageReleaseNotes>See https://github.com/FirelyTeam/firely-cql-sdk/releases</PackageReleaseNotes>
+		<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+	</PropertyGroup>
+
+
 	<!-- Compiler settings -->
 	<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/Demo/cql-demo.props
+++ b/Demo/cql-demo.props
@@ -28,7 +28,7 @@
 	<!-- Compiler settings -->
 	<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>disable</Nullable>
+		<Nullable>enable</Nullable>
 		<LangVersion>12</LangVersion>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Configurations>Debug;Release;</Configurations>

--- a/docs/packager-cli-dependency-graph.md
+++ b/docs/packager-cli-dependency-graph.md
@@ -23,6 +23,13 @@ classDiagram
 
         class WriteToFileCSharpCodeStreamPostProcessor {
         }
+
+        class AssemblyDataPostProcessor {
+            ProcessAssemblyData(name : string, assemblyData : AssemblyData) void
+        }
+
+        class WriteToFileAssemblyDataPostProcessor {
+        }
     }
 
     namespace Expression_Building {
@@ -94,10 +101,12 @@ classDiagram
     CqlOperatorsBinder --> OperatorsBinder : inherits
     CqlContextBinder --> ContextBinder : inherits
     WriteToFileCSharpCodeStreamPostProcessor --> CSharpCodeStreamPostProcessor : inherits
+    WriteToFileAssemblyDataPostProcessor --> AssemblyDataPostProcessor : inherits
     WriteToFileFhirResourcePostProcessor --> FhirResourcePostProcessor : inherits
 
     %% Injected Dependencies
 
+    AssemblyDataPostProcessor ..> AssemblyCompiler : injected\n(optional)
     CSharpCodeStreamPostProcessor ..> AssemblyCompiler : injected\n(optional)
     CSharpLibrarySetToStreamsWriter ..> AssemblyCompiler : injected
     TypeManager ..> AssemblyCompiler : injected


### PR DESCRIPTION
ℹ️Work for issue #337 

* Added `AssemblyDataPostProcessor` with an implementation `WriteToFileAssemblyDataPostProcessor` to allow post process generated and reference asssemblies during the pipeline.  
* Dll's are written out to LibrarySets folder, but are not included in the repo
* A record keeps track of the files so they are deleted on the next round.
* Optional setting `--dll` to specify the output folder. If not set, the dlls are not written out
* Add back all conversions, as these failed during integration tests

Note the new output folders for Assemblies
![image](https://github.com/FirelyTeam/firely-cql-sdk/assets/4639799/849cb8da-ab70-42b9-b74f-d933cc8b313d)


### Application Dependencies (excl Logger and Options)

```mermaid
classDiagram
    direction TB

    %% HACK: Mermaid doesnt support commas withing generic, so use a similar looking character (﹐)

    namespace CSharpCode_Generate_And_Compile {
        class AssemblyCompiler {
%%            Compile(librarySet : LibrarySet,definitions : DefinitionDictionary~LambdaExpression~? = null) IDictionary~string, AssemblyData~
        }

        class CSharpLibrarySetToStreamsWriter {
        }

        class CSharpCodeStreamPostProcessor {
            ProcessStream(name : string, stream : Stream) void
        }

        class WriteToFileCSharpCodeStreamPostProcessor {
        }

        class AssemblyDataPostProcessor {
            ProcessAssemblyData(name : string, assemblyData : AssemblyData) void
        }

        class WriteToFileAssemblyDataPostProcessor {
        }
    }

    namespace Expression_Building {
        class LibrarySetExpressionBuilder {
            ProcessLibrarySet(librarySet : LibrarySet) DefinitionDictionary<LambdaExpression>
        }

        class OperatorsBinder {
        }

        class CqlOperatorsBinder {
        }

        class ContextBinder{
        }

        class CqlContextBinder{
		}

        class TypeConverter {
        }

        class ModelInspector {
        }

        class CqlCompilerFactory {
        }
    }

    namespace Fhir_Resource_Building {
        class ResourcePackager {
%%            PackageResources(elmDirectory : DirectoryInfo, cqlDirectory : DirectoryInfo, resourceCanonicalRootUrl : string? = null) IReadOnlyCollection~Resource~
        }

        class FhirResourcePostProcessor {
%%            ProcessResource(resource : Resource) void
        }

        class WriteToFileFhirResourcePostProcessor {
        }
    }

    namespace Cql_To_Resource_Pipeline {
        class CqlToResourcePackagingPipeline {
        }        
    }

    namespace Application {
        class PackagerCliProgram {
        }

        class OptionsConsoleDumper {
        }
    }

%%    namespace Dependencies {
        class TypeManager {
            get_TypeResolver() TypeResolver
            get_TupleTypes() IEnumerable~Type~
        }

    
        class TypeResolver {
        }
%%    }

    %% Inheritance  

    CqlOperatorsBinder --> OperatorsBinder : inherits
    CqlContextBinder --> ContextBinder : inherits
    WriteToFileCSharpCodeStreamPostProcessor --> CSharpCodeStreamPostProcessor : inherits
    WriteToFileAssemblyDataPostProcessor --> AssemblyDataPostProcessor : inherits
    WriteToFileFhirResourcePostProcessor --> FhirResourcePostProcessor : inherits

    %% Injected Dependencies

    AssemblyDataPostProcessor ..> AssemblyCompiler : injected\n(optional)
    CSharpCodeStreamPostProcessor ..> AssemblyCompiler : injected\n(optional)
    CSharpLibrarySetToStreamsWriter ..> AssemblyCompiler : injected
    TypeManager ..> AssemblyCompiler : injected
    
    AssemblyCompiler ..> CqlToResourcePackagingPipeline : injected
    ILibrarySetExpressionBuilder ..> CqlToResourcePackagingPipeline : injected
    ResourcePackager ..> CqlToResourcePackagingPipeline : injected 
    
    OptionsConsoleDumper ..> PackagerCliProgram : injected 
    CqlToResourcePackagingPipeline ..> PackagerCliProgram : injected
      
    TypeResolver ..> CqlOperatorsBinder : injected
    TypeConverter ..> CqlOperatorsBinder : injected

    ModelInspector ..> TypeConverter : injected  

    TypeResolver ..> TypeManager : injected

    TypeResolver ..> ResourcePackager : injected
    FhirResourcePostProcessor ..> ResourcePackager : injected\n(optional) 
    
    TypeResolver ..> CSharpLibrarySetToStreamsWriter : injected
```

