### PR TITLE
2.0/347 fix comparison between code t and string

### DIFF
--- a/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
+++ b/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
@@ -22,12 +22,13 @@ public class CSharpCodeWriterOptions
     /// </summary>
     internal const string ConfigSection = "CSharpCodeWriter";
 
+    internal const string ArgNameOutDirectory = "--cs";
+
     /// <summary>
     /// Gets or sets the output directory.
     /// </summary>
     public DirectoryInfo? OutDirectory { get; set; }
 
-    internal const string ArgNameOutDirectory = "--cs";
     internal const string ArgNameTypeFormat = "--cs-typeformat";
 
     /// <summary>

--- a/Cql/CoreTests/FhirCodeEqualityTests.cs
+++ b/Cql/CoreTests/FhirCodeEqualityTests.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * Copyright (c) 2024, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Runtime;
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests;
+
+[TestClass]
+public class FhirCodeEqualityTests
+{
+	private static CqlContext GetNewContext() => FhirCqlContext.WithDataSource();
+
+
+	[TestMethod]
+	public void Equal_FhirCode_vs_String()
+	{
+		// Arrange
+		var rtx = GetNewContext();
+
+		var enumVal = Encounter.EncounterStatus.Finished;
+		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
+		var stringVal = "finished"; // EnumLiteral[xxx]
+
+		// Act
+		var equals = rtx.Operators.Comparer.Equals(codeVal, stringVal, null);
+
+		// Assert
+		Assert.IsTrue(equals);
+	}
+
+	[TestMethod]
+	public void Equal_String_vs_FhirCode()
+	{
+		// Arrange
+		var rtx = GetNewContext();
+
+		var enumVal = Encounter.EncounterStatus.Finished;
+		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
+		var stringVal = "finished"; // EnumLiteral[xxx]
+
+		// Act
+		var equals = rtx.Operators.Comparer.Equals(stringVal, codeVal, null);
+
+		// Assert
+		Assert.IsTrue(equals);
+	}
+}

--- a/Cql/CoreTests/FhirCodeEqualityTests.cs
+++ b/Cql/CoreTests/FhirCodeEqualityTests.cs
@@ -6,6 +6,8 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using System;
+using FluentAssertions;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Runtime;
 using Hl7.Fhir.Model;
@@ -14,42 +16,82 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace CoreTests;
 
 [TestClass]
-public class FhirCodeEqualityTests
+public class CqlContextOperatorTests
 {
 	private static CqlContext GetNewContext() => FhirCqlContext.WithDataSource();
 
 
+	#region Equal
+
 	[TestMethod]
-	public void Equal_FhirCode_vs_String()
+	public void Equal_FhirCodeAndString_MustEqual()
 	{
 		// Arrange
 		var rtx = GetNewContext();
 
 		var enumVal = Encounter.EncounterStatus.Finished;
 		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
-		var stringVal = "finished"; // EnumLiteral[xxx]
+		const string stringVal = "finished"; // EnumLiteral[xxx]
 
 		// Act
-		var equals = rtx.Operators.Comparer.Equals(codeVal, stringVal, null);
+		var isEqual = rtx.Operators.Equal(codeVal, stringVal);
 
 		// Assert
-		Assert.IsTrue(equals);
+		isEqual.Should().BeTrue();
 	}
 
 	[TestMethod]
-	public void Equal_String_vs_FhirCode()
+	public void Equal_StringAndFhirCode_MustEqual()
 	{
 		// Arrange
 		var rtx = GetNewContext();
 
 		var enumVal = Encounter.EncounterStatus.Finished;
 		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
-		var stringVal = "finished"; // EnumLiteral[xxx]
+		const string stringVal = "finished"; // EnumLiteral[xxx]
 
 		// Act
-		var equals = rtx.Operators.Comparer.Equals(stringVal, codeVal, null);
+		var isEqual = rtx.Operators.Equal(stringVal, codeVal);
 
 		// Assert
-		Assert.IsTrue(equals);
+		isEqual.Should().BeTrue();
 	}
+
+	#endregion
+
+	#region Convert
+
+	[TestMethod]
+	public void Convert_FhirCodeToString_MustReturnValueFromEnumLiteral()
+	{
+		// Arrange
+		var rtx = GetNewContext();
+
+		var enumVal = Encounter.EncounterStatus.Finished;
+		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
+		const string stringVal = "finished"; // EnumLiteral[xxx]
+
+		// Act
+		var stringValConverted = rtx.Operators.Convert<string>(codeVal);
+
+		// Assert
+		Assert.AreEqual(stringVal, stringValConverted);
+	}
+
+	[TestMethod]
+	public void Convert_StringToFhirCode_ThrowNoConversionIsDefined()
+	{
+		// Arrange
+		var rtx = GetNewContext();
+		const string stringVal = "finished"; // EnumLiteral[xxx]
+
+		// Act
+		Action act = () => rtx.Operators.Convert<Code<Encounter.EncounterStatus>>(stringVal);
+
+		// Assert
+		act.Should().Throw<InvalidOperationException>()
+		   .WithMessage("No conversion from * to * is defined.");
+	}
+
+	#endregion
 }

--- a/Cql/CoreTests/LibrarySetsDirs.cs
+++ b/Cql/CoreTests/LibrarySetsDirs.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using Hl7.Cql.Abstractions.Infrastructure;
 
 namespace CoreTests;

--- a/Cql/CoreTests/PrimitiveTests.cs
+++ b/Cql/CoreTests/PrimitiveTests.cs
@@ -28,6 +28,8 @@ namespace CoreTests
 
         private static CqlPackagerFactory Factory = new(LoggerFactory);
 
+        private CqlContext GetNewContext() => FhirCqlContext.WithDataSource();
+
         [TestMethod]
         public void CqlDateTime_Add_Year_By_Units()
         {
@@ -107,8 +109,6 @@ namespace CoreTests
             Assert.AreEqual("2022-01-01", minus2pt5Months.ToString());
 
         }
-
-        private CqlContext GetNewContext() => FhirCqlContext.WithDataSource();
 
         [TestMethod]
         public void CqlDateTime_Subtract_Day_and_Days()

--- a/Cql/Cql.Abstractions/ICqlComparer.cs
+++ b/Cql/Cql.Abstractions/ICqlComparer.cs
@@ -45,6 +45,22 @@ namespace Hl7.Cql.Abstractions
         int GetHashCode(object x);
     }
 
+    internal abstract class CqlComparerDecorator(ICqlComparer inner) : ICqlComparer
+    {
+        protected ICqlComparer Inner { get; } = inner;
+
+        public virtual bool? Equals(object? x, object? y, string? precision) =>
+            Inner.Equals(x, y, precision);
+
+        public virtual int? Compare(object? x, object? y, string? precision) =>
+            Inner.Compare(x, y, precision);
+
+        public virtual int GetHashCode(object x) => Inner.GetHashCode(x);
+
+        public virtual bool Equivalent(object? x, object? y, string? precision) =>
+            Inner.Equivalent(x, y, precision);
+    }
+
     /// <summary>
     /// Defines a method that a type implements to compare two objects.
     /// </summary>
@@ -83,6 +99,5 @@ namespace Hl7.Cql.Abstractions
         /// <param name="x">The object whose hash code to compute.</param>
         /// <returns>The hash code for <paramref name="x"/>.</returns>
         int GetHashCode(T x);
-
     }
 }

--- a/Cql/Cql.Firely/CqlComparersExtensions.cs
+++ b/Cql/Cql.Firely/CqlComparersExtensions.cs
@@ -6,6 +6,7 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using System.Diagnostics;
 using Hl7.Cql.Abstractions;
 using Hl7.Cql.Comparers;
 using Hl7.Cql.Fhir.Comparers;
@@ -49,11 +50,39 @@ namespace Hl7.Cql.Fhir
             {
                 var codeType = type.GetGenericArguments()[0];
                 var comparerType = typeof(CodeComparer<>).MakeGenericType(codeType);
-                var comparer = (ICqlComparer)Activator.CreateInstance(comparerType, _comparers)!;
-                return comparer;
+                var codeComparer = (ICqlComparer)Activator.CreateInstance(comparerType, _comparers)!;
+                var codeStringComparer = new CodeStringComparer(codeComparer);
+                return codeStringComparer;
             });
 
             return comparers;
+        }
+
+        private class CodeStringComparer(ICqlComparer inner) : CqlComparerDecorator(inner)
+        {
+            public override int? Compare(
+                object? x,
+                object? y,
+                string? precision)
+            {
+                // We always expect x to be a Code<T> but we only need the ObjectValue on the non-generic base type PrimitiveType.
+                if (x is PrimitiveType xCode && y is string yString)
+                {
+                    if (precision != null)
+                        throw new InvalidOperationException(
+                            $"Precision '{precision}' is not supported for comparing Code<T> to string.");
+
+                    return StringComparer.Ordinal.Compare(xCode.ObjectValue, yString);
+                }
+
+                return base.Compare(x, y, precision);
+            }
+
+            public override bool? Equals(
+                object? x,
+                object? y,
+                string? precision) =>
+                throw new UnreachableException("CqlComparers always goes through Compare, so we never reach here");
         }
 
         /// <summary>

--- a/Cql/Cql.Packaging/CqlPackagingPipelineOptions.cs
+++ b/Cql/Cql.Packaging/CqlPackagingPipelineOptions.cs
@@ -9,23 +9,20 @@ namespace Hl7.Cql.Packaging;
 
 internal partial class CqlToResourcePackagingOptions
 {
-    public const string ConfigSection = "Packager";
+	public const string ConfigSection = "Packager";
 
-    public const string ArgNameElmDirectory = "--elm";
-    public DirectoryInfo ElmDirectory { get; set; } = null!;
+	public const string ArgNameElmDirectory = "--elm";
+	public DirectoryInfo ElmDirectory { get; set; } = null!;
 
-    public const string ArgNameCqlDirectory = "--cql";
-    public DirectoryInfo CqlDirectory { get; set; } = null!;
+	public const string ArgNameCqlDirectory = "--cql";
+	public DirectoryInfo CqlDirectory { get; set; } = null!;
 
-    public const string ArgNameDebug = "--d";
-    public bool Debug { get; set; }
+	public const string ArgNameLogDebugEnabled = "--log-debug";
+	public bool LogDebugEnabled { get; set; }
 
-    public const string ArgNameForce = "--f";
-    public bool Force { get; set; } // TODO: There are no usages for this, Remove or implement!
+	public const string ArgNameLogDontClear = "--log-dont-clear";
+	internal bool DontLogClear { get; set; }  // Internal use only!
 
-    public const string ArgNameDontClearLog = "--log-dont-clear";
-    public bool DontClearLog { get; set; }  // Internal use only!
-
-    public const string ArgNameCanonicalRootUrl = "--canonical-root-url";
-    public Uri? CanonicalRootUrl { get; set; }
+	public const string ArgNameCanonicalRootUrl = "--canonical-root-url";
+	public Uri? CanonicalRootUrl { get; set; }
 }

--- a/Cql/MultiPackagerCLI/Program.cs
+++ b/Cql/MultiPackagerCLI/Program.cs
@@ -5,35 +5,35 @@ using Hl7.Cql.CodeGeneration.NET;
 using Microsoft.CodeAnalysis;
 
 var solutionDir = new DirectoryInfo(Environment.CurrentDirectory)
-    .FindParentDirectoryContaining("CqlAndDemo.sln")!;
+	.FindParentDirectoryContaining("CqlAndDemo.sln")!;
 
 CSharpCodeWriterTypeFormat csTypeFormat = CSharpCodeWriterTypeFormat.Var;
 (string subDir, string measureSubDir)[] iteration = [
-    ("Demo", "Measures.Demo"),
-    ("CMS", "Measures.CMS")
+	("Demo", "Measures.Demo"),
+	("CMS", "Measures.CMS")
 ];
 
 bool first = true;
 foreach ((string librarySetSubDir, string measuresSubDir) in iteration)
 {
-    string[] arguments =
-        CommandLineParser
-                    .SplitCommandLineIntoArguments(
-                        $"""
-                        --override-utc-date-time "1970-01-01T00:00:00.000Z"
-                        --canonical-root-url "https://fire.ly/fhir/"
-                        --elm "{solutionDir}/LibrarySets/{librarySetSubDir}/Elm"
-                        --cql "{solutionDir}/LibrarySets/{librarySetSubDir}/Cql"
-                        --fhir "{solutionDir}/LibrarySets/{librarySetSubDir}/Resources"
-                        --dll "{solutionDir}/LibrarySets/{librarySetSubDir}/Assemblies"
-                        --cs "{solutionDir}/Demo/{measuresSubDir}/CSharp"
-                        --cs-typeformat {csTypeFormat}
-                        --f true
-                        {(first ? "" : "--log-dont-clear true")}
-                        """.Replace("\n", " "),
-                        removeHashComments: true)
-                    .ToArray();
+	string[] arguments =
+		CommandLineParser
+			.SplitCommandLineIntoArguments(
+				$"""
+					 --override-utc-date-time "1970-01-01T00:00:00.000Z"
+					 --canonical-root-url "https://fire.ly/fhir/"
+					 --elm "{solutionDir}/LibrarySets/{librarySetSubDir}/Elm"
+					 --cql "{solutionDir}/LibrarySets/{librarySetSubDir}/Cql"
+					 --fhir "{solutionDir}/LibrarySets/{librarySetSubDir}/Resources"
+					 --dll "{solutionDir}/LibrarySets/{librarySetSubDir}/Assemblies"
+					 --cs "{solutionDir}/Demo/{measuresSubDir}/CSharp"
+					 --cs-typeformat {csTypeFormat}
+					 --log-debug true
+					 {(first ? "" : "--log-dont-clear true")}
+					 """.Replace("\n", " "),
+				removeHashComments: true)
+			.ToArray();
 
-    Hl7.Cql.Packager.Program.Main(arguments);
-    first = false;
+	Hl7.Cql.Packager.Program.Main(arguments);
+	first = false;
 }

--- a/Cql/PackagerCLI/OptionsConsoleDumper.cs
+++ b/Cql/PackagerCLI/OptionsConsoleDumper.cs
@@ -40,12 +40,12 @@ internal class OptionsConsoleDumper
 
         WriteLine("PackageCLI");
         WriteLine("- Environment -----------------------------------");
-        WriteLine($"{"Current Directory",-38} : {Environment.CurrentDirectory}");
+        WriteLine($"{"Current Directory",-45} : {Environment.CurrentDirectory}");
         WriteLine("- Arguments Provided ----------------------------");
         (string name, object? value)[] values = new[]
         {
-            ArgFor(_options.Force),
-            ArgFor(_options.Debug),
+            // ArgFor(_options.Force),
+            ArgFor(_options.LogDebugEnabled),
             ArgFor("Resource, CanonicalRootUrl", _options.CanonicalRootUrl),
             ArgFor("Cql, InDirectory", _options.CqlDirectory),
             ArgFor("Elm, InDirectory", _options.ElmDirectory),
@@ -57,7 +57,7 @@ internal class OptionsConsoleDumper
         .ToArray();
 
         foreach (var (name, value) in values)
-            WriteLine($"{name,-38} : {value}");
+            WriteLine($"{name,-45} : {value}");
 
         if (sb is not null)
             _logger.LogInformation("{options}", sb.ToString());

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -53,7 +53,14 @@ public class Program
 
         var hostBuilder = CreateHostBuilder(args);
 
-        return Run(hostBuilder);
+        try
+        {
+            return Run(hostBuilder);
+        }
+        finally
+        {
+            Log.CloseAndFlush();
+        }
     }
 
     public static IHostBuilder CreateHostBuilder(string[] args) =>
@@ -71,22 +78,21 @@ public class Program
         Usage = $"""
                  Packager CLI Usage:
 
-                     {"-?|-h|-help", -26} Show this help
+                     {"-?|-h|-help",-26} Show this help
 
-                     {CqlToResourcePackagingOptions.ArgNameElmDirectory,-26} {"<directory>", -19} Library root directory
-                     {CqlToResourcePackagingOptions.ArgNameCqlDirectory,-26} {"<directory>", -19} CQL root directory
-                     {Optional(FhirResourceWriterOptions.ArgNameOutDirectory),-26} {"<directory>", -19} Resource directory
+                     {CqlToResourcePackagingOptions.ArgNameElmDirectory,-26} {"<directory>",-19} Required: Library root directory
+                     {CqlToResourcePackagingOptions.ArgNameCqlDirectory,-26} {"<directory>",-19} Required: CQL root directory
+                     {Optional(FhirResourceWriterOptions.ArgNameOutDirectory),-26} {"<directory>",-19} Resource directory
                      {Optional(CSharpCodeWriterOptions.ArgNameOutDirectory),-26} {"<directory>",-19} C# output directory
-                     {Optional(CSharpCodeWriterOptions.ArgNameTypeFormat),-26} {"<var|explicit>",-19} Whether to use var or explicit types in the C# output
+                     {Optional(CSharpCodeWriterOptions.ArgNameTypeFormat),-26} {"<var|explicit>",-19} Whether to use var (default) or explicit types in the C# output
                      {Optional(AssemblyDataWriterOptions.ArgNameOutDirectory),-26}{"<directory>",-19} DLL output directory
-                     {Optional(CqlToResourcePackagingOptions.ArgNameDebug),-26} {"<true|false>",-19} Produce as a debug assembly
-                     {Optional(CqlToResourcePackagingOptions.ArgNameCanonicalRootUrl),-26} {"<url>",-19} The root url used for the resource canonical.
-                     {"", -26-19-1} If omitted a '#' will be used.
-                     {Optional(FhirResourceWriterOptions.ArgNameOverrideDate),-26} {"<ISO8601-date-time>",-19} The UTC date to override in the generated FHIR resource libraries.
-                     {"", -26-19-1} (example: 2000-12-31T23:59:59.99Z)
-                     {"", -26-19-1} If omitted the current date time will be used.
+                     {Optional(CqlToResourcePackagingOptions.ArgNameLogDebugEnabled),-26} {"<true|false>",-19} Enable debug logging or not (default)
+                     {Optional(CqlToResourcePackagingOptions.ArgNameCanonicalRootUrl),-26} {"<url>",-19} The root url used for the resource canonical
+                     {"",-26 - 19 - 1} If omitted a '#' will be used
+                     {Optional(FhirResourceWriterOptions.ArgNameOverrideDate),-26} {"<ISO8601-date-time>",-19} The UTC date to override in the generated FHIR resource libraries
+                     {"",-26 - 19 - 1} (example: 2000-12-31T23:59:59.99Z)
+                     {"",-26 - 19 - 1} If omitted the current date time will be used
                  """;
-                     // {Optional(CqlToResourcePackagingOptions.ArgNameForce),-26} {"<true|false>",-19} Force an overwrite even if the output file already exists
 
         static string Optional(string s) => $"[{s}]";
 
@@ -102,9 +108,8 @@ public class Program
                 // @formatter:off
                 [CqlToResourcePackagingOptions.ArgNameElmDirectory] = PackageSection + nameof(CqlToResourcePackagingOptions.ElmDirectory),
                 [CqlToResourcePackagingOptions.ArgNameCqlDirectory] = PackageSection + nameof(CqlToResourcePackagingOptions.CqlDirectory),
-                [CqlToResourcePackagingOptions.ArgNameDebug] = PackageSection + nameof(CqlToResourcePackagingOptions.Debug),
-                [CqlToResourcePackagingOptions.ArgNameForce] = PackageSection + nameof(CqlToResourcePackagingOptions.Force),
-                [CqlToResourcePackagingOptions.ArgNameDontClearLog] = PackageSection + nameof(CqlToResourcePackagingOptions.DontClearLog),
+                [CqlToResourcePackagingOptions.ArgNameLogDebugEnabled] = PackageSection + nameof(CqlToResourcePackagingOptions.LogDebugEnabled),
+                [CqlToResourcePackagingOptions.ArgNameLogDontClear] = PackageSection + nameof(CqlToResourcePackagingOptions.DontLogClear),
                 [CqlToResourcePackagingOptions.ArgNameCanonicalRootUrl] = PackageSection + nameof(CqlToResourcePackagingOptions.CanonicalRootUrl),
 
                 [CSharpCodeWriterOptions.ArgNameOutDirectory] = CSharpCodeWriterSection + nameof(CSharpCodeWriterOptions.OutDirectory),
@@ -129,7 +134,11 @@ public class Program
     {
         logging.ClearProviders();
 
-        var minLogLevel = Debugger.IsAttached ? LogLevel.Trace : LogLevel.Information;// TODO: We should base this on the configuration for the 'Debug' flag
+        bool enableDebugLogging = Debugger.IsAttached;
+        enableDebugLogging = enableDebugLogging || context.Configuration.GetValue<bool>(SwitchMappings[CqlToResourcePackagingOptions.ArgNameLogDebugEnabled]);
+        var minLogLevel = enableDebugLogging ? LogLevel.Trace : LogLevel.Information;
+
+        bool shouldClearLog = !context.Configuration.GetValue<bool>(SwitchMappings[CqlToResourcePackagingOptions.ArgNameLogDontClear]);
 
         logging.AddFilter(level => level >= minLogLevel);
 
@@ -140,9 +149,11 @@ public class Program
 
         var logFile = Path.Combine(".", "build.log");
 
-        bool shouldClearLog = !context.Configuration.GetValue<bool>(SwitchMappings[CqlToResourcePackagingOptions.ArgNameDontClearLog]);
         if (shouldClearLog)
-            File.Delete(logFile);
+            File.WriteAllText(logFile, ""); // Create or clear the log file
+                                            //File.Delete(logFile);
+        else
+            File.OpenText(logFile).Close(); // Touch the file
 
         Log.Logger = new LoggerConfiguration()
             .Enrich.FromLogContext()
@@ -159,13 +170,20 @@ public class Program
         logLevel switch
         {
             // @formatter: off
-            /* 0 */ LogLevel.Trace       => /* 0 */ LogEventLevel.Verbose,
-            /* 1 */ LogLevel.Debug       => /* 1 */ LogEventLevel.Debug,
-            /* 2 */ LogLevel.Information => /* 2 */ LogEventLevel.Information,
-            /* 3 */ LogLevel.Warning     => /* 3 */ LogEventLevel.Warning,
-            /* 4 */ LogLevel.Error       => /* 4 */ LogEventLevel.Error,
-            /* 5 */ LogLevel.Critical    => /* 5 */ LogEventLevel.Fatal,
-            /* 6 */ LogLevel.None        => /* n/a */ null,
+            /* 0 */
+            LogLevel.Trace => /* 0 */ LogEventLevel.Verbose,
+            /* 1 */
+            LogLevel.Debug => /* 1 */ LogEventLevel.Debug,
+            /* 2 */
+            LogLevel.Information => /* 2 */ LogEventLevel.Information,
+            /* 3 */
+            LogLevel.Warning => /* 3 */ LogEventLevel.Warning,
+            /* 4 */
+            LogLevel.Error => /* 4 */ LogEventLevel.Error,
+            /* 5 */
+            LogLevel.Critical => /* 5 */ LogEventLevel.Fatal,
+            /* 6 */
+            LogLevel.None => /* n/a */ null,
             // @formatter: on
             _ => throw new UnsupportedSwitchCaseError(logLevel, typeof(LogLevel).FullName).ToException(),
         };

--- a/Demo/Cql/Build/Common.props
+++ b/Demo/Cql/Build/Common.props
@@ -1,15 +1,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 
-	<!-- Shared properties. $LibrarySet comes from respective measure project-->
-	<PropertyGroup>
-		<LibrarySetRoot>$(SolutionDir)LibrarySets/$(LibrarySet)</LibrarySetRoot>
-		<CqlDirectory>$(LibrarySetRoot)/Cql</CqlDirectory>
-		<ElmDirectory>$(LibrarySetRoot)/Elm</ElmDirectory>
-		<ResourcesDirectory>$(LibrarySetRoot)/Resources</ResourcesDirectory>
-		<TargetDependencies>$(MSBuildThisFileDirectory)target/dependency</TargetDependencies>
-	</PropertyGroup>
-	<PropertyGroup>
-		<Box>==============================================&#10;Text&#10;==============================================</Box>
-	</PropertyGroup>
+  <!-- Shared properties. $LibrarySet comes from respective measure project-->
+  <PropertyGroup>
+    <CqlSolutionDir>$(MSBuildThisFileDirectory)/../../../</CqlSolutionDir>
+    <LibrarySetRoot>$(CqlSolutionDir)/LibrarySets/$(LibrarySet)</LibrarySetRoot>
+    <CqlDirectory>$(LibrarySetRoot)/Cql</CqlDirectory>
+    <ElmDirectory>$(LibrarySetRoot)/Elm</ElmDirectory>
+    <ResourcesDirectory>$(LibrarySetRoot)/Resources</ResourcesDirectory>
+    <TargetDependencies>$(MSBuildThisFileDirectory)target/dependency</TargetDependencies>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Box>==============================================&#10;Text&#10;==============================================</Box>
+  </PropertyGroup>
 </Project>

--- a/Demo/Cql/Build/Cql.Targets.xml
+++ b/Demo/Cql/Build/Cql.Targets.xml
@@ -56,16 +56,27 @@
 	<!-- ELM to CSharp -->
 	<PropertyGroup>
 		<CSharpDirectory>$(MSBuildProjectDirectory)/CSharp</CSharpDirectory>
+
+		<!-- Comment out these if you don't need them -->
+		<CanonicalRootUrl>https://fire.ly/fhir/</CanonicalRootUrl>
+		<CSharpTypeFormat>explicit</CSharpTypeFormat>	<!--CSharpTypeFormat: explicit|var -->
 	</PropertyGroup>
 
 	<Target Name="GenerateCSharp"
 			DependsOnTargets="CQLtoELM"
 			BeforeTargets="PreBuildEvent">
 		<PropertyGroup>
-			<PackagerCLI>$(SolutionDir)Cql/PackagerCLI/bin/debug/$(TargetFramework)/Hl7.Cql.Packager.exe</PackagerCLI>
-			<OverrideUtc>--override-utc-date-time "1970-01-01T00:00:00Z"</OverrideUtc>
-			<CanonicalRootUrl>https://fire.ly/fhir/</CanonicalRootUrl>
-			<PackagerCLIArgs> $(OverrideUtc) --canonical-root-url $(CanonicalRootUrl) --elm $(ElmDirectory) --cql $(CqlDirectory) --cs $(CSharpDirectory) --fhir $(ResourcesDirectory)</PackagerCLIArgs>
+			<PackagerCLI>$(CqlSolutionDir)Cql/PackagerCLI/bin/debug/$(TargetFramework)/Hl7.Cql.Packager.exe</PackagerCLI>
+
+			<!-- Leave these alone, they are automatically picked up from the properties above -->
+			<PackagerCLIArgs Condition="'$(OverrideUtcDateTime)'!=''">$(PackagerCLIArgs) --override-utc-date-time "$(1970-01-01T00:00:00Z)"</PackagerCLIArgs>
+			<PackagerCLIArgs Condition="'$(CanonicalRootUrl)'!=''">$(PackagerCLIArgs) --canonical-root-url "$(CanonicalRootUrl)"</PackagerCLIArgs>
+			<PackagerCLIArgs Condition="'$(ElmDirectory)'!=''">$(PackagerCLIArgs) --elm "$(ElmDirectory)"</PackagerCLIArgs>
+			<PackagerCLIArgs Condition="'$(CqlDirectory)'!=''">$(PackagerCLIArgs) --cql "$(CqlDirectory)"</PackagerCLIArgs>
+			<PackagerCLIArgs Condition="'$(CSharpDirectory)'!=''">$(PackagerCLIArgs) --cs "$(CSharpDirectory)"</PackagerCLIArgs>
+			<PackagerCLIArgs Condition="'$(ResourcesDirectory)'!=''">$(PackagerCLIArgs) --fhir "$(ResourcesDirectory)"</PackagerCLIArgs>
+			<PackagerCLIArgs Condition="'$(CSharpTypeFormat)'!=''">$(PackagerCLIArgs) --cs-typeformat "$(CSharpTypeFormat)"</PackagerCLIArgs>
+			<!-- <PackagerCLICommand>$(PackagerCLI) $(PackagerClIArgs)</PackagerCLICommand> -->
 			<PackagerCLICommand>$(PackagerCLI) $(PackagerClIArgs) &gt; NUL 2&gt; NUL</PackagerCLICommand>
 		</PropertyGroup>
 

--- a/Demo/Cql/Build/Cql.Targets.xml
+++ b/Demo/Cql/Build/Cql.Targets.xml
@@ -36,7 +36,7 @@
 		<Message Text="$(Box.Replace(Text, $(LibrarySet) $(JavaCommandArgs)))" Importance="High" />
 		<Exec Command="$(JavaCommandArgs)" ConsoleToMSBuild="true">
 			<Output TaskParameter="ConsoleOutput" ItemName="OutputOfExec" />
-			</Exec>
+		</Exec>
 		<WriteLinesToFile
             File="$(JavaOutputFile)"
             Lines="@(OutputOfExec)"
@@ -59,7 +59,8 @@
 
 		<!-- Comment out these if you don't need them -->
 		<CanonicalRootUrl>https://fire.ly/fhir/</CanonicalRootUrl>
-		<CSharpTypeFormat>explicit</CSharpTypeFormat>	<!--CSharpTypeFormat: explicit|var -->
+		<CSharpTypeFormat>explicit</CSharpTypeFormat>
+		<!--CSharpTypeFormat: explicit|var -->
 	</PropertyGroup>
 
 	<Target Name="GenerateCSharp"

--- a/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
@@ -96,135 +96,168 @@ public class AHAOverall_2_6_000
 
     #endregion
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility"/>
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility_Value"/>
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
 	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
+    /// <seealso cref="Ejection_Fraction"/>
 	private CqlValueSet Ejection_Fraction_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134", null);
 
+    /// <seealso cref="Ejection_Fraction_Value"/>
     [CqlDeclaration("Ejection Fraction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134")]
 	public CqlValueSet Ejection_Fraction() => 
 		__Ejection_Fraction.Value;
 
+    /// <seealso cref="Heart_Failure"/>
 	private CqlValueSet Heart_Failure_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", null);
 
+    /// <seealso cref="Heart_Failure_Value"/>
     [CqlDeclaration("Heart Failure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376")]
 	public CqlValueSet Heart_Failure() => 
 		__Heart_Failure.Value;
 
+    /// <seealso cref="Heart_Transplant"/>
 	private CqlValueSet Heart_Transplant_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.33", null);
 
+    /// <seealso cref="Heart_Transplant_Value"/>
     [CqlDeclaration("Heart Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.33")]
 	public CqlValueSet Heart_Transplant() => 
 		__Heart_Transplant.Value;
 
+    /// <seealso cref="Heart_Transplant_Complications"/>
 	private CqlValueSet Heart_Transplant_Complications_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.56", null);
 
+    /// <seealso cref="Heart_Transplant_Complications_Value"/>
     [CqlDeclaration("Heart Transplant Complications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.56")]
 	public CqlValueSet Heart_Transplant_Complications() => 
 		__Heart_Transplant_Complications.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Left_Ventricular_Assist_Device_Complications"/>
 	private CqlValueSet Left_Ventricular_Assist_Device_Complications_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.58", null);
 
+    /// <seealso cref="Left_Ventricular_Assist_Device_Complications_Value"/>
     [CqlDeclaration("Left Ventricular Assist Device Complications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.58")]
 	public CqlValueSet Left_Ventricular_Assist_Device_Complications() => 
 		__Left_Ventricular_Assist_Device_Complications.Value;
 
+    /// <seealso cref="Left_Ventricular_Assist_Device_Placement"/>
 	private CqlValueSet Left_Ventricular_Assist_Device_Placement_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", null);
 
+    /// <seealso cref="Left_Ventricular_Assist_Device_Placement_Value"/>
     [CqlDeclaration("Left Ventricular Assist Device Placement")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61")]
 	public CqlValueSet Left_Ventricular_Assist_Device_Placement() => 
 		__Left_Ventricular_Assist_Device_Placement.Value;
 
+    /// <seealso cref="Moderate_or_Severe"/>
 	private CqlValueSet Moderate_or_Severe_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092", null);
 
+    /// <seealso cref="Moderate_or_Severe_Value"/>
     [CqlDeclaration("Moderate or Severe")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092")]
 	public CqlValueSet Moderate_or_Severe() => 
 		__Moderate_or_Severe.Value;
 
+    /// <seealso cref="Moderate_or_Severe_LVSD"/>
 	private CqlValueSet Moderate_or_Severe_LVSD_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090", null);
 
+    /// <seealso cref="Moderate_or_Severe_LVSD_Value"/>
     [CqlDeclaration("Moderate or Severe LVSD")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090")]
 	public CqlValueSet Moderate_or_Severe_LVSD() => 
 		__Moderate_or_Severe_LVSD.Value;
 
+    /// <seealso cref="Nursing_Facility_Visit"/>
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
+    /// <seealso cref="Nursing_Facility_Visit_Value"/>
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
 	public CqlValueSet Nursing_Facility_Visit() => 
 		__Nursing_Facility_Visit.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Patient_Provider_Interaction"/>
 	private CqlValueSet Patient_Provider_Interaction_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", null);
 
+    /// <seealso cref="Patient_Provider_Interaction_Value"/>
     [CqlDeclaration("Patient Provider Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012")]
 	public CqlValueSet Patient_Provider_Interaction() => 
 		__Patient_Provider_Interaction.Value;
 
+    /// <seealso cref="Left_ventricular_systolic_dysfunction__disorder_"/>
 	private CqlCode Left_ventricular_systolic_dysfunction__disorder__Value() => 
 		new CqlCode("134401001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Left_ventricular_systolic_dysfunction__disorder__Value"/>
     [CqlDeclaration("Left ventricular systolic dysfunction (disorder)")]
 	public CqlCode Left_ventricular_systolic_dysfunction__disorder_() => 
 		__Left_ventricular_systolic_dysfunction__disorder_.Value;
 
+    /// <seealso cref="allergy_entered_in_error"/>
 	private CqlCode allergy_entered_in_error_Value() => 
 		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
+    /// <seealso cref="allergy_entered_in_error_Value"/>
     [CqlDeclaration("allergy-entered-in-error")]
 	public CqlCode allergy_entered_in_error() => 
 		__allergy_entered_in_error.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("134401001", "http://snomed.info/sct", null, null),
 		};
@@ -232,13 +265,15 @@ public class AHAOverall_2_6_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="AllergyIntoleranceVerificationStatusCodes"/>
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
 		};
@@ -246,32 +281,37 @@ public class AHAOverall_2_6_000
 		return a_;
 	}
 
+    /// <seealso cref="AllergyIntoleranceVerificationStatusCodes_Value"/>
     [CqlDeclaration("AllergyIntoleranceVerificationStatusCodes")]
 	public CqlCode[] AllergyIntoleranceVerificationStatusCodes() => 
 		__AllergyIntoleranceVerificationStatusCodes.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("AHAOverall-2.6.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("AHAOverall-2.6.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
@@ -279,40 +319,40 @@ public class AHAOverall_2_6_000
     [CqlDeclaration("isConfirmedActiveDiagnosis")]
 	public bool? isConfirmedActiveDiagnosis(Condition Condition)
 	{
-		var a_ = new Condition[]
+		Condition[] a_ = new Condition[]
 		{
 			Condition,
 		};
 		bool? b_(Condition Diagnosis)
 		{
-			var f_ = Diagnosis?.ClinicalStatus;
-			var g_ = FHIRHelpers_4_3_000.ToConcept(f_);
-			var h_ = QICoreCommon_2_0_000.active();
-			var i_ = context.Operators.ConvertCodeToConcept(h_);
-			var j_ = context.Operators.Equivalent(g_, i_);
-			var k_ = Diagnosis?.VerificationStatus;
-			var l_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var m_ = QICoreCommon_2_0_000.unconfirmed();
-			var n_ = context.Operators.ConvertCodeToConcept(m_);
-			var o_ = context.Operators.Equivalent(l_, n_);
-			var q_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var r_ = QICoreCommon_2_0_000.refuted();
-			var s_ = context.Operators.ConvertCodeToConcept(r_);
-			var t_ = context.Operators.Equivalent(q_, s_);
-			var u_ = context.Operators.Or(o_, t_);
-			var w_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var x_ = QICoreCommon_2_0_000.entered_in_error();
-			var y_ = context.Operators.ConvertCodeToConcept(x_);
-			var z_ = context.Operators.Equivalent(w_, y_);
-			var aa_ = context.Operators.Or(u_, z_);
-			var ab_ = context.Operators.Not(aa_);
-			var ac_ = context.Operators.And(j_, ab_);
+			CodeableConcept f_ = Diagnosis?.ClinicalStatus;
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(f_);
+			CqlCode h_ = QICoreCommon_2_0_000.active();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(g_, i_);
+			CodeableConcept k_ = Diagnosis?.VerificationStatus;
+			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode m_ = QICoreCommon_2_0_000.unconfirmed();
+			CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
+			bool? o_ = context.Operators.Equivalent(l_, n_);
+			CqlConcept q_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode r_ = QICoreCommon_2_0_000.refuted();
+			CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+			bool? t_ = context.Operators.Equivalent(q_, s_);
+			bool? u_ = context.Operators.Or(o_, t_);
+			CqlConcept w_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode x_ = QICoreCommon_2_0_000.entered_in_error();
+			CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
+			bool? z_ = context.Operators.Equivalent(w_, y_);
+			bool? aa_ = context.Operators.Or(u_, z_);
+			bool? ab_ = context.Operators.Not(aa_);
+			bool? ac_ = context.Operators.And(j_, ab_);
 
 			return ac_;
 		};
-		var c_ = context.Operators.Where<Condition>((IEnumerable<Condition>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<Condition>(c_);
-		var e_ = context.Operators.Not((bool?)(d_ is null));
+		IEnumerable<Condition> c_ = context.Operators.Where<Condition>((IEnumerable<Condition>)a_, b_);
+		Condition d_ = context.Operators.SingletonFrom<Condition>(c_);
+		bool? e_ = context.Operators.Not((bool?)(d_ is null));
 
 		return e_;
 	}
@@ -320,422 +360,444 @@ public class AHAOverall_2_6_000
     [CqlDeclaration("isFinished")]
 	public bool? isFinished(Encounter Visit)
 	{
-		var a_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(Visit?.StatusElement?.Value);
-		var b_ = context.Operators.Equal(a_, "finished");
+		Code<Encounter.EncounterStatus> a_ = Visit?.StatusElement;
+		Encounter.EncounterStatus? b_ = a_?.Value;
+		Code<Encounter.EncounterStatus> c_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(b_);
+		bool? d_ = context.Operators.Equal(c_, "finished");
 
-		return b_;
+		return d_;
 	}
 
+    /// <seealso cref="Heart_Failure_Outpatient_Encounter"/>
 	private IEnumerable<Encounter> Heart_Failure_Outpatient_Encounter_Value()
 	{
-		var a_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Home_Healthcare_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Nursing_Facility_Visit();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Office_Visit();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Outpatient_Consultation();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = context.Operators.Union<Encounter>(k_, m_);
+		CqlValueSet a_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Nursing_Facility_Visit();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Office_Visit();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		IEnumerable<Encounter> o_(Encounter QualifyingEncounter)
 		{
-			var s_ = this.Heart_Failure();
-			var t_ = context.Operators.RetrieveByValueSet<Condition>(s_, null);
+			CqlValueSet s_ = this.Heart_Failure();
+			IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, null);
 			bool? u_(Condition HeartFailure)
 			{
-				var y_ = QICoreCommon_2_0_000.prevalenceInterval(HeartFailure);
-				var z_ = QualifyingEncounter?.Period;
-				var aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				var ab_ = context.Operators.Overlaps(y_, aa_, null);
-				var ac_ = this.isConfirmedActiveDiagnosis(HeartFailure);
-				var ad_ = context.Operators.And(ab_, ac_);
+				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.prevalenceInterval(HeartFailure);
+				Period z_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
+				bool? ab_ = context.Operators.Overlaps(y_, aa_, null);
+				bool? ac_ = this.isConfirmedActiveDiagnosis(HeartFailure);
+				bool? ad_ = context.Operators.And(ab_, ac_);
 
 				return ad_;
 			};
-			var v_ = context.Operators.Where<Condition>(t_, u_);
+			IEnumerable<Condition> v_ = context.Operators.Where<Condition>(t_, u_);
 			Encounter w_(Condition HeartFailure) => 
 				QualifyingEncounter;
-			var x_ = context.Operators.Select<Condition, Encounter>(v_, w_);
+			IEnumerable<Encounter> x_ = context.Operators.Select<Condition, Encounter>(v_, w_);
 
 			return x_;
 		};
-		var p_ = context.Operators.SelectMany<Encounter, Encounter>(n_, o_);
+		IEnumerable<Encounter> p_ = context.Operators.SelectMany<Encounter, Encounter>(n_, o_);
 		bool? q_(Encounter QualifyingEncounter)
 		{
-			var ae_ = this.Measurement_Period();
-			var af_ = QualifyingEncounter?.Period;
-			var ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-			var ah_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ae_, ag_, null);
-			var ai_ = this.isFinished(QualifyingEncounter);
-			var aj_ = context.Operators.And(ah_, ai_);
+			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
+			Period af_ = QualifyingEncounter?.Period;
+			CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ae_, ag_, null);
+			bool? ai_ = this.isFinished(QualifyingEncounter);
+			bool? aj_ = context.Operators.And(ah_, ai_);
 
 			return aj_;
 		};
-		var r_ = context.Operators.Where<Encounter>(p_, q_);
+		IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 
 		return r_;
 	}
 
+    /// <seealso cref="Heart_Failure_Outpatient_Encounter_Value"/>
     [CqlDeclaration("Heart Failure Outpatient Encounter")]
 	public IEnumerable<Encounter> Heart_Failure_Outpatient_Encounter() => 
 		__Heart_Failure_Outpatient_Encounter.Value;
 
+    /// <seealso cref="Moderate_or_Severe_LVSD_Findings"/>
 	private IEnumerable<object> Moderate_or_Severe_LVSD_Findings_Value()
 	{
-		var a_ = this.Ejection_Fraction();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.Ejection_Fraction();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation EjectionFraction)
 		{
-			var n_ = EjectionFraction?.Value;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = context.Operators.Quantity(40m, "%");
-			var q_ = context.Operators.LessOrEqual((o_ as CqlQuantity), p_);
-			var r_ = EjectionFraction?.StatusElement;
-			var s_ = r_?.Value;
-			var t_ = context.Operators.Convert<Code<ObservationStatus>>(s_);
-			var u_ = context.Operators.Convert<string>(t_);
-			var v_ = new string[]
+			DataType n_ = EjectionFraction?.Value;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			CqlQuantity p_ = context.Operators.Quantity(40m, "%");
+			bool? q_ = context.Operators.LessOrEqual((o_ as CqlQuantity), p_);
+			Code<ObservationStatus> r_ = EjectionFraction?.StatusElement;
+			ObservationStatus? s_ = r_?.Value;
+			Code<ObservationStatus> t_ = context.Operators.Convert<Code<ObservationStatus>>(s_);
+			string u_ = context.Operators.Convert<string>(t_);
+			string[] v_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var w_ = context.Operators.In<string>(u_, (v_ as IEnumerable<string>));
-			var x_ = context.Operators.And(q_, w_);
+			bool? w_ = context.Operators.In<string>(u_, (v_ as IEnumerable<string>));
+			bool? x_ = context.Operators.And(q_, w_);
 
 			return x_;
 		};
-		var d_ = context.Operators.Where<Observation>(b_, c_);
-		var e_ = this.Moderate_or_Severe_LVSD();
-		var f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
-		var g_ = context.Operators.Union<object>((d_ as IEnumerable<object>), (f_ as IEnumerable<object>));
-		var h_ = this.Left_ventricular_systolic_dysfunction__disorder_();
-		var i_ = context.Operators.ToList<CqlCode>(h_);
-		var j_ = context.Operators.RetrieveByCodes<Condition>(i_, null);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
+		CqlValueSet e_ = this.Moderate_or_Severe_LVSD();
+		IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
+		IEnumerable<object> g_ = context.Operators.Union<object>((d_ as IEnumerable<object>), (f_ as IEnumerable<object>));
+		CqlCode h_ = this.Left_ventricular_systolic_dysfunction__disorder_();
+		IEnumerable<CqlCode> i_ = context.Operators.ToList<CqlCode>(h_);
+		IEnumerable<Condition> j_ = context.Operators.RetrieveByCodes<Condition>(i_, null);
 		bool? k_(Condition LVSDDiagnosis)
 		{
-			var y_ = LVSDDiagnosis?.Severity;
-			var z_ = FHIRHelpers_4_3_000.ToConcept(y_);
-			var aa_ = this.Moderate_or_Severe();
-			var ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+			CodeableConcept y_ = LVSDDiagnosis?.Severity;
+			CqlConcept z_ = FHIRHelpers_4_3_000.ToConcept(y_);
+			CqlValueSet aa_ = this.Moderate_or_Severe();
+			bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
 
 			return ab_;
 		};
-		var l_ = context.Operators.Where<Condition>(j_, k_);
-		var m_ = context.Operators.Union<object>(g_, (l_ as IEnumerable<object>));
+		IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
+		IEnumerable<object> m_ = context.Operators.Union<object>(g_, (l_ as IEnumerable<object>));
 
 		return m_;
 	}
 
+    /// <seealso cref="Moderate_or_Severe_LVSD_Findings_Value"/>
     [CqlDeclaration("Moderate or Severe LVSD Findings")]
 	public IEnumerable<object> Moderate_or_Severe_LVSD_Findings() => 
 		__Moderate_or_Severe_LVSD_Findings.Value;
 
+    /// <seealso cref="Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD"/>
 	private IEnumerable<Encounter> Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD_Value()
 	{
-		var a_ = this.Heart_Failure_Outpatient_Encounter();
+		IEnumerable<Encounter> a_ = this.Heart_Failure_Outpatient_Encounter();
 		IEnumerable<Encounter> b_(Encounter HFOutpatientEncounter)
 		{
-			var d_ = this.Moderate_or_Severe_LVSD_Findings();
+			IEnumerable<object> d_ = this.Moderate_or_Severe_LVSD_Findings();
 			bool? e_(object LVSDFindings)
 			{
-				var i_ = QICoreCommon_2_0_000.prevalenceInterval((LVSDFindings as Condition));
-				var j_ = context.Operators.LateBoundProperty<object>(LVSDFindings, "effective");
-				var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-				var l_ = QICoreCommon_2_0_000.toInterval(k_);
-				var m_ = context.Operators.Start((i_ ?? l_));
-				var n_ = HFOutpatientEncounter?.Period;
-				var o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var p_ = context.Operators.End(o_);
-				var q_ = context.Operators.Before(m_, p_, null);
+				CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.prevalenceInterval((LVSDFindings as Condition));
+				object j_ = context.Operators.LateBoundProperty<object>(LVSDFindings, "effective");
+				object k_ = FHIRHelpers_4_3_000.ToValue(j_);
+				CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
+				CqlDateTime m_ = context.Operators.Start((i_ ?? l_));
+				Period n_ = HFOutpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlDateTime p_ = context.Operators.End(o_);
+				bool? q_ = context.Operators.Before(m_, p_, null);
 
 				return q_;
 			};
-			var f_ = context.Operators.Where<object>(d_, e_);
+			IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
 			Encounter g_(object LVSDFindings) => 
 				HFOutpatientEncounter;
-			var h_ = context.Operators.Select<object, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD_Value"/>
     [CqlDeclaration("Heart Failure Outpatient Encounter with History of Moderate or Severe LVSD")]
 	public IEnumerable<Encounter> Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD() => 
 		__Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD.Value;
 
+    /// <seealso cref="Has_Heart_Transplant_Complications"/>
 	private bool? Has_Heart_Transplant_Complications_Value()
 	{
-		var a_ = this.Heart_Transplant_Complications();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Heart_Transplant_Complications();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		IEnumerable<Condition> c_(Condition HeartTransplantComplications)
 		{
-			var h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 			bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
 			{
-				var m_ = HeartTransplantComplications?.RecordedDateElement;
-				var n_ = context.Operators.Convert<CqlDateTime>(m_);
-				var o_ = QICoreCommon_2_0_000.toInterval((n_ as object));
-				var p_ = QICoreCommon_2_0_000.prevalenceInterval(HeartTransplantComplications);
-				var q_ = context.Operators.Start((o_ ?? p_));
-				var r_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-				var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var t_ = context.Operators.End(s_);
-				var u_ = context.Operators.Before(q_, t_, null);
+				FhirDateTime m_ = HeartTransplantComplications?.RecordedDateElement;
+				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval((n_ as object));
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.prevalenceInterval(HeartTransplantComplications);
+				CqlDateTime q_ = context.Operators.Start((o_ ?? p_));
+				Period r_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				CqlDateTime t_ = context.Operators.End(s_);
+				bool? u_ = context.Operators.Before(q_, t_, null);
 
 				return u_;
 			};
-			var j_ = context.Operators.Where<Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
 			Condition k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => 
 				HeartTransplantComplications;
-			var l_ = context.Operators.Select<Encounter, Condition>(j_, k_);
+			IEnumerable<Condition> l_ = context.Operators.Select<Encounter, Condition>(j_, k_);
 
 			return l_;
 		};
-		var d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+		IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
 		bool? e_(Condition HeartTransplantComplications)
 		{
-			var v_ = this.isConfirmedActiveDiagnosis(HeartTransplantComplications);
+			bool? v_ = this.isConfirmedActiveDiagnosis(HeartTransplantComplications);
 
 			return v_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
-		var g_ = context.Operators.Exists<Condition>(f_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+		bool? g_ = context.Operators.Exists<Condition>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Has_Heart_Transplant_Complications_Value"/>
     [CqlDeclaration("Has Heart Transplant Complications")]
 	public bool? Has_Heart_Transplant_Complications() => 
 		__Has_Heart_Transplant_Complications.Value;
 
+    /// <seealso cref="Has_Left_Ventricular_Assist_Device"/>
 	private bool? Has_Left_Ventricular_Assist_Device_Value()
 	{
-		var a_ = this.Left_Ventricular_Assist_Device_Placement();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		CqlValueSet a_ = this.Left_Ventricular_Assist_Device_Placement();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		IEnumerable<Procedure> c_(Procedure LVADOutpatient)
 		{
-			var h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 			bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
 			{
-				var m_ = LVADOutpatient?.Performed;
-				var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var o_ = QICoreCommon_2_0_000.toInterval(n_);
-				var p_ = context.Operators.Start(o_);
-				var q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-				var r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				var s_ = context.Operators.End(r_);
-				var t_ = context.Operators.Before(p_, s_, null);
+				DataType m_ = LVADOutpatient?.Performed;
+				object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				Period q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
+				CqlDateTime s_ = context.Operators.End(r_);
+				bool? t_ = context.Operators.Before(p_, s_, null);
 
 				return t_;
 			};
-			var j_ = context.Operators.Where<Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
 			Procedure k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => 
 				LVADOutpatient;
-			var l_ = context.Operators.Select<Encounter, Procedure>(j_, k_);
+			IEnumerable<Procedure> l_ = context.Operators.Select<Encounter, Procedure>(j_, k_);
 
 			return l_;
 		};
-		var d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+		IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
 		bool? e_(Procedure LVADOutpatient)
 		{
-			var u_ = LVADOutpatient?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<string>(v_);
-			var x_ = context.Operators.Equal(w_, "completed");
+			Code<EventStatus> u_ = LVADOutpatient?.StatusElement;
+			EventStatus? v_ = u_?.Value;
+			string w_ = context.Operators.Convert<string>(v_);
+			bool? x_ = context.Operators.Equal(w_, "completed");
 
 			return x_;
 		};
-		var f_ = context.Operators.Where<Procedure>(d_, e_);
-		var g_ = context.Operators.Exists<Procedure>(f_);
+		IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);
+		bool? g_ = context.Operators.Exists<Procedure>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Has_Left_Ventricular_Assist_Device_Value"/>
     [CqlDeclaration("Has Left Ventricular Assist Device")]
 	public bool? Has_Left_Ventricular_Assist_Device() => 
 		__Has_Left_Ventricular_Assist_Device.Value;
 
+    /// <seealso cref="Has_Left_Ventricular_Assist_Device_Complications"/>
 	private bool? Has_Left_Ventricular_Assist_Device_Complications_Value()
 	{
-		var a_ = this.Left_Ventricular_Assist_Device_Complications();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Left_Ventricular_Assist_Device_Complications();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		IEnumerable<Condition> c_(Condition LVADComplications)
 		{
-			var h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 			bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
 			{
-				var m_ = LVADComplications?.RecordedDateElement;
-				var n_ = context.Operators.Convert<CqlDateTime>(m_);
-				var o_ = QICoreCommon_2_0_000.toInterval((n_ as object));
-				var p_ = QICoreCommon_2_0_000.prevalenceInterval(LVADComplications);
-				var q_ = context.Operators.Start((o_ ?? p_));
-				var r_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-				var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var t_ = context.Operators.End(s_);
-				var u_ = context.Operators.Before(q_, t_, null);
+				FhirDateTime m_ = LVADComplications?.RecordedDateElement;
+				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval((n_ as object));
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.prevalenceInterval(LVADComplications);
+				CqlDateTime q_ = context.Operators.Start((o_ ?? p_));
+				Period r_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				CqlDateTime t_ = context.Operators.End(s_);
+				bool? u_ = context.Operators.Before(q_, t_, null);
 
 				return u_;
 			};
-			var j_ = context.Operators.Where<Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
 			Condition k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => 
 				LVADComplications;
-			var l_ = context.Operators.Select<Encounter, Condition>(j_, k_);
+			IEnumerable<Condition> l_ = context.Operators.Select<Encounter, Condition>(j_, k_);
 
 			return l_;
 		};
-		var d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+		IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
 		bool? e_(Condition LVADComplications)
 		{
-			var v_ = this.isConfirmedActiveDiagnosis(LVADComplications);
+			bool? v_ = this.isConfirmedActiveDiagnosis(LVADComplications);
 
 			return v_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
-		var g_ = context.Operators.Exists<Condition>(f_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+		bool? g_ = context.Operators.Exists<Condition>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Has_Left_Ventricular_Assist_Device_Complications_Value"/>
     [CqlDeclaration("Has Left Ventricular Assist Device Complications")]
 	public bool? Has_Left_Ventricular_Assist_Device_Complications() => 
 		__Has_Left_Ventricular_Assist_Device_Complications.Value;
 
+    /// <seealso cref="Qualifying_Outpatient_Encounter_During_Measurement_Period"/>
 	private IEnumerable<Encounter> Qualifying_Outpatient_Encounter_During_Measurement_Period_Value()
 	{
-		var a_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Home_Healthcare_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Nursing_Facility_Visit();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Office_Visit();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Outpatient_Consultation();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Patient_Provider_Interaction();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet a_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Nursing_Facility_Visit();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Office_Visit();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Patient_Provider_Interaction();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		bool? r_(Encounter ValidEncounter)
 		{
-			var t_ = this.Measurement_Period();
-			var u_ = ValidEncounter?.Period;
-			var v_ = FHIRHelpers_4_3_000.ToInterval(u_);
-			var w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
-			var x_ = this.isFinished(ValidEncounter);
-			var y_ = context.Operators.And(w_, x_);
+			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
+			Period u_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(u_);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
+			bool? x_ = this.isFinished(ValidEncounter);
+			bool? y_ = context.Operators.And(w_, x_);
 
 			return y_;
 		};
-		var s_ = context.Operators.Where<Encounter>(q_, r_);
+		IEnumerable<Encounter> s_ = context.Operators.Where<Encounter>(q_, r_);
 
 		return s_;
 	}
 
+    /// <seealso cref="Qualifying_Outpatient_Encounter_During_Measurement_Period_Value"/>
     [CqlDeclaration("Qualifying Outpatient Encounter During Measurement Period")]
 	public IEnumerable<Encounter> Qualifying_Outpatient_Encounter_During_Measurement_Period() => 
 		__Qualifying_Outpatient_Encounter_During_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Two_Qualifying_Outpatient_Encounters_and_Heart_Failure_Outpatient_Encounter_During_the_Measurement_Period"/>
 	private bool? Has_Two_Qualifying_Outpatient_Encounters_and_Heart_Failure_Outpatient_Encounter_During_the_Measurement_Period_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 18);
-		var h_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period();
-		IEnumerable<Encounter> i_(Encounter Encounter1)
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+		IEnumerable<Encounter> j_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period();
+		IEnumerable<Encounter> k_(Encounter Encounter1)
 		{
-			var p_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period();
-			bool? q_(Encounter Encounter2)
+			IEnumerable<Encounter> r_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period();
+			bool? s_(Encounter Encounter2)
 			{
-				var u_ = Encounter2?.IdElement;
-				var v_ = u_?.Value;
-				var w_ = Encounter1?.IdElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Equivalent(v_, x_);
-				var z_ = context.Operators.Not(y_);
+				Id w_ = Encounter2?.IdElement;
+				string x_ = w_?.Value;
+				Id y_ = Encounter1?.IdElement;
+				string z_ = y_?.Value;
+				bool? aa_ = context.Operators.Equivalent(x_, z_);
+				bool? ab_ = context.Operators.Not(aa_);
 
-				return z_;
+				return ab_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
-			Encounter s_(Encounter Encounter2) => 
+			IEnumerable<Encounter> t_ = context.Operators.Where<Encounter>(r_, s_);
+			Encounter u_(Encounter Encounter2) => 
 				Encounter1;
-			var t_ = context.Operators.Select<Encounter, Encounter>(r_, s_);
+			IEnumerable<Encounter> v_ = context.Operators.Select<Encounter, Encounter>(t_, u_);
 
-			return t_;
+			return v_;
 		};
-		var j_ = context.Operators.SelectMany<Encounter, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
-		var l_ = context.Operators.And(g_, k_);
-		var m_ = this.Heart_Failure_Outpatient_Encounter();
-		var n_ = context.Operators.Exists<Encounter>(m_);
-		var o_ = context.Operators.And(l_, n_);
+		IEnumerable<Encounter> l_ = context.Operators.SelectMany<Encounter, Encounter>(j_, k_);
+		bool? m_ = context.Operators.Exists<Encounter>(l_);
+		bool? n_ = context.Operators.And(i_, m_);
+		IEnumerable<Encounter> o_ = this.Heart_Failure_Outpatient_Encounter();
+		bool? p_ = context.Operators.Exists<Encounter>(o_);
+		bool? q_ = context.Operators.And(n_, p_);
 
-		return o_;
+		return q_;
 	}
 
+    /// <seealso cref="Has_Two_Qualifying_Outpatient_Encounters_and_Heart_Failure_Outpatient_Encounter_During_the_Measurement_Period_Value"/>
     [CqlDeclaration("Has Two Qualifying Outpatient Encounters and Heart Failure Outpatient Encounter During the Measurement Period")]
 	public bool? Has_Two_Qualifying_Outpatient_Encounters_and_Heart_Failure_Outpatient_Encounter_During_the_Measurement_Period() => 
 		__Has_Two_Qualifying_Outpatient_Encounters_and_Heart_Failure_Outpatient_Encounter_During_the_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Heart_Transplant"/>
 	private bool? Has_Heart_Transplant_Value()
 	{
-		var a_ = this.Heart_Transplant();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		CqlValueSet a_ = this.Heart_Transplant();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		IEnumerable<Procedure> c_(Procedure HeartTransplant)
 		{
-			var h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 			bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
 			{
-				var m_ = HeartTransplant?.Performed;
-				var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var o_ = QICoreCommon_2_0_000.toInterval(n_);
-				var p_ = context.Operators.Start(o_);
-				var q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-				var r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				var s_ = context.Operators.End(r_);
-				var t_ = context.Operators.Before(p_, s_, null);
+				DataType m_ = HeartTransplant?.Performed;
+				object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				Period q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
+				CqlDateTime s_ = context.Operators.End(r_);
+				bool? t_ = context.Operators.Before(p_, s_, null);
 
 				return t_;
 			};
-			var j_ = context.Operators.Where<Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
 			Procedure k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => 
 				HeartTransplant;
-			var l_ = context.Operators.Select<Encounter, Procedure>(j_, k_);
+			IEnumerable<Procedure> l_ = context.Operators.Select<Encounter, Procedure>(j_, k_);
 
 			return l_;
 		};
-		var d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+		IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
 		bool? e_(Procedure HeartTransplant)
 		{
-			var u_ = HeartTransplant?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<string>(v_);
-			var x_ = context.Operators.Equal(w_, "completed");
+			Code<EventStatus> u_ = HeartTransplant?.StatusElement;
+			EventStatus? v_ = u_?.Value;
+			string w_ = context.Operators.Convert<string>(v_);
+			bool? x_ = context.Operators.Equal(w_, "completed");
 
 			return x_;
 		};
-		var f_ = context.Operators.Where<Procedure>(d_, e_);
-		var g_ = context.Operators.Exists<Procedure>(f_);
+		IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);
+		bool? g_ = context.Operators.Exists<Procedure>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Has_Heart_Transplant_Value"/>
     [CqlDeclaration("Has Heart Transplant")]
 	public bool? Has_Heart_Transplant() => 
 		__Has_Heart_Transplant.Value;
@@ -743,28 +805,28 @@ public class AHAOverall_2_6_000
     [CqlDeclaration("isOrderedDuringHeartFailureOutpatientEncounter")]
 	public bool? isOrderedDuringHeartFailureOutpatientEncounter(MedicationRequest Order)
 	{
-		var a_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+		IEnumerable<Encounter> a_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 		bool? b_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
 		{
-			var e_ = Order?.AuthoredOnElement;
-			var f_ = context.Operators.Convert<CqlDateTime>(e_);
-			var g_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.In<CqlDateTime>(f_, h_, "day");
-			var j_ = Order?.StatusElement;
-			var k_ = j_?.Value;
-			var l_ = context.Operators.Convert<string>(k_);
-			var m_ = new string[]
+			FhirDateTime e_ = Order?.AuthoredOnElement;
+			CqlDateTime f_ = context.Operators.Convert<CqlDateTime>(e_);
+			Period g_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+			bool? i_ = context.Operators.In<CqlDateTime>(f_, h_, "day");
+			Code<MedicationRequest.MedicationrequestStatus> j_ = Order?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? k_ = j_?.Value;
+			string l_ = context.Operators.Convert<string>(k_);
+			string[] m_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var n_ = context.Operators.In<string>(l_, (m_ as IEnumerable<string>));
-			var o_ = context.Operators.And(i_, n_);
-			var p_ = Order?.IntentElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<string>(q_);
-			var s_ = new string[]
+			bool? n_ = context.Operators.In<string>(l_, (m_ as IEnumerable<string>));
+			bool? o_ = context.Operators.And(i_, n_);
+			Code<MedicationRequest.MedicationRequestIntent> p_ = Order?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? q_ = p_?.Value;
+			string r_ = context.Operators.Convert<string>(q_);
+			string[] s_ = new string[]
 			{
 				"order",
 				"original-order",
@@ -772,18 +834,18 @@ public class AHAOverall_2_6_000
 				"filler-order",
 				"instance-order",
 			};
-			var t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
-			var u_ = context.Operators.And(o_, t_);
-			var v_ = Order?.DoNotPerformElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.IsTrue(w_);
-			var y_ = context.Operators.Not(x_);
-			var z_ = context.Operators.And(u_, y_);
+			bool? t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
+			bool? u_ = context.Operators.And(o_, t_);
+			FhirBoolean v_ = Order?.DoNotPerformElement;
+			bool? w_ = v_?.Value;
+			bool? x_ = context.Operators.IsTrue(w_);
+			bool? y_ = context.Operators.Not(x_);
+			bool? z_ = context.Operators.And(u_, y_);
 
 			return z_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
-		var d_ = context.Operators.Exists<Encounter>(c_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+		bool? d_ = context.Operators.Exists<Encounter>(c_);
 
 		return d_;
 	}
@@ -791,20 +853,20 @@ public class AHAOverall_2_6_000
     [CqlDeclaration("overlapsHeartFailureOutpatientEncounter")]
 	public bool? overlapsHeartFailureOutpatientEncounter(Condition Diagnosis)
 	{
-		var a_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+		IEnumerable<Encounter> a_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 		bool? b_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
 		{
-			var e_ = QICoreCommon_2_0_000.prevalenceInterval(Diagnosis);
-			var f_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-			var g_ = FHIRHelpers_4_3_000.ToInterval(f_);
-			var h_ = context.Operators.Overlaps(e_, g_, "day");
-			var i_ = this.isConfirmedActiveDiagnosis(Diagnosis);
-			var j_ = context.Operators.And(h_, i_);
+			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.prevalenceInterval(Diagnosis);
+			Period f_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_3_000.ToInterval(f_);
+			bool? h_ = context.Operators.Overlaps(e_, g_, "day");
+			bool? i_ = this.isConfirmedActiveDiagnosis(Diagnosis);
+			bool? j_ = context.Operators.And(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
-		var d_ = context.Operators.Exists<Encounter>(c_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+		bool? d_ = context.Operators.Exists<Encounter>(c_);
 
 		return d_;
 	}
@@ -812,178 +874,178 @@ public class AHAOverall_2_6_000
     [CqlDeclaration("overlapsAfterHeartFailureOutpatientEncounter")]
 	public bool? overlapsAfterHeartFailureOutpatientEncounter(object Event)
 	{
-		var a_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+		IEnumerable<Encounter> a_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 		bool? b_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
 		{
 			bool? e_()
 			{
 				if (Event is Condition)
 				{
-					var f_ = QICoreCommon_2_0_000.prevalenceInterval((Event as Condition));
-					var g_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-					var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-					var i_ = context.Operators.OverlapsAfter(f_, h_, "day");
-					var j_ = this.isConfirmedActiveDiagnosis((Event as Condition));
-					var k_ = context.Operators.And(i_, j_);
+					CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval((Event as Condition));
+					Period g_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+					CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+					bool? i_ = context.Operators.OverlapsAfter(f_, h_, "day");
+					bool? j_ = this.isConfirmedActiveDiagnosis((Event as Condition));
+					bool? k_ = context.Operators.And(i_, j_);
 
 					return k_;
 				}
 				else if (Event is Procedure)
 				{
-					var l_ = (Event as Procedure)?.Performed;
-					var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-					var n_ = QICoreCommon_2_0_000.toInterval(m_);
-					var o_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-					var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-					var q_ = context.Operators.OverlapsAfter(n_, p_, "day");
-					var r_ = (Event as Procedure)?.StatusElement;
-					var s_ = r_?.Value;
-					var t_ = context.Operators.Convert<string>(s_);
-					var u_ = context.Operators.Equal(t_, "completed");
-					var v_ = context.Operators.And(q_, u_);
+					DataType l_ = (Event as Procedure)?.Performed;
+					object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+					CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
+					Period o_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+					CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+					bool? q_ = context.Operators.OverlapsAfter(n_, p_, "day");
+					Code<EventStatus> r_ = (Event as Procedure)?.StatusElement;
+					EventStatus? s_ = r_?.Value;
+					string t_ = context.Operators.Convert<string>(s_);
+					bool? u_ = context.Operators.Equal(t_, "completed");
+					bool? v_ = context.Operators.And(q_, u_);
 
 					return v_;
 				}
 				else if (Event is AllergyIntolerance)
 				{
-					var w_ = (Event as AllergyIntolerance)?.Onset;
-					var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-					var y_ = QICoreCommon_2_0_000.toInterval(x_);
-					var z_ = context.Operators.Start(y_);
-					var aa_ = (Event as AllergyIntolerance)?.LastOccurrenceElement;
-					var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-					var ac_ = context.Operators.Interval(z_, ab_, true, true);
-					var ad_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-					var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-					var af_ = context.Operators.OverlapsAfter(ac_, ae_, "day");
-					var ag_ = (Event as AllergyIntolerance)?.ClinicalStatus;
-					var ah_ = FHIRHelpers_4_3_000.ToConcept(ag_);
-					var ai_ = QICoreCommon_2_0_000.allergy_active();
-					var aj_ = context.Operators.ConvertCodeToConcept(ai_);
-					var ak_ = context.Operators.Equivalent(ah_, aj_);
-					var al_ = context.Operators.And(af_, ak_);
-					var am_ = (Event as AllergyIntolerance)?.VerificationStatus;
-					var an_ = FHIRHelpers_4_3_000.ToConcept(am_);
-					var ao_ = QICoreCommon_2_0_000.allergy_unconfirmed();
-					var ap_ = context.Operators.ConvertCodeToConcept(ao_);
-					var aq_ = context.Operators.Equivalent(an_, ap_);
-					var as_ = FHIRHelpers_4_3_000.ToConcept(am_);
-					var at_ = QICoreCommon_2_0_000.allergy_refuted();
-					var au_ = context.Operators.ConvertCodeToConcept(at_);
-					var av_ = context.Operators.Equivalent(as_, au_);
-					var aw_ = context.Operators.Or(aq_, av_);
-					var ay_ = FHIRHelpers_4_3_000.ToConcept(am_);
-					var az_ = this.allergy_entered_in_error();
-					var ba_ = context.Operators.ConvertCodeToConcept(az_);
-					var bb_ = context.Operators.Equivalent(ay_, ba_);
-					var bc_ = context.Operators.Or(aw_, bb_);
-					var bd_ = context.Operators.Not(bc_);
-					var be_ = context.Operators.And(al_, bd_);
+					DataType w_ = (Event as AllergyIntolerance)?.Onset;
+					object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+					CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
+					CqlDateTime z_ = context.Operators.Start(y_);
+					FhirDateTime aa_ = (Event as AllergyIntolerance)?.LastOccurrenceElement;
+					CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+					CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(z_, ab_, true, true);
+					Period ad_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+					CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+					bool? af_ = context.Operators.OverlapsAfter(ac_, ae_, "day");
+					CodeableConcept ag_ = (Event as AllergyIntolerance)?.ClinicalStatus;
+					CqlConcept ah_ = FHIRHelpers_4_3_000.ToConcept(ag_);
+					CqlCode ai_ = QICoreCommon_2_0_000.allergy_active();
+					CqlConcept aj_ = context.Operators.ConvertCodeToConcept(ai_);
+					bool? ak_ = context.Operators.Equivalent(ah_, aj_);
+					bool? al_ = context.Operators.And(af_, ak_);
+					CodeableConcept am_ = (Event as AllergyIntolerance)?.VerificationStatus;
+					CqlConcept an_ = FHIRHelpers_4_3_000.ToConcept(am_);
+					CqlCode ao_ = QICoreCommon_2_0_000.allergy_unconfirmed();
+					CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+					bool? aq_ = context.Operators.Equivalent(an_, ap_);
+					CqlConcept as_ = FHIRHelpers_4_3_000.ToConcept(am_);
+					CqlCode at_ = QICoreCommon_2_0_000.allergy_refuted();
+					CqlConcept au_ = context.Operators.ConvertCodeToConcept(at_);
+					bool? av_ = context.Operators.Equivalent(as_, au_);
+					bool? aw_ = context.Operators.Or(aq_, av_);
+					CqlConcept ay_ = FHIRHelpers_4_3_000.ToConcept(am_);
+					CqlCode az_ = this.allergy_entered_in_error();
+					CqlConcept ba_ = context.Operators.ConvertCodeToConcept(az_);
+					bool? bb_ = context.Operators.Equivalent(ay_, ba_);
+					bool? bc_ = context.Operators.Or(aw_, bb_);
+					bool? bd_ = context.Operators.Not(bc_);
+					bool? be_ = context.Operators.And(al_, bd_);
 
 					return be_;
 				}
 				else if (Event is MedicationRequest)
 				{
-					var bf_ = context.Operators.LateBoundProperty<object>(Event, "dosageInstruction");
-					var bg_ = new object[]
+					object bf_ = context.Operators.LateBoundProperty<object>(Event, "dosageInstruction");
+					object[] bg_ = new object[]
 					{
 						bf_,
 					};
 					bool? bh_(object @this)
 					{
-						var cz_ = context.Operators.LateBoundProperty<object>(@this, "timing");
-						var da_ = context.Operators.Not((bool?)(cz_ is null));
+						object cz_ = context.Operators.LateBoundProperty<object>(@this, "timing");
+						bool? da_ = context.Operators.Not((bool?)(cz_ is null));
 
 						return da_;
 					};
-					var bi_ = context.Operators.Where<object>((IEnumerable<object>)bg_, bh_);
+					IEnumerable<object> bi_ = context.Operators.Where<object>((IEnumerable<object>)bg_, bh_);
 					object bj_(object @this)
 					{
-						var db_ = context.Operators.LateBoundProperty<object>(@this, "timing");
+						object db_ = context.Operators.LateBoundProperty<object>(@this, "timing");
 
 						return db_;
 					};
-					var bk_ = context.Operators.Select<object, object>(bi_, bj_);
-					var bl_ = context.Operators.SingletonFrom<object>(bk_);
-					var bm_ = new object[]
+					IEnumerable<object> bk_ = context.Operators.Select<object, object>(bi_, bj_);
+					object bl_ = context.Operators.SingletonFrom<object>(bk_);
+					object[] bm_ = new object[]
 					{
 						bl_,
 					};
 					bool? bn_(object @this)
 					{
-						var dc_ = context.Operators.LateBoundProperty<object>(@this, "repeat");
-						var dd_ = context.Operators.Not((bool?)(dc_ is null));
+						object dc_ = context.Operators.LateBoundProperty<object>(@this, "repeat");
+						bool? dd_ = context.Operators.Not((bool?)(dc_ is null));
 
 						return dd_;
 					};
-					var bo_ = context.Operators.Where<object>((IEnumerable<object>)bm_, bn_);
+					IEnumerable<object> bo_ = context.Operators.Where<object>((IEnumerable<object>)bm_, bn_);
 					object bp_(object @this)
 					{
-						var de_ = context.Operators.LateBoundProperty<object>(@this, "repeat");
+						object de_ = context.Operators.LateBoundProperty<object>(@this, "repeat");
 
 						return de_;
 					};
-					var bq_ = context.Operators.Select<object, object>(bo_, bp_);
-					var br_ = context.Operators.SingletonFrom<object>(bq_);
-					var bs_ = new object[]
+					IEnumerable<object> bq_ = context.Operators.Select<object, object>(bo_, bp_);
+					object br_ = context.Operators.SingletonFrom<object>(bq_);
+					object[] bs_ = new object[]
 					{
 						br_,
 					};
 					bool? bt_(object @this)
 					{
-						var df_ = context.Operators.LateBoundProperty<object>(@this, "bounds");
-						var dg_ = FHIRHelpers_4_3_000.ToValue(df_);
-						var dh_ = context.Operators.Not((bool?)(dg_ is null));
+						object df_ = context.Operators.LateBoundProperty<object>(@this, "bounds");
+						object dg_ = FHIRHelpers_4_3_000.ToValue(df_);
+						bool? dh_ = context.Operators.Not((bool?)(dg_ is null));
 
 						return dh_;
 					};
-					var bu_ = context.Operators.Where<object>((IEnumerable<object>)bs_, bt_);
+					IEnumerable<object> bu_ = context.Operators.Where<object>((IEnumerable<object>)bs_, bt_);
 					object bv_(object @this)
 					{
-						var di_ = context.Operators.LateBoundProperty<object>(@this, "bounds");
-						var dj_ = FHIRHelpers_4_3_000.ToValue(di_);
+						object di_ = context.Operators.LateBoundProperty<object>(@this, "bounds");
+						object dj_ = FHIRHelpers_4_3_000.ToValue(di_);
 
 						return dj_;
 					};
-					var bw_ = context.Operators.Select<object, object>(bu_, bv_);
-					var bx_ = context.Operators.SingletonFrom<object>(bw_);
-					var by_ = new object[]
+					IEnumerable<object> bw_ = context.Operators.Select<object, object>(bu_, bv_);
+					object bx_ = context.Operators.SingletonFrom<object>(bw_);
+					object[] by_ = new object[]
 					{
 						bx_,
 					};
 					CqlInterval<CqlDateTime> bz_(object DoseTime)
 					{
-						var dk_ = QICoreCommon_2_0_000.toInterval(DoseTime);
+						CqlInterval<CqlDateTime> dk_ = QICoreCommon_2_0_000.toInterval(DoseTime);
 
 						return dk_;
 					};
-					var ca_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>((IEnumerable<object>)by_, bz_);
-					var cb_ = context.Operators.Collapse(ca_, null);
+					IEnumerable<CqlInterval<CqlDateTime>> ca_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>((IEnumerable<object>)by_, bz_);
+					IEnumerable<CqlInterval<CqlDateTime>> cb_ = context.Operators.Collapse(ca_, null);
 					object cc_(CqlInterval<CqlDateTime> @this)
 					{
-						var dl_ = context.Operators.Start(@this);
+						CqlDateTime dl_ = context.Operators.Start(@this);
 
 						return dl_;
 					};
-					var cd_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(cb_, cc_, System.ComponentModel.ListSortDirection.Ascending);
-					var ce_ = context.Operators.First<CqlInterval<CqlDateTime>>(cd_);
-					var cf_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-					var cg_ = FHIRHelpers_4_3_000.ToInterval(cf_);
-					var ch_ = context.Operators.OverlapsAfter(ce_, cg_, "day");
-					var ci_ = (Event as MedicationRequest)?.StatusElement;
-					var cj_ = ci_?.Value;
-					var ck_ = context.Operators.Convert<string>(cj_);
-					var cl_ = new string[]
+					IEnumerable<CqlInterval<CqlDateTime>> cd_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(cb_, cc_, System.ComponentModel.ListSortDirection.Ascending);
+					CqlInterval<CqlDateTime> ce_ = context.Operators.First<CqlInterval<CqlDateTime>>(cd_);
+					Period cf_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+					CqlInterval<CqlDateTime> cg_ = FHIRHelpers_4_3_000.ToInterval(cf_);
+					bool? ch_ = context.Operators.OverlapsAfter(ce_, cg_, "day");
+					Code<MedicationRequest.MedicationrequestStatus> ci_ = (Event as MedicationRequest)?.StatusElement;
+					MedicationRequest.MedicationrequestStatus? cj_ = ci_?.Value;
+					string ck_ = context.Operators.Convert<string>(cj_);
+					string[] cl_ = new string[]
 					{
 						"active",
 						"completed",
 					};
-					var cm_ = context.Operators.In<string>(ck_, (cl_ as IEnumerable<string>));
-					var cn_ = context.Operators.And(ch_, cm_);
-					var co_ = (Event as MedicationRequest)?.IntentElement;
-					var cp_ = co_?.Value;
-					var cq_ = context.Operators.Convert<string>(cp_);
-					var cr_ = new string[]
+					bool? cm_ = context.Operators.In<string>(ck_, (cl_ as IEnumerable<string>));
+					bool? cn_ = context.Operators.And(ch_, cm_);
+					Code<MedicationRequest.MedicationRequestIntent> co_ = (Event as MedicationRequest)?.IntentElement;
+					MedicationRequest.MedicationRequestIntent? cp_ = co_?.Value;
+					string cq_ = context.Operators.Convert<string>(cp_);
+					string[] cr_ = new string[]
 					{
 						"order",
 						"original-order",
@@ -991,35 +1053,35 @@ public class AHAOverall_2_6_000
 						"filler-order",
 						"instance-order",
 					};
-					var cs_ = context.Operators.In<string>(cq_, (cr_ as IEnumerable<string>));
-					var ct_ = context.Operators.And(cn_, cs_);
-					var cu_ = (Event as MedicationRequest)?.DoNotPerformElement;
-					var cv_ = cu_?.Value;
-					var cw_ = context.Operators.IsTrue(cv_);
-					var cx_ = context.Operators.Not(cw_);
-					var cy_ = context.Operators.And(ct_, cx_);
+					bool? cs_ = context.Operators.In<string>(cq_, (cr_ as IEnumerable<string>));
+					bool? ct_ = context.Operators.And(cn_, cs_);
+					FhirBoolean cu_ = (Event as MedicationRequest)?.DoNotPerformElement;
+					bool? cv_ = cu_?.Value;
+					bool? cw_ = context.Operators.IsTrue(cv_);
+					bool? cx_ = context.Operators.Not(cw_);
+					bool? cy_ = context.Operators.And(ct_, cx_);
 
 					return cy_;
 				}
 				else if (Event is Observation)
 				{
-					var dm_ = (Event as Observation)?.Effective;
-					var dn_ = FHIRHelpers_4_3_000.ToValue(dm_);
-					var do_ = QICoreCommon_2_0_000.toInterval(dn_);
-					var dp_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-					var dq_ = FHIRHelpers_4_3_000.ToInterval(dp_);
-					var dr_ = context.Operators.OverlapsAfter(do_, dq_, "day");
-					var ds_ = (Event as Observation)?.StatusElement;
-					var dt_ = ds_?.Value;
-					var du_ = context.Operators.Convert<string>(dt_);
-					var dv_ = new string[]
+					DataType dm_ = (Event as Observation)?.Effective;
+					object dn_ = FHIRHelpers_4_3_000.ToValue(dm_);
+					CqlInterval<CqlDateTime> do_ = QICoreCommon_2_0_000.toInterval(dn_);
+					Period dp_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+					CqlInterval<CqlDateTime> dq_ = FHIRHelpers_4_3_000.ToInterval(dp_);
+					bool? dr_ = context.Operators.OverlapsAfter(do_, dq_, "day");
+					Code<ObservationStatus> ds_ = (Event as Observation)?.StatusElement;
+					ObservationStatus? dt_ = ds_?.Value;
+					string du_ = context.Operators.Convert<string>(dt_);
+					string[] dv_ = new string[]
 					{
 						"final",
 						"amended",
 						"corrected",
 					};
-					var dw_ = context.Operators.In<string>(du_, (dv_ as IEnumerable<string>));
-					var dx_ = context.Operators.And(dr_, dw_);
+					bool? dw_ = context.Operators.In<string>(du_, (dv_ as IEnumerable<string>));
+					bool? dx_ = context.Operators.And(dr_, dw_);
 
 					return dx_;
 				}
@@ -1031,8 +1093,8 @@ public class AHAOverall_2_6_000
 
 			return e_();
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
-		var d_ = context.Operators.Exists<Encounter>(c_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+		bool? d_ = context.Operators.Exists<Encounter>(c_);
 
 		return d_;
 	}

--- a/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
@@ -74,38 +74,47 @@ public class ALARACTOQRFHIR_0_1_001
 
     #endregion
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Calculated_CT_global_noise"/>
 	private CqlCode Calculated_CT_global_noise_Value() => 
 		new CqlCode("96912-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="Calculated_CT_global_noise_Value"/>
     [CqlDeclaration("Calculated CT global noise")]
 	public CqlCode Calculated_CT_global_noise() => 
 		__Calculated_CT_global_noise.Value;
 
+    /// <seealso cref="Calculated_CT_size_adjusted_dose"/>
 	private CqlCode Calculated_CT_size_adjusted_dose_Value() => 
 		new CqlCode("96913-9", "http://loinc.org", null, null);
 
+    /// <seealso cref="Calculated_CT_size_adjusted_dose_Value"/>
     [CqlDeclaration("Calculated CT size-adjusted dose")]
 	public CqlCode Calculated_CT_size_adjusted_dose() => 
 		__Calculated_CT_size_adjusted_dose.Value;
 
+    /// <seealso cref="CT_dose_and_image_quality_category"/>
 	private CqlCode CT_dose_and_image_quality_category_Value() => 
 		new CqlCode("96914-7", "http://loinc.org", null, null);
 
+    /// <seealso cref="CT_dose_and_image_quality_category_Value"/>
     [CqlDeclaration("CT dose and image quality category")]
 	public CqlCode CT_dose_and_image_quality_category() => 
 		__CT_dose_and_image_quality_category.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("96912-1", "http://loinc.org", null, null),
 			new CqlCode("96913-9", "http://loinc.org", null, null),
@@ -115,99 +124,108 @@ public class ALARACTOQRFHIR_0_1_001
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("ALARACTOQRFHIR-0.1.001", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("ALARACTOQRFHIR-0.1.001", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualified_Scan"/>
 	private IEnumerable<Observation> Qualified_Scan_Value()
 	{
-		var a_ = this.CT_dose_and_image_quality_category();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.CT_dose_and_image_quality_category();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation CTScan)
 		{
-			var f_ = this.Measurement_Period();
-			var g_ = CTScan?.Effective;
-			var h_ = FHIRHelpers_4_3_000.ToValue(g_);
-			var i_ = QICoreCommon_2_0_000.ToInterval(h_);
-			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, null);
-			var k_ = this.Patient();
-			var l_ = k_?.BirthDateElement;
-			var m_ = l_?.Value;
-			var n_ = context.Operators.Convert<CqlDate>(m_);
-			var p_ = context.Operators.Start(f_);
-			var q_ = context.Operators.DateFrom(p_);
-			var r_ = context.Operators.CalculateAgeAt(n_, q_, "year");
-			var s_ = context.Operators.GreaterOrEqual(r_, 18);
-			var t_ = context.Operators.And(j_, s_);
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			DataType g_ = CTScan?.Effective;
+			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
+			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToInterval(h_);
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, null);
+			Patient k_ = this.Patient();
+			Date l_ = k_?.BirthDateElement;
+			string m_ = l_?.Value;
+			CqlDate n_ = context.Operators.Convert<CqlDate>(m_);
+			CqlDateTime p_ = context.Operators.Start(f_);
+			CqlDate q_ = context.Operators.DateFrom(p_);
+			int? r_ = context.Operators.CalculateAgeAt(n_, q_, "year");
+			bool? s_ = context.Operators.GreaterOrEqual(r_, 18);
+			bool? t_ = context.Operators.And(j_, s_);
 
 			return t_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Qualified_Scan_Value"/>
     [CqlDeclaration("Qualified Scan")]
 	public IEnumerable<Observation> Qualified_Scan() => 
 		__Qualified_Scan.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Observation> Initial_Population_Value()
 	{
-		var a_ = this.Qualified_Scan();
+		IEnumerable<Observation> a_ = this.Qualified_Scan();
 		IEnumerable<Observation> c_(Observation CTScan)
 		{
-			var f_ = this.Encounter_Inpatient();
-			var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+			CqlValueSet f_ = this.Encounter_Inpatient();
+			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
 			bool? h_(Encounter InpatientEncounter)
 			{
-				var l_ = this.Measurement_Period();
-				var m_ = CTScan?.Effective;
-				var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var o_ = QICoreCommon_2_0_000.ToInterval(n_);
-				var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
+				CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
+				DataType m_ = CTScan?.Effective;
+				object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval(n_);
+				bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
 
 				return p_;
 			};
-			var i_ = context.Operators.Where<Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
 			Observation j_(Encounter InpatientEncounter) => 
 				CTScan;
-			var k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+			IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
 
 			return k_;
 		};
-		var d_ = context.Operators.SelectMany<Observation, Observation>(a_, c_);
-		var e_ = context.Operators.Except<Observation>(a_, d_);
+		IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(a_, c_);
+		IEnumerable<Observation> e_ = context.Operators.Except<Observation>(a_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Observation> Initial_Population() => 
 		__Initial_Population.Value;
@@ -215,127 +233,133 @@ public class ALARACTOQRFHIR_0_1_001
     [CqlDeclaration("Global Noise Value")]
 	public decimal? Global_Noise_Value(Observation Obs)
 	{
-		bool? a_(Observation.ComponentComponent C)
+		List<Observation.ComponentComponent> a_ = Obs?.Component;
+		bool? b_(Observation.ComponentComponent C)
 		{
-			var f_ = C?.Code;
-			var g_ = FHIRHelpers_4_3_000.ToConcept(f_);
-			var h_ = this.Calculated_CT_global_noise();
-			var i_ = context.Operators.ConvertCodeToConcept(h_);
-			var j_ = context.Operators.Equivalent(g_, i_);
-			var k_ = C?.Value;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = (l_ as CqlQuantity)?.unit;
-			var n_ = context.Operators.Equal(m_, "[hnsf'U]");
-			var o_ = context.Operators.And(j_, n_);
+			CodeableConcept g_ = C?.Code;
+			CqlConcept h_ = FHIRHelpers_4_3_000.ToConcept(g_);
+			CqlCode i_ = this.Calculated_CT_global_noise();
+			CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+			bool? k_ = context.Operators.Equivalent(h_, j_);
+			DataType l_ = C?.Value;
+			object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+			string n_ = (m_ as CqlQuantity)?.unit;
+			bool? o_ = context.Operators.Equal(n_, "[hnsf'U]");
+			bool? p_ = context.Operators.And(k_, o_);
 
-			return o_;
+			return p_;
 		};
-		var b_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)Obs?.Component, a_);
-		decimal? c_(Observation.ComponentComponent C)
+		IEnumerable<Observation.ComponentComponent> c_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)a_, b_);
+		decimal? d_(Observation.ComponentComponent C)
 		{
-			var p_ = C?.Value;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = (q_ as CqlQuantity)?.value;
+			DataType q_ = C?.Value;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			decimal? s_ = (r_ as CqlQuantity)?.value;
 
-			return r_;
+			return s_;
 		};
-		var d_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<decimal?>(d_);
+		IEnumerable<decimal?> e_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(c_, d_);
+		decimal? f_ = context.Operators.SingletonFrom<decimal?>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("Size Adjusted Value")]
 	public decimal? Size_Adjusted_Value(Observation Obs)
 	{
-		bool? a_(Observation.ComponentComponent C)
+		List<Observation.ComponentComponent> a_ = Obs?.Component;
+		bool? b_(Observation.ComponentComponent C)
 		{
-			var f_ = C?.Code;
-			var g_ = FHIRHelpers_4_3_000.ToConcept(f_);
-			var h_ = this.Calculated_CT_size_adjusted_dose();
-			var i_ = context.Operators.ConvertCodeToConcept(h_);
-			var j_ = context.Operators.Equivalent(g_, i_);
-			var k_ = C?.Value;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = (l_ as CqlQuantity)?.unit;
-			var n_ = context.Operators.Equal(m_, "mGy.cm");
-			var o_ = context.Operators.And(j_, n_);
+			CodeableConcept g_ = C?.Code;
+			CqlConcept h_ = FHIRHelpers_4_3_000.ToConcept(g_);
+			CqlCode i_ = this.Calculated_CT_size_adjusted_dose();
+			CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+			bool? k_ = context.Operators.Equivalent(h_, j_);
+			DataType l_ = C?.Value;
+			object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+			string n_ = (m_ as CqlQuantity)?.unit;
+			bool? o_ = context.Operators.Equal(n_, "mGy.cm");
+			bool? p_ = context.Operators.And(k_, o_);
 
-			return o_;
+			return p_;
 		};
-		var b_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)Obs?.Component, a_);
-		decimal? c_(Observation.ComponentComponent C)
+		IEnumerable<Observation.ComponentComponent> c_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)a_, b_);
+		decimal? d_(Observation.ComponentComponent C)
 		{
-			var p_ = C?.Value;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = (q_ as CqlQuantity)?.value;
+			DataType q_ = C?.Value;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			decimal? s_ = (r_ as CqlQuantity)?.value;
 
-			return r_;
+			return s_;
 		};
-		var d_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<decimal?>(d_);
+		IEnumerable<decimal?> e_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(c_, d_);
+		decimal? f_ = context.Operators.SingletonFrom<decimal?>(e_);
 
-		return e_;
+		return f_;
 	}
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Observation> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Observation> a_ = this.Initial_Population();
 		bool? b_(Observation IP)
 		{
-			var d_ = this.Global_Noise_Value(IP);
-			var e_ = context.Operators.Not((bool?)(d_ is null));
-			var f_ = this.Size_Adjusted_Value(IP);
-			var g_ = context.Operators.Not((bool?)(f_ is null));
-			var h_ = context.Operators.And(e_, g_);
-			var i_ = IP?.Value;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = context.Operators.Not((bool?)(j_ is null));
-			var l_ = context.Operators.And(h_, k_);
+			decimal? d_ = this.Global_Noise_Value(IP);
+			bool? e_ = context.Operators.Not((bool?)(d_ is null));
+			decimal? f_ = this.Size_Adjusted_Value(IP);
+			bool? g_ = context.Operators.Not((bool?)(f_ is null));
+			bool? h_ = context.Operators.And(e_, g_);
+			DataType i_ = IP?.Value;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			bool? k_ = context.Operators.Not((bool?)(j_ is null));
+			bool? l_ = context.Operators.And(h_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Observation> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusion"/>
 	private IEnumerable<Observation> Denominator_Exclusion_Value()
 	{
-		var a_ = this.Denominator();
+		IEnumerable<Observation> a_ = this.Denominator();
 		bool? b_(Observation Denominator)
 		{
-			var d_ = Denominator?.Value;
-			var e_ = FHIRHelpers_4_3_000.ToValue(d_);
-			var f_ = (e_ as CqlConcept)?.codes;
+			DataType d_ = Denominator?.Value;
+			object e_ = FHIRHelpers_4_3_000.ToValue(d_);
+			CqlCode[] f_ = (e_ as CqlConcept)?.codes;
 			bool? g_(CqlCode @this)
 			{
-				var l_ = @this?.code;
-				var m_ = context.Operators.Not((bool?)(l_ is null));
+				string l_ = @this?.code;
+				bool? m_ = context.Operators.Not((bool?)(l_ is null));
 
 				return m_;
 			};
-			var h_ = context.Operators.Where<CqlCode>((IEnumerable<CqlCode>)f_, g_);
+			IEnumerable<CqlCode> h_ = context.Operators.Where<CqlCode>((IEnumerable<CqlCode>)f_, g_);
 			string i_(CqlCode @this)
 			{
-				var n_ = @this?.code;
+				string n_ = @this?.code;
 
 				return n_;
 			};
-			var j_ = context.Operators.Select<CqlCode, string>(h_, i_);
-			var k_ = context.Operators.Contains<string>(j_, "FULLBODY");
+			IEnumerable<string> j_ = context.Operators.Select<CqlCode, string>(h_, i_);
+			bool? k_ = context.Operators.Contains<string>(j_, "FULLBODY");
 
 			return k_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Exclusion_Value"/>
     [CqlDeclaration("Denominator Exclusion")]
 	public IEnumerable<Observation> Denominator_Exclusion() => 
 		__Denominator_Exclusion.Value;
@@ -343,156 +367,168 @@ public class ALARACTOQRFHIR_0_1_001
     [CqlDeclaration("Qualifies")]
 	public bool? Qualifies(Observation Obs, string code, decimal? noiseThreshold, decimal? sizeDoseThreshold)
 	{
-		var a_ = FHIRHelpers_4_3_000.ToValue(Obs?.Value);
-		bool? b_(CqlCode @this)
+		DataType a_ = Obs?.Value;
+		object b_ = FHIRHelpers_4_3_000.ToValue(a_);
+		CqlCode[] c_ = (b_ as CqlConcept)?.codes;
+		bool? d_(CqlCode @this)
 		{
-			var m_ = @this?.code;
-			var n_ = context.Operators.Not((bool?)(m_ is null));
+			string o_ = @this?.code;
+			bool? p_ = context.Operators.Not((bool?)(o_ is null));
 
-			return n_;
+			return p_;
 		};
-		var c_ = context.Operators.Where<CqlCode>(((IEnumerable<CqlCode>)(a_ as CqlConcept)?.codes), b_);
-		string d_(CqlCode @this)
+		IEnumerable<CqlCode> e_ = context.Operators.Where<CqlCode>((IEnumerable<CqlCode>)c_, d_);
+		string f_(CqlCode @this)
 		{
-			var o_ = @this?.code;
+			string q_ = @this?.code;
 
-			return o_;
+			return q_;
 		};
-		var e_ = context.Operators.Select<CqlCode, string>(c_, d_);
-		var f_ = context.Operators.Contains<string>(e_, code);
-		var g_ = this.Global_Noise_Value(Obs);
-		var h_ = context.Operators.GreaterOrEqual(g_, noiseThreshold);
-		var i_ = this.Size_Adjusted_Value(Obs);
-		var j_ = context.Operators.GreaterOrEqual(i_, sizeDoseThreshold);
-		var k_ = context.Operators.Or(h_, j_);
-		var l_ = context.Operators.And(f_, k_);
+		IEnumerable<string> g_ = context.Operators.Select<CqlCode, string>(e_, f_);
+		bool? h_ = context.Operators.Contains<string>(g_, code);
+		decimal? i_ = this.Global_Noise_Value(Obs);
+		bool? j_ = context.Operators.GreaterOrEqual(i_, noiseThreshold);
+		decimal? k_ = this.Size_Adjusted_Value(Obs);
+		bool? l_ = context.Operators.GreaterOrEqual(k_, sizeDoseThreshold);
+		bool? m_ = context.Operators.Or(j_, l_);
+		bool? n_ = context.Operators.And(h_, m_);
 
-		return l_;
+		return n_;
 	}
 
     [CqlDeclaration("CT Scan Qualifies")]
 	public bool? CT_Scan_Qualifies(Observation IP)
 	{
-		var a_ = context.Operators.ConvertIntegerToDecimal(64);
-		var b_ = context.Operators.ConvertIntegerToDecimal(598);
-		var c_ = this.Qualifies(IP, "ABDOPEL LD", a_, b_);
-		var d_ = context.Operators.ConvertIntegerToDecimal(29);
-		var e_ = context.Operators.ConvertIntegerToDecimal(644);
-		var f_ = this.Qualifies(IP, "ABDOPEL RT", d_, e_);
-		var g_ = context.Operators.Or(c_, f_);
-		var i_ = context.Operators.ConvertIntegerToDecimal(1260);
-		var j_ = this.Qualifies(IP, "ABDOPEL HD", d_, i_);
-		var k_ = context.Operators.Or(g_, j_);
-		var l_ = context.Operators.ConvertIntegerToDecimal(55);
-		var m_ = context.Operators.ConvertIntegerToDecimal(93);
-		var n_ = this.Qualifies(IP, "CARDIAC LD", l_, m_);
-		var o_ = context.Operators.Or(k_, n_);
-		var p_ = context.Operators.ConvertIntegerToDecimal(32);
-		var q_ = context.Operators.ConvertIntegerToDecimal(576);
-		var r_ = this.Qualifies(IP, "CARDIAC RT", p_, q_);
-		var s_ = context.Operators.Or(o_, r_);
-		var u_ = context.Operators.ConvertIntegerToDecimal(377);
-		var v_ = this.Qualifies(IP, "CHEST LD", l_, u_);
-		var w_ = context.Operators.Or(s_, v_);
-		var x_ = context.Operators.ConvertIntegerToDecimal(49);
-		var z_ = this.Qualifies(IP, "CHEST RT", x_, u_);
-		var aa_ = context.Operators.Or(w_, z_);
-		var ac_ = context.Operators.ConvertIntegerToDecimal(1282);
-		var ad_ = this.Qualifies(IP, "CHEST-CARDIAC HD", x_, ac_);
-		var ae_ = context.Operators.Or(aa_, ad_);
-		var af_ = context.Operators.ConvertIntegerToDecimal(115);
-		var ag_ = context.Operators.ConvertIntegerToDecimal(582);
-		var ah_ = this.Qualifies(IP, "HEAD LD", af_, ag_);
-		var ai_ = context.Operators.Or(ae_, ah_);
-		var ak_ = context.Operators.ConvertIntegerToDecimal(1025);
-		var al_ = this.Qualifies(IP, "HEAD RT", af_, ak_);
-		var am_ = context.Operators.Or(ai_, al_);
-		var ao_ = context.Operators.ConvertIntegerToDecimal(1832);
-		var ap_ = this.Qualifies(IP, "HEAD HD", af_, ao_);
-		var aq_ = context.Operators.Or(am_, ap_);
-		var ar_ = context.Operators.ConvertIntegerToDecimal(73);
-		var as_ = context.Operators.ConvertIntegerToDecimal(320);
-		var at_ = this.Qualifies(IP, "EXTREMITIES", ar_, as_);
-		var au_ = context.Operators.Or(aq_, at_);
-		var av_ = context.Operators.ConvertIntegerToDecimal(25);
-		var ax_ = this.Qualifies(IP, "NECK-CSPINE", av_, i_);
-		var ay_ = context.Operators.Or(au_, ax_);
-		var bb_ = this.Qualifies(IP, "TSPINE-LSPINE", av_, i_);
-		var bc_ = context.Operators.Or(ay_, bb_);
-		var be_ = context.Operators.ConvertIntegerToDecimal(1637);
-		var bf_ = this.Qualifies(IP, "CAP", d_, be_);
-		var bg_ = context.Operators.Or(bc_, bf_);
-		var bi_ = context.Operators.ConvertIntegerToDecimal(2520);
-		var bj_ = this.Qualifies(IP, "TLSPINE", av_, bi_);
-		var bk_ = context.Operators.Or(bg_, bj_);
-		var bm_ = context.Operators.ConvertIntegerToDecimal(2285);
-		var bn_ = this.Qualifies(IP, "HEADNECK RT", av_, bm_);
-		var bo_ = context.Operators.Or(bk_, bn_);
-		var bq_ = context.Operators.ConvertIntegerToDecimal(3092);
-		var br_ = this.Qualifies(IP, "HEADNECK HD", av_, bq_);
-		var bs_ = context.Operators.Or(bo_, br_);
+		decimal? a_ = context.Operators.ConvertIntegerToDecimal(64);
+		decimal? b_ = context.Operators.ConvertIntegerToDecimal(598);
+		bool? c_ = this.Qualifies(IP, "ABDOPEL LD", a_, b_);
+		decimal? d_ = context.Operators.ConvertIntegerToDecimal(29);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(644);
+		bool? f_ = this.Qualifies(IP, "ABDOPEL RT", d_, e_);
+		bool? g_ = context.Operators.Or(c_, f_);
+		decimal? i_ = context.Operators.ConvertIntegerToDecimal(1260);
+		bool? j_ = this.Qualifies(IP, "ABDOPEL HD", d_, i_);
+		bool? k_ = context.Operators.Or(g_, j_);
+		decimal? l_ = context.Operators.ConvertIntegerToDecimal(55);
+		decimal? m_ = context.Operators.ConvertIntegerToDecimal(93);
+		bool? n_ = this.Qualifies(IP, "CARDIAC LD", l_, m_);
+		bool? o_ = context.Operators.Or(k_, n_);
+		decimal? p_ = context.Operators.ConvertIntegerToDecimal(32);
+		decimal? q_ = context.Operators.ConvertIntegerToDecimal(576);
+		bool? r_ = this.Qualifies(IP, "CARDIAC RT", p_, q_);
+		bool? s_ = context.Operators.Or(o_, r_);
+		decimal? u_ = context.Operators.ConvertIntegerToDecimal(377);
+		bool? v_ = this.Qualifies(IP, "CHEST LD", l_, u_);
+		bool? w_ = context.Operators.Or(s_, v_);
+		decimal? x_ = context.Operators.ConvertIntegerToDecimal(49);
+		bool? z_ = this.Qualifies(IP, "CHEST RT", x_, u_);
+		bool? aa_ = context.Operators.Or(w_, z_);
+		decimal? ac_ = context.Operators.ConvertIntegerToDecimal(1282);
+		bool? ad_ = this.Qualifies(IP, "CHEST-CARDIAC HD", x_, ac_);
+		bool? ae_ = context.Operators.Or(aa_, ad_);
+		decimal? af_ = context.Operators.ConvertIntegerToDecimal(115);
+		decimal? ag_ = context.Operators.ConvertIntegerToDecimal(582);
+		bool? ah_ = this.Qualifies(IP, "HEAD LD", af_, ag_);
+		bool? ai_ = context.Operators.Or(ae_, ah_);
+		decimal? ak_ = context.Operators.ConvertIntegerToDecimal(1025);
+		bool? al_ = this.Qualifies(IP, "HEAD RT", af_, ak_);
+		bool? am_ = context.Operators.Or(ai_, al_);
+		decimal? ao_ = context.Operators.ConvertIntegerToDecimal(1832);
+		bool? ap_ = this.Qualifies(IP, "HEAD HD", af_, ao_);
+		bool? aq_ = context.Operators.Or(am_, ap_);
+		decimal? ar_ = context.Operators.ConvertIntegerToDecimal(73);
+		decimal? as_ = context.Operators.ConvertIntegerToDecimal(320);
+		bool? at_ = this.Qualifies(IP, "EXTREMITIES", ar_, as_);
+		bool? au_ = context.Operators.Or(aq_, at_);
+		decimal? av_ = context.Operators.ConvertIntegerToDecimal(25);
+		bool? ax_ = this.Qualifies(IP, "NECK-CSPINE", av_, i_);
+		bool? ay_ = context.Operators.Or(au_, ax_);
+		bool? bb_ = this.Qualifies(IP, "TSPINE-LSPINE", av_, i_);
+		bool? bc_ = context.Operators.Or(ay_, bb_);
+		decimal? be_ = context.Operators.ConvertIntegerToDecimal(1637);
+		bool? bf_ = this.Qualifies(IP, "CAP", d_, be_);
+		bool? bg_ = context.Operators.Or(bc_, bf_);
+		decimal? bi_ = context.Operators.ConvertIntegerToDecimal(2520);
+		bool? bj_ = this.Qualifies(IP, "TLSPINE", av_, bi_);
+		bool? bk_ = context.Operators.Or(bg_, bj_);
+		decimal? bm_ = context.Operators.ConvertIntegerToDecimal(2285);
+		bool? bn_ = this.Qualifies(IP, "HEADNECK RT", av_, bm_);
+		bool? bo_ = context.Operators.Or(bk_, bn_);
+		decimal? bq_ = context.Operators.ConvertIntegerToDecimal(3092);
+		bool? br_ = this.Qualifies(IP, "HEADNECK HD", av_, bq_);
+		bool? bs_ = context.Operators.Or(bo_, br_);
 
 		return bs_;
 	}
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Observation> Numerator_Value()
 	{
-		var a_ = this.Denominator();
+		IEnumerable<Observation> a_ = this.Denominator();
 		bool? b_(Observation Denominator)
 		{
-			var d_ = this.CT_Scan_Qualifies(Denominator);
+			bool? d_ = this.CT_Scan_Qualifies(Denominator);
 
 			return d_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Observation> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
@@ -60,123 +60,143 @@ public class AdultOutpatientEncounters_4_8_000
 
     #endregion
 
+    /// <seealso cref="Annual_Wellness_Visit"/>
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
+    /// <seealso cref="Annual_Wellness_Visit_Value"/>
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
 	public CqlValueSet Annual_Wellness_Visit() => 
 		__Annual_Wellness_Visit.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.ResolveParameter("AdultOutpatientEncounters-4.8.000", "Measurement Period", null);
+		object a_ = context.ResolveParameter("AdultOutpatientEncounters-4.8.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Annual_Wellness_Visit();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Home_Healthcare_Services();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Online_Assessments();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Telephone_Visits();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = context.Operators.Union<Encounter>(q_, s_);
-		var u_ = Status_1_6_000.isEncounterPerformed(t_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Online_Assessments();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Telephone_Visits();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
+		IEnumerable<Encounter> u_ = Status_1_6_000.isEncounterPerformed(t_);
 		bool? v_(Encounter ValidEncounter)
 		{
-			var x_ = this.Measurement_Period();
-			var y_ = ValidEncounter?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = QICoreCommon_2_0_000.toInterval((z_ as object));
-			var ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, "day");
+			CqlInterval<CqlDateTime> x_ = this.Measurement_Period();
+			Period y_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlInterval<CqlDateTime> aa_ = QICoreCommon_2_0_000.toInterval((z_ as object));
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, "day");
 
 			return ab_;
 		};
-		var w_ = context.Operators.Where<Encounter>(u_, v_);
+		IEnumerable<Encounter> w_ = context.Operators.Where<Encounter>(u_, v_);
 
 		return w_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;

--- a/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
@@ -96,118 +96,147 @@ public class AdvancedIllnessandFrailty_1_8_000
 
     #endregion
 
+    /// <seealso cref="Acute_Inpatient"/>
 	private CqlValueSet Acute_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
 
+    /// <seealso cref="Acute_Inpatient_Value"/>
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
 	public CqlValueSet Acute_Inpatient() => 
 		__Acute_Inpatient.Value;
 
+    /// <seealso cref="Advanced_Illness"/>
 	private CqlValueSet Advanced_Illness_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
 
+    /// <seealso cref="Advanced_Illness_Value"/>
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
 	public CqlValueSet Advanced_Illness() => 
 		__Advanced_Illness.Value;
 
+    /// <seealso cref="Dementia_Medications"/>
 	private CqlValueSet Dementia_Medications_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
 
+    /// <seealso cref="Dementia_Medications_Value"/>
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
 	public CqlValueSet Dementia_Medications() => 
 		__Dementia_Medications.Value;
 
+    /// <seealso cref="Emergency_Department_Evaluation_and_Management_Visit"/>
 	private CqlValueSet Emergency_Department_Evaluation_and_Management_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
 
+    /// <seealso cref="Emergency_Department_Evaluation_and_Management_Visit_Value"/>
     [CqlDeclaration("Emergency Department Evaluation and Management Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
 	public CqlValueSet Emergency_Department_Evaluation_and_Management_Visit() => 
 		__Emergency_Department_Evaluation_and_Management_Visit.Value;
 
+    /// <seealso cref="Frailty_Device"/>
 	private CqlValueSet Frailty_Device_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
 
+    /// <seealso cref="Frailty_Device_Value"/>
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
 	public CqlValueSet Frailty_Device() => 
 		__Frailty_Device.Value;
 
+    /// <seealso cref="Frailty_Diagnosis"/>
 	private CqlValueSet Frailty_Diagnosis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
 
+    /// <seealso cref="Frailty_Diagnosis_Value"/>
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
 	public CqlValueSet Frailty_Diagnosis() => 
 		__Frailty_Diagnosis.Value;
 
+    /// <seealso cref="Frailty_Encounter"/>
 	private CqlValueSet Frailty_Encounter_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
 
+    /// <seealso cref="Frailty_Encounter_Value"/>
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
 	public CqlValueSet Frailty_Encounter() => 
 		__Frailty_Encounter.Value;
 
+    /// <seealso cref="Frailty_Symptom"/>
 	private CqlValueSet Frailty_Symptom_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
 
+    /// <seealso cref="Frailty_Symptom_Value"/>
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
 	public CqlValueSet Frailty_Symptom() => 
 		__Frailty_Symptom.Value;
 
+    /// <seealso cref="Nonacute_Inpatient"/>
 	private CqlValueSet Nonacute_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
 
+    /// <seealso cref="Nonacute_Inpatient_Value"/>
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
 	public CqlValueSet Nonacute_Inpatient() => 
 		__Nonacute_Inpatient.Value;
 
+    /// <seealso cref="Observation"/>
 	private CqlValueSet Observation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
 
+    /// <seealso cref="Observation_Value"/>
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
 	public CqlValueSet Observation() => 
 		__Observation.Value;
 
+    /// <seealso cref="Outpatient"/>
 	private CqlValueSet Outpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
 
+    /// <seealso cref="Outpatient_Value"/>
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
 	public CqlValueSet Outpatient() => 
 		__Outpatient.Value;
 
+    /// <seealso cref="Housing_status"/>
 	private CqlCode Housing_status_Value() => 
 		new CqlCode("71802-3", "http://loinc.org", null, null);
 
+    /// <seealso cref="Housing_status_Value"/>
     [CqlDeclaration("Housing status")]
 	public CqlCode Housing_status() => 
 		__Housing_status.Value;
 
+    /// <seealso cref="Lives_in_a_nursing_home__finding_"/>
 	private CqlCode Lives_in_a_nursing_home__finding__Value() => 
 		new CqlCode("160734000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Lives_in_a_nursing_home__finding__Value"/>
     [CqlDeclaration("Lives in a nursing home (finding)")]
 	public CqlCode Lives_in_a_nursing_home__finding_() => 
 		__Lives_in_a_nursing_home__finding_.Value;
 
+    /// <seealso cref="Medical_equipment_used"/>
 	private CqlCode Medical_equipment_used_Value() => 
 		new CqlCode("98181-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="Medical_equipment_used_Value"/>
     [CqlDeclaration("Medical equipment used")]
 	public CqlCode Medical_equipment_used() => 
 		__Medical_equipment_used.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("71802-3", "http://loinc.org", null, null),
 			new CqlCode("98181-1", "http://loinc.org", null, null),
@@ -216,13 +245,15 @@ public class AdvancedIllnessandFrailty_1_8_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("160734000", "http://snomed.info/sct", null, null),
 		};
@@ -230,191 +261,201 @@ public class AdvancedIllnessandFrailty_1_8_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.ResolveParameter("AdvancedIllnessandFrailty-1.8.000", "Measurement Period", null);
+		object a_ = context.ResolveParameter("AdvancedIllnessandFrailty-1.8.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Has_Criteria_Indicating_Frailty"/>
 	private bool? Has_Criteria_Indicating_Frailty_Value()
 	{
-		var a_ = this.Frailty_Device();
-		var b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
-		var e_ = context.Operators.Union<DeviceRequest>(b_, d_);
-		var f_ = Status_1_6_000.isDeviceOrder(e_);
+		CqlValueSet a_ = this.Frailty_Device();
+		IEnumerable<DeviceRequest> b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
+		IEnumerable<DeviceRequest> d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
+		IEnumerable<DeviceRequest> e_ = context.Operators.Union<DeviceRequest>(b_, d_);
+		IEnumerable<DeviceRequest> f_ = Status_1_6_000.isDeviceOrder(e_);
 		bool? g_(DeviceRequest FrailtyDeviceOrder)
 		{
-			var al_ = QICoreCommon_2_0_000.doNotPerform(FrailtyDeviceOrder);
-			var am_ = context.Operators.IsTrue(al_);
-			var an_ = context.Operators.Not(am_);
-			var ao_ = this.Measurement_Period();
-			var ap_ = FrailtyDeviceOrder?.AuthoredOnElement;
-			var aq_ = context.Operators.Convert<CqlDateTime>(ap_);
-			var ar_ = QICoreCommon_2_0_000.toInterval((aq_ as object));
-			var as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, ar_, "day");
-			var at_ = context.Operators.And(an_, as_);
+			bool? al_ = QICoreCommon_2_0_000.doNotPerform(FrailtyDeviceOrder);
+			bool? am_ = context.Operators.IsTrue(al_);
+			bool? an_ = context.Operators.Not(am_);
+			CqlInterval<CqlDateTime> ao_ = this.Measurement_Period();
+			FhirDateTime ap_ = FrailtyDeviceOrder?.AuthoredOnElement;
+			CqlDateTime aq_ = context.Operators.Convert<CqlDateTime>(ap_);
+			CqlInterval<CqlDateTime> ar_ = QICoreCommon_2_0_000.toInterval((aq_ as object));
+			bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, ar_, "day");
+			bool? at_ = context.Operators.And(an_, as_);
 
 			return at_;
 		};
-		var h_ = context.Operators.Where<DeviceRequest>(f_, g_);
-		var i_ = context.Operators.Exists<DeviceRequest>(h_);
-		var j_ = this.Medical_equipment_used();
-		var k_ = context.Operators.ToList<CqlCode>(j_);
-		var l_ = context.Operators.RetrieveByCodes<Observation>(k_, null);
-		var m_ = Status_1_6_000.isAssessmentPerformed(l_);
+		IEnumerable<DeviceRequest> h_ = context.Operators.Where<DeviceRequest>(f_, g_);
+		bool? i_ = context.Operators.Exists<DeviceRequest>(h_);
+		CqlCode j_ = this.Medical_equipment_used();
+		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
+		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, null);
+		IEnumerable<Observation> m_ = Status_1_6_000.isAssessmentPerformed(l_);
 		bool? n_(Observation EquipmentUsed)
 		{
-			var au_ = EquipmentUsed?.Value;
-			var av_ = FHIRHelpers_4_3_000.ToValue(au_);
-			var aw_ = this.Frailty_Device();
-			var ax_ = context.Operators.ConceptInValueSet((av_ as CqlConcept), aw_);
-			var ay_ = EquipmentUsed?.Effective;
-			var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-			var ba_ = QICoreCommon_2_0_000.toInterval(az_);
-			var bb_ = context.Operators.End(ba_);
-			var bc_ = this.Measurement_Period();
-			var bd_ = context.Operators.In<CqlDateTime>(bb_, bc_, "day");
-			var be_ = context.Operators.And(ax_, bd_);
+			DataType au_ = EquipmentUsed?.Value;
+			object av_ = FHIRHelpers_4_3_000.ToValue(au_);
+			CqlValueSet aw_ = this.Frailty_Device();
+			bool? ax_ = context.Operators.ConceptInValueSet((av_ as CqlConcept), aw_);
+			DataType ay_ = EquipmentUsed?.Effective;
+			object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+			CqlInterval<CqlDateTime> ba_ = QICoreCommon_2_0_000.toInterval(az_);
+			CqlDateTime bb_ = context.Operators.End(ba_);
+			CqlInterval<CqlDateTime> bc_ = this.Measurement_Period();
+			bool? bd_ = context.Operators.In<CqlDateTime>(bb_, bc_, "day");
+			bool? be_ = context.Operators.And(ax_, bd_);
 
 			return be_;
 		};
-		var o_ = context.Operators.Where<Observation>(m_, n_);
-		var p_ = context.Operators.Exists<Observation>(o_);
-		var q_ = context.Operators.Or(i_, p_);
-		var r_ = this.Frailty_Diagnosis();
-		var s_ = context.Operators.RetrieveByValueSet<Condition>(r_, null);
+		IEnumerable<Observation> o_ = context.Operators.Where<Observation>(m_, n_);
+		bool? p_ = context.Operators.Exists<Observation>(o_);
+		bool? q_ = context.Operators.Or(i_, p_);
+		CqlValueSet r_ = this.Frailty_Diagnosis();
+		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, null);
 		bool? t_(Condition FrailtyDiagnosis)
 		{
-			var bf_ = QICoreCommon_2_0_000.prevalenceInterval(FrailtyDiagnosis);
-			var bg_ = this.Measurement_Period();
-			var bh_ = context.Operators.Overlaps(bf_, bg_, "day");
+			CqlInterval<CqlDateTime> bf_ = QICoreCommon_2_0_000.prevalenceInterval(FrailtyDiagnosis);
+			CqlInterval<CqlDateTime> bg_ = this.Measurement_Period();
+			bool? bh_ = context.Operators.Overlaps(bf_, bg_, "day");
 
 			return bh_;
 		};
-		var u_ = context.Operators.Where<Condition>(s_, t_);
-		var v_ = context.Operators.Exists<Condition>(u_);
-		var w_ = context.Operators.Or(q_, v_);
-		var x_ = this.Frailty_Encounter();
-		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
-		var z_ = Status_1_6_000.isEncounterPerformed(y_);
+		IEnumerable<Condition> u_ = context.Operators.Where<Condition>(s_, t_);
+		bool? v_ = context.Operators.Exists<Condition>(u_);
+		bool? w_ = context.Operators.Or(q_, v_);
+		CqlValueSet x_ = this.Frailty_Encounter();
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> z_ = Status_1_6_000.isEncounterPerformed(y_);
 		bool? aa_(Encounter FrailtyEncounter)
 		{
-			var bi_ = FrailtyEncounter?.Period;
-			var bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
-			var bk_ = QICoreCommon_2_0_000.toInterval((bj_ as object));
-			var bl_ = this.Measurement_Period();
-			var bm_ = context.Operators.Overlaps(bk_, bl_, "day");
+			Period bi_ = FrailtyEncounter?.Period;
+			CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
+			CqlInterval<CqlDateTime> bk_ = QICoreCommon_2_0_000.toInterval((bj_ as object));
+			CqlInterval<CqlDateTime> bl_ = this.Measurement_Period();
+			bool? bm_ = context.Operators.Overlaps(bk_, bl_, "day");
 
 			return bm_;
 		};
-		var ab_ = context.Operators.Where<Encounter>(z_, aa_);
-		var ac_ = context.Operators.Exists<Encounter>(ab_);
-		var ad_ = context.Operators.Or(w_, ac_);
-		var ae_ = this.Frailty_Symptom();
-		var af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, null);
-		var ag_ = Status_1_6_000.isSymptom(af_);
+		IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
+		bool? ac_ = context.Operators.Exists<Encounter>(ab_);
+		bool? ad_ = context.Operators.Or(w_, ac_);
+		CqlValueSet ae_ = this.Frailty_Symptom();
+		IEnumerable<Observation> af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, null);
+		IEnumerable<Observation> ag_ = Status_1_6_000.isSymptom(af_);
 		bool? ah_(Observation FrailtySymptom)
 		{
-			var bn_ = FrailtySymptom?.Effective;
-			var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
-			var bp_ = QICoreCommon_2_0_000.toInterval(bo_);
-			var bq_ = this.Measurement_Period();
-			var br_ = context.Operators.Overlaps(bp_, bq_, "day");
+			DataType bn_ = FrailtySymptom?.Effective;
+			object bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+			CqlInterval<CqlDateTime> bp_ = QICoreCommon_2_0_000.toInterval(bo_);
+			CqlInterval<CqlDateTime> bq_ = this.Measurement_Period();
+			bool? br_ = context.Operators.Overlaps(bp_, bq_, "day");
 
 			return br_;
 		};
-		var ai_ = context.Operators.Where<Observation>(ag_, ah_);
-		var aj_ = context.Operators.Exists<Observation>(ai_);
-		var ak_ = context.Operators.Or(ad_, aj_);
+		IEnumerable<Observation> ai_ = context.Operators.Where<Observation>(ag_, ah_);
+		bool? aj_ = context.Operators.Exists<Observation>(ai_);
+		bool? ak_ = context.Operators.Or(ad_, aj_);
 
 		return ak_;
 	}
 
+    /// <seealso cref="Has_Criteria_Indicating_Frailty_Value"/>
     [CqlDeclaration("Has Criteria Indicating Frailty")]
 	public bool? Has_Criteria_Indicating_Frailty() => 
 		__Has_Criteria_Indicating_Frailty.Value;
 
+    /// <seealso cref="Outpatient_Encounters_with_Advanced_Illness"/>
 	private IEnumerable<Encounter> Outpatient_Encounters_with_Advanced_Illness_Value()
 	{
-		var a_ = this.Outpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Observation();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Emergency_Department_Evaluation_and_Management_Visit();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Nonacute_Inpatient();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = Status_1_6_000.isEncounterPerformed(k_);
+		CqlValueSet a_ = this.Outpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Observation();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Emergency_Department_Evaluation_and_Management_Visit();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Nonacute_Inpatient();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		IEnumerable<Encounter> l_ = Status_1_6_000.isEncounterPerformed(k_);
 		bool? m_(Encounter OutpatientEncounter)
 		{
-			var o_ = CQMCommon_2_0_000.encounterDiagnosis(OutpatientEncounter);
+			IEnumerable<Condition> o_ = CQMCommon_2_0_000.encounterDiagnosis(OutpatientEncounter);
 			bool? p_(Condition Diagnosis)
 			{
-				var af_ = Diagnosis?.Code;
-				var ag_ = FHIRHelpers_4_3_000.ToConcept(af_);
-				var ah_ = this.Advanced_Illness();
-				var ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+				CodeableConcept af_ = Diagnosis?.Code;
+				CqlConcept ag_ = FHIRHelpers_4_3_000.ToConcept(af_);
+				CqlValueSet ah_ = this.Advanced_Illness();
+				bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
 
 				return ai_;
 			};
-			var q_ = context.Operators.Where<Condition>(o_, p_);
-			var r_ = context.Operators.Exists<Condition>(q_);
-			var s_ = OutpatientEncounter?.Period;
-			var t_ = FHIRHelpers_4_3_000.ToInterval(s_);
-			var u_ = QICoreCommon_2_0_000.toInterval((t_ as object));
-			var v_ = context.Operators.Start(u_);
-			var w_ = this.Measurement_Period();
-			var x_ = context.Operators.Start(w_);
-			var y_ = context.Operators.Quantity(1m, "year");
-			var z_ = context.Operators.Subtract(x_, y_);
-			var ab_ = context.Operators.End(w_);
-			var ac_ = context.Operators.Interval(z_, ab_, true, true);
-			var ad_ = context.Operators.In<CqlDateTime>(v_, ac_, "day");
-			var ae_ = context.Operators.And(r_, ad_);
+			IEnumerable<Condition> q_ = context.Operators.Where<Condition>(o_, p_);
+			bool? r_ = context.Operators.Exists<Condition>(q_);
+			Period s_ = OutpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(s_);
+			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval((t_ as object));
+			CqlDateTime v_ = context.Operators.Start(u_);
+			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
+			CqlDateTime x_ = context.Operators.Start(w_);
+			CqlQuantity y_ = context.Operators.Quantity(1m, "year");
+			CqlDateTime z_ = context.Operators.Subtract(x_, y_);
+			CqlDateTime ab_ = context.Operators.End(w_);
+			CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(z_, ab_, true, true);
+			bool? ad_ = context.Operators.In<CqlDateTime>(v_, ac_, "day");
+			bool? ae_ = context.Operators.And(r_, ad_);
 
 			return ae_;
 		};
-		var n_ = context.Operators.Where<Encounter>(l_, m_);
+		IEnumerable<Encounter> n_ = context.Operators.Where<Encounter>(l_, m_);
 
 		return n_;
 	}
 
+    /// <seealso cref="Outpatient_Encounters_with_Advanced_Illness_Value"/>
     [CqlDeclaration("Outpatient Encounters with Advanced Illness")]
 	public IEnumerable<Encounter> Outpatient_Encounters_with_Advanced_Illness() => 
 		__Outpatient_Encounters_with_Advanced_Illness.Value;
 
+    /// <seealso cref="Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service"/>
 	private bool? Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service_Value()
 	{
-		var a_ = this.Outpatient_Encounters_with_Advanced_Illness();
-		var c_ = context.Operators.CrossJoin<Encounter, Encounter>(a_, a_);
+		IEnumerable<Encounter> a_ = this.Outpatient_Encounters_with_Advanced_Illness();
+		IEnumerable<ValueTuple<Encounter, Encounter>> c_ = context.Operators.CrossJoin<Encounter, Encounter>(a_, a_);
 		Tuple_EaLaedgLDgRRYaLbKIIcBTOiA d_(ValueTuple<Encounter, Encounter> _valueTuple)
 		{
-			var k_ = new Tuple_EaLaedgLDgRRYaLbKIIcBTOiA
+			Tuple_EaLaedgLDgRRYaLbKIIcBTOiA k_ = new Tuple_EaLaedgLDgRRYaLbKIIcBTOiA
 			{
 				OutpatientEncounter1 = _valueTuple.Item1,
 				OutpatientEncounter2 = _valueTuple.Item2,
@@ -422,237 +463,256 @@ public class AdvancedIllnessandFrailty_1_8_000
 
 			return k_;
 		};
-		var e_ = context.Operators.Select<ValueTuple<Encounter, Encounter>, Tuple_EaLaedgLDgRRYaLbKIIcBTOiA>(c_, d_);
+		IEnumerable<Tuple_EaLaedgLDgRRYaLbKIIcBTOiA> e_ = context.Operators.Select<ValueTuple<Encounter, Encounter>, Tuple_EaLaedgLDgRRYaLbKIIcBTOiA>(c_, d_);
 		bool? f_(Tuple_EaLaedgLDgRRYaLbKIIcBTOiA tuple_ealaedgldgrryalbkiicbtoia)
 		{
-			var l_ = tuple_ealaedgldgrryalbkiicbtoia.OutpatientEncounter2?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.End(m_);
-			var o_ = tuple_ealaedgldgrryalbkiicbtoia.OutpatientEncounter1?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.End(p_);
-			var r_ = context.Operators.Quantity(1m, "day");
-			var s_ = context.Operators.Add(q_, r_);
-			var t_ = context.Operators.SameOrAfter(n_, s_, "day");
+			Period l_ = tuple_ealaedgldgrryalbkiicbtoia.OutpatientEncounter2?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.End(m_);
+			Period o_ = tuple_ealaedgldgrryalbkiicbtoia.OutpatientEncounter1?.Period;
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime q_ = context.Operators.End(p_);
+			CqlQuantity r_ = context.Operators.Quantity(1m, "day");
+			CqlDateTime s_ = context.Operators.Add(q_, r_);
+			bool? t_ = context.Operators.SameOrAfter(n_, s_, "day");
 
 			return t_;
 		};
-		var g_ = context.Operators.Where<Tuple_EaLaedgLDgRRYaLbKIIcBTOiA>(e_, f_);
+		IEnumerable<Tuple_EaLaedgLDgRRYaLbKIIcBTOiA> g_ = context.Operators.Where<Tuple_EaLaedgLDgRRYaLbKIIcBTOiA>(e_, f_);
 		Encounter h_(Tuple_EaLaedgLDgRRYaLbKIIcBTOiA tuple_ealaedgldgrryalbkiicbtoia) => 
 			tuple_ealaedgldgrryalbkiicbtoia.OutpatientEncounter1;
-		var i_ = context.Operators.Select<Tuple_EaLaedgLDgRRYaLbKIIcBTOiA, Encounter>(g_, h_);
-		var j_ = context.Operators.Exists<Encounter>(i_);
+		IEnumerable<Encounter> i_ = context.Operators.Select<Tuple_EaLaedgLDgRRYaLbKIIcBTOiA, Encounter>(g_, h_);
+		bool? j_ = context.Operators.Exists<Encounter>(i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service_Value"/>
     [CqlDeclaration("Has Two Outpatient Encounters with Advanced Illness on Different Dates of Service")]
 	public bool? Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service() => 
 		__Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service.Value;
 
+    /// <seealso cref="Has_Inpatient_Encounter_with_Advanced_Illness"/>
 	private bool? Has_Inpatient_Encounter_with_Advanced_Illness_Value()
 	{
-		var a_ = this.Acute_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = Status_1_6_000.isEncounterPerformed(b_);
+		CqlValueSet a_ = this.Acute_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter InpatientEncounter)
 		{
-			var g_ = CQMCommon_2_0_000.encounterDiagnosis(InpatientEncounter);
+			IEnumerable<Condition> g_ = CQMCommon_2_0_000.encounterDiagnosis(InpatientEncounter);
 			bool? h_(Condition Diagnosis)
 			{
-				var x_ = Diagnosis?.Code;
-				var y_ = FHIRHelpers_4_3_000.ToConcept(x_);
-				var z_ = this.Advanced_Illness();
-				var aa_ = context.Operators.ConceptInValueSet(y_, z_);
+				CodeableConcept x_ = Diagnosis?.Code;
+				CqlConcept y_ = FHIRHelpers_4_3_000.ToConcept(x_);
+				CqlValueSet z_ = this.Advanced_Illness();
+				bool? aa_ = context.Operators.ConceptInValueSet(y_, z_);
 
 				return aa_;
 			};
-			var i_ = context.Operators.Where<Condition>(g_, h_);
-			var j_ = context.Operators.Exists<Condition>(i_);
-			var k_ = InpatientEncounter?.Period;
-			var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-			var m_ = QICoreCommon_2_0_000.toInterval((l_ as object));
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Measurement_Period();
-			var p_ = context.Operators.Start(o_);
-			var q_ = context.Operators.Quantity(1m, "year");
-			var r_ = context.Operators.Subtract(p_, q_);
-			var t_ = context.Operators.End(o_);
-			var u_ = context.Operators.Interval(r_, t_, true, true);
-			var v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
-			var w_ = context.Operators.And(j_, v_);
+			IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
+			bool? j_ = context.Operators.Exists<Condition>(i_);
+			Period k_ = InpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+			CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.toInterval((l_ as object));
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
+			CqlDateTime p_ = context.Operators.Start(o_);
+			CqlQuantity q_ = context.Operators.Quantity(1m, "year");
+			CqlDateTime r_ = context.Operators.Subtract(p_, q_);
+			CqlDateTime t_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
+			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
+			bool? w_ = context.Operators.And(j_, v_);
 
 			return w_;
 		};
-		var e_ = context.Operators.Where<Encounter>(c_, d_);
-		var f_ = context.Operators.Exists<Encounter>(e_);
+		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
+		bool? f_ = context.Operators.Exists<Encounter>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Has_Inpatient_Encounter_with_Advanced_Illness_Value"/>
     [CqlDeclaration("Has Inpatient Encounter with Advanced Illness")]
 	public bool? Has_Inpatient_Encounter_with_Advanced_Illness() => 
 		__Has_Inpatient_Encounter_with_Advanced_Illness.Value;
 
+    /// <seealso cref="Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period"/>
 	private bool? Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period_Value()
 	{
-		var a_ = this.Dementia_Medications();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = Status_1_6_000.isMedicationActive(e_);
+		CqlValueSet a_ = this.Dementia_Medications();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = Status_1_6_000.isMedicationActive(e_);
 		bool? g_(MedicationRequest DementiaMedication)
 		{
-			var j_ = DementiaMedication?.DoNotPerformElement;
-			var k_ = j_?.Value;
-			var l_ = context.Operators.IsTrue(k_);
-			var m_ = context.Operators.Not(l_);
-			var n_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(DementiaMedication);
-			var o_ = n_?.low;
-			var p_ = context.Operators.ConvertDateToDateTime(o_);
-			var r_ = n_?.high;
-			var s_ = context.Operators.ConvertDateToDateTime(r_);
-			var u_ = n_?.lowClosed;
-			var w_ = n_?.highClosed;
-			var x_ = context.Operators.Interval(p_, s_, u_, w_);
-			var y_ = this.Measurement_Period();
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.Quantity(1m, "year");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = context.Operators.End(y_);
-			var ae_ = context.Operators.Interval(ab_, ad_, true, true);
-			var af_ = context.Operators.Overlaps(x_, ae_, "day");
-			var ag_ = context.Operators.And(m_, af_);
+			FhirBoolean j_ = DementiaMedication?.DoNotPerformElement;
+			bool? k_ = j_?.Value;
+			bool? l_ = context.Operators.IsTrue(k_);
+			bool? m_ = context.Operators.Not(l_);
+			CqlInterval<CqlDate> n_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(DementiaMedication);
+			CqlDate o_ = n_?.low;
+			CqlDateTime p_ = context.Operators.ConvertDateToDateTime(o_);
+			CqlDate r_ = n_?.high;
+			CqlDateTime s_ = context.Operators.ConvertDateToDateTime(r_);
+			bool? u_ = n_?.lowClosed;
+			bool? w_ = n_?.highClosed;
+			CqlInterval<CqlDateTime> x_ = context.Operators.Interval(p_, s_, u_, w_);
+			CqlInterval<CqlDateTime> y_ = this.Measurement_Period();
+			CqlDateTime z_ = context.Operators.Start(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(1m, "year");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlDateTime ad_ = context.Operators.End(y_);
+			CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ab_, ad_, true, true);
+			bool? af_ = context.Operators.Overlaps(x_, ae_, "day");
+			bool? ag_ = context.Operators.And(m_, af_);
 
 			return ag_;
 		};
-		var h_ = context.Operators.Where<MedicationRequest>(f_, g_);
-		var i_ = context.Operators.Exists<MedicationRequest>(h_);
+		IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+		bool? i_ = context.Operators.Exists<MedicationRequest>(h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period_Value"/>
     [CqlDeclaration("Has Dementia Medications in Year Before or During Measurement Period")]
 	public bool? Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period() => 
 		__Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period.Value;
 
+    /// <seealso cref="Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty"/>
 	private bool? Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 66);
-		var h_ = this.Has_Criteria_Indicating_Frailty();
-		var i_ = context.Operators.And(g_, h_);
-		var j_ = this.Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();
-		var k_ = this.Has_Inpatient_Encounter_with_Advanced_Illness();
-		var l_ = context.Operators.Or(j_, k_);
-		var m_ = this.Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period();
-		var n_ = context.Operators.Or(l_, m_);
-		var o_ = context.Operators.And(i_, n_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 66);
+		bool? j_ = this.Has_Criteria_Indicating_Frailty();
+		bool? k_ = context.Operators.And(i_, j_);
+		bool? l_ = this.Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();
+		bool? m_ = this.Has_Inpatient_Encounter_with_Advanced_Illness();
+		bool? n_ = context.Operators.Or(l_, m_);
+		bool? o_ = this.Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period();
+		bool? p_ = context.Operators.Or(n_, o_);
+		bool? q_ = context.Operators.And(k_, p_);
 
-		return o_;
+		return q_;
 	}
 
+    /// <seealso cref="Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty_Value"/>
     [CqlDeclaration("Is Age 66 or Older with Advanced Illness and Frailty")]
 	public bool? Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty() => 
 		__Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty.Value;
 
+    /// <seealso cref="Is_Age_66_to_80_with_Advanced_Illness_and_Frailty_or_Is_Age_81_or_Older_with_Frailty"/>
 	private bool? Is_Age_66_to_80_with_Advanced_Illness_and_Frailty_or_Is_Age_81_or_Older_with_Frailty_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(66, 80, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var i_ = this.Has_Criteria_Indicating_Frailty();
-		var j_ = context.Operators.And(h_, i_);
-		var k_ = this.Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();
-		var l_ = this.Has_Inpatient_Encounter_with_Advanced_Illness();
-		var m_ = context.Operators.Or(k_, l_);
-		var n_ = this.Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period();
-		var o_ = context.Operators.Or(m_, n_);
-		var p_ = context.Operators.And(j_, o_);
-		var r_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var t_ = context.Operators.End(c_);
-		var u_ = context.Operators.DateFrom(t_);
-		var v_ = context.Operators.CalculateAgeAt(r_, u_, "year");
-		var w_ = context.Operators.GreaterOrEqual(v_, 81);
-		var y_ = context.Operators.And(w_, i_);
-		var z_ = context.Operators.Or(p_, y_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? k_ = this.Has_Criteria_Indicating_Frailty();
+		bool? l_ = context.Operators.And(j_, k_);
+		bool? m_ = this.Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();
+		bool? n_ = this.Has_Inpatient_Encounter_with_Advanced_Illness();
+		bool? o_ = context.Operators.Or(m_, n_);
+		bool? p_ = this.Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period();
+		bool? q_ = context.Operators.Or(o_, p_);
+		bool? r_ = context.Operators.And(l_, q_);
+		Date t_ = a_?.BirthDateElement;
+		string u_ = t_?.Value;
+		CqlDate v_ = context.Operators.Convert<CqlDate>(u_);
+		CqlDateTime x_ = context.Operators.End(e_);
+		CqlDate y_ = context.Operators.DateFrom(x_);
+		int? z_ = context.Operators.CalculateAgeAt(v_, y_, "year");
+		bool? aa_ = context.Operators.GreaterOrEqual(z_, 81);
+		bool? ac_ = context.Operators.And(aa_, k_);
+		bool? ad_ = context.Operators.Or(r_, ac_);
 
-		return z_;
+		return ad_;
 	}
 
+    /// <seealso cref="Is_Age_66_to_80_with_Advanced_Illness_and_Frailty_or_Is_Age_81_or_Older_with_Frailty_Value"/>
     [CqlDeclaration("Is Age 66 to 80 with Advanced Illness and Frailty or Is Age 81 or Older with Frailty")]
 	public bool? Is_Age_66_to_80_with_Advanced_Illness_and_Frailty_or_Is_Age_81_or_Older_with_Frailty() => 
 		__Is_Age_66_to_80_with_Advanced_Illness_and_Frailty_or_Is_Age_81_or_Older_with_Frailty.Value;
 
+    /// <seealso cref="Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home"/>
 	private bool? Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 66);
-		var h_ = this.Housing_status();
-		var i_ = context.Operators.ToList<CqlCode>(h_);
-		var j_ = context.Operators.RetrieveByCodes<Observation>(i_, null);
-		var k_ = Status_1_6_000.isAssessmentPerformed(j_);
-		bool? l_(Observation HousingStatus)
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 66);
+		CqlCode j_ = this.Housing_status();
+		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
+		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, null);
+		IEnumerable<Observation> m_ = Status_1_6_000.isAssessmentPerformed(l_);
+		bool? n_(Observation HousingStatus)
 		{
-			var w_ = HousingStatus?.Effective;
-			var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-			var y_ = QICoreCommon_2_0_000.toInterval(x_);
-			var z_ = context.Operators.End(y_);
-			var aa_ = this.Measurement_Period();
-			var ab_ = context.Operators.End(aa_);
-			var ac_ = context.Operators.SameOrBefore(z_, ab_, "day");
+			DataType y_ = HousingStatus?.Effective;
+			object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+			CqlInterval<CqlDateTime> aa_ = QICoreCommon_2_0_000.toInterval(z_);
+			CqlDateTime ab_ = context.Operators.End(aa_);
+			CqlInterval<CqlDateTime> ac_ = this.Measurement_Period();
+			CqlDateTime ad_ = context.Operators.End(ac_);
+			bool? ae_ = context.Operators.SameOrBefore(ab_, ad_, "day");
 
-			return ac_;
+			return ae_;
 		};
-		var m_ = context.Operators.Where<Observation>(k_, l_);
-		object n_(Observation @this)
+		IEnumerable<Observation> o_ = context.Operators.Where<Observation>(m_, n_);
+		object p_(Observation @this)
 		{
-			var ad_ = @this?.Effective;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = QICoreCommon_2_0_000.toInterval(ae_);
-			var ag_ = context.Operators.End(af_);
+			DataType af_ = @this?.Effective;
+			object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+			CqlInterval<CqlDateTime> ah_ = QICoreCommon_2_0_000.toInterval(ag_);
+			CqlDateTime ai_ = context.Operators.End(ah_);
 
-			return ag_;
+			return ai_;
 		};
-		var o_ = context.Operators.SortBy<Observation>(m_, n_, System.ComponentModel.ListSortDirection.Ascending);
-		var p_ = context.Operators.Last<Observation>(o_);
-		var q_ = new Observation[]
+		IEnumerable<Observation> q_ = context.Operators.SortBy<Observation>(o_, p_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation r_ = context.Operators.Last<Observation>(q_);
+		Observation[] s_ = new Observation[]
 		{
-			p_,
+			r_,
 		};
-		bool? r_(Observation LastHousingStatus)
+		bool? t_(Observation LastHousingStatus)
 		{
-			var ah_ = LastHousingStatus?.Value;
-			var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-			var aj_ = this.Lives_in_a_nursing_home__finding_();
-			var ak_ = context.Operators.ConvertCodeToConcept(aj_);
-			var al_ = context.Operators.Equivalent((ai_ as CqlConcept), ak_);
+			DataType aj_ = LastHousingStatus?.Value;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlCode al_ = this.Lives_in_a_nursing_home__finding_();
+			CqlConcept am_ = context.Operators.ConvertCodeToConcept(al_);
+			bool? an_ = context.Operators.Equivalent((ak_ as CqlConcept), am_);
 
-			return al_;
+			return an_;
 		};
-		var s_ = context.Operators.Where<Observation>((IEnumerable<Observation>)q_, r_);
-		var t_ = context.Operators.SingletonFrom<Observation>(s_);
-		var u_ = context.Operators.Not((bool?)(t_ is null));
-		var v_ = context.Operators.And(g_, u_);
+		IEnumerable<Observation> u_ = context.Operators.Where<Observation>((IEnumerable<Observation>)s_, t_);
+		Observation v_ = context.Operators.SingletonFrom<Observation>(u_);
+		bool? w_ = context.Operators.Not((bool?)(v_ is null));
+		bool? x_ = context.Operators.And(i_, w_);
 
-		return v_;
+		return x_;
 	}
 
+    /// <seealso cref="Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home_Value"/>
     [CqlDeclaration("Is Age 66 or Older Living Long Term in a Nursing Home")]
 	public bool? Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home() => 
 		__Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home.Value;

--- a/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
@@ -76,37 +76,46 @@ public class AlaraCTFHIR_0_1_001
 
     #endregion
 
+    /// <seealso cref="Birth_date"/>
 	private CqlCode Birth_date_Value() => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Birth_date_Value"/>
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
+    /// <seealso cref="Calculated_CT_global_noise"/>
 	private CqlCode Calculated_CT_global_noise_Value() => 
 		new CqlCode("96912-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="Calculated_CT_global_noise_Value"/>
     [CqlDeclaration("Calculated CT global noise")]
 	public CqlCode Calculated_CT_global_noise() => 
 		__Calculated_CT_global_noise.Value;
 
+    /// <seealso cref="Calculated_CT_size_adjusted_dose"/>
 	private CqlCode Calculated_CT_size_adjusted_dose_Value() => 
 		new CqlCode("96913-9", "http://loinc.org", null, null);
 
+    /// <seealso cref="Calculated_CT_size_adjusted_dose_Value"/>
     [CqlDeclaration("Calculated CT size-adjusted dose")]
 	public CqlCode Calculated_CT_size_adjusted_dose() => 
 		__Calculated_CT_size_adjusted_dose.Value;
 
+    /// <seealso cref="CT_dose_and_image_quality_category"/>
 	private CqlCode CT_dose_and_image_quality_category_Value() => 
 		new CqlCode("96914-7", "http://loinc.org", null, null);
 
+    /// <seealso cref="CT_dose_and_image_quality_category_Value"/>
     [CqlDeclaration("CT dose and image quality category")]
 	public CqlCode CT_dose_and_image_quality_category() => 
 		__CT_dose_and_image_quality_category.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("21112-8", "http://loinc.org", null, null),
 			new CqlCode("96912-1", "http://loinc.org", null, null),
@@ -117,108 +126,123 @@ public class AlaraCTFHIR_0_1_001
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("AlaraCTFHIR-0.1.001", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("AlaraCTFHIR-0.1.001", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_CTScan"/>
 	private IEnumerable<Observation> Qualifying_CTScan_Value()
 	{
-		var a_ = this.CT_dose_and_image_quality_category();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.CT_dose_and_image_quality_category();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation CTScanResult)
 		{
-			var f_ = this.Measurement_Period();
-			var g_ = CTScanResult?.Effective;
-			var h_ = FHIRHelpers_4_3_000.ToValue(g_);
-			var i_ = QICoreCommon_2_0_000.ToInterval(h_);
-			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, null);
-			var k_ = this.Patient();
-			var l_ = k_?.BirthDateElement;
-			var m_ = l_?.Value;
-			var n_ = context.Operators.ConvertStringToDateTime(m_);
-			var p_ = context.Operators.Start(f_);
-			var q_ = context.Operators.CalculateAgeAt(n_, p_, "year");
-			var r_ = context.Operators.GreaterOrEqual(q_, 18);
-			var s_ = context.Operators.And(j_, r_);
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			DataType g_ = CTScanResult?.Effective;
+			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
+			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToInterval(h_);
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, null);
+			Patient k_ = this.Patient();
+			Date l_ = k_?.BirthDateElement;
+			string m_ = l_?.Value;
+			CqlDateTime n_ = context.Operators.ConvertStringToDateTime(m_);
+			CqlDateTime p_ = context.Operators.Start(f_);
+			int? q_ = context.Operators.CalculateAgeAt(n_, p_, "year");
+			bool? r_ = context.Operators.GreaterOrEqual(q_, 18);
+			bool? s_ = context.Operators.And(j_, r_);
 
 			return s_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Qualifying_CTScan_Value"/>
     [CqlDeclaration("Qualifying CTScan")]
 	public IEnumerable<Observation> Qualifying_CTScan() => 
 		__Qualifying_CTScan.Value;
@@ -226,152 +250,162 @@ public class AlaraCTFHIR_0_1_001
     [CqlDeclaration("Global Noise Value")]
 	public decimal? Global_Noise_Value(Observation Obs)
 	{
-		bool? a_(Observation.ComponentComponent C)
+		List<Observation.ComponentComponent> a_ = Obs?.Component;
+		bool? b_(Observation.ComponentComponent C)
 		{
-			var f_ = C?.Code;
-			var g_ = FHIRHelpers_4_3_000.ToConcept(f_);
-			var h_ = this.Calculated_CT_global_noise();
-			var i_ = context.Operators.ConvertCodeToConcept(h_);
-			var j_ = context.Operators.Equivalent(g_, i_);
-			var k_ = C?.Value;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = (l_ as CqlQuantity)?.unit;
-			var n_ = context.Operators.Equal(m_, "[hnsf'U]");
-			var o_ = context.Operators.And(j_, n_);
+			CodeableConcept g_ = C?.Code;
+			CqlConcept h_ = FHIRHelpers_4_3_000.ToConcept(g_);
+			CqlCode i_ = this.Calculated_CT_global_noise();
+			CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+			bool? k_ = context.Operators.Equivalent(h_, j_);
+			DataType l_ = C?.Value;
+			object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+			string n_ = (m_ as CqlQuantity)?.unit;
+			bool? o_ = context.Operators.Equal(n_, "[hnsf'U]");
+			bool? p_ = context.Operators.And(k_, o_);
 
-			return o_;
+			return p_;
 		};
-		var b_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)Obs?.Component, a_);
-		decimal? c_(Observation.ComponentComponent C)
+		IEnumerable<Observation.ComponentComponent> c_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)a_, b_);
+		decimal? d_(Observation.ComponentComponent C)
 		{
-			var p_ = C?.Value;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = (q_ as CqlQuantity)?.value;
+			DataType q_ = C?.Value;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			decimal? s_ = (r_ as CqlQuantity)?.value;
 
-			return r_;
+			return s_;
 		};
-		var d_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<decimal?>(d_);
+		IEnumerable<decimal?> e_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(c_, d_);
+		decimal? f_ = context.Operators.SingletonFrom<decimal?>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("Size Adjusted Value")]
 	public decimal? Size_Adjusted_Value(Observation Obs)
 	{
-		bool? a_(Observation.ComponentComponent C)
+		List<Observation.ComponentComponent> a_ = Obs?.Component;
+		bool? b_(Observation.ComponentComponent C)
 		{
-			var f_ = C?.Code;
-			var g_ = FHIRHelpers_4_3_000.ToConcept(f_);
-			var h_ = this.Calculated_CT_size_adjusted_dose();
-			var i_ = context.Operators.ConvertCodeToConcept(h_);
-			var j_ = context.Operators.Equivalent(g_, i_);
-			var k_ = C?.Value;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = (l_ as CqlQuantity)?.unit;
-			var n_ = context.Operators.Equal(m_, "mGy.cm");
-			var o_ = context.Operators.And(j_, n_);
+			CodeableConcept g_ = C?.Code;
+			CqlConcept h_ = FHIRHelpers_4_3_000.ToConcept(g_);
+			CqlCode i_ = this.Calculated_CT_size_adjusted_dose();
+			CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+			bool? k_ = context.Operators.Equivalent(h_, j_);
+			DataType l_ = C?.Value;
+			object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+			string n_ = (m_ as CqlQuantity)?.unit;
+			bool? o_ = context.Operators.Equal(n_, "mGy.cm");
+			bool? p_ = context.Operators.And(k_, o_);
 
-			return o_;
+			return p_;
 		};
-		var b_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)Obs?.Component, a_);
-		decimal? c_(Observation.ComponentComponent C)
+		IEnumerable<Observation.ComponentComponent> c_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)a_, b_);
+		decimal? d_(Observation.ComponentComponent C)
 		{
-			var p_ = C?.Value;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = (q_ as CqlQuantity)?.value;
+			DataType q_ = C?.Value;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			decimal? s_ = (r_ as CqlQuantity)?.value;
 
-			return r_;
+			return s_;
 		};
-		var d_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<decimal?>(d_);
+		IEnumerable<decimal?> e_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(c_, d_);
+		decimal? f_ = context.Operators.SingletonFrom<decimal?>(e_);
 
-		return e_;
+		return f_;
 	}
 
+    /// <seealso cref="Qualifying_CTScan_with_Values"/>
 	private IEnumerable<Observation> Qualifying_CTScan_with_Values_Value()
 	{
-		var a_ = this.Qualifying_CTScan();
+		IEnumerable<Observation> a_ = this.Qualifying_CTScan();
 		bool? b_(Observation CTScan)
 		{
-			var d_ = this.Global_Noise_Value(CTScan);
-			var e_ = context.Operators.Not((bool?)(d_ is null));
-			var f_ = this.Size_Adjusted_Value(CTScan);
-			var g_ = context.Operators.Not((bool?)(f_ is null));
-			var h_ = context.Operators.And(e_, g_);
-			var i_ = CTScan?.Value;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = context.Operators.Not((bool?)(j_ is null));
-			var l_ = context.Operators.And(h_, k_);
+			decimal? d_ = this.Global_Noise_Value(CTScan);
+			bool? e_ = context.Operators.Not((bool?)(d_ is null));
+			decimal? f_ = this.Size_Adjusted_Value(CTScan);
+			bool? g_ = context.Operators.Not((bool?)(f_ is null));
+			bool? h_ = context.Operators.And(e_, g_);
+			DataType i_ = CTScan?.Value;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			bool? k_ = context.Operators.Not((bool?)(j_ is null));
+			bool? l_ = context.Operators.And(h_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Qualifying_CTScan_with_Values_Value"/>
     [CqlDeclaration("Qualifying CTScan with Values")]
 	public IEnumerable<Observation> Qualifying_CTScan_with_Values() => 
 		__Qualifying_CTScan_with_Values.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Qualifying_CTScan();
-		var b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> a_ = this.Qualifying_CTScan();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Qualifying_CTScan_with_Values();
-		var b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> a_ = this.Qualifying_CTScan_with_Values();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusion"/>
 	private bool? Denominator_Exclusion_Value()
 	{
-		var a_ = this.Qualifying_CTScan_with_Values();
+		IEnumerable<Observation> a_ = this.Qualifying_CTScan_with_Values();
 		bool? b_(Observation CTScan)
 		{
-			var e_ = CTScan?.Value;
-			var f_ = FHIRHelpers_4_3_000.ToValue(e_);
-			var g_ = (f_ as CqlConcept)?.codes;
+			DataType e_ = CTScan?.Value;
+			object f_ = FHIRHelpers_4_3_000.ToValue(e_);
+			CqlCode[] g_ = (f_ as CqlConcept)?.codes;
 			bool? h_(CqlCode @this)
 			{
-				var m_ = @this?.code;
-				var n_ = context.Operators.Not((bool?)(m_ is null));
+				string m_ = @this?.code;
+				bool? n_ = context.Operators.Not((bool?)(m_ is null));
 
 				return n_;
 			};
-			var i_ = context.Operators.Where<CqlCode>((IEnumerable<CqlCode>)g_, h_);
+			IEnumerable<CqlCode> i_ = context.Operators.Where<CqlCode>((IEnumerable<CqlCode>)g_, h_);
 			string j_(CqlCode @this)
 			{
-				var o_ = @this?.code;
+				string o_ = @this?.code;
 
 				return o_;
 			};
-			var k_ = context.Operators.Select<CqlCode, string>(i_, j_);
-			var l_ = context.Operators.Contains<string>(k_, "FULLBODY");
+			IEnumerable<string> k_ = context.Operators.Select<CqlCode, string>(i_, j_);
+			bool? l_ = context.Operators.Contains<string>(k_, "FULLBODY");
 
 			return l_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
-		var d_ = context.Operators.Exists<Observation>(c_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
+		bool? d_ = context.Operators.Exists<Observation>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Denominator_Exclusion_Value"/>
     [CqlDeclaration("Denominator Exclusion")]
 	public bool? Denominator_Exclusion() => 
 		__Denominator_Exclusion.Value;
@@ -379,113 +413,117 @@ public class AlaraCTFHIR_0_1_001
     [CqlDeclaration("Qualifies")]
 	public bool? Qualifies(Observation Obs, string code, decimal? noiseThreshold, decimal? sizeDoseThreshold)
 	{
-		var a_ = FHIRHelpers_4_3_000.ToValue(Obs?.Value);
-		bool? b_(CqlCode @this)
+		DataType a_ = Obs?.Value;
+		object b_ = FHIRHelpers_4_3_000.ToValue(a_);
+		CqlCode[] c_ = (b_ as CqlConcept)?.codes;
+		bool? d_(CqlCode @this)
 		{
-			var m_ = @this?.code;
-			var n_ = context.Operators.Not((bool?)(m_ is null));
+			string o_ = @this?.code;
+			bool? p_ = context.Operators.Not((bool?)(o_ is null));
 
-			return n_;
+			return p_;
 		};
-		var c_ = context.Operators.Where<CqlCode>(((IEnumerable<CqlCode>)(a_ as CqlConcept)?.codes), b_);
-		string d_(CqlCode @this)
+		IEnumerable<CqlCode> e_ = context.Operators.Where<CqlCode>((IEnumerable<CqlCode>)c_, d_);
+		string f_(CqlCode @this)
 		{
-			var o_ = @this?.code;
+			string q_ = @this?.code;
 
-			return o_;
+			return q_;
 		};
-		var e_ = context.Operators.Select<CqlCode, string>(c_, d_);
-		var f_ = context.Operators.Contains<string>(e_, code);
-		var g_ = this.Global_Noise_Value(Obs);
-		var h_ = context.Operators.GreaterOrEqual(g_, noiseThreshold);
-		var i_ = this.Size_Adjusted_Value(Obs);
-		var j_ = context.Operators.GreaterOrEqual(i_, sizeDoseThreshold);
-		var k_ = context.Operators.Or(h_, j_);
-		var l_ = context.Operators.And(f_, k_);
+		IEnumerable<string> g_ = context.Operators.Select<CqlCode, string>(e_, f_);
+		bool? h_ = context.Operators.Contains<string>(g_, code);
+		decimal? i_ = this.Global_Noise_Value(Obs);
+		bool? j_ = context.Operators.GreaterOrEqual(i_, noiseThreshold);
+		decimal? k_ = this.Size_Adjusted_Value(Obs);
+		bool? l_ = context.Operators.GreaterOrEqual(k_, sizeDoseThreshold);
+		bool? m_ = context.Operators.Or(j_, l_);
+		bool? n_ = context.Operators.And(h_, m_);
 
-		return l_;
+		return n_;
 	}
 
     [CqlDeclaration("CT Scan Qualifies")]
 	public bool? CT_Scan_Qualifies(Observation IP)
 	{
-		var a_ = context.Operators.ConvertIntegerToDecimal(64);
-		var b_ = context.Operators.ConvertIntegerToDecimal(598);
-		var c_ = this.Qualifies(IP, "ABDOPEL LD", a_, b_);
-		var d_ = context.Operators.ConvertIntegerToDecimal(29);
-		var e_ = context.Operators.ConvertIntegerToDecimal(644);
-		var f_ = this.Qualifies(IP, "ABDOPEL RT", d_, e_);
-		var g_ = context.Operators.Or(c_, f_);
-		var i_ = context.Operators.ConvertIntegerToDecimal(1260);
-		var j_ = this.Qualifies(IP, "ABDOPEL HD", d_, i_);
-		var k_ = context.Operators.Or(g_, j_);
-		var l_ = context.Operators.ConvertIntegerToDecimal(55);
-		var m_ = context.Operators.ConvertIntegerToDecimal(93);
-		var n_ = this.Qualifies(IP, "CARDIAC LD", l_, m_);
-		var o_ = context.Operators.Or(k_, n_);
-		var p_ = context.Operators.ConvertIntegerToDecimal(32);
-		var q_ = context.Operators.ConvertIntegerToDecimal(576);
-		var r_ = this.Qualifies(IP, "CARDIAC RT", p_, q_);
-		var s_ = context.Operators.Or(o_, r_);
-		var u_ = context.Operators.ConvertIntegerToDecimal(377);
-		var v_ = this.Qualifies(IP, "CHEST LD", l_, u_);
-		var w_ = context.Operators.Or(s_, v_);
-		var x_ = context.Operators.ConvertIntegerToDecimal(49);
-		var z_ = this.Qualifies(IP, "CHEST RT", x_, u_);
-		var aa_ = context.Operators.Or(w_, z_);
-		var ac_ = context.Operators.ConvertIntegerToDecimal(1282);
-		var ad_ = this.Qualifies(IP, "CHEST-CARDIAC HD", x_, ac_);
-		var ae_ = context.Operators.Or(aa_, ad_);
-		var af_ = context.Operators.ConvertIntegerToDecimal(115);
-		var ag_ = context.Operators.ConvertIntegerToDecimal(582);
-		var ah_ = this.Qualifies(IP, "HEAD LD", af_, ag_);
-		var ai_ = context.Operators.Or(ae_, ah_);
-		var ak_ = context.Operators.ConvertIntegerToDecimal(1025);
-		var al_ = this.Qualifies(IP, "HEAD RT", af_, ak_);
-		var am_ = context.Operators.Or(ai_, al_);
-		var ao_ = context.Operators.ConvertIntegerToDecimal(1832);
-		var ap_ = this.Qualifies(IP, "HEAD HD", af_, ao_);
-		var aq_ = context.Operators.Or(am_, ap_);
-		var ar_ = context.Operators.ConvertIntegerToDecimal(73);
-		var as_ = context.Operators.ConvertIntegerToDecimal(320);
-		var at_ = this.Qualifies(IP, "EXTREMITIES", ar_, as_);
-		var au_ = context.Operators.Or(aq_, at_);
-		var av_ = context.Operators.ConvertIntegerToDecimal(25);
-		var ax_ = this.Qualifies(IP, "NECK-CSPINE", av_, i_);
-		var ay_ = context.Operators.Or(au_, ax_);
-		var bb_ = this.Qualifies(IP, "TSPINE-LSPINE", av_, i_);
-		var bc_ = context.Operators.Or(ay_, bb_);
-		var be_ = context.Operators.ConvertIntegerToDecimal(1637);
-		var bf_ = this.Qualifies(IP, "CAP", d_, be_);
-		var bg_ = context.Operators.Or(bc_, bf_);
-		var bi_ = context.Operators.ConvertIntegerToDecimal(2520);
-		var bj_ = this.Qualifies(IP, "TLSPINE", av_, bi_);
-		var bk_ = context.Operators.Or(bg_, bj_);
-		var bm_ = context.Operators.ConvertIntegerToDecimal(2285);
-		var bn_ = this.Qualifies(IP, "HEADNECK RT", av_, bm_);
-		var bo_ = context.Operators.Or(bk_, bn_);
-		var bq_ = context.Operators.ConvertIntegerToDecimal(3092);
-		var br_ = this.Qualifies(IP, "HEADNECK HD", av_, bq_);
-		var bs_ = context.Operators.Or(bo_, br_);
+		decimal? a_ = context.Operators.ConvertIntegerToDecimal(64);
+		decimal? b_ = context.Operators.ConvertIntegerToDecimal(598);
+		bool? c_ = this.Qualifies(IP, "ABDOPEL LD", a_, b_);
+		decimal? d_ = context.Operators.ConvertIntegerToDecimal(29);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(644);
+		bool? f_ = this.Qualifies(IP, "ABDOPEL RT", d_, e_);
+		bool? g_ = context.Operators.Or(c_, f_);
+		decimal? i_ = context.Operators.ConvertIntegerToDecimal(1260);
+		bool? j_ = this.Qualifies(IP, "ABDOPEL HD", d_, i_);
+		bool? k_ = context.Operators.Or(g_, j_);
+		decimal? l_ = context.Operators.ConvertIntegerToDecimal(55);
+		decimal? m_ = context.Operators.ConvertIntegerToDecimal(93);
+		bool? n_ = this.Qualifies(IP, "CARDIAC LD", l_, m_);
+		bool? o_ = context.Operators.Or(k_, n_);
+		decimal? p_ = context.Operators.ConvertIntegerToDecimal(32);
+		decimal? q_ = context.Operators.ConvertIntegerToDecimal(576);
+		bool? r_ = this.Qualifies(IP, "CARDIAC RT", p_, q_);
+		bool? s_ = context.Operators.Or(o_, r_);
+		decimal? u_ = context.Operators.ConvertIntegerToDecimal(377);
+		bool? v_ = this.Qualifies(IP, "CHEST LD", l_, u_);
+		bool? w_ = context.Operators.Or(s_, v_);
+		decimal? x_ = context.Operators.ConvertIntegerToDecimal(49);
+		bool? z_ = this.Qualifies(IP, "CHEST RT", x_, u_);
+		bool? aa_ = context.Operators.Or(w_, z_);
+		decimal? ac_ = context.Operators.ConvertIntegerToDecimal(1282);
+		bool? ad_ = this.Qualifies(IP, "CHEST-CARDIAC HD", x_, ac_);
+		bool? ae_ = context.Operators.Or(aa_, ad_);
+		decimal? af_ = context.Operators.ConvertIntegerToDecimal(115);
+		decimal? ag_ = context.Operators.ConvertIntegerToDecimal(582);
+		bool? ah_ = this.Qualifies(IP, "HEAD LD", af_, ag_);
+		bool? ai_ = context.Operators.Or(ae_, ah_);
+		decimal? ak_ = context.Operators.ConvertIntegerToDecimal(1025);
+		bool? al_ = this.Qualifies(IP, "HEAD RT", af_, ak_);
+		bool? am_ = context.Operators.Or(ai_, al_);
+		decimal? ao_ = context.Operators.ConvertIntegerToDecimal(1832);
+		bool? ap_ = this.Qualifies(IP, "HEAD HD", af_, ao_);
+		bool? aq_ = context.Operators.Or(am_, ap_);
+		decimal? ar_ = context.Operators.ConvertIntegerToDecimal(73);
+		decimal? as_ = context.Operators.ConvertIntegerToDecimal(320);
+		bool? at_ = this.Qualifies(IP, "EXTREMITIES", ar_, as_);
+		bool? au_ = context.Operators.Or(aq_, at_);
+		decimal? av_ = context.Operators.ConvertIntegerToDecimal(25);
+		bool? ax_ = this.Qualifies(IP, "NECK-CSPINE", av_, i_);
+		bool? ay_ = context.Operators.Or(au_, ax_);
+		bool? bb_ = this.Qualifies(IP, "TSPINE-LSPINE", av_, i_);
+		bool? bc_ = context.Operators.Or(ay_, bb_);
+		decimal? be_ = context.Operators.ConvertIntegerToDecimal(1637);
+		bool? bf_ = this.Qualifies(IP, "CAP", d_, be_);
+		bool? bg_ = context.Operators.Or(bc_, bf_);
+		decimal? bi_ = context.Operators.ConvertIntegerToDecimal(2520);
+		bool? bj_ = this.Qualifies(IP, "TLSPINE", av_, bi_);
+		bool? bk_ = context.Operators.Or(bg_, bj_);
+		decimal? bm_ = context.Operators.ConvertIntegerToDecimal(2285);
+		bool? bn_ = this.Qualifies(IP, "HEADNECK RT", av_, bm_);
+		bool? bo_ = context.Operators.Or(bk_, bn_);
+		decimal? bq_ = context.Operators.ConvertIntegerToDecimal(3092);
+		bool? br_ = this.Qualifies(IP, "HEADNECK HD", av_, bq_);
+		bool? bs_ = context.Operators.Or(bo_, br_);
 
 		return bs_;
 	}
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Qualifying_CTScan_with_Values();
+		IEnumerable<Observation> a_ = this.Qualifying_CTScan_with_Values();
 		bool? b_(Observation CTScan)
 		{
-			var e_ = this.CT_Scan_Qualifies(CTScan);
+			bool? e_ = this.CT_Scan_Qualifies(CTScan);
 
 			return e_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
-		var d_ = context.Operators.Exists<Observation>(c_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
+		bool? d_ = context.Operators.Exists<Observation>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
@@ -74,38 +74,47 @@ public class AlaraCTIQRFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Calculated_CT_global_noise"/>
 	private CqlCode Calculated_CT_global_noise_Value() => 
 		new CqlCode("96912-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="Calculated_CT_global_noise_Value"/>
     [CqlDeclaration("Calculated CT global noise")]
 	public CqlCode Calculated_CT_global_noise() => 
 		__Calculated_CT_global_noise.Value;
 
+    /// <seealso cref="Calculated_CT_size_adjusted_dose"/>
 	private CqlCode Calculated_CT_size_adjusted_dose_Value() => 
 		new CqlCode("96913-9", "http://loinc.org", null, null);
 
+    /// <seealso cref="Calculated_CT_size_adjusted_dose_Value"/>
     [CqlDeclaration("Calculated CT size-adjusted dose")]
 	public CqlCode Calculated_CT_size_adjusted_dose() => 
 		__Calculated_CT_size_adjusted_dose.Value;
 
+    /// <seealso cref="CT_dose_and_image_quality_category"/>
 	private CqlCode CT_dose_and_image_quality_category_Value() => 
 		new CqlCode("96914-7", "http://loinc.org", null, null);
 
+    /// <seealso cref="CT_dose_and_image_quality_category_Value"/>
     [CqlDeclaration("CT dose and image quality category")]
 	public CqlCode CT_dose_and_image_quality_category() => 
 		__CT_dose_and_image_quality_category.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("96912-1", "http://loinc.org", null, null),
 			new CqlCode("96913-9", "http://loinc.org", null, null),
@@ -115,148 +124,165 @@ public class AlaraCTIQRFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("AlaraCTIQRFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("AlaraCTIQRFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Inpatient_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Inpatient_Encounters_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter InpatientEncounter)
 		{
-			var e_ = InpatientEncounter?.Period;
-			var f_ = FHIRHelpers_4_3_000.ToInterval(e_);
-			var g_ = this.Measurement_Period();
-			var h_ = context.Operators.Overlaps(f_, g_, null);
-			var i_ = this.Patient();
-			var j_ = i_?.BirthDateElement;
-			var k_ = j_?.Value;
-			var l_ = context.Operators.Convert<CqlDate>(k_);
-			var n_ = context.Operators.Start(g_);
-			var o_ = context.Operators.DateFrom(n_);
-			var p_ = context.Operators.CalculateAgeAt(l_, o_, "year");
-			var q_ = context.Operators.GreaterOrEqual(p_, 18);
-			var r_ = context.Operators.And(h_, q_);
+			Period e_ = InpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			bool? h_ = context.Operators.Overlaps(f_, g_, null);
+			Patient i_ = this.Patient();
+			Date j_ = i_?.BirthDateElement;
+			string k_ = j_?.Value;
+			CqlDate l_ = context.Operators.Convert<CqlDate>(k_);
+			CqlDateTime n_ = context.Operators.Start(g_);
+			CqlDate o_ = context.Operators.DateFrom(n_);
+			int? p_ = context.Operators.CalculateAgeAt(l_, o_, "year");
+			bool? q_ = context.Operators.GreaterOrEqual(p_, 18);
+			bool? r_ = context.Operators.And(h_, q_);
 
 			return r_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Qualifying_Inpatient_Encounters_Value"/>
     [CqlDeclaration("Qualifying Inpatient Encounters")]
 	public IEnumerable<Encounter> Qualifying_Inpatient_Encounters() => 
 		__Qualifying_Inpatient_Encounters.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Observation> Initial_Population_Value()
 	{
-		var a_ = this.CT_dose_and_image_quality_category();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.CT_dose_and_image_quality_category();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		IEnumerable<Observation> d_(Observation CTScan)
 		{
-			var f_ = this.Qualifying_Inpatient_Encounters();
+			IEnumerable<Encounter> f_ = this.Qualifying_Inpatient_Encounters();
 			bool? g_(Encounter InpatientEncounters)
 			{
-				var k_ = CTScan?.Effective;
-				var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-				var m_ = QICoreCommon_2_0_000.ToInterval(l_);
-				var n_ = context.Operators.Start(m_);
-				var o_ = InpatientEncounters?.Period;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = context.Operators.In<CqlDateTime>(n_, p_, null);
-				var r_ = this.Measurement_Period();
-				var t_ = FHIRHelpers_4_3_000.ToValue(k_);
-				var u_ = QICoreCommon_2_0_000.ToInterval(t_);
-				var v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, null);
-				var w_ = context.Operators.And(q_, v_);
+				DataType k_ = CTScan?.Effective;
+				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.ToInterval(l_);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				Period o_ = InpatientEncounters?.Period;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, null);
+				CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
+				object t_ = FHIRHelpers_4_3_000.ToValue(k_);
+				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
+				bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, null);
+				bool? w_ = context.Operators.And(q_, v_);
 
 				return w_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			Observation i_(Encounter InpatientEncounters) => 
 				CTScan;
-			var j_ = context.Operators.Select<Encounter, Observation>(h_, i_);
+			IEnumerable<Observation> j_ = context.Operators.Select<Encounter, Observation>(h_, i_);
 
 			return j_;
 		};
-		var e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Observation> Initial_Population() => 
 		__Initial_Population.Value;
@@ -264,91 +290,95 @@ public class AlaraCTIQRFHIR_0_1_000
     [CqlDeclaration("Global Noise Value")]
 	public decimal? Global_Noise_Value(Observation Obs)
 	{
-		bool? a_(Observation.ComponentComponent C)
+		List<Observation.ComponentComponent> a_ = Obs?.Component;
+		bool? b_(Observation.ComponentComponent C)
 		{
-			var f_ = C?.Code;
-			var g_ = FHIRHelpers_4_3_000.ToConcept(f_);
-			var h_ = this.Calculated_CT_global_noise();
-			var i_ = context.Operators.ConvertCodeToConcept(h_);
-			var j_ = context.Operators.Equivalent(g_, i_);
-			var k_ = C?.Value;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = (l_ as CqlQuantity)?.unit;
-			var n_ = context.Operators.Equal(m_, "[hnsf'U]");
-			var o_ = context.Operators.And(j_, n_);
+			CodeableConcept g_ = C?.Code;
+			CqlConcept h_ = FHIRHelpers_4_3_000.ToConcept(g_);
+			CqlCode i_ = this.Calculated_CT_global_noise();
+			CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+			bool? k_ = context.Operators.Equivalent(h_, j_);
+			DataType l_ = C?.Value;
+			object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+			string n_ = (m_ as CqlQuantity)?.unit;
+			bool? o_ = context.Operators.Equal(n_, "[hnsf'U]");
+			bool? p_ = context.Operators.And(k_, o_);
 
-			return o_;
+			return p_;
 		};
-		var b_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)Obs?.Component, a_);
-		decimal? c_(Observation.ComponentComponent C)
+		IEnumerable<Observation.ComponentComponent> c_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)a_, b_);
+		decimal? d_(Observation.ComponentComponent C)
 		{
-			var p_ = C?.Value;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = (q_ as CqlQuantity)?.value;
+			DataType q_ = C?.Value;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			decimal? s_ = (r_ as CqlQuantity)?.value;
 
-			return r_;
+			return s_;
 		};
-		var d_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<decimal?>(d_);
+		IEnumerable<decimal?> e_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(c_, d_);
+		decimal? f_ = context.Operators.SingletonFrom<decimal?>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("Size Adjusted Value")]
 	public decimal? Size_Adjusted_Value(Observation Obs)
 	{
-		bool? a_(Observation.ComponentComponent C)
+		List<Observation.ComponentComponent> a_ = Obs?.Component;
+		bool? b_(Observation.ComponentComponent C)
 		{
-			var f_ = C?.Code;
-			var g_ = FHIRHelpers_4_3_000.ToConcept(f_);
-			var h_ = this.Calculated_CT_size_adjusted_dose();
-			var i_ = context.Operators.ConvertCodeToConcept(h_);
-			var j_ = context.Operators.Equivalent(g_, i_);
-			var k_ = C?.Value;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = (l_ as CqlQuantity)?.unit;
-			var n_ = context.Operators.Equal(m_, "mGy.cm");
-			var o_ = context.Operators.And(j_, n_);
+			CodeableConcept g_ = C?.Code;
+			CqlConcept h_ = FHIRHelpers_4_3_000.ToConcept(g_);
+			CqlCode i_ = this.Calculated_CT_size_adjusted_dose();
+			CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+			bool? k_ = context.Operators.Equivalent(h_, j_);
+			DataType l_ = C?.Value;
+			object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+			string n_ = (m_ as CqlQuantity)?.unit;
+			bool? o_ = context.Operators.Equal(n_, "mGy.cm");
+			bool? p_ = context.Operators.And(k_, o_);
 
-			return o_;
+			return p_;
 		};
-		var b_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)Obs?.Component, a_);
-		decimal? c_(Observation.ComponentComponent C)
+		IEnumerable<Observation.ComponentComponent> c_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)a_, b_);
+		decimal? d_(Observation.ComponentComponent C)
 		{
-			var p_ = C?.Value;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = (q_ as CqlQuantity)?.value;
+			DataType q_ = C?.Value;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			decimal? s_ = (r_ as CqlQuantity)?.value;
 
-			return r_;
+			return s_;
 		};
-		var d_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<decimal?>(d_);
+		IEnumerable<decimal?> e_ = context.Operators.Select<Observation.ComponentComponent, decimal?>(c_, d_);
+		decimal? f_ = context.Operators.SingletonFrom<decimal?>(e_);
 
-		return e_;
+		return f_;
 	}
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Observation> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Observation> a_ = this.Initial_Population();
 		bool? b_(Observation IP)
 		{
-			var d_ = this.Global_Noise_Value(IP);
-			var e_ = context.Operators.Not((bool?)(d_ is null));
-			var f_ = this.Size_Adjusted_Value(IP);
-			var g_ = context.Operators.Not((bool?)(f_ is null));
-			var h_ = context.Operators.And(e_, g_);
-			var i_ = IP?.Value;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = context.Operators.Not((bool?)(j_ is null));
-			var l_ = context.Operators.And(h_, k_);
+			decimal? d_ = this.Global_Noise_Value(IP);
+			bool? e_ = context.Operators.Not((bool?)(d_ is null));
+			decimal? f_ = this.Size_Adjusted_Value(IP);
+			bool? g_ = context.Operators.Not((bool?)(f_ is null));
+			bool? h_ = context.Operators.And(e_, g_);
+			DataType i_ = IP?.Value;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			bool? k_ = context.Operators.Not((bool?)(j_ is null));
+			bool? l_ = context.Operators.And(h_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Observation> Denominator() => 
 		__Denominator.Value;
@@ -356,148 +386,154 @@ public class AlaraCTIQRFHIR_0_1_000
     [CqlDeclaration("Qualifies")]
 	public bool? Qualifies(Observation Obs, string code, decimal? noiseThreshold, decimal? sizeDoseThreshold)
 	{
-		var a_ = FHIRHelpers_4_3_000.ToValue(Obs?.Value);
-		bool? b_(CqlCode @this)
+		DataType a_ = Obs?.Value;
+		object b_ = FHIRHelpers_4_3_000.ToValue(a_);
+		CqlCode[] c_ = (b_ as CqlConcept)?.codes;
+		bool? d_(CqlCode @this)
 		{
-			var m_ = @this?.code;
-			var n_ = context.Operators.Not((bool?)(m_ is null));
+			string o_ = @this?.code;
+			bool? p_ = context.Operators.Not((bool?)(o_ is null));
 
-			return n_;
+			return p_;
 		};
-		var c_ = context.Operators.Where<CqlCode>(((IEnumerable<CqlCode>)(a_ as CqlConcept)?.codes), b_);
-		string d_(CqlCode @this)
+		IEnumerable<CqlCode> e_ = context.Operators.Where<CqlCode>((IEnumerable<CqlCode>)c_, d_);
+		string f_(CqlCode @this)
 		{
-			var o_ = @this?.code;
+			string q_ = @this?.code;
 
-			return o_;
+			return q_;
 		};
-		var e_ = context.Operators.Select<CqlCode, string>(c_, d_);
-		var f_ = context.Operators.Contains<string>(e_, code);
-		var g_ = this.Global_Noise_Value(Obs);
-		var h_ = context.Operators.GreaterOrEqual(g_, noiseThreshold);
-		var i_ = this.Size_Adjusted_Value(Obs);
-		var j_ = context.Operators.GreaterOrEqual(i_, sizeDoseThreshold);
-		var k_ = context.Operators.Or(h_, j_);
-		var l_ = context.Operators.And(f_, k_);
+		IEnumerable<string> g_ = context.Operators.Select<CqlCode, string>(e_, f_);
+		bool? h_ = context.Operators.Contains<string>(g_, code);
+		decimal? i_ = this.Global_Noise_Value(Obs);
+		bool? j_ = context.Operators.GreaterOrEqual(i_, noiseThreshold);
+		decimal? k_ = this.Size_Adjusted_Value(Obs);
+		bool? l_ = context.Operators.GreaterOrEqual(k_, sizeDoseThreshold);
+		bool? m_ = context.Operators.Or(j_, l_);
+		bool? n_ = context.Operators.And(h_, m_);
 
-		return l_;
+		return n_;
 	}
 
     [CqlDeclaration("CT Scan Qualifies")]
 	public bool? CT_Scan_Qualifies(Observation IP)
 	{
-		var a_ = context.Operators.ConvertIntegerToDecimal(64);
-		var b_ = context.Operators.ConvertIntegerToDecimal(598);
-		var c_ = this.Qualifies(IP, "ABDOPEL LD", a_, b_);
-		var d_ = context.Operators.ConvertIntegerToDecimal(29);
-		var e_ = context.Operators.ConvertIntegerToDecimal(644);
-		var f_ = this.Qualifies(IP, "ABDOPEL RT", d_, e_);
-		var g_ = context.Operators.Or(c_, f_);
-		var i_ = context.Operators.ConvertIntegerToDecimal(1260);
-		var j_ = this.Qualifies(IP, "ABDOPEL HD", d_, i_);
-		var k_ = context.Operators.Or(g_, j_);
-		var l_ = context.Operators.ConvertIntegerToDecimal(55);
-		var m_ = context.Operators.ConvertIntegerToDecimal(93);
-		var n_ = this.Qualifies(IP, "CARDIAC LD", l_, m_);
-		var o_ = context.Operators.Or(k_, n_);
-		var p_ = context.Operators.ConvertIntegerToDecimal(32);
-		var q_ = context.Operators.ConvertIntegerToDecimal(576);
-		var r_ = this.Qualifies(IP, "CARDIAC RT", p_, q_);
-		var s_ = context.Operators.Or(o_, r_);
-		var u_ = context.Operators.ConvertIntegerToDecimal(377);
-		var v_ = this.Qualifies(IP, "CHEST LD", l_, u_);
-		var w_ = context.Operators.Or(s_, v_);
-		var x_ = context.Operators.ConvertIntegerToDecimal(49);
-		var z_ = this.Qualifies(IP, "CHEST RT", x_, u_);
-		var aa_ = context.Operators.Or(w_, z_);
-		var ac_ = context.Operators.ConvertIntegerToDecimal(1282);
-		var ad_ = this.Qualifies(IP, "CHEST-CARDIAC HD", x_, ac_);
-		var ae_ = context.Operators.Or(aa_, ad_);
-		var af_ = context.Operators.ConvertIntegerToDecimal(115);
-		var ag_ = context.Operators.ConvertIntegerToDecimal(582);
-		var ah_ = this.Qualifies(IP, "HEAD LD", af_, ag_);
-		var ai_ = context.Operators.Or(ae_, ah_);
-		var ak_ = context.Operators.ConvertIntegerToDecimal(1025);
-		var al_ = this.Qualifies(IP, "HEAD RT", af_, ak_);
-		var am_ = context.Operators.Or(ai_, al_);
-		var ao_ = context.Operators.ConvertIntegerToDecimal(1832);
-		var ap_ = this.Qualifies(IP, "HEAD HD", af_, ao_);
-		var aq_ = context.Operators.Or(am_, ap_);
-		var ar_ = context.Operators.ConvertIntegerToDecimal(73);
-		var as_ = context.Operators.ConvertIntegerToDecimal(320);
-		var at_ = this.Qualifies(IP, "EXTREMITIES", ar_, as_);
-		var au_ = context.Operators.Or(aq_, at_);
-		var av_ = context.Operators.ConvertIntegerToDecimal(25);
-		var ax_ = this.Qualifies(IP, "NECK-CSPINE", av_, i_);
-		var ay_ = context.Operators.Or(au_, ax_);
-		var bb_ = this.Qualifies(IP, "TSPINE-LSPINE", av_, i_);
-		var bc_ = context.Operators.Or(ay_, bb_);
-		var be_ = context.Operators.ConvertIntegerToDecimal(1637);
-		var bf_ = this.Qualifies(IP, "CAP", d_, be_);
-		var bg_ = context.Operators.Or(bc_, bf_);
-		var bi_ = context.Operators.ConvertIntegerToDecimal(2520);
-		var bj_ = this.Qualifies(IP, "TLSPINE", av_, bi_);
-		var bk_ = context.Operators.Or(bg_, bj_);
-		var bm_ = context.Operators.ConvertIntegerToDecimal(2285);
-		var bn_ = this.Qualifies(IP, "HEADNECK RT", av_, bm_);
-		var bo_ = context.Operators.Or(bk_, bn_);
-		var bq_ = context.Operators.ConvertIntegerToDecimal(3092);
-		var br_ = this.Qualifies(IP, "HEADNECK HD", av_, bq_);
-		var bs_ = context.Operators.Or(bo_, br_);
+		decimal? a_ = context.Operators.ConvertIntegerToDecimal(64);
+		decimal? b_ = context.Operators.ConvertIntegerToDecimal(598);
+		bool? c_ = this.Qualifies(IP, "ABDOPEL LD", a_, b_);
+		decimal? d_ = context.Operators.ConvertIntegerToDecimal(29);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(644);
+		bool? f_ = this.Qualifies(IP, "ABDOPEL RT", d_, e_);
+		bool? g_ = context.Operators.Or(c_, f_);
+		decimal? i_ = context.Operators.ConvertIntegerToDecimal(1260);
+		bool? j_ = this.Qualifies(IP, "ABDOPEL HD", d_, i_);
+		bool? k_ = context.Operators.Or(g_, j_);
+		decimal? l_ = context.Operators.ConvertIntegerToDecimal(55);
+		decimal? m_ = context.Operators.ConvertIntegerToDecimal(93);
+		bool? n_ = this.Qualifies(IP, "CARDIAC LD", l_, m_);
+		bool? o_ = context.Operators.Or(k_, n_);
+		decimal? p_ = context.Operators.ConvertIntegerToDecimal(32);
+		decimal? q_ = context.Operators.ConvertIntegerToDecimal(576);
+		bool? r_ = this.Qualifies(IP, "CARDIAC RT", p_, q_);
+		bool? s_ = context.Operators.Or(o_, r_);
+		decimal? u_ = context.Operators.ConvertIntegerToDecimal(377);
+		bool? v_ = this.Qualifies(IP, "CHEST LD", l_, u_);
+		bool? w_ = context.Operators.Or(s_, v_);
+		decimal? x_ = context.Operators.ConvertIntegerToDecimal(49);
+		bool? z_ = this.Qualifies(IP, "CHEST RT", x_, u_);
+		bool? aa_ = context.Operators.Or(w_, z_);
+		decimal? ac_ = context.Operators.ConvertIntegerToDecimal(1282);
+		bool? ad_ = this.Qualifies(IP, "CHEST-CARDIAC HD", x_, ac_);
+		bool? ae_ = context.Operators.Or(aa_, ad_);
+		decimal? af_ = context.Operators.ConvertIntegerToDecimal(115);
+		decimal? ag_ = context.Operators.ConvertIntegerToDecimal(582);
+		bool? ah_ = this.Qualifies(IP, "HEAD LD", af_, ag_);
+		bool? ai_ = context.Operators.Or(ae_, ah_);
+		decimal? ak_ = context.Operators.ConvertIntegerToDecimal(1025);
+		bool? al_ = this.Qualifies(IP, "HEAD RT", af_, ak_);
+		bool? am_ = context.Operators.Or(ai_, al_);
+		decimal? ao_ = context.Operators.ConvertIntegerToDecimal(1832);
+		bool? ap_ = this.Qualifies(IP, "HEAD HD", af_, ao_);
+		bool? aq_ = context.Operators.Or(am_, ap_);
+		decimal? ar_ = context.Operators.ConvertIntegerToDecimal(73);
+		decimal? as_ = context.Operators.ConvertIntegerToDecimal(320);
+		bool? at_ = this.Qualifies(IP, "EXTREMITIES", ar_, as_);
+		bool? au_ = context.Operators.Or(aq_, at_);
+		decimal? av_ = context.Operators.ConvertIntegerToDecimal(25);
+		bool? ax_ = this.Qualifies(IP, "NECK-CSPINE", av_, i_);
+		bool? ay_ = context.Operators.Or(au_, ax_);
+		bool? bb_ = this.Qualifies(IP, "TSPINE-LSPINE", av_, i_);
+		bool? bc_ = context.Operators.Or(ay_, bb_);
+		decimal? be_ = context.Operators.ConvertIntegerToDecimal(1637);
+		bool? bf_ = this.Qualifies(IP, "CAP", d_, be_);
+		bool? bg_ = context.Operators.Or(bc_, bf_);
+		decimal? bi_ = context.Operators.ConvertIntegerToDecimal(2520);
+		bool? bj_ = this.Qualifies(IP, "TLSPINE", av_, bi_);
+		bool? bk_ = context.Operators.Or(bg_, bj_);
+		decimal? bm_ = context.Operators.ConvertIntegerToDecimal(2285);
+		bool? bn_ = this.Qualifies(IP, "HEADNECK RT", av_, bm_);
+		bool? bo_ = context.Operators.Or(bk_, bn_);
+		decimal? bq_ = context.Operators.ConvertIntegerToDecimal(3092);
+		bool? br_ = this.Qualifies(IP, "HEADNECK HD", av_, bq_);
+		bool? bs_ = context.Operators.Or(bo_, br_);
 
 		return bs_;
 	}
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Observation> Numerator_Value()
 	{
-		var a_ = this.Denominator();
+		IEnumerable<Observation> a_ = this.Denominator();
 		bool? b_(Observation Denom)
 		{
-			var d_ = this.CT_Scan_Qualifies(Denom);
+			bool? d_ = this.CT_Scan_Qualifies(Denom);
 
 			return d_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Observation> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Denominator_Exclusion"/>
 	private IEnumerable<Observation> Denominator_Exclusion_Value()
 	{
-		var a_ = this.Denominator();
+		IEnumerable<Observation> a_ = this.Denominator();
 		bool? b_(Observation Denom)
 		{
-			var d_ = Denom?.Value;
-			var e_ = FHIRHelpers_4_3_000.ToValue(d_);
-			var f_ = (e_ as CqlConcept)?.codes;
+			DataType d_ = Denom?.Value;
+			object e_ = FHIRHelpers_4_3_000.ToValue(d_);
+			CqlCode[] f_ = (e_ as CqlConcept)?.codes;
 			bool? g_(CqlCode @this)
 			{
-				var l_ = @this?.code;
-				var m_ = context.Operators.Not((bool?)(l_ is null));
+				string l_ = @this?.code;
+				bool? m_ = context.Operators.Not((bool?)(l_ is null));
 
 				return m_;
 			};
-			var h_ = context.Operators.Where<CqlCode>((IEnumerable<CqlCode>)f_, g_);
+			IEnumerable<CqlCode> h_ = context.Operators.Where<CqlCode>((IEnumerable<CqlCode>)f_, g_);
 			string i_(CqlCode @this)
 			{
-				var n_ = @this?.code;
+				string n_ = @this?.code;
 
 				return n_;
 			};
-			var j_ = context.Operators.Select<CqlCode, string>(h_, i_);
-			var k_ = context.Operators.Contains<string>(j_, "FULLBODY");
+			IEnumerable<string> j_ = context.Operators.Select<CqlCode, string>(h_, i_);
+			bool? k_ = context.Operators.Contains<string>(j_, "FULLBODY");
 
 			return k_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Exclusion_Value"/>
     [CqlDeclaration("Denominator Exclusion")]
 	public IEnumerable<Observation> Denominator_Exclusion() => 
 		__Denominator_Exclusion.Value;

--- a/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
@@ -42,25 +42,29 @@ public class Antibiotic_1_5_000
 
     #endregion
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.ResolveParameter("Antibiotic-1.5.000", "Measurement Period", null);
+		object a_ = context.ResolveParameter("Antibiotic-1.5.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
@@ -72,36 +76,36 @@ public class Antibiotic_1_5_000
 		{
 			bool? e_(Condition comcondition)
 			{
-				var i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(comcondition);
-				var j_ = context.Operators.Start(i_);
-				var k_ = context.Operators.DateFrom(j_);
-				var l_ = eDate?.Period;
-				var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-				var n_ = QICoreCommon_2_0_000.ToInterval((m_ as object));
-				var o_ = context.Operators.Start(n_);
-				var p_ = context.Operators.DateFrom(o_);
-				var q_ = context.Operators.Quantity(1m, "year");
-				var r_ = context.Operators.Subtract(p_, q_);
-				var t_ = FHIRHelpers_4_3_000.ToInterval(l_);
-				var u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
-				var v_ = context.Operators.Start(u_);
-				var w_ = context.Operators.DateFrom(v_);
-				var x_ = context.Operators.Interval(r_, w_, true, true);
-				var y_ = context.Operators.In<CqlDate>(k_, x_, null);
+				CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(comcondition);
+				CqlDateTime j_ = context.Operators.Start(i_);
+				CqlDate k_ = context.Operators.DateFrom(j_);
+				Period l_ = eDate?.Period;
+				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.ToInterval((m_ as object));
+				CqlDateTime o_ = context.Operators.Start(n_);
+				CqlDate p_ = context.Operators.DateFrom(o_);
+				CqlQuantity q_ = context.Operators.Quantity(1m, "year");
+				CqlDate r_ = context.Operators.Subtract(p_, q_);
+				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(l_);
+				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
+				CqlDateTime v_ = context.Operators.Start(u_);
+				CqlDate w_ = context.Operators.DateFrom(v_);
+				CqlInterval<CqlDate> x_ = context.Operators.Interval(r_, w_, true, true);
+				bool? y_ = context.Operators.In<CqlDate>(k_, x_, null);
 
 				return y_;
 			};
-			var f_ = context.Operators.Where<Condition>(comorbidConditions, e_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(comorbidConditions, e_);
 			Encounter g_(Condition comcondition) => 
 				eDate;
-			var h_ = context.Operators.Select<Condition, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<Condition, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var b_ = context.Operators.SelectMany<Encounter, Encounter>(episodeDate, a_);
+		IEnumerable<Encounter> b_ = context.Operators.SelectMany<Encounter, Encounter>(episodeDate, a_);
 		Encounter c_(Encounter eDate) => 
 			eDate;
-		var d_ = context.Operators.Select<Encounter, Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Select<Encounter, Encounter>(b_, c_);
 
 		return d_;
 	}
@@ -113,35 +117,35 @@ public class Antibiotic_1_5_000
 		{
 			bool? e_(Condition competcondition)
 			{
-				var i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(competcondition);
-				var j_ = context.Operators.Start(i_);
-				var k_ = eDate?.Period;
-				var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var m_ = context.Operators.Start(l_);
-				var o_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var p_ = context.Operators.Start(o_);
-				var q_ = context.Operators.Quantity(3m, "days");
-				var r_ = context.Operators.Add(p_, q_);
-				var s_ = context.Operators.Interval(m_, r_, true, true);
-				var t_ = context.Operators.In<CqlDateTime>(j_, s_, "day");
-				var v_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var w_ = context.Operators.Start(v_);
-				var x_ = context.Operators.Not((bool?)(w_ is null));
-				var y_ = context.Operators.And(t_, x_);
+				CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(competcondition);
+				CqlDateTime j_ = context.Operators.Start(i_);
+				Period k_ = eDate?.Period;
+				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				CqlDateTime m_ = context.Operators.Start(l_);
+				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlQuantity q_ = context.Operators.Quantity(3m, "days");
+				CqlDateTime r_ = context.Operators.Add(p_, q_);
+				CqlInterval<CqlDateTime> s_ = context.Operators.Interval(m_, r_, true, true);
+				bool? t_ = context.Operators.In<CqlDateTime>(j_, s_, "day");
+				CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				CqlDateTime w_ = context.Operators.Start(v_);
+				bool? x_ = context.Operators.Not((bool?)(w_ is null));
+				bool? y_ = context.Operators.And(t_, x_);
 
 				return y_;
 			};
-			var f_ = context.Operators.Where<Condition>(competingConditions, e_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(competingConditions, e_);
 			Encounter g_(Condition competcondition) => 
 				eDate;
-			var h_ = context.Operators.Select<Condition, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<Condition, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var b_ = context.Operators.SelectMany<Encounter, Encounter>(episodeDate, a_);
+		IEnumerable<Encounter> b_ = context.Operators.SelectMany<Encounter, Encounter>(episodeDate, a_);
 		Encounter c_(Encounter eDate) => 
 			eDate;
-		var d_ = context.Operators.Select<Encounter, Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Select<Encounter, Encounter>(b_, c_);
 
 		return d_;
 	}
@@ -153,99 +157,99 @@ public class Antibiotic_1_5_000
 		{
 			bool? c_(MedicationRequest ActiveMedication)
 			{
-				var g_ = ActiveMedication?.DosageInstruction;
+				List<Dosage> g_ = ActiveMedication?.DosageInstruction;
 				bool? h_(Dosage @this)
 				{
-					var o_ = @this?.Timing;
-					var p_ = context.Operators.Not((bool?)(o_ is null));
+					Timing o_ = @this?.Timing;
+					bool? p_ = context.Operators.Not((bool?)(o_ is null));
 
 					return p_;
 				};
-				var i_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)g_, h_);
+				IEnumerable<Dosage> i_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)g_, h_);
 				Timing j_(Dosage @this)
 				{
-					var q_ = @this?.Timing;
+					Timing q_ = @this?.Timing;
 
 					return q_;
 				};
-				var k_ = context.Operators.Select<Dosage, Timing>(i_, j_);
+				IEnumerable<Timing> k_ = context.Operators.Select<Dosage, Timing>(i_, j_);
 				bool? l_(Timing T)
 				{
-					var r_ = T?.Repeat;
-					var s_ = r_?.Bounds;
-					var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-					var u_ = QICoreCommon_2_0_000.ToInterval(t_);
-					var v_ = DateOfEpisode?.Period;
-					var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-					var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
-					var y_ = context.Operators.Start(x_);
-					var z_ = context.Operators.DateFrom(y_);
-					var aa_ = context.Operators.Quantity(30m, "days");
-					var ab_ = context.Operators.Subtract(z_, aa_);
-					var ad_ = FHIRHelpers_4_3_000.ToInterval(v_);
-					var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-					var af_ = context.Operators.Start(ae_);
-					var ag_ = context.Operators.DateFrom(af_);
-					var ah_ = context.Operators.Quantity(1m, "day");
-					var ai_ = context.Operators.Subtract(ag_, ah_);
-					var aj_ = context.Operators.Interval(ab_, ai_, true, true);
-					var ak_ = aj_?.low;
-					var al_ = context.Operators.ConvertDateToDateTime(ak_);
-					var an_ = FHIRHelpers_4_3_000.ToInterval(v_);
-					var ao_ = QICoreCommon_2_0_000.ToInterval((an_ as object));
-					var ap_ = context.Operators.Start(ao_);
-					var aq_ = context.Operators.DateFrom(ap_);
-					var as_ = context.Operators.Subtract(aq_, aa_);
-					var au_ = FHIRHelpers_4_3_000.ToInterval(v_);
-					var av_ = QICoreCommon_2_0_000.ToInterval((au_ as object));
-					var aw_ = context.Operators.Start(av_);
-					var ax_ = context.Operators.DateFrom(aw_);
-					var az_ = context.Operators.Subtract(ax_, ah_);
-					var ba_ = context.Operators.Interval(as_, az_, true, true);
-					var bb_ = ba_?.high;
-					var bc_ = context.Operators.ConvertDateToDateTime(bb_);
-					var be_ = FHIRHelpers_4_3_000.ToInterval(v_);
-					var bf_ = QICoreCommon_2_0_000.ToInterval((be_ as object));
-					var bg_ = context.Operators.Start(bf_);
-					var bh_ = context.Operators.DateFrom(bg_);
-					var bj_ = context.Operators.Subtract(bh_, aa_);
-					var bl_ = FHIRHelpers_4_3_000.ToInterval(v_);
-					var bm_ = QICoreCommon_2_0_000.ToInterval((bl_ as object));
-					var bn_ = context.Operators.Start(bm_);
-					var bo_ = context.Operators.DateFrom(bn_);
-					var bq_ = context.Operators.Subtract(bo_, ah_);
-					var br_ = context.Operators.Interval(bj_, bq_, true, true);
-					var bs_ = br_?.lowClosed;
-					var bu_ = FHIRHelpers_4_3_000.ToInterval(v_);
-					var bv_ = QICoreCommon_2_0_000.ToInterval((bu_ as object));
-					var bw_ = context.Operators.Start(bv_);
-					var bx_ = context.Operators.DateFrom(bw_);
-					var bz_ = context.Operators.Subtract(bx_, aa_);
-					var cb_ = FHIRHelpers_4_3_000.ToInterval(v_);
-					var cc_ = QICoreCommon_2_0_000.ToInterval((cb_ as object));
-					var cd_ = context.Operators.Start(cc_);
-					var ce_ = context.Operators.DateFrom(cd_);
-					var cg_ = context.Operators.Subtract(ce_, ah_);
-					var ch_ = context.Operators.Interval(bz_, cg_, true, true);
-					var ci_ = ch_?.highClosed;
-					var cj_ = context.Operators.Interval(al_, bc_, bs_, ci_);
-					var ck_ = context.Operators.Overlaps(u_, cj_, "day");
+					Timing.RepeatComponent r_ = T?.Repeat;
+					DataType s_ = r_?.Bounds;
+					object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+					CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
+					Period v_ = DateOfEpisode?.Period;
+					CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+					CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+					CqlDateTime y_ = context.Operators.Start(x_);
+					CqlDate z_ = context.Operators.DateFrom(y_);
+					CqlQuantity aa_ = context.Operators.Quantity(30m, "days");
+					CqlDate ab_ = context.Operators.Subtract(z_, aa_);
+					CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(v_);
+					CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+					CqlDateTime af_ = context.Operators.Start(ae_);
+					CqlDate ag_ = context.Operators.DateFrom(af_);
+					CqlQuantity ah_ = context.Operators.Quantity(1m, "day");
+					CqlDate ai_ = context.Operators.Subtract(ag_, ah_);
+					CqlInterval<CqlDate> aj_ = context.Operators.Interval(ab_, ai_, true, true);
+					CqlDate ak_ = aj_?.low;
+					CqlDateTime al_ = context.Operators.ConvertDateToDateTime(ak_);
+					CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_3_000.ToInterval(v_);
+					CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_0_000.ToInterval((an_ as object));
+					CqlDateTime ap_ = context.Operators.Start(ao_);
+					CqlDate aq_ = context.Operators.DateFrom(ap_);
+					CqlDate as_ = context.Operators.Subtract(aq_, aa_);
+					CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_3_000.ToInterval(v_);
+					CqlInterval<CqlDateTime> av_ = QICoreCommon_2_0_000.ToInterval((au_ as object));
+					CqlDateTime aw_ = context.Operators.Start(av_);
+					CqlDate ax_ = context.Operators.DateFrom(aw_);
+					CqlDate az_ = context.Operators.Subtract(ax_, ah_);
+					CqlInterval<CqlDate> ba_ = context.Operators.Interval(as_, az_, true, true);
+					CqlDate bb_ = ba_?.high;
+					CqlDateTime bc_ = context.Operators.ConvertDateToDateTime(bb_);
+					CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_3_000.ToInterval(v_);
+					CqlInterval<CqlDateTime> bf_ = QICoreCommon_2_0_000.ToInterval((be_ as object));
+					CqlDateTime bg_ = context.Operators.Start(bf_);
+					CqlDate bh_ = context.Operators.DateFrom(bg_);
+					CqlDate bj_ = context.Operators.Subtract(bh_, aa_);
+					CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_3_000.ToInterval(v_);
+					CqlInterval<CqlDateTime> bm_ = QICoreCommon_2_0_000.ToInterval((bl_ as object));
+					CqlDateTime bn_ = context.Operators.Start(bm_);
+					CqlDate bo_ = context.Operators.DateFrom(bn_);
+					CqlDate bq_ = context.Operators.Subtract(bo_, ah_);
+					CqlInterval<CqlDate> br_ = context.Operators.Interval(bj_, bq_, true, true);
+					bool? bs_ = br_?.lowClosed;
+					CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_3_000.ToInterval(v_);
+					CqlInterval<CqlDateTime> bv_ = QICoreCommon_2_0_000.ToInterval((bu_ as object));
+					CqlDateTime bw_ = context.Operators.Start(bv_);
+					CqlDate bx_ = context.Operators.DateFrom(bw_);
+					CqlDate bz_ = context.Operators.Subtract(bx_, aa_);
+					CqlInterval<CqlDateTime> cb_ = FHIRHelpers_4_3_000.ToInterval(v_);
+					CqlInterval<CqlDateTime> cc_ = QICoreCommon_2_0_000.ToInterval((cb_ as object));
+					CqlDateTime cd_ = context.Operators.Start(cc_);
+					CqlDate ce_ = context.Operators.DateFrom(cd_);
+					CqlDate cg_ = context.Operators.Subtract(ce_, ah_);
+					CqlInterval<CqlDate> ch_ = context.Operators.Interval(bz_, cg_, true, true);
+					bool? ci_ = ch_?.highClosed;
+					CqlInterval<CqlDateTime> cj_ = context.Operators.Interval(al_, bc_, bs_, ci_);
+					bool? ck_ = context.Operators.Overlaps(u_, cj_, "day");
 
 					return ck_;
 				};
-				var m_ = context.Operators.Where<Timing>(k_, l_);
-				var n_ = context.Operators.Exists<Timing>(m_);
+				IEnumerable<Timing> m_ = context.Operators.Where<Timing>(k_, l_);
+				bool? n_ = context.Operators.Exists<Timing>(m_);
 
 				return n_;
 			};
-			var d_ = context.Operators.Where<MedicationRequest>(antibioticMedications, c_);
+			IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(antibioticMedications, c_);
 			Encounter e_(MedicationRequest ActiveMedication) => 
 				DateOfEpisode;
-			var f_ = context.Operators.Select<MedicationRequest, Encounter>(d_, e_);
+			IEnumerable<Encounter> f_ = context.Operators.Select<MedicationRequest, Encounter>(d_, e_);
 
 			return f_;
 		};
-		var b_ = context.Operators.SelectMany<Encounter, Encounter>(episodeDate, a_);
+		IEnumerable<Encounter> b_ = context.Operators.SelectMany<Encounter, Encounter>(episodeDate, a_);
 
 		return b_;
 	}

--- a/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
@@ -96,258 +96,287 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 
     #endregion
 
+    /// <seealso cref="Anticoagulant_Therapy"/>
 	private CqlValueSet Anticoagulant_Therapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200", null);
 
+    /// <seealso cref="Anticoagulant_Therapy_Value"/>
     [CqlDeclaration("Anticoagulant Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200")]
 	public CqlValueSet Anticoagulant_Therapy() => 
 		__Anticoagulant_Therapy.Value;
 
+    /// <seealso cref="Atrial_Ablation"/>
 	private CqlValueSet Atrial_Ablation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203", null);
 
+    /// <seealso cref="Atrial_Ablation_Value"/>
     [CqlDeclaration("Atrial Ablation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203")]
 	public CqlValueSet Atrial_Ablation() => 
 		__Atrial_Ablation.Value;
 
+    /// <seealso cref="Atrial_Fibrillation_or_Flutter"/>
 	private CqlValueSet Atrial_Fibrillation_or_Flutter_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202", null);
 
+    /// <seealso cref="Atrial_Fibrillation_or_Flutter_Value"/>
     [CqlDeclaration("Atrial Fibrillation or Flutter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202")]
 	public CqlValueSet Atrial_Fibrillation_or_Flutter() => 
 		__Atrial_Fibrillation_or_Flutter.Value;
 
+    /// <seealso cref="Discharge_To_Acute_Care_Facility"/>
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
 
+    /// <seealso cref="Discharge_To_Acute_Care_Facility_Value"/>
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
 	public CqlValueSet Discharge_To_Acute_Care_Facility() => 
 		__Discharge_To_Acute_Care_Facility.Value;
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
 	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
 	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
+    /// <seealso cref="History_of_Atrial_Ablation"/>
 	private CqlValueSet History_of_Atrial_Ablation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76", null);
 
+    /// <seealso cref="History_of_Atrial_Ablation_Value"/>
     [CqlDeclaration("History of Atrial Ablation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76")]
 	public CqlValueSet History_of_Atrial_Ablation() => 
 		__History_of_Atrial_Ablation.Value;
 
+    /// <seealso cref="Left_Against_Medical_Advice"/>
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
 
+    /// <seealso cref="Left_Against_Medical_Advice_Value"/>
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
 	public CqlValueSet Left_Against_Medical_Advice() => 
 		__Left_Against_Medical_Advice.Value;
 
+    /// <seealso cref="Medical_Reason_For_Not_Providing_Treatment"/>
 	private CqlValueSet Medical_Reason_For_Not_Providing_Treatment_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", null);
 
+    /// <seealso cref="Medical_Reason_For_Not_Providing_Treatment_Value"/>
     [CqlDeclaration("Medical Reason For Not Providing Treatment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
 	public CqlValueSet Medical_Reason_For_Not_Providing_Treatment() => 
 		__Medical_Reason_For_Not_Providing_Treatment.Value;
 
+    /// <seealso cref="Patient_Expired"/>
 	private CqlValueSet Patient_Expired_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
 
+    /// <seealso cref="Patient_Expired_Value"/>
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
 	public CqlValueSet Patient_Expired() => 
 		__Patient_Expired.Value;
 
+    /// <seealso cref="Patient_Refusal"/>
 	private CqlValueSet Patient_Refusal_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", null);
 
+    /// <seealso cref="Patient_Refusal_Value"/>
     [CqlDeclaration("Patient Refusal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
 	public CqlValueSet Patient_Refusal() => 
 		__Patient_Refusal.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = TJCOverall_8_11_000.Encounter_with_Principal_Diagnosis_and_Age();
+		IEnumerable<Encounter> a_ = TJCOverall_8_11_000.Encounter_with_Principal_Diagnosis_and_Age();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Encounter_with_a_History_of_Atrial_Ablation"/>
 	private IEnumerable<Encounter> Encounter_with_a_History_of_Atrial_Ablation_Value()
 	{
-		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
 		bool? b_(Encounter IschemicStrokeEncounter)
 		{
-			var l_ = this.Atrial_Ablation();
-			var m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, null);
+			CqlValueSet l_ = this.Atrial_Ablation();
+			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, null);
 			bool? n_(Procedure AtrialAblationProcedure)
 			{
-				var q_ = AtrialAblationProcedure?.StatusElement;
-				var r_ = q_?.Value;
-				var s_ = context.Operators.Convert<string>(r_);
-				var t_ = context.Operators.Equal(s_, "completed");
-				var u_ = AtrialAblationProcedure?.Performed;
-				var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-				var w_ = QICoreCommon_2_0_000.toInterval(v_);
-				var x_ = context.Operators.Start(w_);
-				var y_ = IschemicStrokeEncounter?.Period;
-				var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-				var aa_ = context.Operators.Start(z_);
-				var ab_ = context.Operators.Before(x_, aa_, null);
-				var ac_ = context.Operators.And(t_, ab_);
+				Code<EventStatus> q_ = AtrialAblationProcedure?.StatusElement;
+				EventStatus? r_ = q_?.Value;
+				string s_ = context.Operators.Convert<string>(r_);
+				bool? t_ = context.Operators.Equal(s_, "completed");
+				DataType u_ = AtrialAblationProcedure?.Performed;
+				object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+				CqlInterval<CqlDateTime> w_ = QICoreCommon_2_0_000.toInterval(v_);
+				CqlDateTime x_ = context.Operators.Start(w_);
+				Period y_ = IschemicStrokeEncounter?.Period;
+				CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+				CqlDateTime aa_ = context.Operators.Start(z_);
+				bool? ab_ = context.Operators.Before(x_, aa_, null);
+				bool? ac_ = context.Operators.And(t_, ab_);
 
 				return ac_;
 			};
-			var o_ = context.Operators.Where<Procedure>(m_, n_);
-			var p_ = context.Operators.Exists<Procedure>(o_);
+			IEnumerable<Procedure> o_ = context.Operators.Where<Procedure>(m_, n_);
+			bool? p_ = context.Operators.Exists<Procedure>(o_);
 
 			return p_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		IEnumerable<Encounter> e_(Encounter IschemicStrokeEncounter)
 		{
-			var ad_ = this.History_of_Atrial_Ablation();
-			var ae_ = context.Operators.RetrieveByValueSet<Condition>(ad_, null);
+			CqlValueSet ad_ = this.History_of_Atrial_Ablation();
+			IEnumerable<Condition> ae_ = context.Operators.RetrieveByValueSet<Condition>(ad_, null);
 			bool? af_(Condition AtrialAblationDiagnosis)
 			{
-				var aj_ = AtrialAblationDiagnosis?.VerificationStatus;
-				var ak_ = FHIRHelpers_4_3_000.ToConcept(aj_);
-				var al_ = context.Operators.Not((bool?)(ak_ is null));
-				var an_ = FHIRHelpers_4_3_000.ToConcept(aj_);
-				var ao_ = QICoreCommon_2_0_000.confirmed();
-				var ap_ = context.Operators.ConvertCodeToConcept(ao_);
-				var aq_ = context.Operators.Equivalent(an_, ap_);
-				var ar_ = context.Operators.And(al_, aq_);
-				var as_ = AtrialAblationDiagnosis?.Onset;
-				var at_ = FHIRHelpers_4_3_000.ToValue(as_);
-				var au_ = QICoreCommon_2_0_000.toInterval(at_);
-				var av_ = context.Operators.Start(au_);
-				var aw_ = IschemicStrokeEncounter?.Period;
-				var ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var ay_ = context.Operators.Start(ax_);
-				var az_ = context.Operators.Before(av_, ay_, null);
-				var ba_ = context.Operators.And(ar_, az_);
+				CodeableConcept aj_ = AtrialAblationDiagnosis?.VerificationStatus;
+				CqlConcept ak_ = FHIRHelpers_4_3_000.ToConcept(aj_);
+				bool? al_ = context.Operators.Not((bool?)(ak_ is null));
+				CqlConcept an_ = FHIRHelpers_4_3_000.ToConcept(aj_);
+				CqlCode ao_ = QICoreCommon_2_0_000.confirmed();
+				CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+				bool? aq_ = context.Operators.Equivalent(an_, ap_);
+				bool? ar_ = context.Operators.And(al_, aq_);
+				DataType as_ = AtrialAblationDiagnosis?.Onset;
+				object at_ = FHIRHelpers_4_3_000.ToValue(as_);
+				CqlInterval<CqlDateTime> au_ = QICoreCommon_2_0_000.toInterval(at_);
+				CqlDateTime av_ = context.Operators.Start(au_);
+				Period aw_ = IschemicStrokeEncounter?.Period;
+				CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime ay_ = context.Operators.Start(ax_);
+				bool? az_ = context.Operators.Before(av_, ay_, null);
+				bool? ba_ = context.Operators.And(ar_, az_);
 
 				return ba_;
 			};
-			var ag_ = context.Operators.Where<Condition>(ae_, af_);
+			IEnumerable<Condition> ag_ = context.Operators.Where<Condition>(ae_, af_);
 			Encounter ah_(Condition AtrialAblationDiagnosis) => 
 				IschemicStrokeEncounter;
-			var ai_ = context.Operators.Select<Condition, Encounter>(ag_, ah_);
+			IEnumerable<Encounter> ai_ = context.Operators.Select<Condition, Encounter>(ag_, ah_);
 
 			return ai_;
 		};
-		var f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
-		var g_ = context.Operators.Union<Encounter>(c_, f_);
+		IEnumerable<Encounter> f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
+		IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
 		IEnumerable<Encounter> i_(Encounter IschemicStrokeEncounter)
 		{
-			var bb_ = this.History_of_Atrial_Ablation();
-			var bc_ = context.Operators.RetrieveByValueSet<Observation>(bb_, null);
+			CqlValueSet bb_ = this.History_of_Atrial_Ablation();
+			IEnumerable<Observation> bc_ = context.Operators.RetrieveByValueSet<Observation>(bb_, null);
 			bool? bd_(Observation AtrialAblationObservation)
 			{
-				var bh_ = AtrialAblationObservation?.StatusElement;
-				var bi_ = bh_?.Value;
-				var bj_ = context.Operators.Convert<Code<ObservationStatus>>(bi_);
-				var bk_ = context.Operators.Convert<string>(bj_);
-				var bl_ = new string[]
+				Code<ObservationStatus> bh_ = AtrialAblationObservation?.StatusElement;
+				ObservationStatus? bi_ = bh_?.Value;
+				Code<ObservationStatus> bj_ = context.Operators.Convert<Code<ObservationStatus>>(bi_);
+				string bk_ = context.Operators.Convert<string>(bj_);
+				string[] bl_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bm_ = context.Operators.In<string>(bk_, (bl_ as IEnumerable<string>));
+				bool? bm_ = context.Operators.In<string>(bk_, (bl_ as IEnumerable<string>));
 				object bn_()
 				{
 					bool bu_()
 					{
-						var bx_ = AtrialAblationObservation?.Effective;
-						var by_ = FHIRHelpers_4_3_000.ToValue(bx_);
-						var bz_ = by_ is CqlDateTime;
+						DataType bx_ = AtrialAblationObservation?.Effective;
+						object by_ = FHIRHelpers_4_3_000.ToValue(bx_);
+						bool bz_ = by_ is CqlDateTime;
 
 						return bz_;
 					};
 					bool bv_()
 					{
-						var ca_ = AtrialAblationObservation?.Effective;
-						var cb_ = FHIRHelpers_4_3_000.ToValue(ca_);
-						var cc_ = cb_ is CqlInterval<CqlDateTime>;
+						DataType ca_ = AtrialAblationObservation?.Effective;
+						object cb_ = FHIRHelpers_4_3_000.ToValue(ca_);
+						bool cc_ = cb_ is CqlInterval<CqlDateTime>;
 
 						return cc_;
 					};
 					bool bw_()
 					{
-						var cd_ = AtrialAblationObservation?.Effective;
-						var ce_ = FHIRHelpers_4_3_000.ToValue(cd_);
-						var cf_ = ce_ is CqlDateTime;
+						DataType cd_ = AtrialAblationObservation?.Effective;
+						object ce_ = FHIRHelpers_4_3_000.ToValue(cd_);
+						bool cf_ = ce_ is CqlDateTime;
 
 						return cf_;
 					};
 					if (bu_())
 					{
-						var cg_ = AtrialAblationObservation?.Effective;
-						var ch_ = FHIRHelpers_4_3_000.ToValue(cg_);
+						DataType cg_ = AtrialAblationObservation?.Effective;
+						object ch_ = FHIRHelpers_4_3_000.ToValue(cg_);
 
 						return ((ch_ as CqlDateTime) as object);
 					}
 					else if (bv_())
 					{
-						var ci_ = AtrialAblationObservation?.Effective;
-						var cj_ = FHIRHelpers_4_3_000.ToValue(ci_);
+						DataType ci_ = AtrialAblationObservation?.Effective;
+						object cj_ = FHIRHelpers_4_3_000.ToValue(ci_);
 
 						return ((cj_ as CqlInterval<CqlDateTime>) as object);
 					}
 					else if (bw_())
 					{
-						var ck_ = AtrialAblationObservation?.Effective;
-						var cl_ = FHIRHelpers_4_3_000.ToValue(ck_);
+						DataType ck_ = AtrialAblationObservation?.Effective;
+						object cl_ = FHIRHelpers_4_3_000.ToValue(ck_);
 
 						return ((cl_ as CqlDateTime) as object);
 					}
@@ -356,221 +385,231 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 						return null;
 					}
 				};
-				var bo_ = QICoreCommon_2_0_000.earliest(bn_());
-				var bp_ = IschemicStrokeEncounter?.Period;
-				var bq_ = FHIRHelpers_4_3_000.ToInterval(bp_);
-				var br_ = context.Operators.End(bq_);
-				var bs_ = context.Operators.SameOrBefore(bo_, br_, null);
-				var bt_ = context.Operators.And(bm_, bs_);
+				CqlDateTime bo_ = QICoreCommon_2_0_000.earliest(bn_());
+				Period bp_ = IschemicStrokeEncounter?.Period;
+				CqlInterval<CqlDateTime> bq_ = FHIRHelpers_4_3_000.ToInterval(bp_);
+				CqlDateTime br_ = context.Operators.End(bq_);
+				bool? bs_ = context.Operators.SameOrBefore(bo_, br_, null);
+				bool? bt_ = context.Operators.And(bm_, bs_);
 
 				return bt_;
 			};
-			var be_ = context.Operators.Where<Observation>(bc_, bd_);
+			IEnumerable<Observation> be_ = context.Operators.Where<Observation>(bc_, bd_);
 			Encounter bf_(Observation AtrialAblationObservation) => 
 				IschemicStrokeEncounter;
-			var bg_ = context.Operators.Select<Observation, Encounter>(be_, bf_);
+			IEnumerable<Encounter> bg_ = context.Operators.Select<Observation, Encounter>(be_, bf_);
 
 			return bg_;
 		};
-		var j_ = context.Operators.SelectMany<Encounter, Encounter>(a_, i_);
-		var k_ = context.Operators.Union<Encounter>(g_, j_);
+		IEnumerable<Encounter> j_ = context.Operators.SelectMany<Encounter, Encounter>(a_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(g_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Encounter_with_a_History_of_Atrial_Ablation_Value"/>
     [CqlDeclaration("Encounter with a History of Atrial Ablation")]
 	public IEnumerable<Encounter> Encounter_with_a_History_of_Atrial_Ablation() => 
 		__Encounter_with_a_History_of_Atrial_Ablation.Value;
 
+    /// <seealso cref="Encounter_with_Prior_or_Present_Diagnosis_of_Atrial_Fibrillation_or_Flutter"/>
 	private IEnumerable<Encounter> Encounter_with_Prior_or_Present_Diagnosis_of_Atrial_Fibrillation_or_Flutter_Value()
 	{
-		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var h_ = this.Atrial_Fibrillation_or_Flutter();
-			var i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
+			CqlValueSet h_ = this.Atrial_Fibrillation_or_Flutter();
+			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
 			bool? j_(Condition AtrialFibrillationFlutter)
 			{
-				var n_ = AtrialFibrillationFlutter?.VerificationStatus;
-				var o_ = FHIRHelpers_4_3_000.ToConcept(n_);
-				var p_ = context.Operators.Not((bool?)(o_ is null));
-				var r_ = FHIRHelpers_4_3_000.ToConcept(n_);
-				var s_ = QICoreCommon_2_0_000.confirmed();
-				var t_ = context.Operators.ConvertCodeToConcept(s_);
-				var u_ = context.Operators.Equivalent(r_, t_);
-				var v_ = context.Operators.And(p_, u_);
-				var w_ = AtrialFibrillationFlutter?.Onset;
-				var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-				var y_ = QICoreCommon_2_0_000.toInterval(x_);
-				var z_ = context.Operators.Start(y_);
-				var aa_ = IschemicStrokeEncounter?.Period;
-				var ab_ = FHIRHelpers_4_3_000.ToInterval(aa_);
-				var ac_ = context.Operators.End(ab_);
-				var ad_ = context.Operators.SameOrBefore(z_, ac_, null);
-				var ae_ = context.Operators.And(v_, ad_);
+				CodeableConcept n_ = AtrialFibrillationFlutter?.VerificationStatus;
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(n_);
+				bool? p_ = context.Operators.Not((bool?)(o_ is null));
+				CqlConcept r_ = FHIRHelpers_4_3_000.ToConcept(n_);
+				CqlCode s_ = QICoreCommon_2_0_000.confirmed();
+				CqlConcept t_ = context.Operators.ConvertCodeToConcept(s_);
+				bool? u_ = context.Operators.Equivalent(r_, t_);
+				bool? v_ = context.Operators.And(p_, u_);
+				DataType w_ = AtrialFibrillationFlutter?.Onset;
+				object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
+				CqlDateTime z_ = context.Operators.Start(y_);
+				Period aa_ = IschemicStrokeEncounter?.Period;
+				CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_3_000.ToInterval(aa_);
+				CqlDateTime ac_ = context.Operators.End(ab_);
+				bool? ad_ = context.Operators.SameOrBefore(z_, ac_, null);
+				bool? ae_ = context.Operators.And(v_, ad_);
 
 				return ae_;
 			};
-			var k_ = context.Operators.Where<Condition>(i_, j_);
+			IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
 			Encounter l_(Condition AtrialFibrillationFlutter) => 
 				IschemicStrokeEncounter;
-			var m_ = context.Operators.Select<Condition, Encounter>(k_, l_);
+			IEnumerable<Encounter> m_ = context.Operators.Select<Condition, Encounter>(k_, l_);
 
 			return m_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 		bool? e_(Encounter IschemicStrokeEncounter)
 		{
-			var af_ = CQMCommon_2_0_000.encounterDiagnosis(IschemicStrokeEncounter);
+			IEnumerable<Condition> af_ = CQMCommon_2_0_000.encounterDiagnosis(IschemicStrokeEncounter);
 			bool? ag_(Condition EncounterDiagnosis)
 			{
-				var aj_ = EncounterDiagnosis?.Code;
-				var ak_ = FHIRHelpers_4_3_000.ToConcept(aj_);
-				var al_ = this.Atrial_Fibrillation_or_Flutter();
-				var am_ = context.Operators.ConceptInValueSet(ak_, al_);
+				CodeableConcept aj_ = EncounterDiagnosis?.Code;
+				CqlConcept ak_ = FHIRHelpers_4_3_000.ToConcept(aj_);
+				CqlValueSet al_ = this.Atrial_Fibrillation_or_Flutter();
+				bool? am_ = context.Operators.ConceptInValueSet(ak_, al_);
 
 				return am_;
 			};
-			var ah_ = context.Operators.Where<Condition>(af_, ag_);
-			var ai_ = context.Operators.Exists<Condition>(ah_);
+			IEnumerable<Condition> ah_ = context.Operators.Where<Condition>(af_, ag_);
+			bool? ai_ = context.Operators.Exists<Condition>(ah_);
 
 			return ai_;
 		};
-		var f_ = context.Operators.Where<Encounter>(a_, e_);
-		var g_ = context.Operators.Union<Encounter>(c_, f_);
+		IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(a_, e_);
+		IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Encounter_with_Prior_or_Present_Diagnosis_of_Atrial_Fibrillation_or_Flutter_Value"/>
     [CqlDeclaration("Encounter with Prior or Present Diagnosis of Atrial Fibrillation or Flutter")]
 	public IEnumerable<Encounter> Encounter_with_Prior_or_Present_Diagnosis_of_Atrial_Fibrillation_or_Flutter() => 
 		__Encounter_with_Prior_or_Present_Diagnosis_of_Atrial_Fibrillation_or_Flutter.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Encounter_with_a_History_of_Atrial_Ablation();
-		var b_ = this.Encounter_with_Prior_or_Present_Diagnosis_of_Atrial_Fibrillation_or_Flutter();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_a_History_of_Atrial_Ablation();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Prior_or_Present_Diagnosis_of_Atrial_Fibrillation_or_Flutter();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Atrial_Fibrillation_or_Flutter"/>
 	private IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Atrial_Fibrillation_or_Flutter_Value()
 	{
-		var a_ = this.Denominator();
+		IEnumerable<Encounter> a_ = this.Denominator();
 		IEnumerable<Encounter> b_(Encounter Encounter)
 		{
-			var d_ = TJCOverall_8_11_000.Intervention_Comfort_Measures();
+			IEnumerable<object> d_ = TJCOverall_8_11_000.Intervention_Comfort_Measures();
 			bool? e_(object ComfortMeasure)
 			{
-				var i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = QICoreCommon_2_0_000.toInterval(j_);
-				var l_ = context.Operators.Start(k_);
-				var m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
-				var n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
-				var o_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
-				var p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
+				object i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
+				CqlDateTime l_ = context.Operators.Start(k_);
+				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
+				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
 
 				return p_;
 			};
-			var f_ = context.Operators.Where<object>(d_, e_);
+			IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
 			Encounter g_(object ComfortMeasure) => 
 				Encounter;
-			var h_ = context.Operators.Select<object, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Atrial_Fibrillation_or_Flutter_Value"/>
     [CqlDeclaration("Encounter with Comfort Measures during Hospitalization for Patients with Documented Atrial Fibrillation or Flutter")]
 	public IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Atrial_Fibrillation_or_Flutter() => 
 		__Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Atrial_Fibrillation_or_Flutter.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private IEnumerable<Encounter> Denominator_Exclusions_Value()
 	{
-		var a_ = this.Denominator();
+		IEnumerable<Encounter> a_ = this.Denominator();
 		bool? b_(Encounter Encounter)
 		{
-			var f_ = Encounter?.StatusElement;
-			var g_ = f_?.Value;
-			var h_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(g_);
-			var i_ = context.Operators.Equal(h_, "finished");
-			var j_ = Encounter?.Hospitalization;
-			var k_ = j_?.DischargeDisposition;
-			var l_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var m_ = this.Discharge_To_Acute_Care_Facility();
-			var n_ = context.Operators.ConceptInValueSet(l_, m_);
-			var p_ = j_?.DischargeDisposition;
-			var q_ = FHIRHelpers_4_3_000.ToConcept(p_);
-			var r_ = this.Left_Against_Medical_Advice();
-			var s_ = context.Operators.ConceptInValueSet(q_, r_);
-			var t_ = context.Operators.Or(n_, s_);
-			var v_ = j_?.DischargeDisposition;
-			var w_ = FHIRHelpers_4_3_000.ToConcept(v_);
-			var x_ = this.Patient_Expired();
-			var y_ = context.Operators.ConceptInValueSet(w_, x_);
-			var z_ = context.Operators.Or(t_, y_);
-			var ab_ = j_?.DischargeDisposition;
-			var ac_ = FHIRHelpers_4_3_000.ToConcept(ab_);
-			var ad_ = this.Discharged_to_Home_for_Hospice_Care();
-			var ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
-			var af_ = context.Operators.Or(z_, ae_);
-			var ah_ = j_?.DischargeDisposition;
-			var ai_ = FHIRHelpers_4_3_000.ToConcept(ah_);
-			var aj_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care();
-			var ak_ = context.Operators.ConceptInValueSet(ai_, aj_);
-			var al_ = context.Operators.Or(af_, ak_);
-			var am_ = context.Operators.And(i_, al_);
+			Code<Encounter.EncounterStatus> f_ = Encounter?.StatusElement;
+			Encounter.EncounterStatus? g_ = f_?.Value;
+			Code<Encounter.EncounterStatus> h_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(g_);
+			bool? i_ = context.Operators.Equal(h_, "finished");
+			Encounter.HospitalizationComponent j_ = Encounter?.Hospitalization;
+			CodeableConcept k_ = j_?.DischargeDisposition;
+			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlValueSet m_ = this.Discharge_To_Acute_Care_Facility();
+			bool? n_ = context.Operators.ConceptInValueSet(l_, m_);
+			CodeableConcept p_ = j_?.DischargeDisposition;
+			CqlConcept q_ = FHIRHelpers_4_3_000.ToConcept(p_);
+			CqlValueSet r_ = this.Left_Against_Medical_Advice();
+			bool? s_ = context.Operators.ConceptInValueSet(q_, r_);
+			bool? t_ = context.Operators.Or(n_, s_);
+			CodeableConcept v_ = j_?.DischargeDisposition;
+			CqlConcept w_ = FHIRHelpers_4_3_000.ToConcept(v_);
+			CqlValueSet x_ = this.Patient_Expired();
+			bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+			bool? z_ = context.Operators.Or(t_, y_);
+			CodeableConcept ab_ = j_?.DischargeDisposition;
+			CqlConcept ac_ = FHIRHelpers_4_3_000.ToConcept(ab_);
+			CqlValueSet ad_ = this.Discharged_to_Home_for_Hospice_Care();
+			bool? ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
+			bool? af_ = context.Operators.Or(z_, ae_);
+			CodeableConcept ah_ = j_?.DischargeDisposition;
+			CqlConcept ai_ = FHIRHelpers_4_3_000.ToConcept(ah_);
+			CqlValueSet aj_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care();
+			bool? ak_ = context.Operators.ConceptInValueSet(ai_, aj_);
+			bool? al_ = context.Operators.Or(af_, ak_);
+			bool? am_ = context.Operators.And(i_, al_);
 
 			return am_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
-		var d_ = this.Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Atrial_Fibrillation_or_Flutter();
-		var e_ = context.Operators.Union<Encounter>(c_, d_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Atrial_Fibrillation_or_Flutter();
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public IEnumerable<Encounter> Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Denominator();
+		IEnumerable<Encounter> a_ = this.Denominator();
 		IEnumerable<Encounter> b_(Encounter Encounter)
 		{
-			var d_ = this.Anticoagulant_Therapy();
-			var e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			var h_ = context.Operators.Union<MedicationRequest>(e_, g_);
+			CqlValueSet d_ = this.Anticoagulant_Therapy();
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			bool? i_(MedicationRequest DischargeAnticoagulant)
 			{
-				var m_ = QICoreCommon_2_0_000.isCommunity(DischargeAnticoagulant);
-				var n_ = QICoreCommon_2_0_000.isDischarge(DischargeAnticoagulant);
-				var o_ = context.Operators.Or(m_, n_);
-				var p_ = DischargeAnticoagulant?.StatusElement;
-				var q_ = p_?.Value;
-				var r_ = context.Operators.Convert<string>(q_);
-				var s_ = new string[]
+				bool? m_ = QICoreCommon_2_0_000.isCommunity(DischargeAnticoagulant);
+				bool? n_ = QICoreCommon_2_0_000.isDischarge(DischargeAnticoagulant);
+				bool? o_ = context.Operators.Or(m_, n_);
+				Code<MedicationRequest.MedicationrequestStatus> p_ = DischargeAnticoagulant?.StatusElement;
+				MedicationRequest.MedicationrequestStatus? q_ = p_?.Value;
+				string r_ = context.Operators.Convert<string>(q_);
+				string[] s_ = new string[]
 				{
 					"active",
 					"completed",
 				};
-				var t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
-				var u_ = context.Operators.And(o_, t_);
-				var v_ = DischargeAnticoagulant?.IntentElement;
-				var w_ = v_?.Value;
-				var x_ = context.Operators.Convert<string>(w_);
-				var y_ = new string[]
+				bool? t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
+				bool? u_ = context.Operators.And(o_, t_);
+				Code<MedicationRequest.MedicationRequestIntent> v_ = DischargeAnticoagulant?.IntentElement;
+				MedicationRequest.MedicationRequestIntent? w_ = v_?.Value;
+				string x_ = context.Operators.Convert<string>(w_);
+				string[] y_ = new string[]
 				{
 					"order",
 					"original-order",
@@ -578,72 +617,74 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 					"filler-order",
 					"instance-order",
 				};
-				var z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
-				var aa_ = context.Operators.And(u_, z_);
-				var ab_ = DischargeAnticoagulant?.DoNotPerformElement;
-				var ac_ = ab_?.Value;
-				var ad_ = context.Operators.IsTrue(ac_);
-				var ae_ = context.Operators.Not(ad_);
-				var af_ = context.Operators.And(aa_, ae_);
-				var ag_ = DischargeAnticoagulant?.AuthoredOnElement;
-				var ah_ = context.Operators.Convert<CqlDateTime>(ag_);
-				var ai_ = Encounter?.Period;
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-				var ak_ = context.Operators.In<CqlDateTime>(ah_, aj_, null);
-				var al_ = context.Operators.And(af_, ak_);
+				bool? z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
+				bool? aa_ = context.Operators.And(u_, z_);
+				FhirBoolean ab_ = DischargeAnticoagulant?.DoNotPerformElement;
+				bool? ac_ = ab_?.Value;
+				bool? ad_ = context.Operators.IsTrue(ac_);
+				bool? ae_ = context.Operators.Not(ad_);
+				bool? af_ = context.Operators.And(aa_, ae_);
+				FhirDateTime ag_ = DischargeAnticoagulant?.AuthoredOnElement;
+				CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(ag_);
+				Period ai_ = Encounter?.Period;
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+				bool? ak_ = context.Operators.In<CqlDateTime>(ah_, aj_, null);
+				bool? al_ = context.Operators.And(af_, ak_);
 
 				return al_;
 			};
-			var j_ = context.Operators.Where<MedicationRequest>(h_, i_);
+			IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
 			Encounter k_(MedicationRequest DischargeAnticoagulant) => 
 				Encounter;
-			var l_ = context.Operators.Select<MedicationRequest, Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Select<MedicationRequest, Encounter>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Documented_Reason_for_Not_Giving_Anticoagulant_at_Discharge"/>
 	private IEnumerable<MedicationRequest> Documented_Reason_for_Not_Giving_Anticoagulant_at_Discharge_Value()
 	{
-		var a_ = this.Anticoagulant_Therapy();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		CqlValueSet a_ = this.Anticoagulant_Therapy();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		bool? c_(MedicationRequest NoAnticoagulant)
 		{
-			var e_ = NoAnticoagulant?.ReasonCode;
+			List<CodeableConcept> e_ = NoAnticoagulant?.ReasonCode;
 			CqlConcept f_(CodeableConcept @this)
 			{
-				var z_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept z_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return z_;
 			};
-			var g_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, f_);
-			var h_ = this.Medical_Reason_For_Not_Providing_Treatment();
-			var i_ = context.Operators.ConceptsInValueSet(g_, h_);
+			IEnumerable<CqlConcept> g_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, f_);
+			CqlValueSet h_ = this.Medical_Reason_For_Not_Providing_Treatment();
+			bool? i_ = context.Operators.ConceptsInValueSet(g_, h_);
 			CqlConcept k_(CodeableConcept @this)
 			{
-				var aa_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept aa_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return aa_;
 			};
-			var l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, k_);
-			var m_ = this.Patient_Refusal();
-			var n_ = context.Operators.ConceptsInValueSet(l_, m_);
-			var o_ = context.Operators.Or(i_, n_);
-			var p_ = QICoreCommon_2_0_000.isCommunity(NoAnticoagulant);
-			var q_ = QICoreCommon_2_0_000.isDischarge(NoAnticoagulant);
-			var r_ = context.Operators.Or(p_, q_);
-			var s_ = context.Operators.And(o_, r_);
-			var t_ = NoAnticoagulant?.IntentElement;
-			var u_ = t_?.Value;
-			var v_ = context.Operators.Convert<string>(u_);
-			var w_ = new string[]
+			IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, k_);
+			CqlValueSet m_ = this.Patient_Refusal();
+			bool? n_ = context.Operators.ConceptsInValueSet(l_, m_);
+			bool? o_ = context.Operators.Or(i_, n_);
+			bool? p_ = QICoreCommon_2_0_000.isCommunity(NoAnticoagulant);
+			bool? q_ = QICoreCommon_2_0_000.isDischarge(NoAnticoagulant);
+			bool? r_ = context.Operators.Or(p_, q_);
+			bool? s_ = context.Operators.And(o_, r_);
+			Code<MedicationRequest.MedicationRequestIntent> t_ = NoAnticoagulant?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? u_ = t_?.Value;
+			string v_ = context.Operators.Convert<string>(u_);
+			string[] w_ = new string[]
 			{
 				"order",
 				"original-order",
@@ -651,92 +692,103 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				"filler-order",
 				"instance-order",
 			};
-			var x_ = context.Operators.In<string>(v_, (w_ as IEnumerable<string>));
-			var y_ = context.Operators.And(s_, x_);
+			bool? x_ = context.Operators.In<string>(v_, (w_ as IEnumerable<string>));
+			bool? y_ = context.Operators.And(s_, x_);
 
 			return y_;
 		};
-		var d_ = context.Operators.Where<MedicationRequest>(b_, c_);
+		IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Documented_Reason_for_Not_Giving_Anticoagulant_at_Discharge_Value"/>
     [CqlDeclaration("Documented Reason for Not Giving Anticoagulant at Discharge")]
 	public IEnumerable<MedicationRequest> Documented_Reason_for_Not_Giving_Anticoagulant_at_Discharge() => 
 		__Documented_Reason_for_Not_Giving_Anticoagulant_at_Discharge.Value;
 
+    /// <seealso cref="Denominator_Exceptions"/>
 	private IEnumerable<Encounter> Denominator_Exceptions_Value()
 	{
-		var a_ = this.Denominator();
+		IEnumerable<Encounter> a_ = this.Denominator();
 		IEnumerable<Encounter> b_(Encounter Encounter)
 		{
-			var d_ = this.Documented_Reason_for_Not_Giving_Anticoagulant_at_Discharge();
+			IEnumerable<MedicationRequest> d_ = this.Documented_Reason_for_Not_Giving_Anticoagulant_at_Discharge();
 			bool? e_(MedicationRequest NoDischargeAnticoagulant)
 			{
-				var i_ = NoDischargeAnticoagulant?.AuthoredOnElement;
-				var j_ = context.Operators.Convert<CqlDateTime>(i_);
-				var k_ = Encounter?.Period;
-				var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
+				FhirDateTime i_ = NoDischargeAnticoagulant?.AuthoredOnElement;
+				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+				Period k_ = Encounter?.Period;
+				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
 
 				return m_;
 			};
-			var f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+			IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
 			Encounter g_(MedicationRequest NoDischargeAnticoagulant) => 
 				Encounter;
-			var h_ = context.Operators.Select<MedicationRequest, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<MedicationRequest, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Exceptions_Value"/>
     [CqlDeclaration("Denominator Exceptions")]
 	public IEnumerable<Encounter> Denominator_Exceptions() => 
 		__Denominator_Exceptions.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
@@ -114,539 +114,608 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Annual_Wellness_Visit"/>
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
+    /// <seealso cref="Annual_Wellness_Visit_Value"/>
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
 	public CqlValueSet Annual_Wellness_Visit() => 
 		__Annual_Wellness_Visit.Value;
 
+    /// <seealso cref="Antidepressant_Medication"/>
 	private CqlValueSet Antidepressant_Medication_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1213", null);
 
+    /// <seealso cref="Antidepressant_Medication_Value"/>
     [CqlDeclaration("Antidepressant Medication")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1213")]
 	public CqlValueSet Antidepressant_Medication() => 
 		__Antidepressant_Medication.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Major_Depression"/>
 	private CqlValueSet Major_Depression_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1007", null);
 
+    /// <seealso cref="Major_Depression_Value"/>
     [CqlDeclaration("Major Depression")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1007")]
 	public CqlValueSet Major_Depression() => 
 		__Major_Depression.Value;
 
+    /// <seealso cref="Nursing_Facility_Visit"/>
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
+    /// <seealso cref="Nursing_Facility_Visit_Value"/>
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
 	public CqlValueSet Nursing_Facility_Visit() => 
 		__Nursing_Facility_Visit.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation"/>
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation_Value"/>
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
 	public CqlValueSet Psych_Visit_Diagnostic_Evaluation() => 
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
+    /// <seealso cref="Psych_Visit_Psychotherapy"/>
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
 
+    /// <seealso cref="Psych_Visit_Psychotherapy_Value"/>
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
 	public CqlValueSet Psych_Visit_Psychotherapy() => 
 		__Psych_Visit_Psychotherapy.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("AntidepressantMedicationManagementFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("AntidepressantMedicationManagementFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="April_30_of_the_Measurement_Period"/>
 	private CqlDateTime April_30_of_the_Measurement_Period_Value()
 	{
-		var a_ = this.Measurement_Period();
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateTimeComponentFrom(b_, "year");
-		var d_ = context.Operators.ConvertIntegerToDecimal(0);
-		var e_ = context.Operators.DateTime(c_, 4, 30, 23, 59, 59, 0, d_);
+		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
+		CqlDateTime b_ = context.Operators.Start(a_);
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		decimal? d_ = context.Operators.ConvertIntegerToDecimal(0);
+		CqlDateTime e_ = context.Operators.DateTime(c_, 4, 30, 23, 59, 59, 0, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="April_30_of_the_Measurement_Period_Value"/>
     [CqlDeclaration("April 30 of the Measurement Period")]
 	public CqlDateTime April_30_of_the_Measurement_Period() => 
 		__April_30_of_the_Measurement_Period.Value;
 
+    /// <seealso cref="May_1_of_the_Year_Prior_to_the_Measurement_Period"/>
 	private CqlDateTime May_1_of_the_Year_Prior_to_the_Measurement_Period_Value()
 	{
-		var a_ = this.Measurement_Period();
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateTimeComponentFrom(b_, "year");
-		var d_ = context.Operators.Subtract(c_, 1);
-		var e_ = context.Operators.ConvertIntegerToDecimal(0);
-		var f_ = context.Operators.DateTime(d_, 5, 1, 0, 0, 0, 0, e_);
+		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
+		CqlDateTime b_ = context.Operators.Start(a_);
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? d_ = context.Operators.Subtract(c_, 1);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
+		CqlDateTime f_ = context.Operators.DateTime(d_, 5, 1, 0, 0, 0, 0, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="May_1_of_the_Year_Prior_to_the_Measurement_Period_Value"/>
     [CqlDeclaration("May 1 of the Year Prior to the Measurement Period")]
 	public CqlDateTime May_1_of_the_Year_Prior_to_the_Measurement_Period() => 
 		__May_1_of_the_Year_Prior_to_the_Measurement_Period.Value;
 
+    /// <seealso cref="Intake_Period"/>
 	private CqlInterval<CqlDateTime> Intake_Period_Value()
 	{
-		var a_ = this.May_1_of_the_Year_Prior_to_the_Measurement_Period();
-		var b_ = this.April_30_of_the_Measurement_Period();
-		var c_ = context.Operators.Interval(a_, b_, true, true);
+		CqlDateTime a_ = this.May_1_of_the_Year_Prior_to_the_Measurement_Period();
+		CqlDateTime b_ = this.April_30_of_the_Measurement_Period();
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, true);
 
 		return c_;
 	}
 
+    /// <seealso cref="Intake_Period_Value"/>
     [CqlDeclaration("Intake Period")]
 	public CqlInterval<CqlDateTime> Intake_Period() => 
 		__Intake_Period.Value;
 
+    /// <seealso cref="Earliest_Antidepressant_Dispensed_During_Intake_Period"/>
 	private CqlDate Earliest_Antidepressant_Dispensed_During_Intake_Period_Value()
 	{
-		var a_ = this.Antidepressant_Medication();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		var e_ = context.Operators.Union<MedicationDispense>(b_, d_);
-		var f_ = Status_1_6_000.Dispensed_Medication(e_);
+		CqlValueSet a_ = this.Antidepressant_Medication();
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
+		IEnumerable<MedicationDispense> f_ = Status_1_6_000.Dispensed_Medication(e_);
 		bool? g_(MedicationDispense Antidepressant)
 		{
-			var n_ = CumulativeMedicationDuration_4_0_000.MedicationDispensePeriod(Antidepressant);
-			var o_ = context.Operators.Start(n_);
-			var p_ = context.Operators.ConvertDateToDateTime(o_);
-			var q_ = this.Intake_Period();
-			var r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
+			CqlInterval<CqlDate> o_ = CumulativeMedicationDuration_4_0_000.MedicationDispensePeriod(Antidepressant);
+			CqlDate p_ = context.Operators.Start(o_);
+			CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+			CqlInterval<CqlDateTime> r_ = this.Intake_Period();
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
 
-			return r_;
+			return s_;
 		};
-		var h_ = context.Operators.Where<MedicationDispense>(f_, g_);
+		IEnumerable<MedicationDispense> h_ = context.Operators.Where<MedicationDispense>(f_, g_);
 		Tuple_BZDEAYEYEiNadHNdHhSIPXaDL i_(MedicationDispense Antidepressant)
 		{
-			var s_ = CumulativeMedicationDuration_4_0_000.MedicationDispensePeriod(Antidepressant);
-			var t_ = context.Operators.Start(s_);
-			var u_ = context.Operators.ConvertDateToDateTime(t_);
-			var v_ = context.Operators.DateFrom(u_);
-			var w_ = new Tuple_BZDEAYEYEiNadHNdHhSIPXaDL
+			CqlInterval<CqlDate> t_ = CumulativeMedicationDuration_4_0_000.MedicationDispensePeriod(Antidepressant);
+			CqlDate u_ = context.Operators.Start(t_);
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(u_);
+			CqlDate w_ = context.Operators.DateFrom(v_);
+			Tuple_BZDEAYEYEiNadHNdHhSIPXaDL x_ = new Tuple_BZDEAYEYEiNadHNdHhSIPXaDL
 			{
-				AntidepressantDate = v_,
+				AntidepressantDate = w_,
 			};
-
-			return w_;
-		};
-		var j_ = context.Operators.Select<MedicationDispense, Tuple_BZDEAYEYEiNadHNdHhSIPXaDL>(h_, i_);
-		object k_(Tuple_BZDEAYEYEiNadHNdHhSIPXaDL @this)
-		{
-			var x_ = @this?.AntidepressantDate;
 
 			return x_;
 		};
-		var l_ = context.Operators.SortBy<Tuple_BZDEAYEYEiNadHNdHhSIPXaDL>(j_, k_, System.ComponentModel.ListSortDirection.Ascending);
-		var m_ = context.Operators.First<Tuple_BZDEAYEYEiNadHNdHhSIPXaDL>(l_);
+		IEnumerable<Tuple_BZDEAYEYEiNadHNdHhSIPXaDL> j_ = context.Operators.Select<MedicationDispense, Tuple_BZDEAYEYEiNadHNdHhSIPXaDL>(h_, i_);
+		object k_(Tuple_BZDEAYEYEiNadHNdHhSIPXaDL @this)
+		{
+			CqlDate y_ = @this?.AntidepressantDate;
 
-		return m_?.AntidepressantDate;
+			return y_;
+		};
+		IEnumerable<Tuple_BZDEAYEYEiNadHNdHhSIPXaDL> l_ = context.Operators.SortBy<Tuple_BZDEAYEYEiNadHNdHhSIPXaDL>(j_, k_, System.ComponentModel.ListSortDirection.Ascending);
+		Tuple_BZDEAYEYEiNadHNdHhSIPXaDL m_ = context.Operators.First<Tuple_BZDEAYEYEiNadHNdHhSIPXaDL>(l_);
+		CqlDate n_ = m_?.AntidepressantDate;
+
+		return n_;
 	}
 
+    /// <seealso cref="Earliest_Antidepressant_Dispensed_During_Intake_Period_Value"/>
     [CqlDeclaration("Earliest Antidepressant Dispensed During Intake Period")]
 	public CqlDate Earliest_Antidepressant_Dispensed_During_Intake_Period() => 
 		__Earliest_Antidepressant_Dispensed_During_Intake_Period.Value;
 
+    /// <seealso cref="Has_Initial_Major_Depression_Diagnosis"/>
 	private bool? Has_Initial_Major_Depression_Diagnosis_Value()
 	{
-		var a_ = this.Major_Depression();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Major_Depression();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition MajorDepression)
 		{
-			var f_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
-			var g_ = context.Operators.Not((bool?)(f_ is null));
-			var h_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MajorDepression);
-			var i_ = context.Operators.Start(h_);
-			var j_ = context.Operators.DateFrom(i_);
-			var l_ = context.Operators.Quantity(60m, "days");
-			var m_ = context.Operators.Subtract(f_, l_);
-			var p_ = context.Operators.Add(f_, l_);
-			var q_ = context.Operators.Interval(m_, p_, true, true);
-			var r_ = context.Operators.In<CqlDate>(j_, q_, null);
-			var t_ = context.Operators.Not((bool?)(f_ is null));
-			var u_ = context.Operators.And(r_, t_);
-			var v_ = context.Operators.And(g_, u_);
+			CqlDate f_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
+			bool? g_ = context.Operators.Not((bool?)(f_ is null));
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MajorDepression);
+			CqlDateTime i_ = context.Operators.Start(h_);
+			CqlDate j_ = context.Operators.DateFrom(i_);
+			CqlQuantity l_ = context.Operators.Quantity(60m, "days");
+			CqlDate m_ = context.Operators.Subtract(f_, l_);
+			CqlDate p_ = context.Operators.Add(f_, l_);
+			CqlInterval<CqlDate> q_ = context.Operators.Interval(m_, p_, true, true);
+			bool? r_ = context.Operators.In<CqlDate>(j_, q_, null);
+			bool? t_ = context.Operators.Not((bool?)(f_ is null));
+			bool? u_ = context.Operators.And(r_, t_);
+			bool? v_ = context.Operators.And(g_, u_);
 
 			return v_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Initial_Major_Depression_Diagnosis_Value"/>
     [CqlDeclaration("Has Initial Major Depression Diagnosis")]
 	public bool? Has_Initial_Major_Depression_Diagnosis() => 
 		__Has_Initial_Major_Depression_Diagnosis.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Home_Healthcare_Services();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Annual_Wellness_Visit();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Nursing_Facility_Visit();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Psych_Visit_Diagnostic_Evaluation();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Psych_Visit_Psychotherapy();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
-		var x_ = this.Telephone_Visits();
-		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
-		var z_ = this.Online_Assessments();
-		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
-		var ab_ = context.Operators.Union<Encounter>(y_, aa_);
-		var ac_ = context.Operators.Union<Encounter>(w_, ab_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Nursing_Facility_Visit();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Psych_Visit_Diagnostic_Evaluation();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Psych_Visit_Psychotherapy();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
+		CqlValueSet x_ = this.Telephone_Visits();
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		CqlValueSet z_ = this.Online_Assessments();
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
+		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		bool? ad_(Encounter ValidEncounter)
 		{
-			var af_ = ValidEncounter?.Period;
-			var ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-			var ah_ = QICoreCommon_2_0_000.ToInterval((ag_ as object));
-			var ai_ = context.Operators.Start(ah_);
-			var aj_ = context.Operators.DateFrom(ai_);
-			var ak_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
-			var al_ = context.Operators.Quantity(60m, "days");
-			var am_ = context.Operators.Subtract(ak_, al_);
-			var ap_ = context.Operators.Add(ak_, al_);
-			var aq_ = context.Operators.Interval(am_, ap_, true, true);
-			var ar_ = context.Operators.In<CqlDate>(aj_, aq_, null);
-			var at_ = context.Operators.Not((bool?)(ak_ is null));
-			var au_ = context.Operators.And(ar_, at_);
+			Period af_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
+			CqlInterval<CqlDateTime> ah_ = QICoreCommon_2_0_000.ToInterval((ag_ as object));
+			CqlDateTime ai_ = context.Operators.Start(ah_);
+			CqlDate aj_ = context.Operators.DateFrom(ai_);
+			CqlDate ak_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
+			CqlQuantity al_ = context.Operators.Quantity(60m, "days");
+			CqlDate am_ = context.Operators.Subtract(ak_, al_);
+			CqlDate ap_ = context.Operators.Add(ak_, al_);
+			CqlInterval<CqlDate> aq_ = context.Operators.Interval(am_, ap_, true, true);
+			bool? ar_ = context.Operators.In<CqlDate>(aj_, aq_, null);
+			bool? at_ = context.Operators.Not((bool?)(ak_ is null));
+			bool? au_ = context.Operators.And(ar_, at_);
 
 			return au_;
 		};
-		var ae_ = context.Operators.Where<Encounter>(ac_, ad_);
+		IEnumerable<Encounter> ae_ = context.Operators.Where<Encounter>(ac_, ad_);
 
 		return ae_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.April_30_of_the_Measurement_Period();
-		var d_ = context.Operators.DateFrom(c_);
-		var e_ = context.Operators.CalculateAgeAt(b_, d_, "year");
-		var f_ = context.Operators.GreaterOrEqual(e_, 18);
-		var g_ = this.Has_Initial_Major_Depression_Diagnosis();
-		var h_ = context.Operators.And(f_, g_);
-		var i_ = this.Qualifying_Encounters();
-		var j_ = context.Operators.Exists<Encounter>(i_);
-		var k_ = context.Operators.And(h_, j_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlDateTime e_ = this.April_30_of_the_Measurement_Period();
+		CqlDate f_ = context.Operators.DateFrom(e_);
+		int? g_ = context.Operators.CalculateAgeAt(d_, f_, "year");
+		bool? h_ = context.Operators.GreaterOrEqual(g_, 18);
+		bool? i_ = this.Has_Initial_Major_Depression_Diagnosis();
+		bool? j_ = context.Operators.And(h_, i_);
+		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
+		bool? l_ = context.Operators.Exists<Encounter>(k_);
+		bool? m_ = context.Operators.And(j_, l_);
 
-		return k_;
+		return m_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = this.Antidepressant_Medication();
-		var c_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, null);
-		var e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, null);
-		var f_ = context.Operators.Union<MedicationRequest>(c_, e_);
-		var g_ = Status_1_6_000.Active_Medication(f_);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		CqlValueSet b_ = this.Antidepressant_Medication();
+		IEnumerable<MedicationRequest> c_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, null);
+		IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(c_, e_);
+		IEnumerable<MedicationRequest> g_ = Status_1_6_000.Active_Medication(f_);
 		bool? h_(MedicationRequest ActiveAntidepressant)
 		{
-			var l_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
-			var m_ = context.Operators.Not((bool?)(l_ is null));
-			var n_ = ActiveAntidepressant?.DosageInstruction;
-			var o_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
-			var p_ = o_?.Timing;
-			var q_ = p_?.Repeat;
-			var r_ = q_?.Bounds;
-			var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-			var t_ = new object[]
+			CqlDate l_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
+			bool? m_ = context.Operators.Not((bool?)(l_ is null));
+			List<Dosage> n_ = ActiveAntidepressant?.DosageInstruction;
+			Dosage o_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
+			Timing p_ = o_?.Timing;
+			Timing.RepeatComponent q_ = p_?.Repeat;
+			DataType r_ = q_?.Bounds;
+			object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+			object[] t_ = new object[]
 			{
 				s_,
 			};
 			CqlInterval<CqlDateTime> u_(object Meds)
 			{
-				var af_ = this.Intake_Period();
-				var ag_ = context.Operators.Start(af_);
-				var ah_ = this.Measurement_Period();
-				var ai_ = context.Operators.End(ah_);
-				var aj_ = context.Operators.Interval(ag_, ai_, true, true);
-				var ak_ = context.Operators.Intersect<CqlDateTime>((Meds as CqlInterval<CqlDateTime>), aj_);
+				CqlInterval<CqlDateTime> af_ = this.Intake_Period();
+				CqlDateTime ag_ = context.Operators.Start(af_);
+				CqlInterval<CqlDateTime> ah_ = this.Measurement_Period();
+				CqlDateTime ai_ = context.Operators.End(ah_);
+				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ag_, ai_, true, true);
+				CqlInterval<CqlDateTime> ak_ = context.Operators.Intersect<CqlDateTime>((Meds as CqlInterval<CqlDateTime>), aj_);
 
 				return ak_;
 			};
-			var v_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>((IEnumerable<object>)t_, u_);
-			var w_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(v_);
-			var x_ = CQMCommon_2_0_000.ToDateInterval(w_);
-			var z_ = context.Operators.Quantity(105m, "days");
-			var aa_ = context.Operators.Subtract(l_, z_);
-			var ac_ = context.Operators.Interval(aa_, l_, true, false);
-			var ad_ = context.Operators.Overlaps(x_, ac_, null);
-			var ae_ = context.Operators.And(m_, ad_);
+			IEnumerable<CqlInterval<CqlDateTime>> v_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>((IEnumerable<object>)t_, u_);
+			CqlInterval<CqlDateTime> w_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(v_);
+			CqlInterval<CqlDate> x_ = CQMCommon_2_0_000.ToDateInterval(w_);
+			CqlQuantity z_ = context.Operators.Quantity(105m, "days");
+			CqlDate aa_ = context.Operators.Subtract(l_, z_);
+			CqlInterval<CqlDate> ac_ = context.Operators.Interval(aa_, l_, true, false);
+			bool? ad_ = context.Operators.Overlaps(x_, ac_, null);
+			bool? ae_ = context.Operators.And(m_, ad_);
 
 			return ae_;
 		};
-		var i_ = context.Operators.Where<MedicationRequest>(g_, h_);
-		var j_ = context.Operators.Exists<MedicationRequest>(i_);
-		var k_ = context.Operators.Or(a_, j_);
+		IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
+		bool? j_ = context.Operators.Exists<MedicationRequest>(i_);
+		bool? k_ = context.Operators.Or(a_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Antidepressant_Medication_Period_Between_IPSD_and_114_Days_After_IPSD"/>
 	private IEnumerable<CqlInterval<CqlDate>> Antidepressant_Medication_Period_Between_IPSD_and_114_Days_After_IPSD_Value()
 	{
-		var a_ = this.Antidepressant_Medication();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		var e_ = context.Operators.Union<MedicationDispense>(b_, d_);
-		var f_ = Status_1_6_000.Dispensed_Medication(e_);
+		CqlValueSet a_ = this.Antidepressant_Medication();
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
+		IEnumerable<MedicationDispense> f_ = Status_1_6_000.Dispensed_Medication(e_);
 		CqlInterval<CqlDate> g_(MedicationDispense Antidepressant)
 		{
-			var i_ = CumulativeMedicationDuration_4_0_000.MedicationDispensePeriod(Antidepressant);
-			var j_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
-			var l_ = context.Operators.Quantity(114m, "days");
-			var m_ = context.Operators.Add(j_, l_);
-			var n_ = context.Operators.Interval(j_, m_, true, true);
-			var o_ = context.Operators.Intersect<CqlDate>(i_, n_);
+			CqlInterval<CqlDate> i_ = CumulativeMedicationDuration_4_0_000.MedicationDispensePeriod(Antidepressant);
+			CqlDate j_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
+			CqlQuantity l_ = context.Operators.Quantity(114m, "days");
+			CqlDate m_ = context.Operators.Add(j_, l_);
+			CqlInterval<CqlDate> n_ = context.Operators.Interval(j_, m_, true, true);
+			CqlInterval<CqlDate> o_ = context.Operators.Intersect<CqlDate>(i_, n_);
 
 			return o_;
 		};
-		var h_ = context.Operators.Select<MedicationDispense, CqlInterval<CqlDate>>(f_, g_);
+		IEnumerable<CqlInterval<CqlDate>> h_ = context.Operators.Select<MedicationDispense, CqlInterval<CqlDate>>(f_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Antidepressant_Medication_Period_Between_IPSD_and_114_Days_After_IPSD_Value"/>
     [CqlDeclaration("Antidepressant Medication Period Between IPSD and 114 Days After IPSD")]
 	public IEnumerable<CqlInterval<CqlDate>> Antidepressant_Medication_Period_Between_IPSD_and_114_Days_After_IPSD() => 
 		__Antidepressant_Medication_Period_Between_IPSD_and_114_Days_After_IPSD.Value;
 
+    /// <seealso cref="Cumulative_Medication_Duration_Greater_Than_or_Equal_to_84_Days"/>
 	private bool? Cumulative_Medication_Duration_Greater_Than_or_Equal_to_84_Days_Value()
 	{
-		var a_ = this.Antidepressant_Medication_Period_Between_IPSD_and_114_Days_After_IPSD();
-		var b_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(a_);
-		var c_ = context.Operators.GreaterOrEqual(b_, 84);
+		IEnumerable<CqlInterval<CqlDate>> a_ = this.Antidepressant_Medication_Period_Between_IPSD_and_114_Days_After_IPSD();
+		int? b_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(a_);
+		bool? c_ = context.Operators.GreaterOrEqual(b_, 84);
 
 		return c_;
 	}
 
+    /// <seealso cref="Cumulative_Medication_Duration_Greater_Than_or_Equal_to_84_Days_Value"/>
     [CqlDeclaration("Cumulative Medication Duration Greater Than or Equal to 84 Days")]
 	public bool? Cumulative_Medication_Duration_Greater_Than_or_Equal_to_84_Days() => 
 		__Cumulative_Medication_Duration_Greater_Than_or_Equal_to_84_Days.Value;
 
+    /// <seealso cref="Numerator_1"/>
 	private bool? Numerator_1_Value()
 	{
-		var a_ = this.Cumulative_Medication_Duration_Greater_Than_or_Equal_to_84_Days();
+		bool? a_ = this.Cumulative_Medication_Duration_Greater_Than_or_Equal_to_84_Days();
 
 		return a_;
 	}
 
+    /// <seealso cref="Numerator_1_Value"/>
     [CqlDeclaration("Numerator 1")]
 	public bool? Numerator_1() => 
 		__Numerator_1.Value;
 
+    /// <seealso cref="Antidepressant_Medication_Period_Between_IPSD_and_231_Days_After_IPSD"/>
 	private IEnumerable<CqlInterval<CqlDate>> Antidepressant_Medication_Period_Between_IPSD_and_231_Days_After_IPSD_Value()
 	{
-		var a_ = this.Antidepressant_Medication();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		var e_ = context.Operators.Union<MedicationDispense>(b_, d_);
-		var f_ = Status_1_6_000.Dispensed_Medication(e_);
+		CqlValueSet a_ = this.Antidepressant_Medication();
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
+		IEnumerable<MedicationDispense> f_ = Status_1_6_000.Dispensed_Medication(e_);
 		CqlInterval<CqlDate> g_(MedicationDispense Antidepressant)
 		{
-			var i_ = CumulativeMedicationDuration_4_0_000.MedicationDispensePeriod(Antidepressant);
-			var j_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
-			var l_ = context.Operators.Quantity(231m, "days");
-			var m_ = context.Operators.Add(j_, l_);
-			var n_ = context.Operators.Interval(j_, m_, true, true);
-			var o_ = context.Operators.Intersect<CqlDate>(i_, n_);
+			CqlInterval<CqlDate> i_ = CumulativeMedicationDuration_4_0_000.MedicationDispensePeriod(Antidepressant);
+			CqlDate j_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
+			CqlQuantity l_ = context.Operators.Quantity(231m, "days");
+			CqlDate m_ = context.Operators.Add(j_, l_);
+			CqlInterval<CqlDate> n_ = context.Operators.Interval(j_, m_, true, true);
+			CqlInterval<CqlDate> o_ = context.Operators.Intersect<CqlDate>(i_, n_);
 
 			return o_;
 		};
-		var h_ = context.Operators.Select<MedicationDispense, CqlInterval<CqlDate>>(f_, g_);
+		IEnumerable<CqlInterval<CqlDate>> h_ = context.Operators.Select<MedicationDispense, CqlInterval<CqlDate>>(f_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Antidepressant_Medication_Period_Between_IPSD_and_231_Days_After_IPSD_Value"/>
     [CqlDeclaration("Antidepressant Medication Period Between IPSD and 231 Days After IPSD")]
 	public IEnumerable<CqlInterval<CqlDate>> Antidepressant_Medication_Period_Between_IPSD_and_231_Days_After_IPSD() => 
 		__Antidepressant_Medication_Period_Between_IPSD_and_231_Days_After_IPSD.Value;
 
+    /// <seealso cref="Cumulative_Medication_Duration_Greater_Than_or_Equal_to_180_Days"/>
 	private bool? Cumulative_Medication_Duration_Greater_Than_or_Equal_to_180_Days_Value()
 	{
-		var a_ = this.Antidepressant_Medication_Period_Between_IPSD_and_231_Days_After_IPSD();
-		var b_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(a_);
-		var c_ = context.Operators.GreaterOrEqual(b_, 180);
+		IEnumerable<CqlInterval<CqlDate>> a_ = this.Antidepressant_Medication_Period_Between_IPSD_and_231_Days_After_IPSD();
+		int? b_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(a_);
+		bool? c_ = context.Operators.GreaterOrEqual(b_, 180);
 
 		return c_;
 	}
 
+    /// <seealso cref="Cumulative_Medication_Duration_Greater_Than_or_Equal_to_180_Days_Value"/>
     [CqlDeclaration("Cumulative Medication Duration Greater Than or Equal to 180 Days")]
 	public bool? Cumulative_Medication_Duration_Greater_Than_or_Equal_to_180_Days() => 
 		__Cumulative_Medication_Duration_Greater_Than_or_Equal_to_180_Days.Value;
 
+    /// <seealso cref="Numerator_2"/>
 	private bool? Numerator_2_Value()
 	{
-		var a_ = this.Cumulative_Medication_Duration_Greater_Than_or_Equal_to_180_Days();
+		bool? a_ = this.Cumulative_Medication_Duration_Greater_Than_or_Equal_to_180_Days();
 
 		return a_;
 	}
 
+    /// <seealso cref="Numerator_2_Value"/>
     [CqlDeclaration("Numerator 2")]
 	public bool? Numerator_2() => 
 		__Numerator_2.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
@@ -218,415 +218,520 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 
     #endregion
 
+    /// <seealso cref="Amenorrhea"/>
 	private CqlValueSet Amenorrhea_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022", null);
 
+    /// <seealso cref="Amenorrhea_Value"/>
     [CqlDeclaration("Amenorrhea")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022")]
 	public CqlValueSet Amenorrhea() => 
 		__Amenorrhea.Value;
 
+    /// <seealso cref="Ankylosing_Spondylitis"/>
 	private CqlValueSet Ankylosing_Spondylitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045", null);
 
+    /// <seealso cref="Ankylosing_Spondylitis_Value"/>
     [CqlDeclaration("Ankylosing Spondylitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045")]
 	public CqlValueSet Ankylosing_Spondylitis() => 
 		__Ankylosing_Spondylitis.Value;
 
+    /// <seealso cref="Aromatase_Inhibitors"/>
 	private CqlValueSet Aromatase_Inhibitors_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265", null);
 
+    /// <seealso cref="Aromatase_Inhibitors_Value"/>
     [CqlDeclaration("Aromatase Inhibitors")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265")]
 	public CqlValueSet Aromatase_Inhibitors() => 
 		__Aromatase_Inhibitors.Value;
 
+    /// <seealso cref="Bilateral_Oophorectomy"/>
 	private CqlValueSet Bilateral_Oophorectomy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471", null);
 
+    /// <seealso cref="Bilateral_Oophorectomy_Value"/>
     [CqlDeclaration("Bilateral Oophorectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471")]
 	public CqlValueSet Bilateral_Oophorectomy() => 
 		__Bilateral_Oophorectomy.Value;
 
+    /// <seealso cref="Bone_Marrow_Transplant"/>
 	private CqlValueSet Bone_Marrow_Transplant_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336", null);
 
+    /// <seealso cref="Bone_Marrow_Transplant_Value"/>
     [CqlDeclaration("Bone Marrow Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336")]
 	public CqlValueSet Bone_Marrow_Transplant() => 
 		__Bone_Marrow_Transplant.Value;
 
+    /// <seealso cref="Chemotherapy"/>
 	private CqlValueSet Chemotherapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485", null);
 
+    /// <seealso cref="Chemotherapy_Value"/>
     [CqlDeclaration("Chemotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485")]
 	public CqlValueSet Chemotherapy() => 
 		__Chemotherapy.Value;
 
+    /// <seealso cref="Chronic_Liver_Disease"/>
 	private CqlValueSet Chronic_Liver_Disease_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035", null);
 
+    /// <seealso cref="Chronic_Liver_Disease_Value"/>
     [CqlDeclaration("Chronic Liver Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035")]
 	public CqlValueSet Chronic_Liver_Disease() => 
 		__Chronic_Liver_Disease.Value;
 
+    /// <seealso cref="Chronic_Malnutrition"/>
 	private CqlValueSet Chronic_Malnutrition_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036", null);
 
+    /// <seealso cref="Chronic_Malnutrition_Value"/>
     [CqlDeclaration("Chronic Malnutrition")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036")]
 	public CqlValueSet Chronic_Malnutrition() => 
 		__Chronic_Malnutrition.Value;
 
+    /// <seealso cref="Cushings_Syndrome"/>
 	private CqlValueSet Cushings_Syndrome_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009", null);
 
+    /// <seealso cref="Cushings_Syndrome_Value"/>
     [CqlDeclaration("Cushings Syndrome")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009")]
 	public CqlValueSet Cushings_Syndrome() => 
 		__Cushings_Syndrome.Value;
 
+    /// <seealso cref="DXA__Dual_energy_Xray_Absorptiometry__Scan"/>
 	private CqlValueSet DXA__Dual_energy_Xray_Absorptiometry__Scan_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051", null);
 
+    /// <seealso cref="DXA__Dual_energy_Xray_Absorptiometry__Scan_Value"/>
     [CqlDeclaration("DXA (Dual energy Xray Absorptiometry) Scan")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051")]
 	public CqlValueSet DXA__Dual_energy_Xray_Absorptiometry__Scan() => 
 		__DXA__Dual_energy_Xray_Absorptiometry__Scan.Value;
 
+    /// <seealso cref="Eating_Disorders"/>
 	private CqlValueSet Eating_Disorders_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039", null);
 
+    /// <seealso cref="Eating_Disorders_Value"/>
     [CqlDeclaration("Eating Disorders")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039")]
 	public CqlValueSet Eating_Disorders() => 
 		__Eating_Disorders.Value;
 
+    /// <seealso cref="Ehlers_Danlos_Syndrome"/>
 	private CqlValueSet Ehlers_Danlos_Syndrome_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047", null);
 
+    /// <seealso cref="Ehlers_Danlos_Syndrome_Value"/>
     [CqlDeclaration("Ehlers Danlos Syndrome")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047")]
 	public CqlValueSet Ehlers_Danlos_Syndrome() => 
 		__Ehlers_Danlos_Syndrome.Value;
 
+    /// <seealso cref="End_Stage_Renal_Disease"/>
 	private CqlValueSet End_Stage_Renal_Disease_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", null);
 
+    /// <seealso cref="End_Stage_Renal_Disease_Value"/>
     [CqlDeclaration("End Stage Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
 	public CqlValueSet End_Stage_Renal_Disease() => 
 		__End_Stage_Renal_Disease.Value;
 
+    /// <seealso cref="Evidence_of_Bilateral_Oophorectomy"/>
 	private CqlValueSet Evidence_of_Bilateral_Oophorectomy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048", null);
 
+    /// <seealso cref="Evidence_of_Bilateral_Oophorectomy_Value"/>
     [CqlDeclaration("Evidence of Bilateral Oophorectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048")]
 	public CqlValueSet Evidence_of_Bilateral_Oophorectomy() => 
 		__Evidence_of_Bilateral_Oophorectomy.Value;
 
+    /// <seealso cref="Gastric_Bypass_Surgery"/>
 	private CqlValueSet Gastric_Bypass_Surgery_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050", null);
 
+    /// <seealso cref="Gastric_Bypass_Surgery_Value"/>
     [CqlDeclaration("Gastric Bypass Surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050")]
 	public CqlValueSet Gastric_Bypass_Surgery() => 
 		__Gastric_Bypass_Surgery.Value;
 
+    /// <seealso cref="Glucocorticoids__oral_only_"/>
 	private CqlValueSet Glucocorticoids__oral_only__Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266", null);
 
+    /// <seealso cref="Glucocorticoids__oral_only__Value"/>
     [CqlDeclaration("Glucocorticoids (oral only)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266")]
 	public CqlValueSet Glucocorticoids__oral_only_() => 
 		__Glucocorticoids__oral_only_.Value;
 
+    /// <seealso cref="History_of_hip_fracture_in_parent"/>
 	private CqlValueSet History_of_hip_fracture_in_parent_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040", null);
 
+    /// <seealso cref="History_of_hip_fracture_in_parent_Value"/>
     [CqlDeclaration("History of hip fracture in parent")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040")]
 	public CqlValueSet History_of_hip_fracture_in_parent() => 
 		__History_of_hip_fracture_in_parent.Value;
 
+    /// <seealso cref="Hyperparathyroidism"/>
 	private CqlValueSet Hyperparathyroidism_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016", null);
 
+    /// <seealso cref="Hyperparathyroidism_Value"/>
     [CqlDeclaration("Hyperparathyroidism")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016")]
 	public CqlValueSet Hyperparathyroidism() => 
 		__Hyperparathyroidism.Value;
 
+    /// <seealso cref="Hyperthyroidism"/>
 	private CqlValueSet Hyperthyroidism_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015", null);
 
+    /// <seealso cref="Hyperthyroidism_Value"/>
     [CqlDeclaration("Hyperthyroidism")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015")]
 	public CqlValueSet Hyperthyroidism() => 
 		__Hyperthyroidism.Value;
 
+    /// <seealso cref="Kidney_Transplant"/>
 	private CqlValueSet Kidney_Transplant_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012", null);
 
+    /// <seealso cref="Kidney_Transplant_Value"/>
     [CqlDeclaration("Kidney Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012")]
 	public CqlValueSet Kidney_Transplant() => 
 		__Kidney_Transplant.Value;
 
+    /// <seealso cref="Lupus"/>
 	private CqlValueSet Lupus_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010", null);
 
+    /// <seealso cref="Lupus_Value"/>
     [CqlDeclaration("Lupus")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010")]
 	public CqlValueSet Lupus() => 
 		__Lupus.Value;
 
+    /// <seealso cref="Major_Transplant"/>
 	private CqlValueSet Major_Transplant_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075", null);
 
+    /// <seealso cref="Major_Transplant_Value"/>
     [CqlDeclaration("Major Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075")]
 	public CqlValueSet Major_Transplant() => 
 		__Major_Transplant.Value;
 
+    /// <seealso cref="Malabsorption_Syndromes"/>
 	private CqlValueSet Malabsorption_Syndromes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050", null);
 
+    /// <seealso cref="Malabsorption_Syndromes_Value"/>
     [CqlDeclaration("Malabsorption Syndromes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050")]
 	public CqlValueSet Malabsorption_Syndromes() => 
 		__Malabsorption_Syndromes.Value;
 
+    /// <seealso cref="Marfans_Syndrome"/>
 	private CqlValueSet Marfans_Syndrome_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048", null);
 
+    /// <seealso cref="Marfans_Syndrome_Value"/>
     [CqlDeclaration("Marfan's Syndrome")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048")]
 	public CqlValueSet Marfans_Syndrome() => 
 		__Marfans_Syndrome.Value;
 
+    /// <seealso cref="Multiple_Myeloma"/>
 	private CqlValueSet Multiple_Myeloma_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011", null);
 
+    /// <seealso cref="Multiple_Myeloma_Value"/>
     [CqlDeclaration("Multiple Myeloma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011")]
 	public CqlValueSet Multiple_Myeloma() => 
 		__Multiple_Myeloma.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Osteogenesis_Imperfecta"/>
 	private CqlValueSet Osteogenesis_Imperfecta_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044", null);
 
+    /// <seealso cref="Osteogenesis_Imperfecta_Value"/>
     [CqlDeclaration("Osteogenesis Imperfecta")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044")]
 	public CqlValueSet Osteogenesis_Imperfecta() => 
 		__Osteogenesis_Imperfecta.Value;
 
+    /// <seealso cref="Osteopenia"/>
 	private CqlValueSet Osteopenia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049", null);
 
+    /// <seealso cref="Osteopenia_Value"/>
     [CqlDeclaration("Osteopenia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049")]
 	public CqlValueSet Osteopenia() => 
 		__Osteopenia.Value;
 
+    /// <seealso cref="Osteoporosis"/>
 	private CqlValueSet Osteoporosis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038", null);
 
+    /// <seealso cref="Osteoporosis_Value"/>
     [CqlDeclaration("Osteoporosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038")]
 	public CqlValueSet Osteoporosis() => 
 		__Osteoporosis.Value;
 
+    /// <seealso cref="Osteoporotic_Fractures"/>
 	private CqlValueSet Osteoporotic_Fractures_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050", null);
 
+    /// <seealso cref="Osteoporotic_Fractures_Value"/>
     [CqlDeclaration("Osteoporotic Fractures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050")]
 	public CqlValueSet Osteoporotic_Fractures() => 
 		__Osteoporotic_Fractures.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Premature_Menopause"/>
 	private CqlValueSet Premature_Menopause_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013", null);
 
+    /// <seealso cref="Premature_Menopause_Value"/>
     [CqlDeclaration("Premature Menopause")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013")]
 	public CqlValueSet Premature_Menopause() => 
 		__Premature_Menopause.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Psoriatic_Arthritis"/>
 	private CqlValueSet Psoriatic_Arthritis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046", null);
 
+    /// <seealso cref="Psoriatic_Arthritis_Value"/>
     [CqlDeclaration("Psoriatic Arthritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046")]
 	public CqlValueSet Psoriatic_Arthritis() => 
 		__Psoriatic_Arthritis.Value;
 
+    /// <seealso cref="Rheumatoid_Arthritis"/>
 	private CqlValueSet Rheumatoid_Arthritis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005", null);
 
+    /// <seealso cref="Rheumatoid_Arthritis_Value"/>
     [CqlDeclaration("Rheumatoid Arthritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005")]
 	public CqlValueSet Rheumatoid_Arthritis() => 
 		__Rheumatoid_Arthritis.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Type_1_Diabetes"/>
 	private CqlValueSet Type_1_Diabetes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020", null);
 
+    /// <seealso cref="Type_1_Diabetes_Value"/>
     [CqlDeclaration("Type 1 Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020")]
 	public CqlValueSet Type_1_Diabetes() => 
 		__Type_1_Diabetes.Value;
 
+    /// <seealso cref="Unilateral_Oophorectomy_Left"/>
 	private CqlValueSet Unilateral_Oophorectomy_Left_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028", null);
 
+    /// <seealso cref="Unilateral_Oophorectomy_Left_Value"/>
     [CqlDeclaration("Unilateral Oophorectomy Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028")]
 	public CqlValueSet Unilateral_Oophorectomy_Left() => 
 		__Unilateral_Oophorectomy_Left.Value;
 
+    /// <seealso cref="Unilateral_Oophorectomy_Right"/>
 	private CqlValueSet Unilateral_Oophorectomy_Right_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032", null);
 
+    /// <seealso cref="Unilateral_Oophorectomy_Right_Value"/>
     [CqlDeclaration("Unilateral Oophorectomy Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032")]
 	public CqlValueSet Unilateral_Oophorectomy_Right() => 
 		__Unilateral_Oophorectomy_Right.Value;
 
+    /// <seealso cref="Unilateral_Oophorectomy__Unspecified_Laterality"/>
 	private CqlValueSet Unilateral_Oophorectomy__Unspecified_Laterality_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035", null);
 
+    /// <seealso cref="Unilateral_Oophorectomy__Unspecified_Laterality_Value"/>
     [CqlDeclaration("Unilateral Oophorectomy, Unspecified Laterality")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035")]
 	public CqlValueSet Unilateral_Oophorectomy__Unspecified_Laterality() => 
 		__Unilateral_Oophorectomy__Unspecified_Laterality.Value;
 
+    /// <seealso cref="Alcoholic_drinks_per_drinking_day___Reported"/>
 	private CqlCode Alcoholic_drinks_per_drinking_day___Reported_Value() => 
 		new CqlCode("11287-0", "http://loinc.org", null, null);
 
+    /// <seealso cref="Alcoholic_drinks_per_drinking_day___Reported_Value"/>
     [CqlDeclaration("Alcoholic drinks per drinking day - Reported")]
 	public CqlCode Alcoholic_drinks_per_drinking_day___Reported() => 
 		__Alcoholic_drinks_per_drinking_day___Reported.Value;
 
+    /// <seealso cref="Body_mass_index__BMI___Ratio_"/>
 	private CqlCode Body_mass_index__BMI___Ratio__Value() => 
 		new CqlCode("39156-5", "http://loinc.org", null, null);
 
+    /// <seealso cref="Body_mass_index__BMI___Ratio__Value"/>
     [CqlDeclaration("Body mass index (BMI) [Ratio]")]
 	public CqlCode Body_mass_index__BMI___Ratio_() => 
 		__Body_mass_index__BMI___Ratio_.Value;
 
+    /// <seealso cref="Female"/>
 	private CqlCode Female_Value() => 
 		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null);
 
+    /// <seealso cref="Female_Value"/>
     [CqlDeclaration("Female")]
 	public CqlCode Female() => 
 		__Female.Value;
 
+    /// <seealso cref="Left__qualifier_value_"/>
 	private CqlCode Left__qualifier_value__Value() => 
 		new CqlCode("7771000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Left__qualifier_value__Value"/>
     [CqlDeclaration("Left (qualifier value)")]
 	public CqlCode Left__qualifier_value_() => 
 		__Left__qualifier_value_.Value;
 
+    /// <seealso cref="Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment"/>
 	private CqlCode Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment_Value() => 
 		new CqlCode("90265-0", "http://loinc.org", null, null);
 
+    /// <seealso cref="Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment_Value"/>
     [CqlDeclaration("Major osteoporotic fracture 10-year probability [Likelihood] Fracture Risk Assessment")]
 	public CqlCode Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment() => 
 		__Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment.Value;
 
+    /// <seealso cref="Osteoporosis_Index_of_Risk_panel"/>
 	private CqlCode Osteoporosis_Index_of_Risk_panel_Value() => 
 		new CqlCode("98133-2", "http://loinc.org", null, null);
 
+    /// <seealso cref="Osteoporosis_Index_of_Risk_panel_Value"/>
     [CqlDeclaration("Osteoporosis Index of Risk panel")]
 	public CqlCode Osteoporosis_Index_of_Risk_panel() => 
 		__Osteoporosis_Index_of_Risk_panel.Value;
 
+    /// <seealso cref="Osteoporosis_Risk_Assessment_Instrument"/>
 	private CqlCode Osteoporosis_Risk_Assessment_Instrument_Value() => 
 		new CqlCode("98139-9", "http://loinc.org", null, null);
 
+    /// <seealso cref="Osteoporosis_Risk_Assessment_Instrument_Value"/>
     [CqlDeclaration("Osteoporosis Risk Assessment Instrument")]
 	public CqlCode Osteoporosis_Risk_Assessment_Instrument() => 
 		__Osteoporosis_Risk_Assessment_Instrument.Value;
 
+    /// <seealso cref="Osteoporosis_Self_Assessment_Tool"/>
 	private CqlCode Osteoporosis_Self_Assessment_Tool_Value() => 
 		new CqlCode("98146-4", "http://loinc.org", null, null);
 
+    /// <seealso cref="Osteoporosis_Self_Assessment_Tool_Value"/>
     [CqlDeclaration("Osteoporosis Self-Assessment Tool")]
 	public CqlCode Osteoporosis_Self_Assessment_Tool() => 
 		__Osteoporosis_Self_Assessment_Tool.Value;
 
+    /// <seealso cref="Right__qualifier_value_"/>
 	private CqlCode Right__qualifier_value__Value() => 
 		new CqlCode("24028007", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Right__qualifier_value__Value"/>
     [CqlDeclaration("Right (qualifier value)")]
 	public CqlCode Right__qualifier_value_() => 
 		__Right__qualifier_value_.Value;
 
+    /// <seealso cref="Unlisted_preventive_medicine_service"/>
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
 		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Unlisted_preventive_medicine_service_Value"/>
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
 		__Unlisted_preventive_medicine_service.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("11287-0", "http://loinc.org", null, null),
 			new CqlCode("39156-5", "http://loinc.org", null, null),
@@ -639,13 +744,15 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="AdministrativeGender"/>
 	private CqlCode[] AdministrativeGender_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null),
 		};
@@ -653,13 +760,15 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		return a_;
 	}
 
+    /// <seealso cref="AdministrativeGender_Value"/>
     [CqlDeclaration("AdministrativeGender")]
 	public CqlCode[] AdministrativeGender() => 
 		__AdministrativeGender.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("7771000", "http://snomed.info/sct", null, null),
 			new CqlCode("24028007", "http://snomed.info/sct", null, null),
@@ -668,13 +777,15 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
 		};
@@ -682,440 +793,480 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("AppropriateDXAScansForWomenUnder65FHIR-0.0.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("AppropriateDXAScansForWomenUnder65FHIR-0.0.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounter"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
 		bool? g_(Encounter E)
 		{
-			var x_ = E?.Type;
+			List<CodeableConcept> x_ = E?.Type;
 			CqlConcept y_(CodeableConcept @this)
 			{
-				var ad_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept ad_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return ad_;
 			};
-			var z_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)x_, y_);
+			IEnumerable<CqlConcept> z_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)x_, y_);
 			bool? aa_(CqlConcept T)
 			{
-				var ae_ = this.Unlisted_preventive_medicine_service();
-				var af_ = context.Operators.ConvertCodeToConcept(ae_);
-				var ag_ = context.Operators.Equivalent(T, af_);
+				CqlCode ae_ = this.Unlisted_preventive_medicine_service();
+				CqlConcept af_ = context.Operators.ConvertCodeToConcept(ae_);
+				bool? ag_ = context.Operators.Equivalent(T, af_);
 
 				return ag_;
 			};
-			var ab_ = context.Operators.Where<CqlConcept>(z_, aa_);
-			var ac_ = context.Operators.Exists<CqlConcept>(ab_);
+			IEnumerable<CqlConcept> ab_ = context.Operators.Where<CqlConcept>(z_, aa_);
+			bool? ac_ = context.Operators.Exists<CqlConcept>(ab_);
 
 			return ac_;
 		};
-		var h_ = context.Operators.Where<Encounter>(f_, g_);
-		var i_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
-		var k_ = context.Operators.Union<Encounter>(h_, j_);
-		var l_ = context.Operators.Union<Encounter>(e_, k_);
-		var m_ = this.Outpatient_Consultation();
-		var n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
-		var o_ = this.Online_Assessments();
-		var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
-		var q_ = context.Operators.Union<Encounter>(n_, p_);
-		var r_ = context.Operators.Union<Encounter>(l_, q_);
-		var s_ = this.Telephone_Visits();
-		var t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
-		var u_ = context.Operators.Union<Encounter>(r_, t_);
+		IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
+		CqlValueSet i_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(h_, j_);
+		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(e_, k_);
+		CqlValueSet m_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		CqlValueSet o_ = this.Online_Assessments();
+		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(n_, p_);
+		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(l_, q_);
+		CqlValueSet s_ = this.Telephone_Visits();
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
+		IEnumerable<Encounter> u_ = context.Operators.Union<Encounter>(r_, t_);
 		bool? v_(Encounter ValidEncounters)
 		{
-			var ah_ = this.Measurement_Period();
-			var ai_ = ValidEncounters?.Period;
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ah_, ak_, "day");
+			CqlInterval<CqlDateTime> ah_ = this.Measurement_Period();
+			Period ai_ = ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			bool? al_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ah_, ak_, "day");
 
 			return al_;
 		};
-		var w_ = context.Operators.Where<Encounter>(u_, v_);
+		IEnumerable<Encounter> w_ = context.Operators.Where<Encounter>(u_, v_);
 
 		return w_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_Value"/>
     [CqlDeclaration("Qualifying Encounter")]
 	public IEnumerable<Encounter> Qualifying_Encounter() => 
 		__Qualifying_Encounter.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(50, 63, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var j_ = context.Operators.Convert<string>(a_?.GenderElement?.Value);
-		var k_ = context.Operators.Equal(j_, "female");
-		var l_ = context.Operators.And(h_, k_);
-		var m_ = this.Qualifying_Encounter();
-		var n_ = context.Operators.Exists<Encounter>(m_);
-		var o_ = context.Operators.And(l_, n_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(50, 63, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		Code<AdministrativeGender> l_ = a_?.GenderElement;
+		AdministrativeGender? m_ = l_?.Value;
+		string n_ = context.Operators.Convert<string>(m_);
+		bool? o_ = context.Operators.Equal(n_, "female");
+		bool? p_ = context.Operators.And(j_, o_);
+		IEnumerable<Encounter> q_ = this.Qualifying_Encounter();
+		bool? r_ = context.Operators.Exists<Encounter>(q_);
+		bool? s_ = context.Operators.And(p_, r_);
 
-		return o_;
+		return s_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="First_BMI_in_Measurement_Period"/>
 	private Observation First_BMI_in_Measurement_Period_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
-		var b_ = Status_1_6_000.BMI(a_);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> b_ = Status_1_6_000.BMI(a_);
 		bool? c_(Observation BMIRatio)
 		{
-			var h_ = this.Measurement_Period();
-			var i_ = BMIRatio?.Effective;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = QICoreCommon_2_0_000.ToInterval(j_);
-			var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, null);
-			var m_ = BMIRatio?.Value;
-			var n_ = context.Operators.Convert<Quantity>(m_);
-			var o_ = FHIRHelpers_4_3_000.ToQuantity(n_);
-			var p_ = context.Operators.Not((bool?)(o_ is null));
-			var q_ = context.Operators.And(l_, p_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			DataType i_ = BMIRatio?.Effective;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval(j_);
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, null);
+			DataType m_ = BMIRatio?.Value;
+			Quantity n_ = context.Operators.Convert<Quantity>(m_);
+			CqlQuantity o_ = FHIRHelpers_4_3_000.ToQuantity(n_);
+			bool? p_ = context.Operators.Not((bool?)(o_ is null));
+			bool? q_ = context.Operators.And(l_, p_);
 
 			return q_;
 		};
-		var d_ = context.Operators.Where<Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		object e_(Observation @this)
 		{
-			var r_ = @this?.Effective;
-			var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-			var t_ = QICoreCommon_2_0_000.ToInterval(s_);
-			var u_ = context.Operators.Start(t_);
+			DataType r_ = @this?.Effective;
+			object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.ToInterval(s_);
+			CqlDateTime u_ = context.Operators.Start(t_);
 
 			return u_;
 		};
-		var f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-		var g_ = context.Operators.First<Observation>(f_);
+		IEnumerable<Observation> f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation g_ = context.Operators.First<Observation>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="First_BMI_in_Measurement_Period_Value"/>
     [CqlDeclaration("First BMI in Measurement Period")]
 	public Observation First_BMI_in_Measurement_Period() => 
 		__First_BMI_in_Measurement_Period.Value;
 
+    /// <seealso cref="First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2"/>
 	private Observation First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2_Value()
 	{
-		var a_ = this.First_BMI_in_Measurement_Period();
-		var b_ = new Observation[]
+		Observation a_ = this.First_BMI_in_Measurement_Period();
+		Observation[] b_ = new Observation[]
 		{
 			a_,
 		};
 		bool? c_(Observation FirstBMI)
 		{
-			var f_ = FirstBMI?.Value;
-			var g_ = context.Operators.Convert<Quantity>(f_);
-			var h_ = FHIRHelpers_4_3_000.ToQuantity(g_);
-			var i_ = context.Operators.Quantity(20m, "kg/m2");
-			var j_ = context.Operators.LessOrEqual(h_, i_);
+			DataType f_ = FirstBMI?.Value;
+			Quantity g_ = context.Operators.Convert<Quantity>(f_);
+			CqlQuantity h_ = FHIRHelpers_4_3_000.ToQuantity(g_);
+			CqlQuantity i_ = context.Operators.Quantity(20m, "kg/m2");
+			bool? j_ = context.Operators.LessOrEqual(h_, i_);
 
 			return j_;
 		};
-		var d_ = context.Operators.Where<Observation>((IEnumerable<Observation>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<Observation>(d_);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>((IEnumerable<Observation>)b_, c_);
+		Observation e_ = context.Operators.SingletonFrom<Observation>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2_Value"/>
     [CqlDeclaration("First BMI in Measurement Period Less Than or Equal to 20 kg m2")]
 	public Observation First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2() => 
 		__First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2.Value;
 
+    /// <seealso cref="First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day"/>
 	private Observation First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day_Value()
 	{
-		var a_ = this.Alcoholic_drinks_per_drinking_day___Reported();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode a_ = this.Alcoholic_drinks_per_drinking_day___Reported();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation AverageDrinks)
 		{
-			var j_ = AverageDrinks?.Effective;
-			var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-			var l_ = QICoreCommon_2_0_000.ToInterval(k_);
-			var m_ = context.Operators.Start(l_);
-			var n_ = this.Measurement_Period();
-			var o_ = context.Operators.In<CqlDateTime>(m_, n_, null);
-			var p_ = AverageDrinks?.Value;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = context.Operators.Quantity(2m, "{drinks}/d");
-			var s_ = context.Operators.Greater((q_ as CqlQuantity), r_);
-			var t_ = context.Operators.And(o_, s_);
+			DataType j_ = AverageDrinks?.Effective;
+			object k_ = FHIRHelpers_4_3_000.ToValue(j_);
+			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.ToInterval(k_);
+			CqlDateTime m_ = context.Operators.Start(l_);
+			CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
+			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, null);
+			DataType p_ = AverageDrinks?.Value;
+			object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+			CqlQuantity r_ = context.Operators.Quantity(2m, "{drinks}/d");
+			bool? s_ = context.Operators.Greater((q_ as CqlQuantity), r_);
+			bool? t_ = context.Operators.And(o_, s_);
 
 			return t_;
 		};
-		var f_ = context.Operators.Where<Observation>(d_, e_);
+		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 		object g_(Observation @this)
 		{
-			var u_ = @this?.Effective;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = QICoreCommon_2_0_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
+			DataType u_ = @this?.Effective;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			CqlInterval<CqlDateTime> w_ = QICoreCommon_2_0_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
 
 			return x_;
 		};
-		var h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
-		var i_ = context.Operators.First<Observation>(h_);
+		IEnumerable<Observation> h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation i_ = context.Operators.First<Observation>(h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day_Value"/>
     [CqlDeclaration("First Average Number of Drinks Assessments Indicating More Than Two Per Day")]
 	public Observation First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day() => 
 		__First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day.Value;
 
+    /// <seealso cref="Has_Risk_Factor_Active_During_the_Measurement_Period"/>
 	private bool? Has_Risk_Factor_Active_During_the_Measurement_Period_Value()
 	{
-		var a_ = this.First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2();
-		var b_ = context.Operators.Not((bool?)(a_ is null));
-		var c_ = this.First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day();
-		var d_ = context.Operators.Not((bool?)(c_ is null));
-		var e_ = context.Operators.Or(b_, d_);
+		Observation a_ = this.First_BMI_in_Measurement_Period_Less_Than_or_Equal_to_20_kg_m2();
+		bool? b_ = context.Operators.Not((bool?)(a_ is null));
+		Observation c_ = this.First_Average_Number_of_Drinks_Assessments_Indicating_More_Than_Two_Per_Day();
+		bool? d_ = context.Operators.Not((bool?)(c_ is null));
+		bool? e_ = context.Operators.Or(b_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Risk_Factor_Active_During_the_Measurement_Period_Value"/>
     [CqlDeclaration("Has Risk Factor Active During the Measurement Period")]
 	public bool? Has_Risk_Factor_Active_During_the_Measurement_Period() => 
 		__Has_Risk_Factor_Active_During_the_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Osteoporosis_Before_Measurement_Period"/>
 	private bool? Has_Osteoporosis_Before_Measurement_Period_Value()
 	{
-		var a_ = this.Osteoporosis();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Osteoporosis();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition OsteoporosisDiagnosis)
 		{
-			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteoporosisDiagnosis);
-			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.Start(h_);
-			var j_ = context.Operators.Before(g_, i_, null);
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteoporosisDiagnosis);
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.Start(h_);
+			bool? j_ = context.Operators.Before(g_, i_, null);
 
 			return j_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Osteoporosis_Before_Measurement_Period_Value"/>
     [CqlDeclaration("Has Osteoporosis Before Measurement Period")]
 	public bool? Has_Osteoporosis_Before_Measurement_Period() => 
 		__Has_Osteoporosis_Before_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Osteopenia_Before_Measurement_Period"/>
 	private bool? Has_Osteopenia_Before_Measurement_Period_Value()
 	{
-		var a_ = this.Osteopenia();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Osteopenia();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition OsteopeniaDiagnosis)
 		{
-			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteopeniaDiagnosis);
-			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.Start(h_);
-			var j_ = context.Operators.Before(g_, i_, null);
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteopeniaDiagnosis);
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.Start(h_);
+			bool? j_ = context.Operators.Before(g_, i_, null);
 
 			return j_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Osteopenia_Before_Measurement_Period_Value"/>
     [CqlDeclaration("Has Osteopenia Before Measurement Period")]
 	public bool? Has_Osteopenia_Before_Measurement_Period() => 
 		__Has_Osteopenia_Before_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period"/>
 	private bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_Value()
 	{
-		var a_ = this.Has_Osteoporosis_Before_Measurement_Period();
-		var b_ = this.Has_Osteopenia_Before_Measurement_Period();
-		var c_ = context.Operators.Or(a_, b_);
+		bool? a_ = this.Has_Osteoporosis_Before_Measurement_Period();
+		bool? b_ = this.Has_Osteopenia_Before_Measurement_Period();
+		bool? c_ = context.Operators.Or(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_Value"/>
     [CqlDeclaration("Has Risk Factor Any Time in History Prior to Measurement Period")]
 	public bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period() => 
 		__Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period.Value;
 
+    /// <seealso cref="Parent_History_of_Hip_Fracture_Assessment"/>
 	private IEnumerable<Observation> Parent_History_of_Hip_Fracture_Assessment_Value()
 	{
-		var a_ = this.History_of_hip_fracture_in_parent();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.Final_Survey_Observation(b_);
+		CqlValueSet a_ = this.History_of_hip_fracture_in_parent();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.Final_Survey_Observation(b_);
 		bool? d_(Observation ParentFractureHistory)
 		{
-			var f_ = ParentFractureHistory?.Effective;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			var i_ = context.Operators.Start(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.Before(i_, k_, null);
+			DataType f_ = ParentFractureHistory?.Effective;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
+			CqlDateTime i_ = context.Operators.Start(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			bool? l_ = context.Operators.Before(i_, k_, null);
 
 			return l_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Parent_History_of_Hip_Fracture_Assessment_Value"/>
     [CqlDeclaration("Parent History of Hip Fracture Assessment")]
 	public IEnumerable<Observation> Parent_History_of_Hip_Fracture_Assessment() => 
 		__Parent_History_of_Hip_Fracture_Assessment.Value;
 
+    /// <seealso cref="Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period"/>
 	private bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period_Value()
 	{
-		var a_ = this.Gastric_Bypass_Surgery();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		CqlValueSet a_ = this.Gastric_Bypass_Surgery();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure GastricBypass)
 		{
-			var aa_ = GastricBypass?.Performed;
-			var ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
-			var ac_ = QICoreCommon_2_0_000.ToInterval(ab_);
-			var ad_ = context.Operators.End(ac_);
-			var ae_ = this.Measurement_Period();
-			var af_ = context.Operators.Start(ae_);
-			var ag_ = context.Operators.Before(ad_, af_, null);
+			DataType aa_ = GastricBypass?.Performed;
+			object ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
+			CqlInterval<CqlDateTime> ac_ = QICoreCommon_2_0_000.ToInterval(ab_);
+			CqlDateTime ad_ = context.Operators.End(ac_);
+			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
+			CqlDateTime af_ = context.Operators.Start(ae_);
+			bool? ag_ = context.Operators.Before(ad_, af_, null);
 
 			return ag_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
-		var f_ = this.Aromatase_Inhibitors();
-		var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		var j_ = context.Operators.Union<MedicationRequest>(g_, i_);
-		var k_ = Status_1_6_000.Active_Medication(j_);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
+		CqlValueSet f_ = this.Aromatase_Inhibitors();
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
+		IEnumerable<MedicationRequest> k_ = Status_1_6_000.Active_Medication(j_);
 		bool? l_(MedicationRequest AromataseInhibitorActive)
 		{
-			var ah_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(AromataseInhibitorActive);
-			var ai_ = context.Operators.Start(ah_);
-			var aj_ = context.Operators.ConvertDateToDateTime(ai_);
-			var ak_ = this.Measurement_Period();
-			var al_ = context.Operators.Start(ak_);
-			var am_ = context.Operators.Before(aj_, al_, null);
+			CqlInterval<CqlDate> ah_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(AromataseInhibitorActive);
+			CqlDate ai_ = context.Operators.Start(ah_);
+			CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
+			CqlInterval<CqlDateTime> ak_ = this.Measurement_Period();
+			CqlDateTime al_ = context.Operators.Start(ak_);
+			bool? am_ = context.Operators.Before(aj_, al_, null);
 
 			return am_;
 		};
-		var m_ = context.Operators.Where<MedicationRequest>(k_, l_);
-		var n_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (m_ as IEnumerable<object>));
-		var p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		var r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		var s_ = context.Operators.Union<MedicationRequest>(p_, r_);
-		var t_ = Status_1_6_000.Active_or_Completed_Medication_Request(s_);
+		IEnumerable<MedicationRequest> m_ = context.Operators.Where<MedicationRequest>(k_, l_);
+		IEnumerable<object> n_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (m_ as IEnumerable<object>));
+		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> s_ = context.Operators.Union<MedicationRequest>(p_, r_);
+		IEnumerable<MedicationRequest> t_ = Status_1_6_000.Active_or_Completed_Medication_Request(s_);
 		bool? u_(MedicationRequest AromataseInhibitorOrder)
 		{
-			var an_ = AromataseInhibitorOrder?.AuthoredOnElement;
-			var ao_ = context.Operators.Convert<CqlDateTime>(an_);
-			var ap_ = QICoreCommon_2_0_000.ToInterval((ao_ as object));
+			FhirDateTime an_ = AromataseInhibitorOrder?.AuthoredOnElement;
+			CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(an_);
+			CqlInterval<CqlDateTime> ap_ = QICoreCommon_2_0_000.ToInterval((ao_ as object));
 			CqlInterval<CqlDateTime> aq_()
 			{
 				bool as_()
 				{
-					var at_ = this.Measurement_Period();
-					var au_ = context.Operators.Start(at_);
+					CqlInterval<CqlDateTime> at_ = this.Measurement_Period();
+					CqlDateTime au_ = context.Operators.Start(at_);
 
 					return (au_ is null);
 				};
@@ -1125,94 +1276,101 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 				}
 				else
 				{
-					var av_ = this.Measurement_Period();
-					var aw_ = context.Operators.Start(av_);
-					var ay_ = context.Operators.Start(av_);
-					var az_ = context.Operators.Interval(aw_, ay_, true, true);
+					CqlInterval<CqlDateTime> av_ = this.Measurement_Period();
+					CqlDateTime aw_ = context.Operators.Start(av_);
+					CqlDateTime ay_ = context.Operators.Start(av_);
+					CqlInterval<CqlDateTime> az_ = context.Operators.Interval(aw_, ay_, true, true);
 
 					return az_;
 				}
 			};
-			var ar_ = context.Operators.Before(ap_, aq_(), null);
+			bool? ar_ = context.Operators.Before(ap_, aq_(), null);
 
 			return ar_;
 		};
-		var v_ = context.Operators.Where<MedicationRequest>(t_, u_);
-		var w_ = context.Operators.Union<object>(n_, (v_ as IEnumerable<object>));
-		var x_ = this.Parent_History_of_Hip_Fracture_Assessment();
-		var y_ = context.Operators.Union<object>(w_, (x_ as IEnumerable<object>));
-		var z_ = context.Operators.Exists<object>(y_);
+		IEnumerable<MedicationRequest> v_ = context.Operators.Where<MedicationRequest>(t_, u_);
+		IEnumerable<object> w_ = context.Operators.Union<object>(n_, (v_ as IEnumerable<object>));
+		IEnumerable<Observation> x_ = this.Parent_History_of_Hip_Fracture_Assessment();
+		IEnumerable<object> y_ = context.Operators.Union<object>(w_, (x_ as IEnumerable<object>));
+		bool? z_ = context.Operators.Exists<object>(y_);
 
 		return z_;
 	}
 
+    /// <seealso cref="Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period_Value"/>
     [CqlDeclaration("Has Risk Factor Any Time in History Prior to Measurement Period and Do Not Need to be Active During Measurement Period")]
 	public bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period() => 
 		__Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period.Value;
 
+    /// <seealso cref="Glucocorticoid_Active_Medication_Duration_in_Days"/>
 	private int? Glucocorticoid_Active_Medication_Duration_in_Days_Value()
 	{
-		var a_ = this.Glucocorticoids__oral_only_();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = Status_1_6_000.Active_Medication(e_);
+		CqlValueSet a_ = this.Glucocorticoids__oral_only_();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_Medication(e_);
 		bool? g_(MedicationRequest OralGlucocorticoid)
 		{
-			var l_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OralGlucocorticoid);
-			var m_ = context.Operators.Start(l_);
-			var n_ = context.Operators.ConvertDateToDateTime(m_);
-			var o_ = this.Measurement_Period();
-			var p_ = context.Operators.End(o_);
-			var q_ = context.Operators.Before(n_, p_, null);
+			CqlInterval<CqlDate> l_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OralGlucocorticoid);
+			CqlDate m_ = context.Operators.Start(l_);
+			CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
+			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
+			CqlDateTime p_ = context.Operators.End(o_);
+			bool? q_ = context.Operators.Before(n_, p_, null);
 
 			return q_;
 		};
-		var h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+		IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 		CqlInterval<CqlDate> i_(MedicationRequest Glucocorticoid)
 		{
-			var r_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(Glucocorticoid);
-			var s_ = this.Patient();
-			var t_ = s_?.BirthDateElement;
-			var u_ = t_?.Value;
-			var v_ = context.Operators.ConvertStringToDate(u_);
-			var w_ = this.Measurement_Period();
-			var x_ = context.Operators.End(w_);
-			var y_ = context.Operators.DateFrom(x_);
-			var z_ = context.Operators.Interval(v_, y_, true, true);
-			var aa_ = context.Operators.Intersect<CqlDate>(r_, z_);
+			CqlInterval<CqlDate> r_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(Glucocorticoid);
+			Patient s_ = this.Patient();
+			Date t_ = s_?.BirthDateElement;
+			string u_ = t_?.Value;
+			CqlDate v_ = context.Operators.ConvertStringToDate(u_);
+			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
+			CqlDateTime x_ = context.Operators.End(w_);
+			CqlDate y_ = context.Operators.DateFrom(x_);
+			CqlInterval<CqlDate> z_ = context.Operators.Interval(v_, y_, true, true);
+			CqlInterval<CqlDate> aa_ = context.Operators.Intersect<CqlDate>(r_, z_);
 
 			return aa_;
 		};
-		var j_ = context.Operators.Select<MedicationRequest, CqlInterval<CqlDate>>(h_, i_);
-		var k_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(j_);
+		IEnumerable<CqlInterval<CqlDate>> j_ = context.Operators.Select<MedicationRequest, CqlInterval<CqlDate>>(h_, i_);
+		int? k_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Glucocorticoid_Active_Medication_Duration_in_Days_Value"/>
     [CqlDeclaration("Glucocorticoid Active Medication Duration in Days")]
 	public int? Glucocorticoid_Active_Medication_Duration_in_Days() => 
 		__Glucocorticoid_Active_Medication_Duration_in_Days.Value;
 
+    /// <seealso cref="Glucocorticoid_Active_Medication_Days"/>
 	private int? Glucocorticoid_Active_Medication_Days_Value()
 	{
-		var a_ = this.Glucocorticoid_Active_Medication_Duration_in_Days();
+		int? a_ = this.Glucocorticoid_Active_Medication_Duration_in_Days();
 
 		return a_;
 	}
 
+    /// <seealso cref="Glucocorticoid_Active_Medication_Days_Value"/>
     [CqlDeclaration("Glucocorticoid Active Medication Days")]
 	public int? Glucocorticoid_Active_Medication_Days() => 
 		__Glucocorticoid_Active_Medication_Days.Value;
 
+    /// <seealso cref="Has_90_or_More_Active_Glucocorticoid_Medication_Days"/>
 	private bool? Has_90_or_More_Active_Glucocorticoid_Medication_Days_Value()
 	{
-		var a_ = this.Glucocorticoid_Active_Medication_Days();
-		var b_ = context.Operators.GreaterOrEqual(a_, 90);
+		int? a_ = this.Glucocorticoid_Active_Medication_Days();
+		bool? b_ = context.Operators.GreaterOrEqual(a_, 90);
 
 		return b_;
 	}
 
+    /// <seealso cref="Has_90_or_More_Active_Glucocorticoid_Medication_Days_Value"/>
     [CqlDeclaration("Has 90 or More Active Glucocorticoid Medication Days")]
 	public bool? Has_90_or_More_Active_Glucocorticoid_Medication_Days() => 
 		__Has_90_or_More_Active_Glucocorticoid_Medication_Days.Value;
@@ -1222,15 +1380,15 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	{
 		bool? a_(Condition Dx)
 		{
-			var c_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Dx);
-			var d_ = context.Operators.Start(c_);
-			var e_ = this.Measurement_Period();
-			var f_ = context.Operators.End(e_);
-			var g_ = context.Operators.SameOrBefore(d_, f_, "day");
+			CqlInterval<CqlDateTime> c_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Dx);
+			CqlDateTime d_ = context.Operators.Start(c_);
+			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+			CqlDateTime f_ = context.Operators.End(e_);
+			bool? g_ = context.Operators.SameOrBefore(d_, f_, "day");
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Condition>(Condition, a_);
+		IEnumerable<Condition> b_ = context.Operators.Where<Condition>(Condition, a_);
 
 		return b_;
 	}
@@ -1238,360 +1396,376 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
     [CqlDeclaration("ProcedureInPatientHistory")]
 	public IEnumerable<Procedure> ProcedureInPatientHistory(IEnumerable<Procedure> Procedure)
 	{
-		var a_ = Status_1_6_000.Completed_Procedure(Procedure);
+		IEnumerable<Procedure> a_ = Status_1_6_000.Completed_Procedure(Procedure);
 		bool? b_(Procedure Proc)
 		{
-			var d_ = Proc?.Performed;
-			var e_ = FHIRHelpers_4_3_000.ToValue(d_);
-			var f_ = QICoreCommon_2_0_000.ToInterval(e_);
-			var g_ = context.Operators.End(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.End(h_);
-			var j_ = context.Operators.SameOrBefore(g_, i_, "day");
+			DataType d_ = Proc?.Performed;
+			object e_ = FHIRHelpers_4_3_000.ToValue(d_);
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToInterval(e_);
+			CqlDateTime g_ = context.Operators.End(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.End(h_);
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, "day");
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Procedure>(a_, b_);
+		IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Has_Double_or_Bilateral_Oophorectomy"/>
 	private bool? Has_Double_or_Bilateral_Oophorectomy_Value()
 	{
-		var a_ = this.Bilateral_Oophorectomy();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = this.ProcedureInPatientHistory(b_);
-		var d_ = context.Operators.Exists<Procedure>(c_);
-		var e_ = this.Evidence_of_Bilateral_Oophorectomy();
-		var f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
-		var g_ = this.ProcedureInPatientHistory(f_);
-		var h_ = context.Operators.Exists<Procedure>(g_);
-		var i_ = context.Operators.Or(d_, h_);
-		var j_ = this.Unilateral_Oophorectomy__Unspecified_Laterality();
-		var k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
+		CqlValueSet a_ = this.Bilateral_Oophorectomy();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = this.ProcedureInPatientHistory(b_);
+		bool? d_ = context.Operators.Exists<Procedure>(c_);
+		CqlValueSet e_ = this.Evidence_of_Bilateral_Oophorectomy();
+		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
+		IEnumerable<Procedure> g_ = this.ProcedureInPatientHistory(f_);
+		bool? h_ = context.Operators.Exists<Procedure>(g_);
+		bool? i_ = context.Operators.Or(d_, h_);
+		CqlValueSet j_ = this.Unilateral_Oophorectomy__Unspecified_Laterality();
+		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
 		bool? l_(Procedure UnilateralOophorectomy)
 		{
-			var ad_ = UnilateralOophorectomy?.BodySite;
+			List<CodeableConcept> ad_ = UnilateralOophorectomy?.BodySite;
 			CqlConcept ae_(CodeableConcept @this)
 			{
-				var aj_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept aj_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return aj_;
 			};
-			var af_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ad_, ae_);
+			IEnumerable<CqlConcept> af_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ad_, ae_);
 			bool? ag_(CqlConcept C)
 			{
-				var ak_ = this.Right__qualifier_value_();
-				var al_ = context.Operators.ConvertCodeToConcept(ak_);
-				var am_ = context.Operators.Equivalent(C, al_);
+				CqlCode ak_ = this.Right__qualifier_value_();
+				CqlConcept al_ = context.Operators.ConvertCodeToConcept(ak_);
+				bool? am_ = context.Operators.Equivalent(C, al_);
 
 				return am_;
 			};
-			var ah_ = context.Operators.Where<CqlConcept>(af_, ag_);
-			var ai_ = context.Operators.Exists<CqlConcept>(ah_);
+			IEnumerable<CqlConcept> ah_ = context.Operators.Where<CqlConcept>(af_, ag_);
+			bool? ai_ = context.Operators.Exists<CqlConcept>(ah_);
 
 			return ai_;
 		};
-		var m_ = context.Operators.Where<Procedure>(k_, l_);
-		var n_ = this.Unilateral_Oophorectomy_Right();
-		var o_ = context.Operators.RetrieveByValueSet<Procedure>(n_, null);
-		var p_ = context.Operators.Union<Procedure>(m_, o_);
-		var q_ = this.ProcedureInPatientHistory(p_);
-		var r_ = context.Operators.Exists<Procedure>(q_);
-		var t_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
+		IEnumerable<Procedure> m_ = context.Operators.Where<Procedure>(k_, l_);
+		CqlValueSet n_ = this.Unilateral_Oophorectomy_Right();
+		IEnumerable<Procedure> o_ = context.Operators.RetrieveByValueSet<Procedure>(n_, null);
+		IEnumerable<Procedure> p_ = context.Operators.Union<Procedure>(m_, o_);
+		IEnumerable<Procedure> q_ = this.ProcedureInPatientHistory(p_);
+		bool? r_ = context.Operators.Exists<Procedure>(q_);
+		IEnumerable<Procedure> t_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
 		bool? u_(Procedure UnilateralOophorectomy)
 		{
-			var an_ = UnilateralOophorectomy?.BodySite;
+			List<CodeableConcept> an_ = UnilateralOophorectomy?.BodySite;
 			CqlConcept ao_(CodeableConcept @this)
 			{
-				var at_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept at_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return at_;
 			};
-			var ap_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)an_, ao_);
+			IEnumerable<CqlConcept> ap_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)an_, ao_);
 			bool? aq_(CqlConcept D)
 			{
-				var au_ = this.Left__qualifier_value_();
-				var av_ = context.Operators.ConvertCodeToConcept(au_);
-				var aw_ = context.Operators.Equivalent(D, av_);
+				CqlCode au_ = this.Left__qualifier_value_();
+				CqlConcept av_ = context.Operators.ConvertCodeToConcept(au_);
+				bool? aw_ = context.Operators.Equivalent(D, av_);
 
 				return aw_;
 			};
-			var ar_ = context.Operators.Where<CqlConcept>(ap_, aq_);
-			var as_ = context.Operators.Exists<CqlConcept>(ar_);
+			IEnumerable<CqlConcept> ar_ = context.Operators.Where<CqlConcept>(ap_, aq_);
+			bool? as_ = context.Operators.Exists<CqlConcept>(ar_);
 
 			return as_;
 		};
-		var v_ = context.Operators.Where<Procedure>(t_, u_);
-		var w_ = this.Unilateral_Oophorectomy_Left();
-		var x_ = context.Operators.RetrieveByValueSet<Procedure>(w_, null);
-		var y_ = context.Operators.Union<Procedure>(v_, x_);
-		var z_ = this.ProcedureInPatientHistory(y_);
-		var aa_ = context.Operators.Exists<Procedure>(z_);
-		var ab_ = context.Operators.And(r_, aa_);
-		var ac_ = context.Operators.Or(i_, ab_);
+		IEnumerable<Procedure> v_ = context.Operators.Where<Procedure>(t_, u_);
+		CqlValueSet w_ = this.Unilateral_Oophorectomy_Left();
+		IEnumerable<Procedure> x_ = context.Operators.RetrieveByValueSet<Procedure>(w_, null);
+		IEnumerable<Procedure> y_ = context.Operators.Union<Procedure>(v_, x_);
+		IEnumerable<Procedure> z_ = this.ProcedureInPatientHistory(y_);
+		bool? aa_ = context.Operators.Exists<Procedure>(z_);
+		bool? ab_ = context.Operators.And(r_, aa_);
+		bool? ac_ = context.Operators.Or(i_, ab_);
 
 		return ac_;
 	}
 
+    /// <seealso cref="Has_Double_or_Bilateral_Oophorectomy_Value"/>
     [CqlDeclaration("Has Double or Bilateral Oophorectomy")]
 	public bool? Has_Double_or_Bilateral_Oophorectomy() => 
 		__Has_Double_or_Bilateral_Oophorectomy.Value;
 
+    /// <seealso cref="Has_Organ_Transplants"/>
 	private bool? Has_Organ_Transplants_Value()
 	{
-		var a_ = this.Major_Transplant();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = this.Kidney_Transplant();
-		var d_ = context.Operators.RetrieveByValueSet<Procedure>(c_, null);
-		var e_ = context.Operators.Union<Procedure>(b_, d_);
-		var f_ = this.Bone_Marrow_Transplant();
-		var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
-		var h_ = context.Operators.Union<Procedure>(e_, g_);
-		var i_ = this.ProcedureInPatientHistory(h_);
-		var j_ = context.Operators.Exists<Procedure>(i_);
+		CqlValueSet a_ = this.Major_Transplant();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		CqlValueSet c_ = this.Kidney_Transplant();
+		IEnumerable<Procedure> d_ = context.Operators.RetrieveByValueSet<Procedure>(c_, null);
+		IEnumerable<Procedure> e_ = context.Operators.Union<Procedure>(b_, d_);
+		CqlValueSet f_ = this.Bone_Marrow_Transplant();
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		IEnumerable<Procedure> h_ = context.Operators.Union<Procedure>(e_, g_);
+		IEnumerable<Procedure> i_ = this.ProcedureInPatientHistory(h_);
+		bool? j_ = context.Operators.Exists<Procedure>(i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Has_Organ_Transplants_Value"/>
     [CqlDeclaration("Has Organ Transplants")]
 	public bool? Has_Organ_Transplants() => 
 		__Has_Organ_Transplants.Value;
 
+    /// <seealso cref="Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period"/>
 	private bool? Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period_Value()
 	{
-		var a_ = this.Has_90_or_More_Active_Glucocorticoid_Medication_Days();
-		var b_ = this.Osteoporotic_Fractures();
-		var c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
-		var d_ = this.Malabsorption_Syndromes();
-		var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
-		var f_ = context.Operators.Union<Condition>(c_, e_);
-		var g_ = this.Chronic_Malnutrition();
-		var h_ = context.Operators.RetrieveByValueSet<Condition>(g_, null);
-		var i_ = this.Chronic_Liver_Disease();
-		var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
-		var k_ = context.Operators.Union<Condition>(h_, j_);
-		var l_ = context.Operators.Union<Condition>(f_, k_);
-		var m_ = this.Rheumatoid_Arthritis();
-		var n_ = context.Operators.RetrieveByValueSet<Condition>(m_, null);
-		var o_ = this.Hyperthyroidism();
-		var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
-		var q_ = context.Operators.Union<Condition>(n_, p_);
-		var r_ = context.Operators.Union<Condition>(l_, q_);
-		var s_ = this.Type_1_Diabetes();
-		var t_ = context.Operators.RetrieveByValueSet<Condition>(s_, null);
-		var u_ = this.End_Stage_Renal_Disease();
-		var v_ = context.Operators.RetrieveByValueSet<Condition>(u_, null);
-		var w_ = context.Operators.Union<Condition>(t_, v_);
-		var x_ = context.Operators.Union<Condition>(r_, w_);
-		var y_ = this.Osteogenesis_Imperfecta();
-		var z_ = context.Operators.RetrieveByValueSet<Condition>(y_, null);
-		var aa_ = this.Ankylosing_Spondylitis();
-		var ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, null);
-		var ac_ = context.Operators.Union<Condition>(z_, ab_);
-		var ad_ = context.Operators.Union<Condition>(x_, ac_);
-		var ae_ = this.Psoriatic_Arthritis();
-		var af_ = context.Operators.RetrieveByValueSet<Condition>(ae_, null);
-		var ag_ = this.Ehlers_Danlos_Syndrome();
-		var ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, null);
-		var ai_ = context.Operators.Union<Condition>(af_, ah_);
-		var aj_ = context.Operators.Union<Condition>(ad_, ai_);
-		var ak_ = this.Cushings_Syndrome();
-		var al_ = context.Operators.RetrieveByValueSet<Condition>(ak_, null);
-		var am_ = this.Hyperparathyroidism();
-		var an_ = context.Operators.RetrieveByValueSet<Condition>(am_, null);
-		var ao_ = context.Operators.Union<Condition>(al_, an_);
-		var ap_ = context.Operators.Union<Condition>(aj_, ao_);
-		var aq_ = this.Marfans_Syndrome();
-		var ar_ = context.Operators.RetrieveByValueSet<Condition>(aq_, null);
-		var as_ = this.Lupus();
-		var at_ = context.Operators.RetrieveByValueSet<Condition>(as_, null);
-		var au_ = context.Operators.Union<Condition>(ar_, at_);
-		var av_ = context.Operators.Union<Condition>(ap_, au_);
-		var aw_ = this.Multiple_Myeloma();
-		var ax_ = context.Operators.RetrieveByValueSet<Condition>(aw_, null);
-		var ay_ = this.Premature_Menopause();
-		var az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, null);
-		var ba_ = context.Operators.Union<Condition>(ax_, az_);
-		var bb_ = context.Operators.Union<Condition>(av_, ba_);
-		var bc_ = this.Eating_Disorders();
-		var bd_ = context.Operators.RetrieveByValueSet<Condition>(bc_, null);
-		var be_ = this.Amenorrhea();
-		var bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, null);
-		var bg_ = context.Operators.Union<Condition>(bd_, bf_);
-		var bh_ = context.Operators.Union<Condition>(bb_, bg_);
-		var bi_ = this.DiagnosisInPatientHistory(bh_);
-		var bj_ = context.Operators.Exists<Condition>(bi_);
-		var bk_ = context.Operators.Or(a_, bj_);
-		var bl_ = this.Chemotherapy();
-		var bm_ = context.Operators.RetrieveByValueSet<Procedure>(bl_, null);
-		var bn_ = this.ProcedureInPatientHistory(bm_);
-		var bo_ = context.Operators.Exists<Procedure>(bn_);
-		var bp_ = context.Operators.Or(bk_, bo_);
-		var bq_ = this.Has_Double_or_Bilateral_Oophorectomy();
-		var br_ = context.Operators.Or(bp_, bq_);
-		var bs_ = this.Has_Organ_Transplants();
-		var bt_ = context.Operators.Or(br_, bs_);
+		bool? a_ = this.Has_90_or_More_Active_Glucocorticoid_Medication_Days();
+		CqlValueSet b_ = this.Osteoporotic_Fractures();
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		CqlValueSet d_ = this.Malabsorption_Syndromes();
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(c_, e_);
+		CqlValueSet g_ = this.Chronic_Malnutrition();
+		IEnumerable<Condition> h_ = context.Operators.RetrieveByValueSet<Condition>(g_, null);
+		CqlValueSet i_ = this.Chronic_Liver_Disease();
+		IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+		IEnumerable<Condition> k_ = context.Operators.Union<Condition>(h_, j_);
+		IEnumerable<Condition> l_ = context.Operators.Union<Condition>(f_, k_);
+		CqlValueSet m_ = this.Rheumatoid_Arthritis();
+		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, null);
+		CqlValueSet o_ = this.Hyperthyroidism();
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		IEnumerable<Condition> q_ = context.Operators.Union<Condition>(n_, p_);
+		IEnumerable<Condition> r_ = context.Operators.Union<Condition>(l_, q_);
+		CqlValueSet s_ = this.Type_1_Diabetes();
+		IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, null);
+		CqlValueSet u_ = this.End_Stage_Renal_Disease();
+		IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, null);
+		IEnumerable<Condition> w_ = context.Operators.Union<Condition>(t_, v_);
+		IEnumerable<Condition> x_ = context.Operators.Union<Condition>(r_, w_);
+		CqlValueSet y_ = this.Osteogenesis_Imperfecta();
+		IEnumerable<Condition> z_ = context.Operators.RetrieveByValueSet<Condition>(y_, null);
+		CqlValueSet aa_ = this.Ankylosing_Spondylitis();
+		IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, null);
+		IEnumerable<Condition> ac_ = context.Operators.Union<Condition>(z_, ab_);
+		IEnumerable<Condition> ad_ = context.Operators.Union<Condition>(x_, ac_);
+		CqlValueSet ae_ = this.Psoriatic_Arthritis();
+		IEnumerable<Condition> af_ = context.Operators.RetrieveByValueSet<Condition>(ae_, null);
+		CqlValueSet ag_ = this.Ehlers_Danlos_Syndrome();
+		IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, null);
+		IEnumerable<Condition> ai_ = context.Operators.Union<Condition>(af_, ah_);
+		IEnumerable<Condition> aj_ = context.Operators.Union<Condition>(ad_, ai_);
+		CqlValueSet ak_ = this.Cushings_Syndrome();
+		IEnumerable<Condition> al_ = context.Operators.RetrieveByValueSet<Condition>(ak_, null);
+		CqlValueSet am_ = this.Hyperparathyroidism();
+		IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, null);
+		IEnumerable<Condition> ao_ = context.Operators.Union<Condition>(al_, an_);
+		IEnumerable<Condition> ap_ = context.Operators.Union<Condition>(aj_, ao_);
+		CqlValueSet aq_ = this.Marfans_Syndrome();
+		IEnumerable<Condition> ar_ = context.Operators.RetrieveByValueSet<Condition>(aq_, null);
+		CqlValueSet as_ = this.Lupus();
+		IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, null);
+		IEnumerable<Condition> au_ = context.Operators.Union<Condition>(ar_, at_);
+		IEnumerable<Condition> av_ = context.Operators.Union<Condition>(ap_, au_);
+		CqlValueSet aw_ = this.Multiple_Myeloma();
+		IEnumerable<Condition> ax_ = context.Operators.RetrieveByValueSet<Condition>(aw_, null);
+		CqlValueSet ay_ = this.Premature_Menopause();
+		IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, null);
+		IEnumerable<Condition> ba_ = context.Operators.Union<Condition>(ax_, az_);
+		IEnumerable<Condition> bb_ = context.Operators.Union<Condition>(av_, ba_);
+		CqlValueSet bc_ = this.Eating_Disorders();
+		IEnumerable<Condition> bd_ = context.Operators.RetrieveByValueSet<Condition>(bc_, null);
+		CqlValueSet be_ = this.Amenorrhea();
+		IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, null);
+		IEnumerable<Condition> bg_ = context.Operators.Union<Condition>(bd_, bf_);
+		IEnumerable<Condition> bh_ = context.Operators.Union<Condition>(bb_, bg_);
+		IEnumerable<Condition> bi_ = this.DiagnosisInPatientHistory(bh_);
+		bool? bj_ = context.Operators.Exists<Condition>(bi_);
+		bool? bk_ = context.Operators.Or(a_, bj_);
+		CqlValueSet bl_ = this.Chemotherapy();
+		IEnumerable<Procedure> bm_ = context.Operators.RetrieveByValueSet<Procedure>(bl_, null);
+		IEnumerable<Procedure> bn_ = this.ProcedureInPatientHistory(bm_);
+		bool? bo_ = context.Operators.Exists<Procedure>(bn_);
+		bool? bp_ = context.Operators.Or(bk_, bo_);
+		bool? bq_ = this.Has_Double_or_Bilateral_Oophorectomy();
+		bool? br_ = context.Operators.Or(bp_, bq_);
+		bool? bs_ = this.Has_Organ_Transplants();
+		bool? bt_ = context.Operators.Or(br_, bs_);
 
 		return bt_;
 	}
 
+    /// <seealso cref="Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period_Value"/>
     [CqlDeclaration("Has Risk Factor Any Time in History or During Measurement Period")]
 	public bool? Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period() => 
 		__Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = this.Has_Risk_Factor_Active_During_the_Measurement_Period();
-		var b_ = this.Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period();
-		var e_ = context.Operators.Or(c_, d_);
-		var f_ = this.Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period();
-		var g_ = context.Operators.Or(e_, f_);
+		bool? a_ = this.Has_Risk_Factor_Active_During_the_Measurement_Period();
+		bool? b_ = this.Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = this.Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period();
+		bool? e_ = context.Operators.Or(c_, d_);
+		bool? f_ = this.Has_Risk_Factor_Any_Time_in_History_or_During_Measurement_Period();
+		bool? g_ = context.Operators.Or(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="DXA_Scan_Order_During_Measurement_Period"/>
 	private IEnumerable<ServiceRequest> DXA_Scan_Order_During_Measurement_Period_Value()
 	{
-		var a_ = this.DXA__Dual_energy_Xray_Absorptiometry__Scan();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
+		CqlValueSet a_ = this.DXA__Dual_energy_Xray_Absorptiometry__Scan();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		bool? d_(ServiceRequest DXA)
 		{
-			var h_ = this.Measurement_Period();
-			var i_ = DXA?.AuthoredOnElement;
-			var j_ = context.Operators.Convert<CqlDateTime>(i_);
-			var k_ = QICoreCommon_2_0_000.ToInterval((j_ as object));
-			var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, null);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			FhirDateTime i_ = DXA?.AuthoredOnElement;
+			CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval((j_ as object));
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, null);
 
 			return l_;
 		};
-		var e_ = context.Operators.Where<ServiceRequest>(c_, d_);
+		IEnumerable<ServiceRequest> e_ = context.Operators.Where<ServiceRequest>(c_, d_);
 		object f_(ServiceRequest @this)
 		{
-			var m_ = @this?.AuthoredOnElement;
-			var n_ = context.Operators.Convert<CqlDateTime>(m_);
+			FhirDateTime m_ = @this?.AuthoredOnElement;
+			CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 
 			return n_;
 		};
-		var g_ = context.Operators.SortBy<ServiceRequest>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<ServiceRequest> g_ = context.Operators.SortBy<ServiceRequest>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
 
 		return g_;
 	}
 
+    /// <seealso cref="DXA_Scan_Order_During_Measurement_Period_Value"/>
     [CqlDeclaration("DXA Scan Order During Measurement Period")]
 	public IEnumerable<ServiceRequest> DXA_Scan_Order_During_Measurement_Period() => 
 		__DXA_Scan_Order_During_Measurement_Period.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.DXA_Scan_Order_During_Measurement_Period();
-		var b_ = context.Operators.Exists<ServiceRequest>(a_);
+		IEnumerable<ServiceRequest> a_ = this.DXA_Scan_Order_During_Measurement_Period();
+		bool? b_ = context.Operators.Exists<ServiceRequest>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan"/>
 	private IEnumerable<Observation> Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan_Value()
 	{
-		var a_ = this.Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode a_ = this.Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation FRAX)
 		{
-			var ad_ = FRAX?.Value;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = context.Operators.Quantity(8.4m, "%");
-			var ag_ = context.Operators.GreaterOrEqual((ae_ as CqlQuantity), af_);
+			DataType ad_ = FRAX?.Value;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlQuantity af_ = context.Operators.Quantity(8.4m, "%");
+			bool? ag_ = context.Operators.GreaterOrEqual((ae_ as CqlQuantity), af_);
 
 			return ag_;
 		};
-		var f_ = context.Operators.Where<Observation>(d_, e_);
-		var g_ = this.Osteoporosis_Risk_Assessment_Instrument();
-		var h_ = context.Operators.ToList<CqlCode>(g_);
-		var i_ = context.Operators.RetrieveByCodes<Observation>(h_, null);
-		var j_ = Status_1_6_000.Final_Survey_Observation(i_);
+		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
+		CqlCode g_ = this.Osteoporosis_Risk_Assessment_Instrument();
+		IEnumerable<CqlCode> h_ = context.Operators.ToList<CqlCode>(g_);
+		IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, null);
+		IEnumerable<Observation> j_ = Status_1_6_000.Final_Survey_Observation(i_);
 		bool? k_(Observation ORAI)
 		{
-			var ah_ = ORAI?.Value;
-			var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-			var aj_ = context.Operators.GreaterOrEqual((int?)ai_, 9);
+			DataType ah_ = ORAI?.Value;
+			object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+			bool? aj_ = context.Operators.GreaterOrEqual((int?)ai_, 9);
 
 			return aj_;
 		};
-		var l_ = context.Operators.Where<Observation>(j_, k_);
-		var m_ = context.Operators.Union<Observation>(f_, l_);
-		var n_ = this.Osteoporosis_Index_of_Risk_panel();
-		var o_ = context.Operators.ToList<CqlCode>(n_);
-		var p_ = context.Operators.RetrieveByCodes<Observation>(o_, null);
-		var q_ = Status_1_6_000.Final_Survey_Observation(p_);
+		IEnumerable<Observation> l_ = context.Operators.Where<Observation>(j_, k_);
+		IEnumerable<Observation> m_ = context.Operators.Union<Observation>(f_, l_);
+		CqlCode n_ = this.Osteoporosis_Index_of_Risk_panel();
+		IEnumerable<CqlCode> o_ = context.Operators.ToList<CqlCode>(n_);
+		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, null);
+		IEnumerable<Observation> q_ = Status_1_6_000.Final_Survey_Observation(p_);
 		bool? r_(Observation OSIRIS)
 		{
-			var ak_ = OSIRIS?.Value;
-			var al_ = FHIRHelpers_4_3_000.ToValue(ak_);
-			var am_ = context.Operators.ConvertDecimalToQuantity(1.0m);
-			var an_ = context.Operators.Less((al_ as CqlQuantity), am_);
+			DataType ak_ = OSIRIS?.Value;
+			object al_ = FHIRHelpers_4_3_000.ToValue(ak_);
+			CqlQuantity am_ = context.Operators.ConvertDecimalToQuantity(1.0m);
+			bool? an_ = context.Operators.Less((al_ as CqlQuantity), am_);
 
 			return an_;
 		};
-		var s_ = context.Operators.Where<Observation>(q_, r_);
-		var t_ = this.Osteoporosis_Self_Assessment_Tool();
-		var u_ = context.Operators.ToList<CqlCode>(t_);
-		var v_ = context.Operators.RetrieveByCodes<Observation>(u_, null);
-		var w_ = Status_1_6_000.Final_Survey_Observation(v_);
+		IEnumerable<Observation> s_ = context.Operators.Where<Observation>(q_, r_);
+		CqlCode t_ = this.Osteoporosis_Self_Assessment_Tool();
+		IEnumerable<CqlCode> u_ = context.Operators.ToList<CqlCode>(t_);
+		IEnumerable<Observation> v_ = context.Operators.RetrieveByCodes<Observation>(u_, null);
+		IEnumerable<Observation> w_ = Status_1_6_000.Final_Survey_Observation(v_);
 		bool? x_(Observation OST)
 		{
-			var ao_ = OST?.Value;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = context.Operators.ConvertDecimalToQuantity(2.0m);
-			var ar_ = context.Operators.Less((ap_ as CqlQuantity), aq_);
+			DataType ao_ = OST?.Value;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			CqlQuantity aq_ = context.Operators.ConvertDecimalToQuantity(2.0m);
+			bool? ar_ = context.Operators.Less((ap_ as CqlQuantity), aq_);
 
 			return ar_;
 		};
-		var y_ = context.Operators.Where<Observation>(w_, x_);
-		var z_ = context.Operators.Union<Observation>(s_, y_);
-		var aa_ = context.Operators.Union<Observation>(m_, z_);
+		IEnumerable<Observation> y_ = context.Operators.Where<Observation>(w_, x_);
+		IEnumerable<Observation> z_ = context.Operators.Union<Observation>(s_, y_);
+		IEnumerable<Observation> aa_ = context.Operators.Union<Observation>(m_, z_);
 		bool? ab_(Observation RiskAssessment)
 		{
-			var as_ = RiskAssessment?.Effective;
-			var at_ = FHIRHelpers_4_3_000.ToValue(as_);
-			var au_ = QICoreCommon_2_0_000.ToInterval(at_);
-			var av_ = context.Operators.Start(au_);
-			var aw_ = this.DXA_Scan_Order_During_Measurement_Period();
-			var ax_ = context.Operators.First<ServiceRequest>(aw_);
-			var ay_ = ax_?.AuthoredOnElement;
-			var az_ = context.Operators.Convert<CqlDateTime>(ay_);
-			var ba_ = context.Operators.Before(av_, az_, null);
+			DataType as_ = RiskAssessment?.Effective;
+			object at_ = FHIRHelpers_4_3_000.ToValue(as_);
+			CqlInterval<CqlDateTime> au_ = QICoreCommon_2_0_000.ToInterval(at_);
+			CqlDateTime av_ = context.Operators.Start(au_);
+			IEnumerable<ServiceRequest> aw_ = this.DXA_Scan_Order_During_Measurement_Period();
+			ServiceRequest ax_ = context.Operators.First<ServiceRequest>(aw_);
+			FhirDateTime ay_ = ax_?.AuthoredOnElement;
+			CqlDateTime az_ = context.Operators.Convert<CqlDateTime>(ay_);
+			bool? ba_ = context.Operators.Before(av_, az_, null);
 
 			return ba_;
 		};
-		var ac_ = context.Operators.Where<Observation>(aa_, ab_);
+		IEnumerable<Observation> ac_ = context.Operators.Where<Observation>(aa_, ab_);
 
 		return ac_;
 	}
 
+    /// <seealso cref="Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan_Value"/>
     [CqlDeclaration("Osteoporosis Fracture Risk Assessment Prior to First DXA Scan")]
 	public IEnumerable<Observation> Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan() => 
 		__Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan.Value;
 
+    /// <seealso cref="Numerator_Exclusion"/>
 	private bool? Numerator_Exclusion_Value()
 	{
-		var a_ = this.Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan();
-		var b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> a_ = this.Osteoporosis_Fracture_Risk_Assessment_Prior_to_First_DXA_Scan();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Numerator_Exclusion_Value"/>
     [CqlDeclaration("Numerator Exclusion")]
 	public bool? Numerator_Exclusion() => 
 		__Numerator_Exclusion.Value;
@@ -1601,31 +1775,31 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var n_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept n_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return n_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
-			var l_ = context.Operators.Exists<CqlConcept>(k_);
-			var m_ = context.Operators.And(h_, l_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			bool? l_ = context.Operators.Exists<CqlConcept>(k_);
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}

--- a/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
@@ -136,199 +136,248 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Acute_Pharyngitis"/>
 	private CqlValueSet Acute_Pharyngitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011", null);
 
+    /// <seealso cref="Acute_Pharyngitis_Value"/>
     [CqlDeclaration("Acute Pharyngitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011")]
 	public CqlValueSet Acute_Pharyngitis() => 
 		__Acute_Pharyngitis.Value;
 
+    /// <seealso cref="Acute_Tonsillitis"/>
 	private CqlValueSet Acute_Tonsillitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012", null);
 
+    /// <seealso cref="Acute_Tonsillitis_Value"/>
     [CqlDeclaration("Acute Tonsillitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012")]
 	public CqlValueSet Acute_Tonsillitis() => 
 		__Acute_Tonsillitis.Value;
 
+    /// <seealso cref="Antibiotic_Medications_for_Pharyngitis"/>
 	private CqlValueSet Antibiotic_Medications_for_Pharyngitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", null);
 
+    /// <seealso cref="Antibiotic_Medications_for_Pharyngitis_Value"/>
     [CqlDeclaration("Antibiotic Medications for Pharyngitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001")]
 	public CqlValueSet Antibiotic_Medications_for_Pharyngitis() => 
 		__Antibiotic_Medications_for_Pharyngitis.Value;
 
+    /// <seealso cref="Comorbid_Conditions_for_Respiratory_Conditions"/>
 	private CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", null);
 
+    /// <seealso cref="Comorbid_Conditions_for_Respiratory_Conditions_Value"/>
     [CqlDeclaration("Comorbid Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025")]
 	public CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions() => 
 		__Comorbid_Conditions_for_Respiratory_Conditions.Value;
 
+    /// <seealso cref="Competing_Conditions_for_Respiratory_Conditions"/>
 	private CqlValueSet Competing_Conditions_for_Respiratory_Conditions_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", null);
 
+    /// <seealso cref="Competing_Conditions_for_Respiratory_Conditions_Value"/>
     [CqlDeclaration("Competing Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017")]
 	public CqlValueSet Competing_Conditions_for_Respiratory_Conditions() => 
 		__Competing_Conditions_for_Respiratory_Conditions.Value;
 
+    /// <seealso cref="Discharge_Services_Observation_Care"/>
 	private CqlValueSet Discharge_Services_Observation_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039", null);
 
+    /// <seealso cref="Discharge_Services_Observation_Care_Value"/>
     [CqlDeclaration("Discharge Services Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039")]
 	public CqlValueSet Discharge_Services_Observation_Care() => 
 		__Discharge_Services_Observation_Care.Value;
 
+    /// <seealso cref="Emergency_Department_Visit"/>
 	private CqlValueSet Emergency_Department_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
 
+    /// <seealso cref="Emergency_Department_Visit_Value"/>
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
 	public CqlValueSet Emergency_Department_Visit() => 
 		__Emergency_Department_Visit.Value;
 
+    /// <seealso cref="Group_A_Streptococcus_Test"/>
 	private CqlValueSet Group_A_Streptococcus_Test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012", null);
 
+    /// <seealso cref="Group_A_Streptococcus_Test_Value"/>
     [CqlDeclaration("Group A Streptococcus Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012")]
 	public CqlValueSet Group_A_Streptococcus_Test() => 
 		__Group_A_Streptococcus_Test.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Initial_Hospital_Observation_Care"/>
 	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", null);
 
+    /// <seealso cref="Initial_Hospital_Observation_Care_Value"/>
     [CqlDeclaration("Initial Hospital Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
 	public CqlValueSet Initial_Hospital_Observation_Care() => 
 		__Initial_Hospital_Observation_Care.Value;
 
+    /// <seealso cref="Medical_Disability_Exam"/>
 	private CqlValueSet Medical_Disability_Exam_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", null);
 
+    /// <seealso cref="Medical_Disability_Exam_Value"/>
     [CqlDeclaration("Medical Disability Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073")]
 	public CqlValueSet Medical_Disability_Exam() => 
 		__Medical_Disability_Exam.Value;
 
+    /// <seealso cref="Observation"/>
 	private CqlValueSet Observation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
 
+    /// <seealso cref="Observation_Value"/>
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
 	public CqlValueSet Observation() => 
 		__Observation.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Group_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
 
+    /// <seealso cref="Preventive_Care_Services_Group_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
 	public CqlValueSet Preventive_Care_Services_Group_Counseling() => 
 		__Preventive_Care_Services_Group_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
 	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
 	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
 	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___"/>
 	private CqlCode Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate____Value() => 
 		new CqlCode("99217", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate____Value"/>
     [CqlDeclaration("Observation care discharge day management (This code is to be utilized to report all services provided to a patient on discharge from outpatient hospital observation status if the discharge is on other than the initial date of observation status. To report services to a patient designated as observation status or inpatient status and discharged on the same date, use the codes for Observation or Inpatient Care Services [including Admission and Discharge Services, 99234-99236 as appropriate.])")]
 	public CqlCode Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___() => 
 		__Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___.Value;
 
+    /// <seealso cref="Unlisted_preventive_medicine_service"/>
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
 		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Unlisted_preventive_medicine_service_Value"/>
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
 		__Unlisted_preventive_medicine_service.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("99217", "http://www.ama-assn.org/go/cpt", null, null),
 			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
@@ -337,268 +386,288 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("AppropriateTestingforPharyngitisFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("AppropriateTestingforPharyngitisFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounter"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
-		var a_ = this.Emergency_Department_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		CqlValueSet a_ = this.Emergency_Department_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
 		bool? d_(Encounter E)
 		{
-			var bg_ = E?.Type;
+			List<CodeableConcept> bg_ = E?.Type;
 			CqlConcept bh_(CodeableConcept @this)
 			{
-				var bm_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept bm_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return bm_;
 			};
-			var bi_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bg_, bh_);
+			IEnumerable<CqlConcept> bi_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bg_, bh_);
 			bool? bj_(CqlConcept T)
 			{
-				var bn_ = this.Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___();
-				var bo_ = context.Operators.ConvertCodeToConcept(bn_);
-				var bp_ = context.Operators.Equivalent(T, bo_);
+				CqlCode bn_ = this.Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___();
+				CqlConcept bo_ = context.Operators.ConvertCodeToConcept(bn_);
+				bool? bp_ = context.Operators.Equivalent(T, bo_);
 
 				return bp_;
 			};
-			var bk_ = context.Operators.Where<CqlConcept>(bi_, bj_);
-			var bl_ = context.Operators.Exists<CqlConcept>(bk_);
+			IEnumerable<CqlConcept> bk_ = context.Operators.Where<CqlConcept>(bi_, bj_);
+			bool? bl_ = context.Operators.Exists<CqlConcept>(bk_);
 
 			return bl_;
 		};
-		var e_ = context.Operators.Where<Encounter>(c_, d_);
-		var f_ = context.Operators.Union<Encounter>(b_, e_);
-		var h_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var i_ = this.Home_Healthcare_Services();
-		var j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
-		var k_ = context.Operators.Union<Encounter>(h_, j_);
-		var l_ = context.Operators.Union<Encounter>(f_, k_);
-		var m_ = this.Initial_Hospital_Observation_Care();
-		var n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
-		var o_ = this.Medical_Disability_Exam();
-		var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
-		var q_ = context.Operators.Union<Encounter>(n_, p_);
-		var r_ = context.Operators.Union<Encounter>(l_, q_);
-		var s_ = this.Observation();
-		var t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
-		var u_ = this.Office_Visit();
-		var v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, null);
-		var w_ = context.Operators.Union<Encounter>(t_, v_);
-		var x_ = context.Operators.Union<Encounter>(r_, w_);
-		var y_ = this.Telephone_Visits();
-		var z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
-		var aa_ = this.Online_Assessments();
-		var ab_ = context.Operators.RetrieveByValueSet<Encounter>(aa_, null);
-		var ac_ = context.Operators.Union<Encounter>(z_, ab_);
-		var ad_ = context.Operators.Union<Encounter>(x_, ac_);
-		var ae_ = this.Outpatient_Consultation();
-		var af_ = context.Operators.RetrieveByValueSet<Encounter>(ae_, null);
-		var ag_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var ah_ = context.Operators.RetrieveByValueSet<Encounter>(ag_, null);
-		var ai_ = context.Operators.Union<Encounter>(af_, ah_);
-		var aj_ = context.Operators.Union<Encounter>(ad_, ai_);
-		var ak_ = this.Preventive_Care_Services_Group_Counseling();
-		var al_ = context.Operators.RetrieveByValueSet<Encounter>(ak_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
+		IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(b_, e_);
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet i_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(h_, j_);
+		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(f_, k_);
+		CqlValueSet m_ = this.Initial_Hospital_Observation_Care();
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		CqlValueSet o_ = this.Medical_Disability_Exam();
+		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(n_, p_);
+		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(l_, q_);
+		CqlValueSet s_ = this.Observation();
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
+		CqlValueSet u_ = this.Office_Visit();
+		IEnumerable<Encounter> v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, null);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(t_, v_);
+		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(r_, w_);
+		CqlValueSet y_ = this.Telephone_Visits();
+		IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
+		CqlValueSet aa_ = this.Online_Assessments();
+		IEnumerable<Encounter> ab_ = context.Operators.RetrieveByValueSet<Encounter>(aa_, null);
+		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(z_, ab_);
+		IEnumerable<Encounter> ad_ = context.Operators.Union<Encounter>(x_, ac_);
+		CqlValueSet ae_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(ae_, null);
+		CqlValueSet ag_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> ah_ = context.Operators.RetrieveByValueSet<Encounter>(ag_, null);
+		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(af_, ah_);
+		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ad_, ai_);
+		CqlValueSet ak_ = this.Preventive_Care_Services_Group_Counseling();
+		IEnumerable<Encounter> al_ = context.Operators.RetrieveByValueSet<Encounter>(ak_, null);
 		bool? an_(Encounter E)
 		{
-			var bq_ = E?.Type;
+			List<CodeableConcept> bq_ = E?.Type;
 			CqlConcept br_(CodeableConcept @this)
 			{
-				var bw_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept bw_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return bw_;
 			};
-			var bs_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bq_, br_);
+			IEnumerable<CqlConcept> bs_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bq_, br_);
 			bool? bt_(CqlConcept T)
 			{
-				var bx_ = this.Unlisted_preventive_medicine_service();
-				var by_ = context.Operators.ConvertCodeToConcept(bx_);
-				var bz_ = context.Operators.Equivalent(T, by_);
+				CqlCode bx_ = this.Unlisted_preventive_medicine_service();
+				CqlConcept by_ = context.Operators.ConvertCodeToConcept(bx_);
+				bool? bz_ = context.Operators.Equivalent(T, by_);
 
 				return bz_;
 			};
-			var bu_ = context.Operators.Where<CqlConcept>(bs_, bt_);
-			var bv_ = context.Operators.Exists<CqlConcept>(bu_);
+			IEnumerable<CqlConcept> bu_ = context.Operators.Where<CqlConcept>(bs_, bt_);
+			bool? bv_ = context.Operators.Exists<CqlConcept>(bu_);
 
 			return bv_;
 		};
-		var ao_ = context.Operators.Where<Encounter>(c_, an_);
-		var ap_ = context.Operators.Union<Encounter>(al_, ao_);
-		var aq_ = context.Operators.Union<Encounter>(aj_, ap_);
-		var ar_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var as_ = context.Operators.RetrieveByValueSet<Encounter>(ar_, null);
-		var at_ = this.Preventive_Care_Services_Individual_Counseling();
-		var au_ = context.Operators.RetrieveByValueSet<Encounter>(at_, null);
-		var av_ = context.Operators.Union<Encounter>(as_, au_);
-		var aw_ = context.Operators.Union<Encounter>(aq_, av_);
-		var ax_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var ay_ = context.Operators.RetrieveByValueSet<Encounter>(ax_, null);
-		var az_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var ba_ = context.Operators.RetrieveByValueSet<Encounter>(az_, null);
-		var bb_ = context.Operators.Union<Encounter>(ay_, ba_);
-		var bc_ = context.Operators.Union<Encounter>(aw_, bb_);
-		var bd_ = Status_1_6_000.Finished_Encounter(bc_);
+		IEnumerable<Encounter> ao_ = context.Operators.Where<Encounter>(c_, an_);
+		IEnumerable<Encounter> ap_ = context.Operators.Union<Encounter>(al_, ao_);
+		IEnumerable<Encounter> aq_ = context.Operators.Union<Encounter>(aj_, ap_);
+		CqlValueSet ar_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> as_ = context.Operators.RetrieveByValueSet<Encounter>(ar_, null);
+		CqlValueSet at_ = this.Preventive_Care_Services_Individual_Counseling();
+		IEnumerable<Encounter> au_ = context.Operators.RetrieveByValueSet<Encounter>(at_, null);
+		IEnumerable<Encounter> av_ = context.Operators.Union<Encounter>(as_, au_);
+		IEnumerable<Encounter> aw_ = context.Operators.Union<Encounter>(aq_, av_);
+		CqlValueSet ax_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ax_, null);
+		CqlValueSet az_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> ba_ = context.Operators.RetrieveByValueSet<Encounter>(az_, null);
+		IEnumerable<Encounter> bb_ = context.Operators.Union<Encounter>(ay_, ba_);
+		IEnumerable<Encounter> bc_ = context.Operators.Union<Encounter>(aw_, bb_);
+		IEnumerable<Encounter> bd_ = Status_1_6_000.Finished_Encounter(bc_);
 		bool? be_(Encounter ValidEncounter)
 		{
-			var ca_ = this.Measurement_Period();
-			var cb_ = ValidEncounter?.Period;
-			var cc_ = FHIRHelpers_4_3_000.ToInterval(cb_);
-			var cd_ = QICoreCommon_2_0_000.ToInterval((cc_ as object));
-			var ce_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ca_, cd_, null);
+			CqlInterval<CqlDateTime> ca_ = this.Measurement_Period();
+			Period cb_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> cc_ = FHIRHelpers_4_3_000.ToInterval(cb_);
+			CqlInterval<CqlDateTime> cd_ = QICoreCommon_2_0_000.ToInterval((cc_ as object));
+			bool? ce_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ca_, cd_, null);
 
 			return ce_;
 		};
-		var bf_ = context.Operators.Where<Encounter>(bd_, be_);
+		IEnumerable<Encounter> bf_ = context.Operators.Where<Encounter>(bd_, be_);
 
 		return bf_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_Value"/>
     [CqlDeclaration("Qualifying Encounter")]
 	public IEnumerable<Encounter> Qualifying_Encounter() => 
 		__Qualifying_Encounter.Value;
 
+    /// <seealso cref="Encounter_With_Antibiotic_Ordered_Within_Three_Days"/>
 	private IEnumerable<Encounter> Encounter_With_Antibiotic_Ordered_Within_Three_Days_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		IEnumerable<Encounter> b_(Encounter EDOrAmbulatoryVisit)
 		{
-			var d_ = this.Antibiotic_Medications_for_Pharyngitis();
-			var e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			var h_ = context.Operators.Union<MedicationRequest>(e_, g_);
-			var i_ = Status_1_6_000.Active_Medication(h_);
+			CqlValueSet d_ = this.Antibiotic_Medications_for_Pharyngitis();
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
+			IEnumerable<MedicationRequest> i_ = Status_1_6_000.Active_Medication(h_);
 			bool? j_(MedicationRequest AntibioticOrdered)
 			{
-				var n_ = EDOrAmbulatoryVisit?.Period;
-				var o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var p_ = QICoreCommon_2_0_000.ToInterval((o_ as object));
-				var q_ = context.Operators.Start(p_);
-				var r_ = AntibioticOrdered?.AuthoredOnElement;
-				var s_ = context.Operators.Convert<CqlDateTime>(r_);
-				var t_ = context.Operators.Quantity(3m, "days");
-				var u_ = context.Operators.Subtract(s_, t_);
-				var w_ = context.Operators.Convert<CqlDateTime>(r_);
-				var x_ = context.Operators.Interval(u_, w_, true, true);
-				var y_ = context.Operators.In<CqlDateTime>(q_, x_, null);
-				var aa_ = context.Operators.Convert<CqlDateTime>(r_);
-				var ab_ = context.Operators.Not((bool?)(aa_ is null));
-				var ac_ = context.Operators.And(y_, ab_);
+				Period n_ = EDOrAmbulatoryVisit?.Period;
+				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.ToInterval((o_ as object));
+				CqlDateTime q_ = context.Operators.Start(p_);
+				FhirDateTime r_ = AntibioticOrdered?.AuthoredOnElement;
+				CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(r_);
+				CqlQuantity t_ = context.Operators.Quantity(3m, "days");
+				CqlDateTime u_ = context.Operators.Subtract(s_, t_);
+				CqlDateTime w_ = context.Operators.Convert<CqlDateTime>(r_);
+				CqlInterval<CqlDateTime> x_ = context.Operators.Interval(u_, w_, true, true);
+				bool? y_ = context.Operators.In<CqlDateTime>(q_, x_, null);
+				CqlDateTime aa_ = context.Operators.Convert<CqlDateTime>(r_);
+				bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+				bool? ac_ = context.Operators.And(y_, ab_);
 
 				return ac_;
 			};
-			var k_ = context.Operators.Where<MedicationRequest>(i_, j_);
+			IEnumerable<MedicationRequest> k_ = context.Operators.Where<MedicationRequest>(i_, j_);
 			Encounter l_(MedicationRequest AntibioticOrdered) => 
 				EDOrAmbulatoryVisit;
-			var m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
+			IEnumerable<Encounter> m_ = context.Operators.Select<MedicationRequest, Encounter>(k_, l_);
 
 			return m_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_With_Antibiotic_Ordered_Within_Three_Days_Value"/>
     [CqlDeclaration("Encounter With Antibiotic Ordered Within Three Days")]
 	public IEnumerable<Encounter> Encounter_With_Antibiotic_Ordered_Within_Three_Days() => 
 		__Encounter_With_Antibiotic_Ordered_Within_Three_Days.Value;
 
+    /// <seealso cref="Pharyngitis_or_Tonsillitis"/>
 	private IEnumerable<Condition> Pharyngitis_or_Tonsillitis_Value()
 	{
-		var a_ = this.Acute_Pharyngitis();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Acute_Tonsillitis();
-		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
-		var e_ = context.Operators.Union<Condition>(b_, d_);
-		var f_ = Status_1_6_000.Active_Condition(e_);
+		CqlValueSet a_ = this.Acute_Pharyngitis();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet c_ = this.Acute_Tonsillitis();
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
+		IEnumerable<Condition> f_ = Status_1_6_000.Active_Condition(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Pharyngitis_or_Tonsillitis_Value"/>
     [CqlDeclaration("Pharyngitis or Tonsillitis")]
 	public IEnumerable<Condition> Pharyngitis_or_Tonsillitis() => 
 		__Pharyngitis_or_Tonsillitis.Value;
 
+    /// <seealso cref="Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic"/>
 	private IEnumerable<Encounter> Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic_Value()
 	{
-		var a_ = this.Encounter_With_Antibiotic_Ordered_Within_Three_Days();
-		var b_ = this.Pharyngitis_or_Tonsillitis();
-		var c_ = context.Operators.CrossJoin<Encounter, Condition>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_With_Antibiotic_Ordered_Within_Three_Days();
+		IEnumerable<Condition> b_ = this.Pharyngitis_or_Tonsillitis();
+		IEnumerable<ValueTuple<Encounter, Condition>> c_ = context.Operators.CrossJoin<Encounter, Condition>(a_, b_);
 		Tuple_YPYXEdbbCQBdAVHXVcKUWMfH d_(ValueTuple<Encounter, Condition> _valueTuple)
 		{
-			var j_ = new Tuple_YPYXEdbbCQBdAVHXVcKUWMfH
+			Tuple_YPYXEdbbCQBdAVHXVcKUWMfH j_ = new Tuple_YPYXEdbbCQBdAVHXVcKUWMfH
 			{
 				VisitWithAntibiotic = _valueTuple.Item1,
 				AcutePharyngitisTonsillitis = _valueTuple.Item2,
@@ -606,144 +675,156 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 
 			return j_;
 		};
-		var e_ = context.Operators.Select<ValueTuple<Encounter, Condition>, Tuple_YPYXEdbbCQBdAVHXVcKUWMfH>(c_, d_);
+		IEnumerable<Tuple_YPYXEdbbCQBdAVHXVcKUWMfH> e_ = context.Operators.Select<ValueTuple<Encounter, Condition>, Tuple_YPYXEdbbCQBdAVHXVcKUWMfH>(c_, d_);
 		bool? f_(Tuple_YPYXEdbbCQBdAVHXVcKUWMfH tuple_ypyxedbbcqbdavhxvckuwmfh)
 		{
-			var k_ = QICoreCommon_2_0_000.ToPrevalenceInterval(tuple_ypyxedbbcqbdavhxvckuwmfh.AcutePharyngitisTonsillitis);
-			var l_ = context.Operators.Start(k_);
-			var m_ = tuple_ypyxedbbcqbdavhxvckuwmfh.VisitWithAntibiotic?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.In<CqlDateTime>(l_, o_, null);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToPrevalenceInterval(tuple_ypyxedbbcqbdavhxvckuwmfh.AcutePharyngitisTonsillitis);
+			CqlDateTime l_ = context.Operators.Start(k_);
+			Period m_ = tuple_ypyxedbbcqbdavhxvckuwmfh.VisitWithAntibiotic?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			bool? p_ = context.Operators.In<CqlDateTime>(l_, o_, null);
 
 			return p_;
 		};
-		var g_ = context.Operators.Where<Tuple_YPYXEdbbCQBdAVHXVcKUWMfH>(e_, f_);
+		IEnumerable<Tuple_YPYXEdbbCQBdAVHXVcKUWMfH> g_ = context.Operators.Where<Tuple_YPYXEdbbCQBdAVHXVcKUWMfH>(e_, f_);
 		Encounter h_(Tuple_YPYXEdbbCQBdAVHXVcKUWMfH tuple_ypyxedbbcqbdavhxvckuwmfh) => 
 			tuple_ypyxedbbcqbdavhxvckuwmfh.VisitWithAntibiotic;
-		var i_ = context.Operators.Select<Tuple_YPYXEdbbCQBdAVHXVcKUWMfH, Encounter>(g_, h_);
+		IEnumerable<Encounter> i_ = context.Operators.Select<Tuple_YPYXEdbbCQBdAVHXVcKUWMfH, Encounter>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic_Value"/>
     [CqlDeclaration("Encounter With Pharyngitis or Tonsillitis With Antibiotic")]
 	public IEnumerable<Encounter> Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic() => 
 		__Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		IEnumerable<Encounter> a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
 		bool? b_(Encounter EncounterWithPharyngitis)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-			var n_ = context.Operators.GreaterOrEqual(m_, 3);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			bool? n_ = context.Operators.GreaterOrEqual(m_, 3);
 
 			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter EncounterWithPharyngitis) => 
 			EncounterWithPharyngitis;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="In_Hospice"/>
 	private IEnumerable<Encounter> In_Hospice_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 		bool? b_(Encounter EligibleEncounters)
 		{
-			var d_ = Hospice_6_9_000.Has_Hospice_Services();
+			bool? d_ = Hospice_6_9_000.Has_Hospice_Services();
 
 			return d_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="In_Hospice_Value"/>
     [CqlDeclaration("In Hospice")]
 	public IEnumerable<Encounter> In_Hospice() => 
 		__In_Hospice.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private IEnumerable<Encounter> Denominator_Exclusions_Value()
 	{
-		var a_ = this.In_Hospice();
-		var b_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
-		var c_ = this.Antibiotic_Medications_for_Pharyngitis();
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, null);
-		var f_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, null);
-		var g_ = context.Operators.Union<MedicationRequest>(d_, f_);
-		var h_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, g_);
-		var i_ = context.Operators.Union<Encounter>(a_, h_);
-		var k_ = this.Competing_Conditions_for_Respiratory_Conditions();
-		var l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
-		var m_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, l_);
-		var o_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
-		var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
-		var q_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, p_);
-		var r_ = context.Operators.Union<Encounter>(m_, q_);
-		var s_ = context.Operators.Union<Encounter>(i_, r_);
+		IEnumerable<Encounter> a_ = this.In_Hospice();
+		IEnumerable<Encounter> b_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		CqlValueSet c_ = this.Antibiotic_Medications_for_Pharyngitis();
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, null);
+		IEnumerable<MedicationRequest> f_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, null);
+		IEnumerable<MedicationRequest> g_ = context.Operators.Union<MedicationRequest>(d_, f_);
+		IEnumerable<Encounter> h_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, g_);
+		IEnumerable<Encounter> i_ = context.Operators.Union<Encounter>(a_, h_);
+		CqlValueSet k_ = this.Competing_Conditions_for_Respiratory_Conditions();
+		IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+		IEnumerable<Encounter> m_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, l_);
+		CqlValueSet o_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		IEnumerable<Encounter> q_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, p_);
+		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(m_, q_);
+		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(i_, r_);
 
 		return s_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public IEnumerable<Encounter> Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Group_A_Streptococcus_Lab_Test_With_Result"/>
 	private IEnumerable<Observation> Group_A_Streptococcus_Lab_Test_With_Result_Value()
 	{
-		var a_ = this.Group_A_Streptococcus_Test();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.Final_Lab_Observation(b_);
+		CqlValueSet a_ = this.Group_A_Streptococcus_Test();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation GroupAStreptococcusTest)
 		{
-			var f_ = GroupAStreptococcusTest?.Value;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = context.Operators.Not((bool?)(g_ is null));
+			DataType f_ = GroupAStreptococcusTest?.Value;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			bool? h_ = context.Operators.Not((bool?)(g_ is null));
 
 			return h_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Group_A_Streptococcus_Lab_Test_With_Result_Value"/>
     [CqlDeclaration("Group A Streptococcus Lab Test With Result")]
 	public IEnumerable<Observation> Group_A_Streptococcus_Lab_Test_With_Result() => 
 		__Group_A_Streptococcus_Lab_Test_With_Result.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Group_A_Streptococcus_Lab_Test_With_Result();
-		var b_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
-		var c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
+		IEnumerable<Observation> a_ = this.Group_A_Streptococcus_Lab_Test_With_Result();
+		IEnumerable<Encounter> b_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		IEnumerable<ValueTuple<Observation, Encounter>> c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
 		Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ d_(ValueTuple<Observation, Encounter> _valueTuple)
 		{
-			var j_ = new Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ
+			Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ j_ = new Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ
 			{
 				GroupAStreptococcusTest = _valueTuple.Item1,
 				EncounterWithPharyngitis = _valueTuple.Item2,
@@ -751,123 +832,130 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 
 			return j_;
 		};
-		var e_ = context.Operators.Select<ValueTuple<Observation, Encounter>, Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ>(c_, d_);
+		IEnumerable<Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ> e_ = context.Operators.Select<ValueTuple<Observation, Encounter>, Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ>(c_, d_);
 		bool? f_(Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ tuple_ffguysnebcxllexfcmjoehbij)
 		{
-			var k_ = tuple_ffguysnebcxllexfcmjoehbij.GroupAStreptococcusTest?.Effective;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = QICoreCommon_2_0_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = tuple_ffguysnebcxllexfcmjoehbij.EncounterWithPharyngitis?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.End(p_);
-			var r_ = context.Operators.Quantity(3m, "days");
-			var s_ = context.Operators.Subtract(q_, r_);
-			var u_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var v_ = context.Operators.End(u_);
-			var x_ = context.Operators.Add(v_, r_);
-			var y_ = context.Operators.Interval(s_, x_, true, true);
-			var z_ = context.Operators.In<CqlDateTime>(n_, y_, "day");
+			DataType k_ = tuple_ffguysnebcxllexfcmjoehbij.GroupAStreptococcusTest?.Effective;
+			object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+			CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			Period o_ = tuple_ffguysnebcxllexfcmjoehbij.EncounterWithPharyngitis?.Period;
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime q_ = context.Operators.End(p_);
+			CqlQuantity r_ = context.Operators.Quantity(3m, "days");
+			CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime v_ = context.Operators.End(u_);
+			CqlDateTime x_ = context.Operators.Add(v_, r_);
+			CqlInterval<CqlDateTime> y_ = context.Operators.Interval(s_, x_, true, true);
+			bool? z_ = context.Operators.In<CqlDateTime>(n_, y_, "day");
 
 			return z_;
 		};
-		var g_ = context.Operators.Where<Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ>(e_, f_);
+		IEnumerable<Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ> g_ = context.Operators.Where<Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ>(e_, f_);
 		Encounter h_(Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ tuple_ffguysnebcxllexfcmjoehbij) => 
 			tuple_ffguysnebcxllexfcmjoehbij.EncounterWithPharyngitis;
-		var i_ = context.Operators.Select<Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ, Encounter>(g_, h_);
+		IEnumerable<Encounter> i_ = context.Operators.Select<Tuple_FfgUYSNEbcXLLEXFcMJOEHbiJ, Encounter>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Stratification_1"/>
 	private IEnumerable<Encounter> Stratification_1_Value()
 	{
-		var a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		IEnumerable<Encounter> a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
 		bool? b_(Encounter EncounterWithPharyngitis)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-			var n_ = context.Operators.Interval(3, 17, true, true);
-			var o_ = context.Operators.In<int?>(m_, n_, null);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			CqlInterval<int?> n_ = context.Operators.Interval(3, 17, true, true);
+			bool? o_ = context.Operators.In<int?>(m_, n_, null);
 
 			return o_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter EncounterWithPharyngitis) => 
 			EncounterWithPharyngitis;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Stratification_1_Value"/>
     [CqlDeclaration("Stratification 1")]
 	public IEnumerable<Encounter> Stratification_1() => 
 		__Stratification_1.Value;
 
+    /// <seealso cref="Stratification_2"/>
 	private IEnumerable<Encounter> Stratification_2_Value()
 	{
-		var a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		IEnumerable<Encounter> a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
 		bool? b_(Encounter EncounterWithPharyngitis)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-			var n_ = context.Operators.Interval(18, 64, true, true);
-			var o_ = context.Operators.In<int?>(m_, n_, null);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			CqlInterval<int?> n_ = context.Operators.Interval(18, 64, true, true);
+			bool? o_ = context.Operators.In<int?>(m_, n_, null);
 
 			return o_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter EncounterWithPharyngitis) => 
 			EncounterWithPharyngitis;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Stratification_2_Value"/>
     [CqlDeclaration("Stratification 2")]
 	public IEnumerable<Encounter> Stratification_2() => 
 		__Stratification_2.Value;
 
+    /// <seealso cref="Stratification_3"/>
 	private IEnumerable<Encounter> Stratification_3_Value()
 	{
-		var a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
+		IEnumerable<Encounter> a_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
 		bool? b_(Encounter EncounterWithPharyngitis)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-			var n_ = context.Operators.GreaterOrEqual(m_, 65);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			bool? n_ = context.Operators.GreaterOrEqual(m_, 65);
 
 			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter EncounterWithPharyngitis) => 
 			EncounterWithPharyngitis;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Stratification_3_Value"/>
     [CqlDeclaration("Stratification 3")]
 	public IEnumerable<Encounter> Stratification_3() => 
 		__Stratification_3.Value;

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
@@ -166,260 +166,325 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 
     #endregion
 
+    /// <seealso cref="Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis"/>
 	private CqlValueSet Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036", null);
 
+    /// <seealso cref="Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis_Value"/>
     [CqlDeclaration("Active Bleeding Excluding Menses or Bleeding Diathesis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036")]
 	public CqlValueSet Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis() => 
 		__Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis.Value;
 
+    /// <seealso cref="Active_Peptic_Ulcer"/>
 	private CqlValueSet Active_Peptic_Ulcer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031", null);
 
+    /// <seealso cref="Active_Peptic_Ulcer_Value"/>
     [CqlDeclaration("Active Peptic Ulcer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031")]
 	public CqlValueSet Active_Peptic_Ulcer() => 
 		__Active_Peptic_Ulcer.Value;
 
+    /// <seealso cref="Adverse_reaction_to_thrombolytics"/>
 	private CqlValueSet Adverse_reaction_to_thrombolytics_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6", null);
 
+    /// <seealso cref="Adverse_reaction_to_thrombolytics_Value"/>
     [CqlDeclaration("Adverse reaction to thrombolytics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6")]
 	public CqlValueSet Adverse_reaction_to_thrombolytics() => 
 		__Adverse_reaction_to_thrombolytics.Value;
 
+    /// <seealso cref="Allergy_to_thrombolytics"/>
 	private CqlValueSet Allergy_to_thrombolytics_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5", null);
 
+    /// <seealso cref="Allergy_to_thrombolytics_Value"/>
     [CqlDeclaration("Allergy to thrombolytics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5")]
 	public CqlValueSet Allergy_to_thrombolytics() => 
 		__Allergy_to_thrombolytics.Value;
 
+    /// <seealso cref="Oral_Anticoagulant_Medications"/>
 	private CqlValueSet Oral_Anticoagulant_Medications_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045", null);
 
+    /// <seealso cref="Oral_Anticoagulant_Medications_Value"/>
     [CqlDeclaration("Oral Anticoagulant Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045")]
 	public CqlValueSet Oral_Anticoagulant_Medications() => 
 		__Oral_Anticoagulant_Medications.Value;
 
+    /// <seealso cref="Aortic_Dissection_and_Rupture"/>
 	private CqlValueSet Aortic_Dissection_and_Rupture_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028", null);
 
+    /// <seealso cref="Aortic_Dissection_and_Rupture_Value"/>
     [CqlDeclaration("Aortic Dissection and Rupture")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028")]
 	public CqlValueSet Aortic_Dissection_and_Rupture() => 
 		__Aortic_Dissection_and_Rupture.Value;
 
+    /// <seealso cref="birth_date"/>
 	private CqlValueSet birth_date_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
 
+    /// <seealso cref="birth_date_Value"/>
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
 	public CqlValueSet birth_date() => 
 		__birth_date.Value;
 
+    /// <seealso cref="Cardiopulmonary_Arrest"/>
 	private CqlValueSet Cardiopulmonary_Arrest_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048", null);
 
+    /// <seealso cref="Cardiopulmonary_Arrest_Value"/>
     [CqlDeclaration("Cardiopulmonary Arrest")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048")]
 	public CqlValueSet Cardiopulmonary_Arrest() => 
 		__Cardiopulmonary_Arrest.Value;
 
+    /// <seealso cref="Cerebral_Vascular_Lesion"/>
 	private CqlValueSet Cerebral_Vascular_Lesion_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025", null);
 
+    /// <seealso cref="Cerebral_Vascular_Lesion_Value"/>
     [CqlDeclaration("Cerebral Vascular Lesion")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025")]
 	public CqlValueSet Cerebral_Vascular_Lesion() => 
 		__Cerebral_Vascular_Lesion.Value;
 
+    /// <seealso cref="Closed_Head_and_Facial_Trauma"/>
 	private CqlValueSet Closed_Head_and_Facial_Trauma_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026", null);
 
+    /// <seealso cref="Closed_Head_and_Facial_Trauma_Value"/>
     [CqlDeclaration("Closed Head and Facial Trauma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026")]
 	public CqlValueSet Closed_Head_and_Facial_Trauma() => 
 		__Closed_Head_and_Facial_Trauma.Value;
 
+    /// <seealso cref="Dementia"/>
 	private CqlValueSet Dementia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043", null);
 
+    /// <seealso cref="Dementia_Value"/>
     [CqlDeclaration("Dementia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043")]
 	public CqlValueSet Dementia() => 
 		__Dementia.Value;
 
+    /// <seealso cref="Discharge_To_Acute_Care_Facility"/>
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
 
+    /// <seealso cref="Discharge_To_Acute_Care_Facility_Value"/>
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
 	public CqlValueSet Discharge_To_Acute_Care_Facility() => 
 		__Discharge_To_Acute_Care_Facility.Value;
 
+    /// <seealso cref="ED"/>
 	private CqlValueSet ED_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085", null);
 
+    /// <seealso cref="ED_Value"/>
     [CqlDeclaration("ED")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085")]
 	public CqlValueSet ED() => 
 		__ED.Value;
 
+    /// <seealso cref="Emergency_Department_Visit"/>
 	private CqlValueSet Emergency_Department_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
+    /// <seealso cref="Emergency_Department_Visit_Value"/>
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
 	public CqlValueSet Emergency_Department_Visit() => 
 		__Emergency_Department_Visit.Value;
 
+    /// <seealso cref="Endotracheal_Intubation"/>
 	private CqlValueSet Endotracheal_Intubation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69", null);
 
+    /// <seealso cref="Endotracheal_Intubation_Value"/>
     [CqlDeclaration("Endotracheal Intubation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69")]
 	public CqlValueSet Endotracheal_Intubation() => 
 		__Endotracheal_Intubation.Value;
 
+    /// <seealso cref="Fibrinolytic_Therapy"/>
 	private CqlValueSet Fibrinolytic_Therapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020", null);
 
+    /// <seealso cref="Fibrinolytic_Therapy_Value"/>
     [CqlDeclaration("Fibrinolytic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020")]
 	public CqlValueSet Fibrinolytic_Therapy() => 
 		__Fibrinolytic_Therapy.Value;
 
+    /// <seealso cref="Intracranial_or_Intraspinal_surgery"/>
 	private CqlValueSet Intracranial_or_Intraspinal_surgery_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2", null);
 
+    /// <seealso cref="Intracranial_or_Intraspinal_surgery_Value"/>
     [CqlDeclaration("Intracranial or Intraspinal surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2")]
 	public CqlValueSet Intracranial_or_Intraspinal_surgery() => 
 		__Intracranial_or_Intraspinal_surgery.Value;
 
+    /// <seealso cref="Ischemic_Stroke"/>
 	private CqlValueSet Ischemic_Stroke_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024", null);
 
+    /// <seealso cref="Ischemic_Stroke_Value"/>
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024")]
 	public CqlValueSet Ischemic_Stroke() => 
 		__Ischemic_Stroke.Value;
 
+    /// <seealso cref="Major_Surgical_Procedure"/>
 	private CqlValueSet Major_Surgical_Procedure_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056", null);
 
+    /// <seealso cref="Major_Surgical_Procedure_Value"/>
     [CqlDeclaration("Major Surgical Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056")]
 	public CqlValueSet Major_Surgical_Procedure() => 
 		__Major_Surgical_Procedure.Value;
 
+    /// <seealso cref="Malignant_Intracranial_Neoplasm_Group"/>
 	private CqlValueSet Malignant_Intracranial_Neoplasm_Group_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3", null);
 
+    /// <seealso cref="Malignant_Intracranial_Neoplasm_Group_Value"/>
     [CqlDeclaration("Malignant Intracranial Neoplasm Group")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3")]
 	public CqlValueSet Malignant_Intracranial_Neoplasm_Group() => 
 		__Malignant_Intracranial_Neoplasm_Group.Value;
 
+    /// <seealso cref="Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device"/>
 	private CqlValueSet Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052", null);
 
+    /// <seealso cref="Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device_Value"/>
     [CqlDeclaration("Insertion or Replacement of Mechanical Circulatory Assist Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052")]
 	public CqlValueSet Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device() => 
 		__Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device.Value;
 
+    /// <seealso cref="Neurologic_impairment"/>
 	private CqlValueSet Neurologic_impairment_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012", null);
 
+    /// <seealso cref="Neurologic_impairment_Value"/>
     [CqlDeclaration("Neurologic impairment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012")]
 	public CqlValueSet Neurologic_impairment() => 
 		__Neurologic_impairment.Value;
 
+    /// <seealso cref="Patient_Expired"/>
 	private CqlValueSet Patient_Expired_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
 
+    /// <seealso cref="Patient_Expired_Value"/>
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
 	public CqlValueSet Patient_Expired() => 
 		__Patient_Expired.Value;
 
+    /// <seealso cref="Percutaneous_Coronary_Intervention"/>
 	private CqlValueSet Percutaneous_Coronary_Intervention_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5", null);
 
+    /// <seealso cref="Percutaneous_Coronary_Intervention_Value"/>
     [CqlDeclaration("Percutaneous Coronary Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5")]
 	public CqlValueSet Percutaneous_Coronary_Intervention() => 
 		__Percutaneous_Coronary_Intervention.Value;
 
+    /// <seealso cref="Pregnancy_ICD10_SNOMEDCT"/>
 	private CqlValueSet Pregnancy_ICD10_SNOMEDCT_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055", null);
 
+    /// <seealso cref="Pregnancy_ICD10_SNOMEDCT_Value"/>
     [CqlDeclaration("Pregnancy ICD10 SNOMEDCT")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055")]
 	public CqlValueSet Pregnancy_ICD10_SNOMEDCT() => 
 		__Pregnancy_ICD10_SNOMEDCT.Value;
 
+    /// <seealso cref="STEMI"/>
 	private CqlValueSet STEMI_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017", null);
 
+    /// <seealso cref="STEMI_Value"/>
     [CqlDeclaration("STEMI")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017")]
 	public CqlValueSet STEMI() => 
 		__STEMI.Value;
 
+    /// <seealso cref="Thrombolytic_medications"/>
 	private CqlValueSet Thrombolytic_medications_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4", null);
 
+    /// <seealso cref="Thrombolytic_medications_Value"/>
     [CqlDeclaration("Thrombolytic medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4")]
 	public CqlValueSet Thrombolytic_medications() => 
 		__Thrombolytic_medications.Value;
 
+    /// <seealso cref="Birthdate"/>
 	private CqlCode Birthdate_Value() => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Birthdate_Value"/>
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
+    /// <seealso cref="Emergency_Department"/>
 	private CqlCode Emergency_Department_Value() => 
 		new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", null, null);
 
+    /// <seealso cref="Emergency_Department_Value"/>
     [CqlDeclaration("Emergency Department")]
 	public CqlCode Emergency_Department() => 
 		__Emergency_Department.Value;
 
+    /// <seealso cref="Patient_transfer__procedure_"/>
 	private CqlCode Patient_transfer__procedure__Value() => 
 		new CqlCode("107724000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Patient_transfer__procedure__Value"/>
     [CqlDeclaration("Patient transfer (procedure)")]
 	public CqlCode Patient_transfer__procedure_() => 
 		__Patient_transfer__procedure_.Value;
 
+    /// <seealso cref="Streptokinase_adverse_reaction__disorder_"/>
 	private CqlCode Streptokinase_adverse_reaction__disorder__Value() => 
 		new CqlCode("293571007", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Streptokinase_adverse_reaction__disorder__Value"/>
     [CqlDeclaration("Streptokinase adverse reaction (disorder)")]
 	public CqlCode Streptokinase_adverse_reaction__disorder_() => 
 		__Streptokinase_adverse_reaction__disorder_.Value;
 
+    /// <seealso cref="EMER"/>
 	private CqlCode EMER_Value() => 
 		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="EMER_Value"/>
     [CqlDeclaration("EMER")]
 	public CqlCode EMER() => 
 		__EMER.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("21112-8", "http://loinc.org", null, null),
 		};
@@ -427,13 +492,15 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="HSLOC"/>
 	private CqlCode[] HSLOC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", null, null),
 		};
@@ -441,13 +508,15 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		return a_;
 	}
 
+    /// <seealso cref="HSLOC_Value"/>
     [CqlDeclaration("HSLOC")]
 	public CqlCode[] HSLOC() => 
 		__HSLOC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("107724000", "http://snomed.info/sct", null, null),
 			new CqlCode("293571007", "http://snomed.info/sct", null, null),
@@ -456,13 +525,15 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 		};
@@ -470,676 +541,713 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("AppropriateTreatmentforSTEMIFHIR-1.0.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("AppropriateTreatmentforSTEMIFHIR-1.0.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="ED_Encounter_with_Encounter_Diagnosis_of_STEMI"/>
 	private IEnumerable<Encounter> ED_Encounter_with_Encounter_Diagnosis_of_STEMI_Value()
 	{
-		var a_ = this.ED();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.ED();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EDEncounter)
 		{
-			var e_ = EDEncounter?.StatusElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
-			var h_ = context.Operators.Equal(g_, "finished");
-			var i_ = EDEncounter?.Class;
-			var j_ = FHIRHelpers_4_3_000.ToCode(i_);
-			var k_ = this.EMER();
-			var l_ = context.Operators.Equivalent(j_, k_);
-			var m_ = context.Operators.And(h_, l_);
-			var n_ = EDEncounter?.ReasonCode;
+			Code<Encounter.EncounterStatus> e_ = EDEncounter?.StatusElement;
+			Encounter.EncounterStatus? f_ = e_?.Value;
+			Code<Encounter.EncounterStatus> g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
+			bool? h_ = context.Operators.Equal(g_, "finished");
+			Coding i_ = EDEncounter?.Class;
+			CqlCode j_ = FHIRHelpers_4_3_000.ToCode(i_);
+			CqlCode k_ = this.EMER();
+			bool? l_ = context.Operators.Equivalent(j_, k_);
+			bool? m_ = context.Operators.And(h_, l_);
+			List<CodeableConcept> n_ = EDEncounter?.ReasonCode;
 			CqlConcept o_(CodeableConcept @this)
 			{
-				var ad_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept ad_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return ad_;
 			};
-			var p_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)n_, o_);
-			var q_ = this.STEMI();
-			var r_ = context.Operators.ConceptsInValueSet(p_, q_);
-			var s_ = CQMCommon_2_0_000.encounterDiagnosis(EDEncounter);
+			IEnumerable<CqlConcept> p_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)n_, o_);
+			CqlValueSet q_ = this.STEMI();
+			bool? r_ = context.Operators.ConceptsInValueSet(p_, q_);
+			IEnumerable<Condition> s_ = CQMCommon_2_0_000.encounterDiagnosis(EDEncounter);
 			bool? t_(Condition EncDiagnosis)
 			{
-				var ae_ = EncDiagnosis?.Code;
-				var af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
-				var ag_ = this.STEMI();
-				var ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+				CodeableConcept ae_ = EncDiagnosis?.Code;
+				CqlConcept af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
+				CqlValueSet ag_ = this.STEMI();
+				bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
 
 				return ah_;
 			};
-			var u_ = context.Operators.Where<Condition>(s_, t_);
-			var v_ = context.Operators.Exists<Condition>(u_);
-			var w_ = context.Operators.Or(r_, v_);
-			var x_ = context.Operators.And(m_, w_);
-			var y_ = this.Measurement_Period();
-			var z_ = EDEncounter?.Period;
-			var aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-			var ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, null);
-			var ac_ = context.Operators.And(x_, ab_);
+			IEnumerable<Condition> u_ = context.Operators.Where<Condition>(s_, t_);
+			bool? v_ = context.Operators.Exists<Condition>(u_);
+			bool? w_ = context.Operators.Or(r_, v_);
+			bool? x_ = context.Operators.And(m_, w_);
+			CqlInterval<CqlDateTime> y_ = this.Measurement_Period();
+			Period z_ = EDEncounter?.Period;
+			CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, null);
+			bool? ac_ = context.Operators.And(x_, ab_);
 
 			return ac_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="ED_Encounter_with_Encounter_Diagnosis_of_STEMI_Value"/>
     [CqlDeclaration("ED Encounter with Encounter Diagnosis of STEMI")]
 	public IEnumerable<Encounter> ED_Encounter_with_Encounter_Diagnosis_of_STEMI() => 
 		__ED_Encounter_with_Encounter_Diagnosis_of_STEMI.Value;
 
+    /// <seealso cref="ED_Encounter_with_Diagnosis_of_STEMI"/>
 	private IEnumerable<Encounter> ED_Encounter_with_Diagnosis_of_STEMI_Value()
 	{
-		var a_ = this.ED();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.ED();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		IEnumerable<Encounter> c_(Encounter EDEncounter)
 		{
-			var e_ = this.STEMI();
-			var f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
+			CqlValueSet e_ = this.STEMI();
+			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
 			bool? g_(Condition DxSTEMI)
 			{
-				var k_ = DxSTEMI?.ClinicalStatus;
-				var l_ = FHIRHelpers_4_3_000.ToConcept(k_);
-				var m_ = QICoreCommon_2_0_000.active();
-				var n_ = context.Operators.ConvertCodeToConcept(m_);
-				var o_ = context.Operators.Equivalent(l_, n_);
-				var p_ = EDEncounter?.StatusElement;
-				var q_ = p_?.Value;
-				var r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
-				var s_ = context.Operators.Equal(r_, "finished");
-				var t_ = context.Operators.And(o_, s_);
-				var u_ = EDEncounter?.Class;
-				var v_ = FHIRHelpers_4_3_000.ToCode(u_);
-				var w_ = this.EMER();
-				var x_ = context.Operators.Equivalent(v_, w_);
-				var y_ = context.Operators.And(t_, x_);
-				var z_ = QICoreCommon_2_0_000.prevalenceInterval(DxSTEMI);
-				var aa_ = context.Operators.Start(z_);
-				var ab_ = EDEncounter?.Period;
-				var ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, null);
-				var ae_ = context.Operators.And(y_, ad_);
-				var af_ = this.Measurement_Period();
-				var ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ai_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ah_, "day");
-				var aj_ = context.Operators.And(ae_, ai_);
+				CodeableConcept k_ = DxSTEMI?.ClinicalStatus;
+				CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
+				CqlCode m_ = QICoreCommon_2_0_000.active();
+				CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
+				bool? o_ = context.Operators.Equivalent(l_, n_);
+				Code<Encounter.EncounterStatus> p_ = EDEncounter?.StatusElement;
+				Encounter.EncounterStatus? q_ = p_?.Value;
+				Code<Encounter.EncounterStatus> r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
+				bool? s_ = context.Operators.Equal(r_, "finished");
+				bool? t_ = context.Operators.And(o_, s_);
+				Coding u_ = EDEncounter?.Class;
+				CqlCode v_ = FHIRHelpers_4_3_000.ToCode(u_);
+				CqlCode w_ = this.EMER();
+				bool? x_ = context.Operators.Equivalent(v_, w_);
+				bool? y_ = context.Operators.And(t_, x_);
+				CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.prevalenceInterval(DxSTEMI);
+				CqlDateTime aa_ = context.Operators.Start(z_);
+				Period ab_ = EDEncounter?.Period;
+				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, null);
+				bool? ae_ = context.Operators.And(y_, ad_);
+				CqlInterval<CqlDateTime> af_ = this.Measurement_Period();
+				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				bool? ai_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ah_, "day");
+				bool? aj_ = context.Operators.And(ae_, ai_);
 
 				return aj_;
 			};
-			var h_ = context.Operators.Where<Condition>(f_, g_);
+			IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
 			Encounter i_(Condition DxSTEMI) => 
 				EDEncounter;
-			var j_ = context.Operators.Select<Condition, Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Select<Condition, Encounter>(h_, i_);
 
 			return j_;
 		};
-		var d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="ED_Encounter_with_Diagnosis_of_STEMI_Value"/>
     [CqlDeclaration("ED Encounter with Diagnosis of STEMI")]
 	public IEnumerable<Encounter> ED_Encounter_with_Diagnosis_of_STEMI() => 
 		__ED_Encounter_with_Diagnosis_of_STEMI.Value;
 
+    /// <seealso cref="ED_Encounter_with_STEMI_Diagnosis"/>
 	private IEnumerable<Encounter> ED_Encounter_with_STEMI_Diagnosis_Value()
 	{
-		var a_ = this.ED_Encounter_with_Encounter_Diagnosis_of_STEMI();
-		var b_ = this.ED_Encounter_with_Diagnosis_of_STEMI();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_Encounter_Diagnosis_of_STEMI();
+		IEnumerable<Encounter> b_ = this.ED_Encounter_with_Diagnosis_of_STEMI();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="ED_Encounter_with_STEMI_Diagnosis_Value"/>
     [CqlDeclaration("ED Encounter with STEMI Diagnosis")]
 	public IEnumerable<Encounter> ED_Encounter_with_STEMI_Diagnosis() => 
 		__ED_Encounter_with_STEMI_Diagnosis.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		bool? b_(Encounter EDwithSTEMI)
 		{
-			var d_ = this.Patient();
-			var e_ = d_?.BirthDateElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.Convert<CqlDate>(f_);
-			var h_ = EDwithSTEMI?.Period;
-			var i_ = FHIRHelpers_4_3_000.ToInterval(h_);
-			var j_ = context.Operators.Start(i_);
-			var k_ = context.Operators.DateFrom(j_);
-			var l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
-			var m_ = context.Operators.GreaterOrEqual(l_, 18);
+			Patient d_ = this.Patient();
+			Date e_ = d_?.BirthDateElement;
+			string f_ = e_?.Value;
+			CqlDate g_ = context.Operators.Convert<CqlDate>(f_);
+			Period h_ = EDwithSTEMI?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
+			CqlDate k_ = context.Operators.DateFrom(j_);
+			int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
+			bool? m_ = context.Operators.GreaterOrEqual(l_, 18);
 
 			return m_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter"/>
 	private IEnumerable<Encounter> Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
 		{
-			var d_ = this.Thrombolytic_medications();
-			var e_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(d_, null);
+			CqlValueSet d_ = this.Thrombolytic_medications();
+			IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(d_, null);
 			bool? f_(AllergyIntolerance ThrombolyticAllergy)
 			{
-				var j_ = ThrombolyticAllergy?.ClinicalStatus;
-				var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
-				var l_ = QICoreCommon_2_0_000.allergy_active();
-				var m_ = context.Operators.ConvertCodeToConcept(l_);
-				var n_ = context.Operators.Equivalent(k_, m_);
-				var o_ = ThrombolyticAllergy?.Onset;
-				var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-				var q_ = QICoreCommon_2_0_000.toInterval(p_);
-				var r_ = EDwSTEMI?.Period;
-				var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var t_ = context.Operators.Overlaps(q_, s_, null);
-				var u_ = context.Operators.And(n_, t_);
+				CodeableConcept j_ = ThrombolyticAllergy?.ClinicalStatus;
+				CqlConcept k_ = FHIRHelpers_4_3_000.ToConcept(j_);
+				CqlCode l_ = QICoreCommon_2_0_000.allergy_active();
+				CqlConcept m_ = context.Operators.ConvertCodeToConcept(l_);
+				bool? n_ = context.Operators.Equivalent(k_, m_);
+				DataType o_ = ThrombolyticAllergy?.Onset;
+				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+				CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
+				Period r_ = EDwSTEMI?.Period;
+				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				bool? t_ = context.Operators.Overlaps(q_, s_, null);
+				bool? u_ = context.Operators.And(n_, t_);
 
 				return u_;
 			};
-			var g_ = context.Operators.Where<AllergyIntolerance>(e_, f_);
+			IEnumerable<AllergyIntolerance> g_ = context.Operators.Where<AllergyIntolerance>(e_, f_);
 			Encounter h_(AllergyIntolerance ThrombolyticAllergy) => 
 				EDwSTEMI;
-			var i_ = context.Operators.Select<AllergyIntolerance, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<AllergyIntolerance, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter_Value"/>
     [CqlDeclaration("Allergy or Intolerance to Thrombolytic Medications Overlaps ED Encounter")]
 	public IEnumerable<Encounter> Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter() => 
 		__Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter.Value;
 
+    /// <seealso cref="Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter"/>
 	private IEnumerable<Encounter> Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
 		{
-			var d_ = this.Adverse_reaction_to_thrombolytics();
-			var e_ = context.Operators.RetrieveByValueSet<AdverseEvent>(d_, null);
+			CqlValueSet d_ = this.Adverse_reaction_to_thrombolytics();
+			IEnumerable<AdverseEvent> e_ = context.Operators.RetrieveByValueSet<AdverseEvent>(d_, null);
 			bool? f_(AdverseEvent ThrombolyticAdverseEvent)
 			{
-				var j_ = ThrombolyticAdverseEvent?.RecordedDateElement;
-				var k_ = context.Operators.Convert<CqlDateTime>(j_);
-				var l_ = EDwSTEMI?.Period;
-				var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-				var n_ = context.Operators.End(m_);
-				var o_ = context.Operators.Before(k_, n_, null);
-				var p_ = ThrombolyticAdverseEvent?.ActualityElement;
-				var q_ = p_?.Value;
-				var r_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(q_);
-				var s_ = context.Operators.Equal(r_, "actual");
-				var t_ = context.Operators.And(o_, s_);
+				FhirDateTime j_ = ThrombolyticAdverseEvent?.RecordedDateElement;
+				CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
+				Period l_ = EDwSTEMI?.Period;
+				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+				CqlDateTime n_ = context.Operators.End(m_);
+				bool? o_ = context.Operators.Before(k_, n_, null);
+				Code<AdverseEvent.AdverseEventActuality> p_ = ThrombolyticAdverseEvent?.ActualityElement;
+				AdverseEvent.AdverseEventActuality? q_ = p_?.Value;
+				Code<AdverseEvent.AdverseEventActuality> r_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(q_);
+				bool? s_ = context.Operators.Equal(r_, "actual");
+				bool? t_ = context.Operators.And(o_, s_);
 
 				return t_;
 			};
-			var g_ = context.Operators.Where<AdverseEvent>(e_, f_);
+			IEnumerable<AdverseEvent> g_ = context.Operators.Where<AdverseEvent>(e_, f_);
 			Encounter h_(AdverseEvent ThrombolyticAdverseEvent) => 
 				EDwSTEMI;
-			var i_ = context.Operators.Select<AdverseEvent, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<AdverseEvent, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter_Value"/>
     [CqlDeclaration("Adverse Effect to Thrombolytic Medications Before End of ED Encounter")]
 	public IEnumerable<Encounter> Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter() => 
 		__Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter.Value;
 
+    /// <seealso cref="Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter"/>
 	private IEnumerable<Encounter> Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
-			var d_ = this.Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis();
-			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
-			var f_ = this.Malignant_Intracranial_Neoplasm_Group();
-			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
-			var h_ = context.Operators.Union<Condition>(e_, g_);
-			var i_ = this.Cerebral_Vascular_Lesion();
-			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
-			var k_ = this.Dementia();
-			var l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
-			var m_ = context.Operators.Union<Condition>(j_, l_);
-			var n_ = context.Operators.Union<Condition>(h_, m_);
-			var o_ = this.Pregnancy_ICD10_SNOMEDCT();
-			var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
-			var q_ = this.Allergy_to_thrombolytics();
-			var r_ = context.Operators.RetrieveByValueSet<Condition>(q_, null);
-			var s_ = context.Operators.Union<Condition>(p_, r_);
-			var t_ = context.Operators.Union<Condition>(n_, s_);
+			CqlValueSet d_ = this.Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis();
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			CqlValueSet f_ = this.Malignant_Intracranial_Neoplasm_Group();
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
+			CqlValueSet i_ = this.Cerebral_Vascular_Lesion();
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			CqlValueSet k_ = this.Dementia();
+			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+			IEnumerable<Condition> m_ = context.Operators.Union<Condition>(j_, l_);
+			IEnumerable<Condition> n_ = context.Operators.Union<Condition>(h_, m_);
+			CqlValueSet o_ = this.Pregnancy_ICD10_SNOMEDCT();
+			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+			CqlValueSet q_ = this.Allergy_to_thrombolytics();
+			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, null);
+			IEnumerable<Condition> s_ = context.Operators.Union<Condition>(p_, r_);
+			IEnumerable<Condition> t_ = context.Operators.Union<Condition>(n_, s_);
 			bool? u_(Condition ActiveExclusionDx)
 			{
-				var y_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveExclusionDx);
-				var z_ = EDwithSTEMI?.Period;
-				var aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				var ab_ = context.Operators.OverlapsBefore(y_, aa_, null);
+				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveExclusionDx);
+				Period z_ = EDwithSTEMI?.Period;
+				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
+				bool? ab_ = context.Operators.OverlapsBefore(y_, aa_, null);
 
 				return ab_;
 			};
-			var v_ = context.Operators.Where<Condition>(t_, u_);
+			IEnumerable<Condition> v_ = context.Operators.Where<Condition>(t_, u_);
 			Encounter w_(Condition ActiveExclusionDx) => 
 				EDwithSTEMI;
-			var x_ = context.Operators.Select<Condition, Encounter>(v_, w_);
+			IEnumerable<Encounter> x_ = context.Operators.Select<Condition, Encounter>(v_, w_);
 
 			return x_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter_Value"/>
     [CqlDeclaration("Active Exclusion Diagnosis at Start of ED Encounter")]
 	public IEnumerable<Encounter> Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter() => 
 		__Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter.Value;
 
+    /// <seealso cref="Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter"/>
 	private IEnumerable<Encounter> Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
-			var d_ = this.Oral_Anticoagulant_Medications();
-			var e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			var h_ = context.Operators.Union<MedicationRequest>(e_, g_);
+			CqlValueSet d_ = this.Oral_Anticoagulant_Medications();
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			bool? i_(MedicationRequest OralAnticoagulant)
 			{
-				var m_ = OralAnticoagulant?.StatusElement;
-				var n_ = m_?.Value;
-				var o_ = context.Operators.Convert<string>(n_);
-				var p_ = context.Operators.Equal(o_, "active");
-				var q_ = OralAnticoagulant?.IntentElement;
-				var r_ = q_?.Value;
-				var s_ = context.Operators.Convert<string>(r_);
-				var t_ = context.Operators.Equal(s_, "order");
-				var u_ = context.Operators.And(p_, t_);
-				var v_ = OralAnticoagulant?.AuthoredOnElement;
-				var w_ = context.Operators.Convert<CqlDateTime>(v_);
-				var x_ = EDwithSTEMI?.Period;
-				var y_ = FHIRHelpers_4_3_000.ToInterval(x_);
-				var z_ = context.Operators.Start(y_);
-				var aa_ = context.Operators.SameOrBefore(w_, z_, null);
-				var ab_ = context.Operators.And(u_, aa_);
+				Code<MedicationRequest.MedicationrequestStatus> m_ = OralAnticoagulant?.StatusElement;
+				MedicationRequest.MedicationrequestStatus? n_ = m_?.Value;
+				string o_ = context.Operators.Convert<string>(n_);
+				bool? p_ = context.Operators.Equal(o_, "active");
+				Code<MedicationRequest.MedicationRequestIntent> q_ = OralAnticoagulant?.IntentElement;
+				MedicationRequest.MedicationRequestIntent? r_ = q_?.Value;
+				string s_ = context.Operators.Convert<string>(r_);
+				bool? t_ = context.Operators.Equal(s_, "order");
+				bool? u_ = context.Operators.And(p_, t_);
+				FhirDateTime v_ = OralAnticoagulant?.AuthoredOnElement;
+				CqlDateTime w_ = context.Operators.Convert<CqlDateTime>(v_);
+				Period x_ = EDwithSTEMI?.Period;
+				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(x_);
+				CqlDateTime z_ = context.Operators.Start(y_);
+				bool? aa_ = context.Operators.SameOrBefore(w_, z_, null);
+				bool? ab_ = context.Operators.And(u_, aa_);
 
 				return ab_;
 			};
-			var j_ = context.Operators.Where<MedicationRequest>(h_, i_);
+			IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
 			Encounter k_(MedicationRequest OralAnticoagulant) => 
 				EDwithSTEMI;
-			var l_ = context.Operators.Select<MedicationRequest, Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Select<MedicationRequest, Encounter>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter_Value"/>
     [CqlDeclaration("Active Oral Anticoagulant Medication at the Start of ED Encounter")]
 	public IEnumerable<Encounter> Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter() => 
 		__Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter.Value;
 
+    /// <seealso cref="Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start"/>
 	private IEnumerable<Encounter> Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
-			var d_ = this.Aortic_Dissection_and_Rupture();
-			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
-			var f_ = this.Neurologic_impairment();
-			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
-			var h_ = context.Operators.Union<Condition>(e_, g_);
-			var i_ = this.Cardiopulmonary_Arrest();
-			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
-			var k_ = context.Operators.Union<Condition>(h_, j_);
+			CqlValueSet d_ = this.Aortic_Dissection_and_Rupture();
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			CqlValueSet f_ = this.Neurologic_impairment();
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
+			CqlValueSet i_ = this.Cardiopulmonary_Arrest();
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			IEnumerable<Condition> k_ = context.Operators.Union<Condition>(h_, j_);
 			bool? l_(Condition ExclusionDiagnosis)
 			{
-				var p_ = QICoreCommon_2_0_000.prevalenceInterval(ExclusionDiagnosis);
-				var q_ = context.Operators.Start(p_);
-				var r_ = EDwithSTEMI?.Period;
-				var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
-				var v_ = context.Operators.Start(p_);
-				var x_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var y_ = context.Operators.Start(x_);
-				var z_ = context.Operators.Quantity(24m, "hours");
-				var aa_ = context.Operators.Subtract(y_, z_);
-				var ac_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var ad_ = context.Operators.Start(ac_);
-				var ae_ = context.Operators.Interval(aa_, ad_, true, false);
-				var af_ = context.Operators.In<CqlDateTime>(v_, ae_, null);
-				var ah_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var ai_ = context.Operators.Start(ah_);
-				var aj_ = context.Operators.Not((bool?)(ai_ is null));
-				var ak_ = context.Operators.And(af_, aj_);
-				var al_ = context.Operators.Or(t_, ak_);
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.prevalenceInterval(ExclusionDiagnosis);
+				CqlDateTime q_ = context.Operators.Start(p_);
+				Period r_ = EDwithSTEMI?.Period;
+				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
+				CqlDateTime v_ = context.Operators.Start(p_);
+				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				CqlDateTime y_ = context.Operators.Start(x_);
+				CqlQuantity z_ = context.Operators.Quantity(24m, "hours");
+				CqlDateTime aa_ = context.Operators.Subtract(y_, z_);
+				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				CqlDateTime ad_ = context.Operators.Start(ac_);
+				CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(aa_, ad_, true, false);
+				bool? af_ = context.Operators.In<CqlDateTime>(v_, ae_, null);
+				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				CqlDateTime ai_ = context.Operators.Start(ah_);
+				bool? aj_ = context.Operators.Not((bool?)(ai_ is null));
+				bool? ak_ = context.Operators.And(af_, aj_);
+				bool? al_ = context.Operators.Or(t_, ak_);
 
 				return al_;
 			};
-			var m_ = context.Operators.Where<Condition>(k_, l_);
+			IEnumerable<Condition> m_ = context.Operators.Where<Condition>(k_, l_);
 			Encounter n_(Condition ExclusionDiagnosis) => 
 				EDwithSTEMI;
-			var o_ = context.Operators.Select<Condition, Encounter>(m_, n_);
+			IEnumerable<Encounter> o_ = context.Operators.Select<Condition, Encounter>(m_, n_);
 
 			return o_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start_Value"/>
     [CqlDeclaration("Exclusion Diagnosis During ED Encounter or Within 24 Hours of ED Encounter Start")]
 	public IEnumerable<Encounter> Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start() => 
 		__Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start.Value;
 
+    /// <seealso cref="Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter"/>
 	private IEnumerable<Encounter> Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
-			var d_ = this.Major_Surgical_Procedure();
-			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			CqlValueSet d_ = this.Major_Surgical_Procedure();
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
 			bool? f_(Procedure MajorSurgery)
 			{
-				var j_ = MajorSurgery?.Performed;
-				var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-				var l_ = QICoreCommon_2_0_000.toInterval(k_);
-				var m_ = context.Operators.Start(l_);
-				var n_ = EDwithSTEMI?.Period;
-				var o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var p_ = context.Operators.Start(o_);
-				var q_ = context.Operators.Quantity(21m, "days");
-				var r_ = context.Operators.Subtract(p_, q_);
-				var t_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var u_ = context.Operators.Start(t_);
-				var v_ = context.Operators.Interval(r_, u_, true, false);
-				var w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
-				var y_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var z_ = context.Operators.Start(y_);
-				var aa_ = context.Operators.Not((bool?)(z_ is null));
-				var ab_ = context.Operators.And(w_, aa_);
-				var ac_ = MajorSurgery?.StatusElement;
-				var ad_ = ac_?.Value;
-				var ae_ = context.Operators.Convert<string>(ad_);
-				var af_ = context.Operators.Equal(ae_, "completed");
-				var ag_ = context.Operators.And(ab_, af_);
+				DataType j_ = MajorSurgery?.Performed;
+				object k_ = FHIRHelpers_4_3_000.ToValue(j_);
+				CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
+				CqlDateTime m_ = context.Operators.Start(l_);
+				Period n_ = EDwithSTEMI?.Period;
+				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlQuantity q_ = context.Operators.Quantity(21m, "days");
+				CqlDateTime r_ = context.Operators.Subtract(p_, q_);
+				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlDateTime u_ = context.Operators.Start(t_);
+				CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, false);
+				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
+				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlDateTime z_ = context.Operators.Start(y_);
+				bool? aa_ = context.Operators.Not((bool?)(z_ is null));
+				bool? ab_ = context.Operators.And(w_, aa_);
+				Code<EventStatus> ac_ = MajorSurgery?.StatusElement;
+				EventStatus? ad_ = ac_?.Value;
+				string ae_ = context.Operators.Convert<string>(ad_);
+				bool? af_ = context.Operators.Equal(ae_, "completed");
+				bool? ag_ = context.Operators.And(ab_, af_);
 
 				return ag_;
 			};
-			var g_ = context.Operators.Where<Procedure>(e_, f_);
+			IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
 			Encounter h_(Procedure MajorSurgery) => 
 				EDwithSTEMI;
-			var i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter_Value"/>
     [CqlDeclaration("Major Surgical Procedure 21 Days or Less Before Start of or Starts During ED Encounter")]
 	public IEnumerable<Encounter> Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter() => 
 		__Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter.Value;
 
+    /// <seealso cref="Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start"/>
 	private IEnumerable<Encounter> Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
-			var d_ = this.Endotracheal_Intubation();
-			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
-			var f_ = this.Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device();
-			var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
-			var h_ = context.Operators.Union<Procedure>(e_, g_);
+			CqlValueSet d_ = this.Endotracheal_Intubation();
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			CqlValueSet f_ = this.Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device();
+			IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+			IEnumerable<Procedure> h_ = context.Operators.Union<Procedure>(e_, g_);
 			bool? i_(Procedure AirwayProcedure)
 			{
-				var m_ = AirwayProcedure?.Performed;
-				var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var o_ = QICoreCommon_2_0_000.toInterval(n_);
-				var p_ = context.Operators.Start(o_);
-				var q_ = EDwithSTEMI?.Period;
-				var r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				var s_ = context.Operators.In<CqlDateTime>(p_, r_, null);
-				var u_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var v_ = QICoreCommon_2_0_000.toInterval(u_);
-				var w_ = context.Operators.Start(v_);
-				var y_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				var z_ = context.Operators.Start(y_);
-				var aa_ = context.Operators.Quantity(24m, "hours");
-				var ab_ = context.Operators.Subtract(z_, aa_);
-				var ad_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				var ae_ = context.Operators.Start(ad_);
-				var af_ = context.Operators.Interval(ab_, ae_, true, false);
-				var ag_ = context.Operators.In<CqlDateTime>(w_, af_, null);
-				var ai_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				var aj_ = context.Operators.Start(ai_);
-				var ak_ = context.Operators.Not((bool?)(aj_ is null));
-				var al_ = context.Operators.And(ag_, ak_);
-				var am_ = context.Operators.Or(s_, al_);
-				var an_ = AirwayProcedure?.StatusElement;
-				var ao_ = an_?.Value;
-				var ap_ = context.Operators.Convert<string>(ao_);
-				var aq_ = context.Operators.Equal(ap_, "completed");
-				var ar_ = context.Operators.And(am_, aq_);
+				DataType m_ = AirwayProcedure?.Performed;
+				object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				Period q_ = EDwithSTEMI?.Period;
+				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
+				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, null);
+				object u_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.toInterval(u_);
+				CqlDateTime w_ = context.Operators.Start(v_);
+				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(q_);
+				CqlDateTime z_ = context.Operators.Start(y_);
+				CqlQuantity aa_ = context.Operators.Quantity(24m, "hours");
+				CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+				CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(q_);
+				CqlDateTime ae_ = context.Operators.Start(ad_);
+				CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ab_, ae_, true, false);
+				bool? ag_ = context.Operators.In<CqlDateTime>(w_, af_, null);
+				CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_3_000.ToInterval(q_);
+				CqlDateTime aj_ = context.Operators.Start(ai_);
+				bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
+				bool? al_ = context.Operators.And(ag_, ak_);
+				bool? am_ = context.Operators.Or(s_, al_);
+				Code<EventStatus> an_ = AirwayProcedure?.StatusElement;
+				EventStatus? ao_ = an_?.Value;
+				string ap_ = context.Operators.Convert<string>(ao_);
+				bool? aq_ = context.Operators.Equal(ap_, "completed");
+				bool? ar_ = context.Operators.And(am_, aq_);
 
 				return ar_;
 			};
-			var j_ = context.Operators.Where<Procedure>(h_, i_);
+			IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>(h_, i_);
 			Encounter k_(Procedure AirwayProcedure) => 
 				EDwithSTEMI;
-			var l_ = context.Operators.Select<Procedure, Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Select<Procedure, Encounter>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start_Value"/>
     [CqlDeclaration("Intubation or Mechanical Circulatory Assist Procedure During ED Encounter or Within 24 Hours of ED Encounter Start")]
 	public IEnumerable<Encounter> Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start() => 
 		__Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start.Value;
 
+    /// <seealso cref="Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter"/>
 	private IEnumerable<Encounter> Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
 		{
-			var d_ = this.Ischemic_Stroke();
-			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
-			var f_ = this.Closed_Head_and_Facial_Trauma();
-			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
-			var h_ = context.Operators.Union<Condition>(e_, g_);
-			var i_ = this.Active_Peptic_Ulcer();
-			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
-			var k_ = this.Cardiopulmonary_Arrest();
-			var l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
-			var m_ = context.Operators.Union<Condition>(j_, l_);
-			var n_ = context.Operators.Union<Condition>(h_, m_);
+			CqlValueSet d_ = this.Ischemic_Stroke();
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			CqlValueSet f_ = this.Closed_Head_and_Facial_Trauma();
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
+			CqlValueSet i_ = this.Active_Peptic_Ulcer();
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			CqlValueSet k_ = this.Cardiopulmonary_Arrest();
+			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+			IEnumerable<Condition> m_ = context.Operators.Union<Condition>(j_, l_);
+			IEnumerable<Condition> n_ = context.Operators.Union<Condition>(h_, m_);
 			bool? o_(Condition ExclusionCondition)
 			{
-				var s_ = QICoreCommon_2_0_000.prevalenceInterval(ExclusionCondition);
-				var t_ = context.Operators.Start(s_);
-				var u_ = EDwSTEMI?.Period;
-				var v_ = FHIRHelpers_4_3_000.ToInterval(u_);
-				var w_ = context.Operators.Start(v_);
-				var x_ = context.Operators.Quantity(90m, "days");
-				var y_ = context.Operators.Subtract(w_, x_);
-				var aa_ = FHIRHelpers_4_3_000.ToInterval(u_);
-				var ab_ = context.Operators.Start(aa_);
-				var ac_ = context.Operators.Interval(y_, ab_, true, true);
-				var ad_ = context.Operators.In<CqlDateTime>(t_, ac_, null);
+				CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.prevalenceInterval(ExclusionCondition);
+				CqlDateTime t_ = context.Operators.Start(s_);
+				Period u_ = EDwSTEMI?.Period;
+				CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(u_);
+				CqlDateTime w_ = context.Operators.Start(v_);
+				CqlQuantity x_ = context.Operators.Quantity(90m, "days");
+				CqlDateTime y_ = context.Operators.Subtract(w_, x_);
+				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(u_);
+				CqlDateTime ab_ = context.Operators.Start(aa_);
+				CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, true);
+				bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, null);
 
 				return ad_;
 			};
-			var p_ = context.Operators.Where<Condition>(n_, o_);
+			IEnumerable<Condition> p_ = context.Operators.Where<Condition>(n_, o_);
 			Encounter q_(Condition ExclusionCondition) => 
 				EDwSTEMI;
-			var r_ = context.Operators.Select<Condition, Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Select<Condition, Encounter>(p_, q_);
 
 			return r_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter_Value"/>
     [CqlDeclaration("Active Exclusion Diagnosis Within 90 Days Before or At the Start of ED Encounter")]
 	public IEnumerable<Encounter> Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter() => 
 		__Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter.Value;
 
+    /// <seealso cref="Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter"/>
 	private IEnumerable<Encounter> Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
-			var d_ = this.Intracranial_or_Intraspinal_surgery();
-			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			CqlValueSet d_ = this.Intracranial_or_Intraspinal_surgery();
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
 			bool? f_(Procedure CranialorSpinalSurgery)
 			{
-				var j_ = CranialorSpinalSurgery?.Performed;
-				var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-				var l_ = QICoreCommon_2_0_000.toInterval(k_);
-				var m_ = context.Operators.Start(l_);
-				var n_ = EDwithSTEMI?.Period;
-				var o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var p_ = context.Operators.Start(o_);
-				var q_ = context.Operators.Quantity(90m, "days");
-				var r_ = context.Operators.Subtract(p_, q_);
-				var t_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var u_ = context.Operators.Start(t_);
-				var v_ = context.Operators.Interval(r_, u_, true, false);
-				var w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
-				var y_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var z_ = context.Operators.Start(y_);
-				var aa_ = context.Operators.Not((bool?)(z_ is null));
-				var ab_ = context.Operators.And(w_, aa_);
-				var ac_ = CranialorSpinalSurgery?.StatusElement;
-				var ad_ = ac_?.Value;
-				var ae_ = context.Operators.Convert<string>(ad_);
-				var af_ = context.Operators.Equal(ae_, "completed");
-				var ag_ = context.Operators.And(ab_, af_);
+				DataType j_ = CranialorSpinalSurgery?.Performed;
+				object k_ = FHIRHelpers_4_3_000.ToValue(j_);
+				CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
+				CqlDateTime m_ = context.Operators.Start(l_);
+				Period n_ = EDwithSTEMI?.Period;
+				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlQuantity q_ = context.Operators.Quantity(90m, "days");
+				CqlDateTime r_ = context.Operators.Subtract(p_, q_);
+				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlDateTime u_ = context.Operators.Start(t_);
+				CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, false);
+				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
+				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlDateTime z_ = context.Operators.Start(y_);
+				bool? aa_ = context.Operators.Not((bool?)(z_ is null));
+				bool? ab_ = context.Operators.And(w_, aa_);
+				Code<EventStatus> ac_ = CranialorSpinalSurgery?.StatusElement;
+				EventStatus? ad_ = ac_?.Value;
+				string ae_ = context.Operators.Convert<string>(ad_);
+				bool? af_ = context.Operators.Equal(ae_, "completed");
+				bool? ag_ = context.Operators.And(ab_, af_);
 
 				return ag_;
 			};
-			var g_ = context.Operators.Where<Procedure>(e_, f_);
+			IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
 			Encounter h_(Procedure CranialorSpinalSurgery) => 
 				EDwithSTEMI;
-			var i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter_Value"/>
     [CqlDeclaration("Intracranial or Intraspinal Procedure 90 Days or Less Before Start of ED Encounter")]
 	public IEnumerable<Encounter> Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter() => 
 		__Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter.Value;
 
+    /// <seealso cref="ED_Encounter_with_Discharge_Disposition_as_Patient_Expired"/>
 	private IEnumerable<Encounter> ED_Encounter_with_Discharge_Disposition_as_Patient_Expired_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		bool? b_(Encounter EDwithSTEMI)
 		{
-			var d_ = EDwithSTEMI?.Hospitalization;
-			var e_ = d_?.DischargeDisposition;
-			var f_ = FHIRHelpers_4_3_000.ToConcept(e_);
-			var g_ = this.Patient_Expired();
-			var h_ = context.Operators.ConceptInValueSet(f_, g_);
+			Encounter.HospitalizationComponent d_ = EDwithSTEMI?.Hospitalization;
+			CodeableConcept e_ = d_?.DischargeDisposition;
+			CqlConcept f_ = FHIRHelpers_4_3_000.ToConcept(e_);
+			CqlValueSet g_ = this.Patient_Expired();
+			bool? h_ = context.Operators.ConceptInValueSet(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="ED_Encounter_with_Discharge_Disposition_as_Patient_Expired_Value"/>
     [CqlDeclaration("ED Encounter with Discharge Disposition as Patient Expired")]
 	public IEnumerable<Encounter> ED_Encounter_with_Discharge_Disposition_as_Patient_Expired() => 
 		__ED_Encounter_with_Discharge_Disposition_as_Patient_Expired.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private IEnumerable<Encounter> Denominator_Exclusions_Value()
 	{
-		var a_ = this.Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter();
-		var b_ = this.Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
-		var d_ = this.Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter();
-		var e_ = this.Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter();
-		var f_ = context.Operators.Union<Encounter>(d_, e_);
-		var g_ = context.Operators.Union<Encounter>(c_, f_);
-		var h_ = this.Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start();
-		var i_ = this.Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter();
-		var j_ = context.Operators.Union<Encounter>(h_, i_);
-		var k_ = context.Operators.Union<Encounter>(g_, j_);
-		var l_ = this.Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start();
-		var m_ = this.Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter();
-		var n_ = context.Operators.Union<Encounter>(l_, m_);
-		var o_ = context.Operators.Union<Encounter>(k_, n_);
-		var p_ = this.Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter();
-		var q_ = this.ED_Encounter_with_Discharge_Disposition_as_Patient_Expired();
-		var r_ = context.Operators.Union<Encounter>(p_, q_);
-		var s_ = context.Operators.Union<Encounter>(o_, r_);
+		IEnumerable<Encounter> a_ = this.Allergy_or_Intolerance_to_Thrombolytic_Medications_Overlaps_ED_Encounter();
+		IEnumerable<Encounter> b_ = this.Adverse_Effect_to_Thrombolytic_Medications_Before_End_of_ED_Encounter();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.Active_Exclusion_Diagnosis_at_Start_of_ED_Encounter();
+		IEnumerable<Encounter> e_ = this.Active_Oral_Anticoagulant_Medication_at_the_Start_of_ED_Encounter();
+		IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(d_, e_);
+		IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
+		IEnumerable<Encounter> h_ = this.Exclusion_Diagnosis_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start();
+		IEnumerable<Encounter> i_ = this.Major_Surgical_Procedure_21_Days_or_Less_Before_Start_of_or_Starts_During_ED_Encounter();
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(h_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(g_, j_);
+		IEnumerable<Encounter> l_ = this.Intubation_or_Mechanical_Circulatory_Assist_Procedure_During_ED_Encounter_or_Within_24_Hours_of_ED_Encounter_Start();
+		IEnumerable<Encounter> m_ = this.Active_Exclusion_Diagnosis_Within_90_Days_Before_or_At_the_Start_of_ED_Encounter();
+		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(l_, m_);
+		IEnumerable<Encounter> o_ = context.Operators.Union<Encounter>(k_, n_);
+		IEnumerable<Encounter> p_ = this.Intracranial_or_Intraspinal_Procedure_90_Days_or_Less_Before_Start_of_ED_Encounter();
+		IEnumerable<Encounter> q_ = this.ED_Encounter_with_Discharge_Disposition_as_Patient_Expired();
+		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(p_, q_);
+		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(o_, r_);
 
 		return s_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public IEnumerable<Encounter> Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
@@ -1148,214 +1256,232 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
     [CqlTag("description", "Returns the emergency department arrival time for the encounter.")]
 	public CqlDateTime currentemergencyDepartmentArrivalTime(Encounter EDEncounter)
 	{
-		bool? a_(Encounter.LocationComponent EDLocation)
+		List<Encounter.LocationComponent> a_ = EDEncounter?.Location;
+		bool? b_(Encounter.LocationComponent EDLocation)
 		{
-			var f_ = EDLocation?.Location;
-			var g_ = CQMCommon_2_0_000.GetLocation(f_);
-			var h_ = g_?.Type;
-			CqlConcept i_(CodeableConcept @this)
+			ResourceReference h_ = EDLocation?.Location;
+			Location i_ = CQMCommon_2_0_000.GetLocation(h_);
+			List<CodeableConcept> j_ = i_?.Type;
+			CqlConcept k_(CodeableConcept @this)
 			{
-				var m_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-				return m_;
+				return o_;
 			};
-			var j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
-			var k_ = this.Emergency_Department_Visit();
-			var l_ = context.Operators.ConceptsInValueSet(j_, k_);
+			IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
+			CqlValueSet m_ = this.Emergency_Department_Visit();
+			bool? n_ = context.Operators.ConceptsInValueSet(l_, m_);
 
-			return l_;
+			return n_;
 		};
-		var b_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)EDEncounter?.Location, a_);
-		var c_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(b_);
-		var d_ = FHIRHelpers_4_3_000.ToInterval(c_?.Period);
-		var e_ = context.Operators.Start(d_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
+		Encounter.LocationComponent d_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.Start(f_);
 
-		return e_;
+		return g_;
 	}
 
+    /// <seealso cref="Fibrinolytic_Therapy_within_30_Minutes_of_Arrival"/>
 	private IEnumerable<Encounter> Fibrinolytic_Therapy_within_30_Minutes_of_Arrival_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
-			var d_ = this.Fibrinolytic_Therapy();
-			var e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, null);
-			var g_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, null);
-			var h_ = context.Operators.Union<MedicationAdministration>(e_, g_);
+			CqlValueSet d_ = this.Fibrinolytic_Therapy();
+			IEnumerable<MedicationAdministration> e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, null);
+			IEnumerable<MedicationAdministration> g_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, null);
+			IEnumerable<MedicationAdministration> h_ = context.Operators.Union<MedicationAdministration>(e_, g_);
 			bool? i_(MedicationAdministration Fibrinolytic)
 			{
-				var m_ = Fibrinolytic?.StatusElement;
-				var n_ = m_?.Value;
-				var o_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(n_);
-				var p_ = context.Operators.Equal(o_, "completed");
-				var q_ = Fibrinolytic?.Effective;
-				var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-				var s_ = QICoreCommon_2_0_000.toInterval(r_);
-				var t_ = context.Operators.Start(s_);
-				var u_ = this.currentemergencyDepartmentArrivalTime(EDwithSTEMI);
-				var w_ = context.Operators.Quantity(30m, "minutes");
-				var x_ = context.Operators.Add(u_, w_);
-				var y_ = context.Operators.Interval(u_, x_, false, true);
-				var z_ = context.Operators.In<CqlDateTime>(t_, y_, null);
-				var ab_ = context.Operators.Not((bool?)(u_ is null));
-				var ac_ = context.Operators.And(z_, ab_);
-				var ad_ = context.Operators.And(p_, ac_);
+				Code<MedicationAdministration.MedicationAdministrationStatusCodes> m_ = Fibrinolytic?.StatusElement;
+				MedicationAdministration.MedicationAdministrationStatusCodes? n_ = m_?.Value;
+				Code<MedicationAdministration.MedicationAdministrationStatusCodes> o_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(n_);
+				bool? p_ = context.Operators.Equal(o_, "completed");
+				DataType q_ = Fibrinolytic?.Effective;
+				object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+				CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.toInterval(r_);
+				CqlDateTime t_ = context.Operators.Start(s_);
+				CqlDateTime u_ = this.currentemergencyDepartmentArrivalTime(EDwithSTEMI);
+				CqlQuantity w_ = context.Operators.Quantity(30m, "minutes");
+				CqlDateTime x_ = context.Operators.Add(u_, w_);
+				CqlInterval<CqlDateTime> y_ = context.Operators.Interval(u_, x_, false, true);
+				bool? z_ = context.Operators.In<CqlDateTime>(t_, y_, null);
+				bool? ab_ = context.Operators.Not((bool?)(u_ is null));
+				bool? ac_ = context.Operators.And(z_, ab_);
+				bool? ad_ = context.Operators.And(p_, ac_);
 
 				return ad_;
 			};
-			var j_ = context.Operators.Where<MedicationAdministration>(h_, i_);
+			IEnumerable<MedicationAdministration> j_ = context.Operators.Where<MedicationAdministration>(h_, i_);
 			Encounter k_(MedicationAdministration Fibrinolytic) => 
 				EDwithSTEMI;
-			var l_ = context.Operators.Select<MedicationAdministration, Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Select<MedicationAdministration, Encounter>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Fibrinolytic_Therapy_within_30_Minutes_of_Arrival_Value"/>
     [CqlDeclaration("Fibrinolytic Therapy within 30 Minutes of Arrival")]
 	public IEnumerable<Encounter> Fibrinolytic_Therapy_within_30_Minutes_of_Arrival() => 
 		__Fibrinolytic_Therapy_within_30_Minutes_of_Arrival.Value;
 
+    /// <seealso cref="PCI_within_90_Minutes_of_Arrival"/>
 	private IEnumerable<Encounter> PCI_within_90_Minutes_of_Arrival_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
-			var d_ = this.Percutaneous_Coronary_Intervention();
-			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			CqlValueSet d_ = this.Percutaneous_Coronary_Intervention();
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
 			bool? f_(Procedure PCI)
 			{
-				var j_ = PCI?.Performed;
-				var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-				var l_ = QICoreCommon_2_0_000.toInterval(k_);
-				var m_ = context.Operators.Start(l_);
-				var n_ = this.currentemergencyDepartmentArrivalTime(EDwithSTEMI);
-				var p_ = context.Operators.Quantity(90m, "minutes");
-				var q_ = context.Operators.Add(n_, p_);
-				var r_ = context.Operators.Interval(n_, q_, false, true);
-				var s_ = context.Operators.In<CqlDateTime>(m_, r_, null);
-				var u_ = context.Operators.Not((bool?)(n_ is null));
-				var v_ = context.Operators.And(s_, u_);
-				var w_ = PCI?.StatusElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Convert<string>(x_);
-				var z_ = context.Operators.Equal(y_, "completed");
-				var aa_ = context.Operators.And(v_, z_);
+				DataType j_ = PCI?.Performed;
+				object k_ = FHIRHelpers_4_3_000.ToValue(j_);
+				CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
+				CqlDateTime m_ = context.Operators.Start(l_);
+				CqlDateTime n_ = this.currentemergencyDepartmentArrivalTime(EDwithSTEMI);
+				CqlQuantity p_ = context.Operators.Quantity(90m, "minutes");
+				CqlDateTime q_ = context.Operators.Add(n_, p_);
+				CqlInterval<CqlDateTime> r_ = context.Operators.Interval(n_, q_, false, true);
+				bool? s_ = context.Operators.In<CqlDateTime>(m_, r_, null);
+				bool? u_ = context.Operators.Not((bool?)(n_ is null));
+				bool? v_ = context.Operators.And(s_, u_);
+				Code<EventStatus> w_ = PCI?.StatusElement;
+				EventStatus? x_ = w_?.Value;
+				string y_ = context.Operators.Convert<string>(x_);
+				bool? z_ = context.Operators.Equal(y_, "completed");
+				bool? aa_ = context.Operators.And(v_, z_);
 
 				return aa_;
 			};
-			var g_ = context.Operators.Where<Procedure>(e_, f_);
+			IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
 			Encounter h_(Procedure PCI) => 
 				EDwithSTEMI;
-			var i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="PCI_within_90_Minutes_of_Arrival_Value"/>
     [CqlDeclaration("PCI within 90 Minutes of Arrival")]
 	public IEnumerable<Encounter> PCI_within_90_Minutes_of_Arrival() => 
 		__PCI_within_90_Minutes_of_Arrival.Value;
 
+    /// <seealso cref="ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival"/>
 	private IEnumerable<Encounter> ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival_Value()
 	{
-		var a_ = this.ED_Encounter_with_STEMI_Diagnosis();
+		IEnumerable<Encounter> a_ = this.ED_Encounter_with_STEMI_Diagnosis();
 		bool? b_(Encounter EDwithSTEMI)
 		{
-			var d_ = EDwithSTEMI?.Period;
-			var e_ = FHIRHelpers_4_3_000.ToInterval(d_);
-			var f_ = context.Operators.End(e_);
-			var h_ = FHIRHelpers_4_3_000.ToInterval(d_);
-			var i_ = context.Operators.Start(h_);
-			var k_ = FHIRHelpers_4_3_000.ToInterval(d_);
-			var l_ = context.Operators.Start(k_);
-			var m_ = context.Operators.Quantity(45m, "minutes");
-			var n_ = context.Operators.Add(l_, m_);
-			var o_ = context.Operators.Interval(i_, n_, false, true);
-			var p_ = context.Operators.In<CqlDateTime>(f_, o_, null);
-			var r_ = FHIRHelpers_4_3_000.ToInterval(d_);
-			var s_ = context.Operators.Start(r_);
-			var t_ = context.Operators.Not((bool?)(s_ is null));
-			var u_ = context.Operators.And(p_, t_);
-			var v_ = EDwithSTEMI?.Hospitalization;
-			var w_ = v_?.DischargeDisposition;
-			var x_ = FHIRHelpers_4_3_000.ToConcept(w_);
-			var y_ = this.Discharge_To_Acute_Care_Facility();
-			var z_ = context.Operators.ConceptInValueSet(x_, y_);
-			var aa_ = context.Operators.And(u_, z_);
+			Period d_ = EDwithSTEMI?.Period;
+			CqlInterval<CqlDateTime> e_ = FHIRHelpers_4_3_000.ToInterval(d_);
+			CqlDateTime f_ = context.Operators.End(e_);
+			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(d_);
+			CqlDateTime i_ = context.Operators.Start(h_);
+			CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_3_000.ToInterval(d_);
+			CqlDateTime l_ = context.Operators.Start(k_);
+			CqlQuantity m_ = context.Operators.Quantity(45m, "minutes");
+			CqlDateTime n_ = context.Operators.Add(l_, m_);
+			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(i_, n_, false, true);
+			bool? p_ = context.Operators.In<CqlDateTime>(f_, o_, null);
+			CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(d_);
+			CqlDateTime s_ = context.Operators.Start(r_);
+			bool? t_ = context.Operators.Not((bool?)(s_ is null));
+			bool? u_ = context.Operators.And(p_, t_);
+			Encounter.HospitalizationComponent v_ = EDwithSTEMI?.Hospitalization;
+			CodeableConcept w_ = v_?.DischargeDisposition;
+			CqlConcept x_ = FHIRHelpers_4_3_000.ToConcept(w_);
+			CqlValueSet y_ = this.Discharge_To_Acute_Care_Facility();
+			bool? z_ = context.Operators.ConceptInValueSet(x_, y_);
+			bool? aa_ = context.Operators.And(u_, z_);
 
 			return aa_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival_Value"/>
     [CqlDeclaration("ED Departure with Transfer to Acute Care Facility Within 45 Minutes of Arrival")]
 	public IEnumerable<Encounter> ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival() => 
 		__ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Fibrinolytic_Therapy_within_30_Minutes_of_Arrival();
-		var b_ = this.PCI_within_90_Minutes_of_Arrival();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
-		var d_ = this.ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival();
-		var e_ = context.Operators.Union<Encounter>(c_, d_);
+		IEnumerable<Encounter> a_ = this.Fibrinolytic_Therapy_within_30_Minutes_of_Arrival();
+		IEnumerable<Encounter> b_ = this.PCI_within_90_Minutes_of_Arrival();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.ED_Departure_with_Transfer_to_Acute_Care_Facility_Within_45_Minutes_of_Arrival();
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
@@ -122,168 +122,209 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Antibiotic_Medications_for_Upper_Respiratory_Infection"/>
 	private CqlValueSet Antibiotic_Medications_for_Upper_Respiratory_Infection_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", null);
 
+    /// <seealso cref="Antibiotic_Medications_for_Upper_Respiratory_Infection_Value"/>
     [CqlDeclaration("Antibiotic Medications for Upper Respiratory Infection")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001")]
 	public CqlValueSet Antibiotic_Medications_for_Upper_Respiratory_Infection() => 
 		__Antibiotic_Medications_for_Upper_Respiratory_Infection.Value;
 
+    /// <seealso cref="Comorbid_Conditions_for_Respiratory_Conditions"/>
 	private CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", null);
 
+    /// <seealso cref="Comorbid_Conditions_for_Respiratory_Conditions_Value"/>
     [CqlDeclaration("Comorbid Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025")]
 	public CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions() => 
 		__Comorbid_Conditions_for_Respiratory_Conditions.Value;
 
+    /// <seealso cref="Competing_Conditions_for_Respiratory_Conditions"/>
 	private CqlValueSet Competing_Conditions_for_Respiratory_Conditions_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", null);
 
+    /// <seealso cref="Competing_Conditions_for_Respiratory_Conditions_Value"/>
     [CqlDeclaration("Competing Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017")]
 	public CqlValueSet Competing_Conditions_for_Respiratory_Conditions() => 
 		__Competing_Conditions_for_Respiratory_Conditions.Value;
 
+    /// <seealso cref="Emergency_Department_Evaluation_and_Management_Visit"/>
 	private CqlValueSet Emergency_Department_Evaluation_and_Management_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
 
+    /// <seealso cref="Emergency_Department_Evaluation_and_Management_Visit_Value"/>
     [CqlDeclaration("Emergency Department Evaluation and Management Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
 	public CqlValueSet Emergency_Department_Evaluation_and_Management_Visit() => 
 		__Emergency_Department_Evaluation_and_Management_Visit.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Initial_Hospital_Observation_Care"/>
 	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", null);
 
+    /// <seealso cref="Initial_Hospital_Observation_Care_Value"/>
     [CqlDeclaration("Initial Hospital Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
 	public CqlValueSet Initial_Hospital_Observation_Care() => 
 		__Initial_Hospital_Observation_Care.Value;
 
+    /// <seealso cref="Medical_Disability_Exam"/>
 	private CqlValueSet Medical_Disability_Exam_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", null);
 
+    /// <seealso cref="Medical_Disability_Exam_Value"/>
     [CqlDeclaration("Medical Disability Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073")]
 	public CqlValueSet Medical_Disability_Exam() => 
 		__Medical_Disability_Exam.Value;
 
+    /// <seealso cref="Observation"/>
 	private CqlValueSet Observation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
 
+    /// <seealso cref="Observation_Value"/>
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
 	public CqlValueSet Observation() => 
 		__Observation.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Group_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
 
+    /// <seealso cref="Preventive_Care_Services_Group_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
 	public CqlValueSet Preventive_Care_Services_Group_Counseling() => 
 		__Preventive_Care_Services_Group_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
 	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
 	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
 	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Upper_Respiratory_Infection"/>
 	private CqlValueSet Upper_Respiratory_Infection_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022", null);
 
+    /// <seealso cref="Upper_Respiratory_Infection_Value"/>
     [CqlDeclaration("Upper Respiratory Infection")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022")]
 	public CqlValueSet Upper_Respiratory_Infection() => 
 		__Upper_Respiratory_Infection.Value;
 
+    /// <seealso cref="Unlisted_preventive_medicine_service"/>
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
 		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Unlisted_preventive_medicine_service_Value"/>
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
 		__Unlisted_preventive_medicine_service.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
 		};
@@ -291,187 +332,203 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Emergency_Department_Evaluation_and_Management_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Home_Healthcare_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Initial_Hospital_Observation_Care();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Medical_Disability_Exam();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Observation();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Office_Visit();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Outpatient_Consultation();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Preventive_Care_Services_Group_Counseling();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
-		var x_ = this.Preventive_Care_Services_Individual_Counseling();
-		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
-		var z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
-		var ab_ = context.Operators.Union<Encounter>(y_, aa_);
-		var ac_ = context.Operators.Union<Encounter>(w_, ab_);
-		var ad_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
-		var af_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
-		var ah_ = context.Operators.Union<Encounter>(ae_, ag_);
-		var ai_ = context.Operators.Union<Encounter>(ac_, ah_);
-		var aj_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, null);
-		var al_ = this.Telephone_Visits();
-		var am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
-		var an_ = context.Operators.Union<Encounter>(ak_, am_);
-		var ao_ = context.Operators.Union<Encounter>(ai_, an_);
-		var ap_ = this.Online_Assessments();
-		var aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, null);
-		var ar_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		CqlValueSet a_ = this.Emergency_Department_Evaluation_and_Management_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Initial_Hospital_Observation_Care();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Medical_Disability_Exam();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Observation();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Office_Visit();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Preventive_Care_Services_Group_Counseling();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
+		CqlValueSet x_ = this.Preventive_Care_Services_Individual_Counseling();
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		CqlValueSet z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
+		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
+		CqlValueSet ad_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		CqlValueSet af_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		IEnumerable<Encounter> ah_ = context.Operators.Union<Encounter>(ae_, ag_);
+		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(ac_, ah_);
+		CqlValueSet aj_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, null);
+		CqlValueSet al_ = this.Telephone_Visits();
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
+		IEnumerable<Encounter> ao_ = context.Operators.Union<Encounter>(ai_, an_);
+		CqlValueSet ap_ = this.Online_Assessments();
+		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, null);
+		IEnumerable<Encounter> ar_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
 		bool? as_(Encounter E)
 		{
-			var az_ = E?.Type;
+			List<CodeableConcept> az_ = E?.Type;
 			CqlConcept ba_(CodeableConcept @this)
 			{
-				var bf_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept bf_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return bf_;
 			};
-			var bb_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)az_, ba_);
+			IEnumerable<CqlConcept> bb_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)az_, ba_);
 			bool? bc_(CqlConcept T)
 			{
-				var bg_ = this.Unlisted_preventive_medicine_service();
-				var bh_ = context.Operators.ConvertCodeToConcept(bg_);
-				var bi_ = context.Operators.Equivalent(T, bh_);
+				CqlCode bg_ = this.Unlisted_preventive_medicine_service();
+				CqlConcept bh_ = context.Operators.ConvertCodeToConcept(bg_);
+				bool? bi_ = context.Operators.Equivalent(T, bh_);
 
 				return bi_;
 			};
-			var bd_ = context.Operators.Where<CqlConcept>(bb_, bc_);
-			var be_ = context.Operators.Exists<CqlConcept>(bd_);
+			IEnumerable<CqlConcept> bd_ = context.Operators.Where<CqlConcept>(bb_, bc_);
+			bool? be_ = context.Operators.Exists<CqlConcept>(bd_);
 
 			return be_;
 		};
-		var at_ = context.Operators.Where<Encounter>(ar_, as_);
-		var au_ = context.Operators.Union<Encounter>(aq_, at_);
-		var av_ = context.Operators.Union<Encounter>(ao_, au_);
-		var aw_ = Status_1_6_000.Finished_Encounter(av_);
+		IEnumerable<Encounter> at_ = context.Operators.Where<Encounter>(ar_, as_);
+		IEnumerable<Encounter> au_ = context.Operators.Union<Encounter>(aq_, at_);
+		IEnumerable<Encounter> av_ = context.Operators.Union<Encounter>(ao_, au_);
+		IEnumerable<Encounter> aw_ = Status_1_6_000.Finished_Encounter(av_);
 		bool? ax_(Encounter ValidEncounter)
 		{
-			var bj_ = ValidEncounter?.Period;
-			var bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
-			var bl_ = QICoreCommon_2_0_000.ToInterval((bk_ as object));
-			var bm_ = context.Operators.End(bl_);
-			var bn_ = this.Measurement_Period();
-			var bo_ = context.Operators.Start(bn_);
-			var bq_ = context.Operators.End(bn_);
-			var br_ = context.Operators.Quantity(3m, "days");
-			var bs_ = context.Operators.Subtract(bq_, br_);
-			var bt_ = context.Operators.Interval(bo_, bs_, true, true);
-			var bu_ = context.Operators.In<CqlDateTime>(bm_, bt_, "day");
+			Period bj_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
+			CqlInterval<CqlDateTime> bl_ = QICoreCommon_2_0_000.ToInterval((bk_ as object));
+			CqlDateTime bm_ = context.Operators.End(bl_);
+			CqlInterval<CqlDateTime> bn_ = this.Measurement_Period();
+			CqlDateTime bo_ = context.Operators.Start(bn_);
+			CqlDateTime bq_ = context.Operators.End(bn_);
+			CqlQuantity br_ = context.Operators.Quantity(3m, "days");
+			CqlDateTime bs_ = context.Operators.Subtract(bq_, br_);
+			CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(bo_, bs_, true, true);
+			bool? bu_ = context.Operators.In<CqlDateTime>(bm_, bt_, "day");
 
 			return bu_;
 		};
-		var ay_ = context.Operators.Where<Encounter>(aw_, ax_);
+		IEnumerable<Encounter> ay_ = context.Operators.Where<Encounter>(aw_, ax_);
 
 		return ay_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Encounter_with_Upper_Respiratory_Infection"/>
 	private IEnumerable<Encounter> Encounter_with_Upper_Respiratory_Infection_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Upper_Respiratory_Infection();
-		var c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Condition>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		CqlValueSet b_ = this.Upper_Respiratory_Infection();
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Condition>> d_ = context.Operators.CrossJoin<Encounter, Condition>(a_, c_);
 		Tuple_FiGMIRiNMNcaAVFKbMahDKTce e_(ValueTuple<Encounter, Condition> _valueTuple)
 		{
-			var k_ = new Tuple_FiGMIRiNMNcaAVFKbMahDKTce
+			Tuple_FiGMIRiNMNcaAVFKbMahDKTce k_ = new Tuple_FiGMIRiNMNcaAVFKbMahDKTce
 			{
 				QualifyingEncounters = _valueTuple.Item1,
 				URI = _valueTuple.Item2,
@@ -479,262 +536,279 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Condition>, Tuple_FiGMIRiNMNcaAVFKbMahDKTce>(d_, e_);
+		IEnumerable<Tuple_FiGMIRiNMNcaAVFKbMahDKTce> f_ = context.Operators.Select<ValueTuple<Encounter, Condition>, Tuple_FiGMIRiNMNcaAVFKbMahDKTce>(d_, e_);
 		bool? g_(Tuple_FiGMIRiNMNcaAVFKbMahDKTce tuple_figmirinmncaavfkbmahdktce)
 		{
-			var l_ = QICoreCommon_2_0_000.ToPrevalenceInterval(tuple_figmirinmncaavfkbmahdktce.URI);
-			var m_ = context.Operators.Start(l_);
-			var n_ = tuple_figmirinmncaavfkbmahdktce.QualifyingEncounters?.Period;
-			var o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-			var p_ = QICoreCommon_2_0_000.ToInterval((o_ as object));
-			var q_ = context.Operators.In<CqlDateTime>(m_, p_, "day");
-			var t_ = FHIRHelpers_4_3_000.ToInterval(n_);
-			var u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
-			var v_ = context.Operators.OverlapsBefore(l_, u_, null);
-			var w_ = context.Operators.Or(q_, v_);
+			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.ToPrevalenceInterval(tuple_figmirinmncaavfkbmahdktce.URI);
+			CqlDateTime m_ = context.Operators.Start(l_);
+			Period n_ = tuple_figmirinmncaavfkbmahdktce.QualifyingEncounters?.Period;
+			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.ToInterval((o_ as object));
+			bool? q_ = context.Operators.In<CqlDateTime>(m_, p_, "day");
+			CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
+			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
+			bool? v_ = context.Operators.OverlapsBefore(l_, u_, null);
+			bool? w_ = context.Operators.Or(q_, v_);
 
 			return w_;
 		};
-		var h_ = context.Operators.Where<Tuple_FiGMIRiNMNcaAVFKbMahDKTce>(f_, g_);
+		IEnumerable<Tuple_FiGMIRiNMNcaAVFKbMahDKTce> h_ = context.Operators.Where<Tuple_FiGMIRiNMNcaAVFKbMahDKTce>(f_, g_);
 		Encounter i_(Tuple_FiGMIRiNMNcaAVFKbMahDKTce tuple_figmirinmncaavfkbmahdktce) => 
 			tuple_figmirinmncaavfkbmahdktce.QualifyingEncounters;
-		var j_ = context.Operators.Select<Tuple_FiGMIRiNMNcaAVFKbMahDKTce, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_FiGMIRiNMNcaAVFKbMahDKTce, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Upper_Respiratory_Infection_Value"/>
     [CqlDeclaration("Encounter with Upper Respiratory Infection")]
 	public IEnumerable<Encounter> Encounter_with_Upper_Respiratory_Infection() => 
 		__Encounter_with_Upper_Respiratory_Infection.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Upper_Respiratory_Infection();
 		bool? b_(Encounter EncounterWithURI)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(i_, l_, "month");
-			var n_ = context.Operators.GreaterOrEqual(m_, 3);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "month");
+			bool? n_ = context.Operators.GreaterOrEqual(m_, 3);
 
 			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter EncounterWithURI) => 
 			EncounterWithURI;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Encounters_and_Assessments_with_Hospice_Patient"/>
 	private IEnumerable<Encounter> Encounters_and_Assessments_with_Hospice_Patient_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 		bool? b_(Encounter EligibleEncounters)
 		{
-			var d_ = Hospice_6_9_000.Has_Hospice_Services();
+			bool? d_ = Hospice_6_9_000.Has_Hospice_Services();
 
 			return d_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounters_and_Assessments_with_Hospice_Patient_Value"/>
     [CqlDeclaration("Encounters and Assessments with Hospice Patient")]
 	public IEnumerable<Encounter> Encounters_and_Assessments_with_Hospice_Patient() => 
 		__Encounters_and_Assessments_with_Hospice_Patient.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private IEnumerable<Encounter> Denominator_Exclusions_Value()
 	{
-		var a_ = this.Encounters_and_Assessments_with_Hospice_Patient();
-		var b_ = this.Encounter_with_Upper_Respiratory_Infection();
-		var c_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
-		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
-		var e_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, d_);
-		var f_ = context.Operators.Union<Encounter>(a_, e_);
-		var h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
-		var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
-		var k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
-		var l_ = context.Operators.Union<MedicationRequest>(i_, k_);
-		var m_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, l_);
-		var o_ = this.Competing_Conditions_for_Respiratory_Conditions();
-		var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
-		var q_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, p_);
-		var r_ = context.Operators.Union<Encounter>(m_, q_);
-		var s_ = context.Operators.Union<Encounter>(f_, r_);
+		IEnumerable<Encounter> a_ = this.Encounters_and_Assessments_with_Hospice_Patient();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Upper_Respiratory_Infection();
+		CqlValueSet c_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Encounter> e_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, d_);
+		IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(a_, e_);
+		CqlValueSet h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+		IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(i_, k_);
+		IEnumerable<Encounter> m_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, l_);
+		CqlValueSet o_ = this.Competing_Conditions_for_Respiratory_Conditions();
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		IEnumerable<Encounter> q_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, p_);
+		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(m_, q_);
+		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(f_, r_);
 
 		return s_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public IEnumerable<Encounter> Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Upper_Respiratory_Infection();
 		IEnumerable<Encounter> c_(Encounter EncounterWithURI)
 		{
-			var h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
-			var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
-			var k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
-			var l_ = context.Operators.Union<MedicationRequest>(i_, k_);
+			CqlValueSet h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
+			IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+			IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+			IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(i_, k_);
 			bool? m_(MedicationRequest OrderedAntibiotic)
 			{
-				var q_ = OrderedAntibiotic?.AuthoredOnElement;
-				var r_ = context.Operators.Convert<CqlDateTime>(q_);
-				var s_ = EncounterWithURI?.Period;
-				var t_ = FHIRHelpers_4_3_000.ToInterval(s_);
-				var u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
-				var v_ = context.Operators.Start(u_);
-				var x_ = FHIRHelpers_4_3_000.ToInterval(s_);
-				var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-				var z_ = context.Operators.Start(y_);
-				var aa_ = context.Operators.Quantity(3m, "days");
-				var ab_ = context.Operators.Add(z_, aa_);
-				var ac_ = context.Operators.Interval(v_, ab_, true, true);
-				var ad_ = context.Operators.In<CqlDateTime>(r_, ac_, null);
-				var af_ = FHIRHelpers_4_3_000.ToInterval(s_);
-				var ag_ = QICoreCommon_2_0_000.ToInterval((af_ as object));
-				var ah_ = context.Operators.Start(ag_);
-				var ai_ = context.Operators.Not((bool?)(ah_ is null));
-				var aj_ = context.Operators.And(ad_, ai_);
+				FhirDateTime q_ = OrderedAntibiotic?.AuthoredOnElement;
+				CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
+				Period s_ = EncounterWithURI?.Period;
+				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(s_);
+				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
+				CqlDateTime v_ = context.Operators.Start(u_);
+				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(s_);
+				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+				CqlDateTime z_ = context.Operators.Start(y_);
+				CqlQuantity aa_ = context.Operators.Quantity(3m, "days");
+				CqlDateTime ab_ = context.Operators.Add(z_, aa_);
+				CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(v_, ab_, true, true);
+				bool? ad_ = context.Operators.In<CqlDateTime>(r_, ac_, null);
+				CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_3_000.ToInterval(s_);
+				CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.ToInterval((af_ as object));
+				CqlDateTime ah_ = context.Operators.Start(ag_);
+				bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+				bool? aj_ = context.Operators.And(ad_, ai_);
 
 				return aj_;
 			};
-			var n_ = context.Operators.Where<MedicationRequest>(l_, m_);
+			IEnumerable<MedicationRequest> n_ = context.Operators.Where<MedicationRequest>(l_, m_);
 			Encounter o_(MedicationRequest OrderedAntibiotic) => 
 				EncounterWithURI;
-			var p_ = context.Operators.Select<MedicationRequest, Encounter>(n_, o_);
+			IEnumerable<Encounter> p_ = context.Operators.Select<MedicationRequest, Encounter>(n_, o_);
 
 			return p_;
 		};
-		var d_ = context.Operators.SelectMany<Encounter, Encounter>(a_, c_);
-		var e_ = context.Operators.Except<Encounter>(a_, d_);
+		IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(a_, c_);
+		IEnumerable<Encounter> e_ = context.Operators.Except<Encounter>(a_, d_);
 		Encounter f_(Encounter EncounterWithURI) => 
 			EncounterWithURI;
-		var g_ = context.Operators.Select<Encounter, Encounter>(e_, f_);
+		IEnumerable<Encounter> g_ = context.Operators.Select<Encounter, Encounter>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Stratification_1"/>
 	private IEnumerable<Encounter> Stratification_1_Value()
 	{
-		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Upper_Respiratory_Infection();
 		bool? b_(Encounter EncounterWithURI)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(i_, l_, "month");
-			var n_ = context.Operators.GreaterOrEqual(m_, 3);
-			var p_ = f_?.BirthDateElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<CqlDate>(q_);
-			var t_ = context.Operators.Start(j_);
-			var u_ = context.Operators.DateFrom(t_);
-			var v_ = context.Operators.CalculateAgeAt(r_, u_, "year");
-			var w_ = context.Operators.LessOrEqual(v_, 17);
-			var x_ = context.Operators.And(n_, w_);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "month");
+			bool? n_ = context.Operators.GreaterOrEqual(m_, 3);
+			Date p_ = f_?.BirthDateElement;
+			string q_ = p_?.Value;
+			CqlDate r_ = context.Operators.Convert<CqlDate>(q_);
+			CqlDateTime t_ = context.Operators.Start(j_);
+			CqlDate u_ = context.Operators.DateFrom(t_);
+			int? v_ = context.Operators.CalculateAgeAt(r_, u_, "year");
+			bool? w_ = context.Operators.LessOrEqual(v_, 17);
+			bool? x_ = context.Operators.And(n_, w_);
 
 			return x_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter EncounterWithURI) => 
 			EncounterWithURI;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Stratification_1_Value"/>
     [CqlDeclaration("Stratification 1")]
 	public IEnumerable<Encounter> Stratification_1() => 
 		__Stratification_1.Value;
 
+    /// <seealso cref="Stratification_2"/>
 	private IEnumerable<Encounter> Stratification_2_Value()
 	{
-		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Upper_Respiratory_Infection();
 		bool? b_(Encounter EncounterWithURI)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-			var n_ = context.Operators.Interval(18, 64, true, true);
-			var o_ = context.Operators.In<int?>(m_, n_, null);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			CqlInterval<int?> n_ = context.Operators.Interval(18, 64, true, true);
+			bool? o_ = context.Operators.In<int?>(m_, n_, null);
 
 			return o_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter EncounterWithURI) => 
 			EncounterWithURI;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Stratification_2_Value"/>
     [CqlDeclaration("Stratification 2")]
 	public IEnumerable<Encounter> Stratification_2() => 
 		__Stratification_2.Value;
 
+    /// <seealso cref="Stratification_3"/>
 	private IEnumerable<Encounter> Stratification_3_Value()
 	{
-		var a_ = this.Encounter_with_Upper_Respiratory_Infection();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Upper_Respiratory_Infection();
 		bool? b_(Encounter EncounterWithURI)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-			var n_ = context.Operators.GreaterOrEqual(m_, 65);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			bool? n_ = context.Operators.GreaterOrEqual(m_, 65);
 
 			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter EncounterWithURI) => 
 			EncounterWithURI;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Stratification_3_Value"/>
     [CqlDeclaration("Stratification 3")]
 	public IEnumerable<Encounter> Stratification_3() => 
 		__Stratification_3.Value;

--- a/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
@@ -56,104 +56,122 @@ public class CQMCommon_2_0_000
 
     #endregion
 
+    /// <seealso cref="Emergency_Department_Visit"/>
 	private CqlValueSet Emergency_Department_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
+    /// <seealso cref="Emergency_Department_Visit_Value"/>
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
 	public CqlValueSet Emergency_Department_Visit() => 
 		__Emergency_Department_Visit.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Intensive_Care_Unit"/>
 	private CqlValueSet Intensive_Care_Unit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", null);
 
+    /// <seealso cref="Intensive_Care_Unit_Value"/>
     [CqlDeclaration("Intensive Care Unit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206")]
 	public CqlValueSet Intensive_Care_Unit() => 
 		__Intensive_Care_Unit.Value;
 
+    /// <seealso cref="Observation_Services"/>
 	private CqlValueSet Observation_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
+    /// <seealso cref="Observation_Services_Value"/>
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
 	public CqlValueSet Observation_Services() => 
 		__Observation_Services.Value;
 
+    /// <seealso cref="Outpatient_Surgery_Service"/>
 	private CqlValueSet Outpatient_Surgery_Service_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.38", null);
 
+    /// <seealso cref="Outpatient_Surgery_Service_Value"/>
     [CqlDeclaration("Outpatient Surgery Service")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.38")]
 	public CqlValueSet Outpatient_Surgery_Service() => 
 		__Outpatient_Surgery_Service.Value;
 
+    /// <seealso cref="Present_on_Admission_or_Clinically_Undetermined"/>
 	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", null);
 
+    /// <seealso cref="Present_on_Admission_or_Clinically_Undetermined_Value"/>
     [CqlDeclaration("Present on Admission or Clinically Undetermined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
 	public CqlValueSet Present_on_Admission_or_Clinically_Undetermined() => 
 		__Present_on_Admission_or_Clinically_Undetermined.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("CQMCommon-2.0.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("CQMCommon-2.0.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Inpatient_Encounter"/>
 	private IEnumerable<Encounter> Inpatient_Encounter_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EncounterInpatient)
 		{
-			var e_ = EncounterInpatient?.StatusElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
-			var h_ = context.Operators.Equal(g_, "finished");
-			var i_ = EncounterInpatient?.Period;
-			var j_ = FHIRHelpers_4_3_000.ToInterval(i_);
-			var k_ = context.Operators.End(j_);
-			var l_ = this.Measurement_Period();
-			var m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
-			var n_ = context.Operators.And(h_, m_);
+			Code<Encounter.EncounterStatus> e_ = EncounterInpatient?.StatusElement;
+			Encounter.EncounterStatus? f_ = e_?.Value;
+			Code<Encounter.EncounterStatus> g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
+			bool? h_ = context.Operators.Equal(g_, "finished");
+			Period i_ = EncounterInpatient?.Period;
+			CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
+			CqlDateTime k_ = context.Operators.End(j_);
+			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
+			bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
+			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Inpatient_Encounter_Value"/>
     [CqlDeclaration("Inpatient Encounter")]
 	public IEnumerable<Encounter> Inpatient_Encounter() => 
 		__Inpatient_Encounter.Value;
@@ -163,11 +181,11 @@ public class CQMCommon_2_0_000
     [CqlTag("comment", "This function returns an interval constructed using the `date from` extractor on the start and end values of the input date-time interval. Note that using a precision specifier such as `day of` as part of a timing phrase is preferred to communicate intent to perform day-level comparison, as well as for general readability.")]
 	public CqlInterval<CqlDate> ToDateInterval(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.Start(period);
-		var b_ = context.Operators.DateFrom(a_);
-		var c_ = context.Operators.End(period);
-		var d_ = context.Operators.DateFrom(c_);
-		var e_ = context.Operators.Interval(b_, d_, true, true);
+		CqlDateTime a_ = context.Operators.Start(period);
+		CqlDate b_ = context.Operators.DateFrom(a_);
+		CqlDateTime c_ = context.Operators.End(period);
+		CqlDate d_ = context.Operators.DateFrom(c_);
+		CqlInterval<CqlDate> e_ = context.Operators.Interval(b_, d_, true, true);
 
 		return e_;
 	}
@@ -177,9 +195,9 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function in deprecated. Use the fluent function `lengthInDays()` instead.")]
 	public int? LengthInDays(CqlInterval<CqlDateTime> Value)
 	{
-		var a_ = context.Operators.Start(Value);
-		var b_ = context.Operators.End(Value);
-		var c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		CqlDateTime a_ = context.Operators.Start(Value);
+		CqlDateTime b_ = context.Operators.End(Value);
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, "day");
 
 		return c_;
 	}
@@ -188,9 +206,9 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Calculates the difference in calendar days between the start and end of the given interval.")]
 	public int? lengthInDays(CqlInterval<CqlDateTime> Value)
 	{
-		var a_ = context.Operators.Start(Value);
-		var b_ = context.Operators.End(Value);
-		var c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		CqlDateTime a_ = context.Operators.Start(Value);
+		CqlDateTime b_ = context.Operators.End(Value);
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, "day");
 
 		return c_;
 	}
@@ -200,45 +218,45 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `edVisit()` instead.")]
 	public Encounter ED_Visit(Encounter TheEncounter)
 	{
-		var a_ = this.Emergency_Department_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Emergency_Department_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EDVisit)
 		{
-			var h_ = EDVisit?.StatusElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
-			var k_ = context.Operators.Equal(j_, "finished");
-			var l_ = EDVisit?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.End(m_);
-			var o_ = TheEncounter?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.Start(p_);
-			var r_ = context.Operators.Quantity(1m, "hour");
-			var s_ = context.Operators.Subtract(q_, r_);
-			var u_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var v_ = context.Operators.Start(u_);
-			var w_ = context.Operators.Interval(s_, v_, true, true);
-			var x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
-			var z_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var aa_ = context.Operators.Start(z_);
-			var ab_ = context.Operators.Not((bool?)(aa_ is null));
-			var ac_ = context.Operators.And(x_, ab_);
-			var ad_ = context.Operators.And(k_, ac_);
+			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
+			Encounter.EncounterStatus? i_ = h_?.Value;
+			Code<Encounter.EncounterStatus> j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
+			bool? k_ = context.Operators.Equal(j_, "finished");
+			Period l_ = EDVisit?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.End(m_);
+			Period o_ = TheEncounter?.Period;
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime q_ = context.Operators.Start(p_);
+			CqlQuantity r_ = context.Operators.Quantity(1m, "hour");
+			CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime v_ = context.Operators.Start(u_);
+			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
+			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime aa_ = context.Operators.Start(z_);
+			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+			bool? ac_ = context.Operators.And(x_, ab_);
+			bool? ad_ = context.Operators.And(k_, ac_);
 
 			return ad_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 		object e_(Encounter @this)
 		{
-			var ae_ = @this?.Period;
-			var af_ = FHIRHelpers_4_3_000.ToInterval(ae_);
-			var ag_ = context.Operators.End(af_);
+			Period ae_ = @this?.Period;
+			CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_3_000.ToInterval(ae_);
+			CqlDateTime ag_ = context.Operators.End(af_);
 
 			return ag_;
 		};
-		var f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-		var g_ = context.Operators.Last<Encounter>(f_);
+		IEnumerable<Encounter> f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter g_ = context.Operators.Last<Encounter>(f_);
 
 		return g_;
 	}
@@ -247,45 +265,45 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the most recent emergency department visit, if any, that occurs 1 hour or less prior to the given encounter.")]
 	public Encounter edVisit(Encounter TheEncounter)
 	{
-		var a_ = this.Emergency_Department_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Emergency_Department_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EDVisit)
 		{
-			var h_ = EDVisit?.StatusElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
-			var k_ = context.Operators.Equal(j_, "finished");
-			var l_ = EDVisit?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.End(m_);
-			var o_ = TheEncounter?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.Start(p_);
-			var r_ = context.Operators.Quantity(1m, "hour");
-			var s_ = context.Operators.Subtract(q_, r_);
-			var u_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var v_ = context.Operators.Start(u_);
-			var w_ = context.Operators.Interval(s_, v_, true, true);
-			var x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
-			var z_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var aa_ = context.Operators.Start(z_);
-			var ab_ = context.Operators.Not((bool?)(aa_ is null));
-			var ac_ = context.Operators.And(x_, ab_);
-			var ad_ = context.Operators.And(k_, ac_);
+			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
+			Encounter.EncounterStatus? i_ = h_?.Value;
+			Code<Encounter.EncounterStatus> j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
+			bool? k_ = context.Operators.Equal(j_, "finished");
+			Period l_ = EDVisit?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.End(m_);
+			Period o_ = TheEncounter?.Period;
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime q_ = context.Operators.Start(p_);
+			CqlQuantity r_ = context.Operators.Quantity(1m, "hour");
+			CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime v_ = context.Operators.Start(u_);
+			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
+			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime aa_ = context.Operators.Start(z_);
+			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+			bool? ac_ = context.Operators.And(x_, ab_);
+			bool? ad_ = context.Operators.And(k_, ac_);
 
 			return ad_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 		object e_(Encounter @this)
 		{
-			var ae_ = @this?.Period;
-			var af_ = FHIRHelpers_4_3_000.ToInterval(ae_);
-			var ag_ = context.Operators.End(af_);
+			Period ae_ = @this?.Period;
+			CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_3_000.ToInterval(ae_);
+			CqlDateTime ag_ = context.Operators.End(af_);
 
 			return ag_;
 		};
-		var f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-		var g_ = context.Operators.Last<Encounter>(f_);
+		IEnumerable<Encounter> f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter g_ = context.Operators.Last<Encounter>(f_);
 
 		return g_;
 	}
@@ -295,8 +313,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalization()` instead.")]
 	public CqlInterval<CqlDateTime> Hospitalization(Encounter TheEncounter)
 	{
-		var a_ = this.ED_Visit(TheEncounter);
-		var b_ = new Encounter[]
+		Encounter a_ = this.ED_Visit(TheEncounter);
+		Encounter[] b_ = new Encounter[]
 		{
 			a_,
 		};
@@ -306,20 +324,20 @@ public class CQMCommon_2_0_000
 			{
 				if ((X is null))
 				{
-					var g_ = TheEncounter?.Period;
-					var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+					Period g_ = TheEncounter?.Period;
+					CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
 
 					return h_;
 				}
 				else
 				{
-					var i_ = X?.Period;
-					var j_ = FHIRHelpers_4_3_000.ToInterval(i_);
-					var k_ = context.Operators.Start(j_);
-					var l_ = TheEncounter?.Period;
-					var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-					var n_ = context.Operators.End(m_);
-					var o_ = context.Operators.Interval(k_, n_, true, false);
+					Period i_ = X?.Period;
+					CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
+					CqlDateTime k_ = context.Operators.Start(j_);
+					Period l_ = TheEncounter?.Period;
+					CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+					CqlDateTime n_ = context.Operators.End(m_);
+					CqlInterval<CqlDateTime> o_ = context.Operators.Interval(k_, n_, true, false);
 
 					return o_;
 				}
@@ -327,8 +345,8 @@ public class CQMCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(d_);
+		IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)b_, c_);
+		CqlInterval<CqlDateTime> e_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(d_);
 
 		return e_;
 	}
@@ -337,8 +355,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Hospitalization returns the total interval for admission to discharge for the given encounter, or for the admission of any immediately prior emergency department visit to the discharge of the given encounter.")]
 	public CqlInterval<CqlDateTime> hospitalization(Encounter TheEncounter)
 	{
-		var a_ = this.edVisit(TheEncounter);
-		var b_ = new Encounter[]
+		Encounter a_ = this.edVisit(TheEncounter);
+		Encounter[] b_ = new Encounter[]
 		{
 			a_,
 		};
@@ -348,20 +366,20 @@ public class CQMCommon_2_0_000
 			{
 				if ((X is null))
 				{
-					var g_ = TheEncounter?.Period;
-					var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+					Period g_ = TheEncounter?.Period;
+					CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
 
 					return h_;
 				}
 				else
 				{
-					var i_ = X?.Period;
-					var j_ = FHIRHelpers_4_3_000.ToInterval(i_);
-					var k_ = context.Operators.Start(j_);
-					var l_ = TheEncounter?.Period;
-					var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-					var n_ = context.Operators.End(m_);
-					var o_ = context.Operators.Interval(k_, n_, true, true);
+					Period i_ = X?.Period;
+					CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
+					CqlDateTime k_ = context.Operators.Start(j_);
+					Period l_ = TheEncounter?.Period;
+					CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+					CqlDateTime n_ = context.Operators.End(m_);
+					CqlInterval<CqlDateTime> o_ = context.Operators.Interval(k_, n_, true, true);
 
 					return o_;
 				}
@@ -369,8 +387,8 @@ public class CQMCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(d_);
+		IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)b_, c_);
+		CqlInterval<CqlDateTime> e_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(d_);
 
 		return e_;
 	}
@@ -380,8 +398,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationLocations()` instead.")]
 	public IEnumerable<Encounter.LocationComponent> Hospitalization_Locations(Encounter TheEncounter)
 	{
-		var a_ = this.ED_Visit(TheEncounter);
-		var b_ = new Encounter[]
+		Encounter a_ = this.ED_Visit(TheEncounter);
+		Encounter[] b_ = new Encounter[]
 		{
 			a_,
 		};
@@ -391,20 +409,20 @@ public class CQMCommon_2_0_000
 			{
 				if ((EDEncounter is null))
 				{
-					var g_ = TheEncounter?.Location;
+					List<Encounter.LocationComponent> g_ = TheEncounter?.Location;
 
 					return (IEnumerable<Encounter.LocationComponent>)g_;
 				}
 				else
 				{
-					var h_ = EDEncounter?.Location;
-					var i_ = TheEncounter?.Location;
-					var j_ = new IEnumerable<Encounter.LocationComponent>[]
+					List<Encounter.LocationComponent> h_ = EDEncounter?.Location;
+					List<Encounter.LocationComponent> i_ = TheEncounter?.Location;
+					IEnumerable<Encounter.LocationComponent>[] j_ = new IEnumerable<Encounter.LocationComponent>[]
 					{
 						(IEnumerable<Encounter.LocationComponent>)h_,
 						(IEnumerable<Encounter.LocationComponent>)i_,
 					};
-					var k_ = context.Operators.Flatten<Encounter.LocationComponent>((j_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>));
+					IEnumerable<Encounter.LocationComponent> k_ = context.Operators.Flatten<Encounter.LocationComponent>((j_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>));
 
 					return k_;
 				}
@@ -412,8 +430,8 @@ public class CQMCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<Encounter, IEnumerable<Encounter.LocationComponent>>((IEnumerable<Encounter>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<IEnumerable<Encounter.LocationComponent>>(d_);
+		IEnumerable<IEnumerable<Encounter.LocationComponent>> d_ = context.Operators.Select<Encounter, IEnumerable<Encounter.LocationComponent>>((IEnumerable<Encounter>)b_, c_);
+		IEnumerable<Encounter.LocationComponent> e_ = context.Operators.SingletonFrom<IEnumerable<Encounter.LocationComponent>>(d_);
 
 		return e_;
 	}
@@ -422,8 +440,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns list of all locations within an encounter, including locations for immediately prior ED visit.")]
 	public IEnumerable<Encounter.LocationComponent> hospitalizationLocations(Encounter TheEncounter)
 	{
-		var a_ = this.edVisit(TheEncounter);
-		var b_ = new Encounter[]
+		Encounter a_ = this.edVisit(TheEncounter);
+		Encounter[] b_ = new Encounter[]
 		{
 			a_,
 		};
@@ -433,20 +451,20 @@ public class CQMCommon_2_0_000
 			{
 				if ((EDEncounter is null))
 				{
-					var g_ = TheEncounter?.Location;
+					List<Encounter.LocationComponent> g_ = TheEncounter?.Location;
 
 					return (IEnumerable<Encounter.LocationComponent>)g_;
 				}
 				else
 				{
-					var h_ = EDEncounter?.Location;
-					var i_ = TheEncounter?.Location;
-					var j_ = new IEnumerable<Encounter.LocationComponent>[]
+					List<Encounter.LocationComponent> h_ = EDEncounter?.Location;
+					List<Encounter.LocationComponent> i_ = TheEncounter?.Location;
+					IEnumerable<Encounter.LocationComponent>[] j_ = new IEnumerable<Encounter.LocationComponent>[]
 					{
 						(IEnumerable<Encounter.LocationComponent>)h_,
 						(IEnumerable<Encounter.LocationComponent>)i_,
 					};
-					var k_ = context.Operators.Flatten<Encounter.LocationComponent>((j_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>));
+					IEnumerable<Encounter.LocationComponent> k_ = context.Operators.Flatten<Encounter.LocationComponent>((j_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>));
 
 					return k_;
 				}
@@ -454,8 +472,8 @@ public class CQMCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<Encounter, IEnumerable<Encounter.LocationComponent>>((IEnumerable<Encounter>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<IEnumerable<Encounter.LocationComponent>>(d_);
+		IEnumerable<IEnumerable<Encounter.LocationComponent>> d_ = context.Operators.Select<Encounter, IEnumerable<Encounter.LocationComponent>>((IEnumerable<Encounter>)b_, c_);
+		IEnumerable<Encounter.LocationComponent> e_ = context.Operators.SingletonFrom<IEnumerable<Encounter.LocationComponent>>(d_);
 
 		return e_;
 	}
@@ -465,8 +483,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationLengthOfStay()` instead.")]
 	public int? Hospitalization_Length_of_Stay(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization(TheEncounter);
-		var b_ = this.LengthInDays(a_);
+		CqlInterval<CqlDateTime> a_ = this.Hospitalization(TheEncounter);
+		int? b_ = this.LengthInDays(a_);
 
 		return b_;
 	}
@@ -475,8 +493,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the length of stay in days (i.e. the number of days between admission and discharge) for the given encounter, or from the admission of any immediately prior emergency department visit to the discharge of the encounter")]
 	public int? hospitalizationLengthOfStay(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalization(TheEncounter);
-		var b_ = this.lengthInDays(a_);
+		CqlInterval<CqlDateTime> a_ = this.hospitalization(TheEncounter);
+		int? b_ = this.lengthInDays(a_);
 
 		return b_;
 	}
@@ -486,8 +504,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalAdmissionTime()` instead.")]
 	public CqlDateTime Hospital_Admission_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization(TheEncounter);
-		var b_ = context.Operators.Start(a_);
+		CqlInterval<CqlDateTime> a_ = this.Hospitalization(TheEncounter);
+		CqlDateTime b_ = context.Operators.Start(a_);
 
 		return b_;
 	}
@@ -496,8 +514,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns admission time for an encounter or for immediately prior emergency department visit.")]
 	public CqlDateTime hospitalAdmissionTime(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalization(TheEncounter);
-		var b_ = context.Operators.Start(a_);
+		CqlInterval<CqlDateTime> a_ = this.hospitalization(TheEncounter);
+		CqlDateTime b_ = context.Operators.Start(a_);
 
 		return b_;
 	}
@@ -507,20 +525,22 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalDischargeTime()` instead.")]
 	public CqlDateTime Hospital_Discharge_Time(Encounter TheEncounter)
 	{
-		var a_ = FHIRHelpers_4_3_000.ToInterval(TheEncounter?.Period);
-		var b_ = context.Operators.End(a_);
+		Period a_ = TheEncounter?.Period;
+		CqlInterval<CqlDateTime> b_ = FHIRHelpers_4_3_000.ToInterval(a_);
+		CqlDateTime c_ = context.Operators.End(b_);
 
-		return b_;
+		return c_;
 	}
 
     [CqlDeclaration("hospitalDischargeTime")]
     [CqlTag("description", "Hospital Discharge Time returns the discharge time for an encounter")]
 	public CqlDateTime hospitalDischargeTime(Encounter TheEncounter)
 	{
-		var a_ = FHIRHelpers_4_3_000.ToInterval(TheEncounter?.Period);
-		var b_ = context.Operators.End(a_);
+		Period a_ = TheEncounter?.Period;
+		CqlInterval<CqlDateTime> b_ = FHIRHelpers_4_3_000.ToInterval(a_);
+		CqlDateTime c_ = context.Operators.End(b_);
 
-		return b_;
+		return c_;
 	}
 
     [CqlDeclaration("Hospital Arrival Time")]
@@ -528,42 +548,44 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalArrivalTime()` instead.")]
 	public CqlDateTime Hospital_Arrival_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization_Locations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.Hospitalization_Locations(TheEncounter);
 		object b_(Encounter.LocationComponent @this)
 		{
-			var g_ = @this?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.Start(h_);
+			Period h_ = @this?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
 
-			return i_;
+			return j_;
 		};
-		var c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
-		var d_ = context.Operators.First<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.Start(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent d_ = context.Operators.First<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.Start(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("hospitalArrivalTime")]
     [CqlTag("description", "Returns earliest arrival time for an encounter including any prior ED visit.")]
 	public CqlDateTime hospitalArrivalTime(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalizationLocations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.hospitalizationLocations(TheEncounter);
 		object b_(Encounter.LocationComponent @this)
 		{
-			var g_ = @this?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.Start(h_);
+			Period h_ = @this?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
 
-			return i_;
+			return j_;
 		};
-		var c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
-		var d_ = context.Operators.First<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.Start(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent d_ = context.Operators.First<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.Start(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("Hospital Departure Time")]
@@ -571,42 +593,44 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalDepartureTime()` instead.")]
 	public CqlDateTime Hospital_Departure_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization_Locations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.Hospitalization_Locations(TheEncounter);
 		object b_(Encounter.LocationComponent @this)
 		{
-			var g_ = @this?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.Start(h_);
+			Period h_ = @this?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
 
-			return i_;
+			return j_;
 		};
-		var c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
-		var d_ = context.Operators.Last<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.End(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent d_ = context.Operators.Last<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.End(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("hospitalDepartureTime")]
     [CqlTag("description", "Returns the latest departure time for encounter including any prior ED visit.")]
 	public CqlDateTime hospitalDepartureTime(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalizationLocations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.hospitalizationLocations(TheEncounter);
 		object b_(Encounter.LocationComponent @this)
 		{
-			var g_ = @this?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.Start(h_);
+			Period h_ = @this?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
 
-			return i_;
+			return j_;
 		};
-		var c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
-		var d_ = context.Operators.Last<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.End(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent d_ = context.Operators.Last<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.End(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("GetLocation")]
@@ -614,20 +638,20 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getLocation()` instead.")]
 	public Location GetLocation(ResourceReference reference)
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
 		bool? b_(Location L)
 		{
-			var e_ = L?.IdElement;
-			var f_ = e_?.Value;
-			var g_ = reference?.ReferenceElement;
-			var h_ = g_?.Value;
-			var i_ = QICoreCommon_2_0_000.getId(h_);
-			var j_ = context.Operators.Equal(f_, i_);
+			Id e_ = L?.IdElement;
+			string f_ = e_?.Value;
+			FhirString g_ = reference?.ReferenceElement;
+			string h_ = g_?.Value;
+			string i_ = QICoreCommon_2_0_000.getId(h_);
+			bool? j_ = context.Operators.Equal(f_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Location>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Location>(c_);
+		IEnumerable<Location> c_ = context.Operators.Where<Location>(a_, b_);
+		Location d_ = context.Operators.SingletonFrom<Location>(c_);
 
 		return d_;
 	}
@@ -636,60 +660,62 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the emergency department arrival time for the encounter.")]
 	public CqlDateTime Emergency_Department_Arrival_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization_Locations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.Hospitalization_Locations(TheEncounter);
 		bool? b_(Encounter.LocationComponent HospitalLocation)
 		{
-			var g_ = HospitalLocation?.Location;
-			var h_ = this.GetLocation(g_);
-			var i_ = h_?.Type;
-			CqlConcept j_(CodeableConcept @this)
+			ResourceReference h_ = HospitalLocation?.Location;
+			Location i_ = this.GetLocation(h_);
+			List<CodeableConcept> j_ = i_?.Type;
+			CqlConcept k_(CodeableConcept @this)
 			{
-				var n_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-				return n_;
+				return o_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
-			var l_ = this.Emergency_Department_Visit();
-			var m_ = context.Operators.ConceptsInValueSet(k_, l_);
+			IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
+			CqlValueSet m_ = this.Emergency_Department_Visit();
+			bool? n_ = context.Operators.ConceptsInValueSet(l_, m_);
 
-			return m_;
+			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter.LocationComponent>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.Start(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>(a_, b_);
+		Encounter.LocationComponent d_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.Start(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("emergencyDepartmentArrivalTime")]
     [CqlTag("description", "Returns the emergency department arrival time for the encounter.")]
 	public CqlDateTime emergencyDepartmentArrivalTime(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalizationLocations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.hospitalizationLocations(TheEncounter);
 		bool? b_(Encounter.LocationComponent HospitalLocation)
 		{
-			var g_ = HospitalLocation?.Location;
-			var h_ = this.GetLocation(g_);
-			var i_ = h_?.Type;
-			CqlConcept j_(CodeableConcept @this)
+			ResourceReference h_ = HospitalLocation?.Location;
+			Location i_ = this.GetLocation(h_);
+			List<CodeableConcept> j_ = i_?.Type;
+			CqlConcept k_(CodeableConcept @this)
 			{
-				var n_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-				return n_;
+				return o_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
-			var l_ = this.Emergency_Department_Visit();
-			var m_ = context.Operators.ConceptsInValueSet(k_, l_);
+			IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
+			CqlValueSet m_ = this.Emergency_Department_Visit();
+			bool? n_ = context.Operators.ConceptsInValueSet(l_, m_);
 
-			return m_;
+			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter.LocationComponent>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.Start(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>(a_, b_);
+		Encounter.LocationComponent d_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.Start(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("HospitalizationWithObservationAndOutpatientSurgeryService")]
@@ -697,888 +723,888 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationWithObservationAndOutpatientSurgeryService()` instead.")]
 	public CqlInterval<CqlDateTime> HospitalizationWithObservationAndOutpatientSurgeryService(Encounter TheEncounter)
 	{
-		var a_ = new Encounter[]
+		Encounter[] a_ = new Encounter[]
 		{
 			TheEncounter,
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Outpatient_Surgery_Service();
-			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			CqlValueSet e_ = this.Outpatient_Surgery_Service();
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastSurgeryOP)
 			{
-				var ap_ = LastSurgeryOP?.Period;
-				var aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				var ar_ = context.Operators.End(aq_);
-				var as_ = this.Emergency_Department_Visit();
-				var at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				Period ap_ = LastSurgeryOP?.Period;
+				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
+				CqlDateTime ar_ = context.Operators.End(aq_);
+				CqlValueSet as_ = this.Emergency_Department_Visit();
+				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? au_(Encounter LastED)
 				{
-					var dp_ = LastED?.StatusElement;
-					var dq_ = dp_?.Value;
-					var dr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dq_);
-					var ds_ = context.Operators.Equal(dr_, "finished");
-					var dt_ = LastED?.Period;
-					var du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
-					var dv_ = context.Operators.End(du_);
-					var dw_ = this.Observation_Services();
-					var dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					Code<Encounter.EncounterStatus> dp_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? dq_ = dp_?.Value;
+					Code<Encounter.EncounterStatus> dr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dq_);
+					bool? ds_ = context.Operators.Equal(dr_, "finished");
+					Period dt_ = LastED?.Period;
+					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
+					CqlDateTime dv_ = context.Operators.End(du_);
+					CqlValueSet dw_ = this.Observation_Services();
+					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? dy_(Encounter LastObs)
 					{
-						var fq_ = LastObs?.StatusElement;
-						var fr_ = fq_?.Value;
-						var fs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fr_);
-						var ft_ = context.Operators.Equal(fs_, "finished");
-						var fu_ = LastObs?.Period;
-						var fv_ = FHIRHelpers_4_3_000.ToInterval(fu_);
-						var fw_ = context.Operators.End(fv_);
-						var fx_ = Visit?.Period;
-						var fy_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var fz_ = context.Operators.Start(fy_);
-						var ga_ = context.Operators.Quantity(1m, "hour");
-						var gb_ = context.Operators.Subtract(fz_, ga_);
-						var gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var ge_ = context.Operators.Start(gd_);
-						var gf_ = context.Operators.Interval(gb_, ge_, true, true);
-						var gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
-						var gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var gj_ = context.Operators.Start(gi_);
-						var gk_ = context.Operators.Not((bool?)(gj_ is null));
-						var gl_ = context.Operators.And(gg_, gk_);
-						var gm_ = context.Operators.And(ft_, gl_);
+						Code<Encounter.EncounterStatus> fq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? fr_ = fq_?.Value;
+						Code<Encounter.EncounterStatus> fs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fr_);
+						bool? ft_ = context.Operators.Equal(fs_, "finished");
+						Period fu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> fv_ = FHIRHelpers_4_3_000.ToInterval(fu_);
+						CqlDateTime fw_ = context.Operators.End(fv_);
+						Period fx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> fy_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime fz_ = context.Operators.Start(fy_);
+						CqlQuantity ga_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime gb_ = context.Operators.Subtract(fz_, ga_);
+						CqlInterval<CqlDateTime> gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime ge_ = context.Operators.Start(gd_);
+						CqlInterval<CqlDateTime> gf_ = context.Operators.Interval(gb_, ge_, true, true);
+						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
+						CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime gj_ = context.Operators.Start(gi_);
+						bool? gk_ = context.Operators.Not((bool?)(gj_ is null));
+						bool? gl_ = context.Operators.And(gg_, gk_);
+						bool? gm_ = context.Operators.And(ft_, gl_);
 
 						return gm_;
 					};
-					var dz_ = context.Operators.Where<Encounter>(dx_, dy_);
+					IEnumerable<Encounter> dz_ = context.Operators.Where<Encounter>(dx_, dy_);
 					object ea_(Encounter @this)
 					{
-						var gn_ = @this?.Period;
-						var go_ = FHIRHelpers_4_3_000.ToInterval(gn_);
-						var gp_ = context.Operators.End(go_);
+						Period gn_ = @this?.Period;
+						CqlInterval<CqlDateTime> go_ = FHIRHelpers_4_3_000.ToInterval(gn_);
+						CqlDateTime gp_ = context.Operators.End(go_);
 
 						return gp_;
 					};
-					var eb_ = context.Operators.SortBy<Encounter>(dz_, ea_, System.ComponentModel.ListSortDirection.Ascending);
-					var ec_ = context.Operators.Last<Encounter>(eb_);
-					var ed_ = ec_?.Period;
-					var ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
-					var ef_ = context.Operators.Start(ee_);
-					var eg_ = Visit?.Period;
-					var eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var ei_ = context.Operators.Start(eh_);
-					var ej_ = context.Operators.Quantity(1m, "hour");
-					var ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
-					var em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> eb_ = context.Operators.SortBy<Encounter>(dz_, ea_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter ec_ = context.Operators.Last<Encounter>(eb_);
+					Period ed_ = ec_?.Period;
+					CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
+					CqlDateTime ef_ = context.Operators.Start(ee_);
+					Period eg_ = Visit?.Period;
+					CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime ei_ = context.Operators.Start(eh_);
+					CqlQuantity ej_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
+					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? en_(Encounter LastObs)
 					{
-						var gq_ = LastObs?.StatusElement;
-						var gr_ = gq_?.Value;
-						var gs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gr_);
-						var gt_ = context.Operators.Equal(gs_, "finished");
-						var gu_ = LastObs?.Period;
-						var gv_ = FHIRHelpers_4_3_000.ToInterval(gu_);
-						var gw_ = context.Operators.End(gv_);
-						var gx_ = Visit?.Period;
-						var gy_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var gz_ = context.Operators.Start(gy_);
-						var ha_ = context.Operators.Quantity(1m, "hour");
-						var hb_ = context.Operators.Subtract(gz_, ha_);
-						var hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var he_ = context.Operators.Start(hd_);
-						var hf_ = context.Operators.Interval(hb_, he_, true, true);
-						var hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
-						var hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var hj_ = context.Operators.Start(hi_);
-						var hk_ = context.Operators.Not((bool?)(hj_ is null));
-						var hl_ = context.Operators.And(hg_, hk_);
-						var hm_ = context.Operators.And(gt_, hl_);
+						Code<Encounter.EncounterStatus> gq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? gr_ = gq_?.Value;
+						Code<Encounter.EncounterStatus> gs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gr_);
+						bool? gt_ = context.Operators.Equal(gs_, "finished");
+						Period gu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> gv_ = FHIRHelpers_4_3_000.ToInterval(gu_);
+						CqlDateTime gw_ = context.Operators.End(gv_);
+						Period gx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> gy_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime gz_ = context.Operators.Start(gy_);
+						CqlQuantity ha_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime hb_ = context.Operators.Subtract(gz_, ha_);
+						CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime he_ = context.Operators.Start(hd_);
+						CqlInterval<CqlDateTime> hf_ = context.Operators.Interval(hb_, he_, true, true);
+						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
+						CqlInterval<CqlDateTime> hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime hj_ = context.Operators.Start(hi_);
+						bool? hk_ = context.Operators.Not((bool?)(hj_ is null));
+						bool? hl_ = context.Operators.And(hg_, hk_);
+						bool? hm_ = context.Operators.And(gt_, hl_);
 
 						return hm_;
 					};
-					var eo_ = context.Operators.Where<Encounter>(em_, en_);
+					IEnumerable<Encounter> eo_ = context.Operators.Where<Encounter>(em_, en_);
 					object ep_(Encounter @this)
 					{
-						var hn_ = @this?.Period;
-						var ho_ = FHIRHelpers_4_3_000.ToInterval(hn_);
-						var hp_ = context.Operators.End(ho_);
+						Period hn_ = @this?.Period;
+						CqlInterval<CqlDateTime> ho_ = FHIRHelpers_4_3_000.ToInterval(hn_);
+						CqlDateTime hp_ = context.Operators.End(ho_);
 
 						return hp_;
 					};
-					var eq_ = context.Operators.SortBy<Encounter>(eo_, ep_, System.ComponentModel.ListSortDirection.Ascending);
-					var er_ = context.Operators.Last<Encounter>(eq_);
-					var es_ = er_?.Period;
-					var et_ = FHIRHelpers_4_3_000.ToInterval(es_);
-					var eu_ = context.Operators.Start(et_);
-					var ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var ex_ = context.Operators.Start(ew_);
-					var ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
-					var ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
-					var fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> eq_ = context.Operators.SortBy<Encounter>(eo_, ep_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter er_ = context.Operators.Last<Encounter>(eq_);
+					Period es_ = er_?.Period;
+					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(es_);
+					CqlDateTime eu_ = context.Operators.Start(et_);
+					CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime ex_ = context.Operators.Start(ew_);
+					CqlInterval<CqlDateTime> ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
+					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
+					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? fc_(Encounter LastObs)
 					{
-						var hq_ = LastObs?.StatusElement;
-						var hr_ = hq_?.Value;
-						var hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
-						var ht_ = context.Operators.Equal(hs_, "finished");
-						var hu_ = LastObs?.Period;
-						var hv_ = FHIRHelpers_4_3_000.ToInterval(hu_);
-						var hw_ = context.Operators.End(hv_);
-						var hx_ = Visit?.Period;
-						var hy_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var hz_ = context.Operators.Start(hy_);
-						var ia_ = context.Operators.Quantity(1m, "hour");
-						var ib_ = context.Operators.Subtract(hz_, ia_);
-						var id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var ie_ = context.Operators.Start(id_);
-						var if_ = context.Operators.Interval(ib_, ie_, true, true);
-						var ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
-						var ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var ij_ = context.Operators.Start(ii_);
-						var ik_ = context.Operators.Not((bool?)(ij_ is null));
-						var il_ = context.Operators.And(ig_, ik_);
-						var im_ = context.Operators.And(ht_, il_);
+						Code<Encounter.EncounterStatus> hq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? hr_ = hq_?.Value;
+						Code<Encounter.EncounterStatus> hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
+						bool? ht_ = context.Operators.Equal(hs_, "finished");
+						Period hu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> hv_ = FHIRHelpers_4_3_000.ToInterval(hu_);
+						CqlDateTime hw_ = context.Operators.End(hv_);
+						Period hx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> hy_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime hz_ = context.Operators.Start(hy_);
+						CqlQuantity ia_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime ib_ = context.Operators.Subtract(hz_, ia_);
+						CqlInterval<CqlDateTime> id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime ie_ = context.Operators.Start(id_);
+						CqlInterval<CqlDateTime> if_ = context.Operators.Interval(ib_, ie_, true, true);
+						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
+						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime ij_ = context.Operators.Start(ii_);
+						bool? ik_ = context.Operators.Not((bool?)(ij_ is null));
+						bool? il_ = context.Operators.And(ig_, ik_);
+						bool? im_ = context.Operators.And(ht_, il_);
 
 						return im_;
 					};
-					var fd_ = context.Operators.Where<Encounter>(fb_, fc_);
+					IEnumerable<Encounter> fd_ = context.Operators.Where<Encounter>(fb_, fc_);
 					object fe_(Encounter @this)
 					{
-						var in_ = @this?.Period;
-						var io_ = FHIRHelpers_4_3_000.ToInterval(in_);
-						var ip_ = context.Operators.End(io_);
+						Period in_ = @this?.Period;
+						CqlInterval<CqlDateTime> io_ = FHIRHelpers_4_3_000.ToInterval(in_);
+						CqlDateTime ip_ = context.Operators.End(io_);
 
 						return ip_;
 					};
-					var ff_ = context.Operators.SortBy<Encounter>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
-					var fg_ = context.Operators.Last<Encounter>(ff_);
-					var fh_ = fg_?.Period;
-					var fi_ = FHIRHelpers_4_3_000.ToInterval(fh_);
-					var fj_ = context.Operators.Start(fi_);
-					var fl_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var fm_ = context.Operators.Start(fl_);
-					var fn_ = context.Operators.Not((bool?)((fj_ ?? fm_) is null));
-					var fo_ = context.Operators.And(ez_, fn_);
-					var fp_ = context.Operators.And(ds_, fo_);
+					IEnumerable<Encounter> ff_ = context.Operators.SortBy<Encounter>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter fg_ = context.Operators.Last<Encounter>(ff_);
+					Period fh_ = fg_?.Period;
+					CqlInterval<CqlDateTime> fi_ = FHIRHelpers_4_3_000.ToInterval(fh_);
+					CqlDateTime fj_ = context.Operators.Start(fi_);
+					CqlInterval<CqlDateTime> fl_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime fm_ = context.Operators.Start(fl_);
+					bool? fn_ = context.Operators.Not((bool?)((fj_ ?? fm_) is null));
+					bool? fo_ = context.Operators.And(ez_, fn_);
+					bool? fp_ = context.Operators.And(ds_, fo_);
 
 					return fp_;
 				};
-				var av_ = context.Operators.Where<Encounter>(at_, au_);
+				IEnumerable<Encounter> av_ = context.Operators.Where<Encounter>(at_, au_);
 				object aw_(Encounter @this)
 				{
-					var iq_ = @this?.Period;
-					var ir_ = FHIRHelpers_4_3_000.ToInterval(iq_);
-					var is_ = context.Operators.End(ir_);
+					Period iq_ = @this?.Period;
+					CqlInterval<CqlDateTime> ir_ = FHIRHelpers_4_3_000.ToInterval(iq_);
+					CqlDateTime is_ = context.Operators.End(ir_);
 
 					return is_;
 				};
-				var ax_ = context.Operators.SortBy<Encounter>(av_, aw_, System.ComponentModel.ListSortDirection.Ascending);
-				var ay_ = context.Operators.Last<Encounter>(ax_);
-				var az_ = ay_?.Period;
-				var ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
-				var bb_ = context.Operators.Start(ba_);
-				var bc_ = this.Observation_Services();
-				var bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> ax_ = context.Operators.SortBy<Encounter>(av_, aw_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter ay_ = context.Operators.Last<Encounter>(ax_);
+				Period az_ = ay_?.Period;
+				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
+				CqlDateTime bb_ = context.Operators.Start(ba_);
+				CqlValueSet bc_ = this.Observation_Services();
+				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? be_(Encounter LastObs)
 				{
-					var it_ = LastObs?.StatusElement;
-					var iu_ = it_?.Value;
-					var iv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iu_);
-					var iw_ = context.Operators.Equal(iv_, "finished");
-					var ix_ = LastObs?.Period;
-					var iy_ = FHIRHelpers_4_3_000.ToInterval(ix_);
-					var iz_ = context.Operators.End(iy_);
-					var ja_ = Visit?.Period;
-					var jb_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jc_ = context.Operators.Start(jb_);
-					var jd_ = context.Operators.Quantity(1m, "hour");
-					var je_ = context.Operators.Subtract(jc_, jd_);
-					var jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jh_ = context.Operators.Start(jg_);
-					var ji_ = context.Operators.Interval(je_, jh_, true, true);
-					var jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
-					var jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jm_ = context.Operators.Start(jl_);
-					var jn_ = context.Operators.Not((bool?)(jm_ is null));
-					var jo_ = context.Operators.And(jj_, jn_);
-					var jp_ = context.Operators.And(iw_, jo_);
+					Code<Encounter.EncounterStatus> it_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? iu_ = it_?.Value;
+					Code<Encounter.EncounterStatus> iv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iu_);
+					bool? iw_ = context.Operators.Equal(iv_, "finished");
+					Period ix_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> iy_ = FHIRHelpers_4_3_000.ToInterval(ix_);
+					CqlDateTime iz_ = context.Operators.End(iy_);
+					Period ja_ = Visit?.Period;
+					CqlInterval<CqlDateTime> jb_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jc_ = context.Operators.Start(jb_);
+					CqlQuantity jd_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime je_ = context.Operators.Subtract(jc_, jd_);
+					CqlInterval<CqlDateTime> jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jh_ = context.Operators.Start(jg_);
+					CqlInterval<CqlDateTime> ji_ = context.Operators.Interval(je_, jh_, true, true);
+					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
+					CqlInterval<CqlDateTime> jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jm_ = context.Operators.Start(jl_);
+					bool? jn_ = context.Operators.Not((bool?)(jm_ is null));
+					bool? jo_ = context.Operators.And(jj_, jn_);
+					bool? jp_ = context.Operators.And(iw_, jo_);
 
 					return jp_;
 				};
-				var bf_ = context.Operators.Where<Encounter>(bd_, be_);
+				IEnumerable<Encounter> bf_ = context.Operators.Where<Encounter>(bd_, be_);
 				object bg_(Encounter @this)
 				{
-					var jq_ = @this?.Period;
-					var jr_ = FHIRHelpers_4_3_000.ToInterval(jq_);
-					var js_ = context.Operators.End(jr_);
+					Period jq_ = @this?.Period;
+					CqlInterval<CqlDateTime> jr_ = FHIRHelpers_4_3_000.ToInterval(jq_);
+					CqlDateTime js_ = context.Operators.End(jr_);
 
 					return js_;
 				};
-				var bh_ = context.Operators.SortBy<Encounter>(bf_, bg_, System.ComponentModel.ListSortDirection.Ascending);
-				var bi_ = context.Operators.Last<Encounter>(bh_);
-				var bj_ = bi_?.Period;
-				var bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
-				var bl_ = context.Operators.Start(bk_);
-				var bm_ = Visit?.Period;
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var bo_ = context.Operators.Start(bn_);
-				var bp_ = context.Operators.Quantity(1m, "hour");
-				var bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
-				var bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> bh_ = context.Operators.SortBy<Encounter>(bf_, bg_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bi_ = context.Operators.Last<Encounter>(bh_);
+				Period bj_ = bi_?.Period;
+				CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
+				CqlDateTime bl_ = context.Operators.Start(bk_);
+				Period bm_ = Visit?.Period;
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlQuantity bp_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
+				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? bt_(Encounter LastED)
 				{
-					var jt_ = LastED?.StatusElement;
-					var ju_ = jt_?.Value;
-					var jv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ju_);
-					var jw_ = context.Operators.Equal(jv_, "finished");
-					var jx_ = LastED?.Period;
-					var jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
-					var jz_ = context.Operators.End(jy_);
-					var ka_ = this.Observation_Services();
-					var kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					Code<Encounter.EncounterStatus> jt_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? ju_ = jt_?.Value;
+					Code<Encounter.EncounterStatus> jv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ju_);
+					bool? jw_ = context.Operators.Equal(jv_, "finished");
+					Period jx_ = LastED?.Period;
+					CqlInterval<CqlDateTime> jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
+					CqlDateTime jz_ = context.Operators.End(jy_);
+					CqlValueSet ka_ = this.Observation_Services();
+					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? kc_(Encounter LastObs)
 					{
-						var lu_ = LastObs?.StatusElement;
-						var lv_ = lu_?.Value;
-						var lw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lv_);
-						var lx_ = context.Operators.Equal(lw_, "finished");
-						var ly_ = LastObs?.Period;
-						var lz_ = FHIRHelpers_4_3_000.ToInterval(ly_);
-						var ma_ = context.Operators.End(lz_);
-						var mb_ = Visit?.Period;
-						var mc_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var md_ = context.Operators.Start(mc_);
-						var me_ = context.Operators.Quantity(1m, "hour");
-						var mf_ = context.Operators.Subtract(md_, me_);
-						var mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var mi_ = context.Operators.Start(mh_);
-						var mj_ = context.Operators.Interval(mf_, mi_, true, true);
-						var mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
-						var mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var mn_ = context.Operators.Start(mm_);
-						var mo_ = context.Operators.Not((bool?)(mn_ is null));
-						var mp_ = context.Operators.And(mk_, mo_);
-						var mq_ = context.Operators.And(lx_, mp_);
+						Code<Encounter.EncounterStatus> lu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? lv_ = lu_?.Value;
+						Code<Encounter.EncounterStatus> lw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lv_);
+						bool? lx_ = context.Operators.Equal(lw_, "finished");
+						Period ly_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> lz_ = FHIRHelpers_4_3_000.ToInterval(ly_);
+						CqlDateTime ma_ = context.Operators.End(lz_);
+						Period mb_ = Visit?.Period;
+						CqlInterval<CqlDateTime> mc_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime md_ = context.Operators.Start(mc_);
+						CqlQuantity me_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime mf_ = context.Operators.Subtract(md_, me_);
+						CqlInterval<CqlDateTime> mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime mi_ = context.Operators.Start(mh_);
+						CqlInterval<CqlDateTime> mj_ = context.Operators.Interval(mf_, mi_, true, true);
+						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
+						CqlInterval<CqlDateTime> mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime mn_ = context.Operators.Start(mm_);
+						bool? mo_ = context.Operators.Not((bool?)(mn_ is null));
+						bool? mp_ = context.Operators.And(mk_, mo_);
+						bool? mq_ = context.Operators.And(lx_, mp_);
 
 						return mq_;
 					};
-					var kd_ = context.Operators.Where<Encounter>(kb_, kc_);
+					IEnumerable<Encounter> kd_ = context.Operators.Where<Encounter>(kb_, kc_);
 					object ke_(Encounter @this)
 					{
-						var mr_ = @this?.Period;
-						var ms_ = FHIRHelpers_4_3_000.ToInterval(mr_);
-						var mt_ = context.Operators.End(ms_);
+						Period mr_ = @this?.Period;
+						CqlInterval<CqlDateTime> ms_ = FHIRHelpers_4_3_000.ToInterval(mr_);
+						CqlDateTime mt_ = context.Operators.End(ms_);
 
 						return mt_;
 					};
-					var kf_ = context.Operators.SortBy<Encounter>(kd_, ke_, System.ComponentModel.ListSortDirection.Ascending);
-					var kg_ = context.Operators.Last<Encounter>(kf_);
-					var kh_ = kg_?.Period;
-					var ki_ = FHIRHelpers_4_3_000.ToInterval(kh_);
-					var kj_ = context.Operators.Start(ki_);
-					var kk_ = Visit?.Period;
-					var kl_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var km_ = context.Operators.Start(kl_);
-					var kn_ = context.Operators.Quantity(1m, "hour");
-					var ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
-					var kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> kf_ = context.Operators.SortBy<Encounter>(kd_, ke_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter kg_ = context.Operators.Last<Encounter>(kf_);
+					Period kh_ = kg_?.Period;
+					CqlInterval<CqlDateTime> ki_ = FHIRHelpers_4_3_000.ToInterval(kh_);
+					CqlDateTime kj_ = context.Operators.Start(ki_);
+					Period kk_ = Visit?.Period;
+					CqlInterval<CqlDateTime> kl_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime km_ = context.Operators.Start(kl_);
+					CqlQuantity kn_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
+					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? kr_(Encounter LastObs)
 					{
-						var mu_ = LastObs?.StatusElement;
-						var mv_ = mu_?.Value;
-						var mw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mv_);
-						var mx_ = context.Operators.Equal(mw_, "finished");
-						var my_ = LastObs?.Period;
-						var mz_ = FHIRHelpers_4_3_000.ToInterval(my_);
-						var na_ = context.Operators.End(mz_);
-						var nb_ = Visit?.Period;
-						var nc_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var nd_ = context.Operators.Start(nc_);
-						var ne_ = context.Operators.Quantity(1m, "hour");
-						var nf_ = context.Operators.Subtract(nd_, ne_);
-						var nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var ni_ = context.Operators.Start(nh_);
-						var nj_ = context.Operators.Interval(nf_, ni_, true, true);
-						var nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
-						var nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var nn_ = context.Operators.Start(nm_);
-						var no_ = context.Operators.Not((bool?)(nn_ is null));
-						var np_ = context.Operators.And(nk_, no_);
-						var nq_ = context.Operators.And(mx_, np_);
+						Code<Encounter.EncounterStatus> mu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? mv_ = mu_?.Value;
+						Code<Encounter.EncounterStatus> mw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mv_);
+						bool? mx_ = context.Operators.Equal(mw_, "finished");
+						Period my_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> mz_ = FHIRHelpers_4_3_000.ToInterval(my_);
+						CqlDateTime na_ = context.Operators.End(mz_);
+						Period nb_ = Visit?.Period;
+						CqlInterval<CqlDateTime> nc_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime nd_ = context.Operators.Start(nc_);
+						CqlQuantity ne_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime nf_ = context.Operators.Subtract(nd_, ne_);
+						CqlInterval<CqlDateTime> nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime ni_ = context.Operators.Start(nh_);
+						CqlInterval<CqlDateTime> nj_ = context.Operators.Interval(nf_, ni_, true, true);
+						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
+						CqlInterval<CqlDateTime> nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime nn_ = context.Operators.Start(nm_);
+						bool? no_ = context.Operators.Not((bool?)(nn_ is null));
+						bool? np_ = context.Operators.And(nk_, no_);
+						bool? nq_ = context.Operators.And(mx_, np_);
 
 						return nq_;
 					};
-					var ks_ = context.Operators.Where<Encounter>(kq_, kr_);
+					IEnumerable<Encounter> ks_ = context.Operators.Where<Encounter>(kq_, kr_);
 					object kt_(Encounter @this)
 					{
-						var nr_ = @this?.Period;
-						var ns_ = FHIRHelpers_4_3_000.ToInterval(nr_);
-						var nt_ = context.Operators.End(ns_);
+						Period nr_ = @this?.Period;
+						CqlInterval<CqlDateTime> ns_ = FHIRHelpers_4_3_000.ToInterval(nr_);
+						CqlDateTime nt_ = context.Operators.End(ns_);
 
 						return nt_;
 					};
-					var ku_ = context.Operators.SortBy<Encounter>(ks_, kt_, System.ComponentModel.ListSortDirection.Ascending);
-					var kv_ = context.Operators.Last<Encounter>(ku_);
-					var kw_ = kv_?.Period;
-					var kx_ = FHIRHelpers_4_3_000.ToInterval(kw_);
-					var ky_ = context.Operators.Start(kx_);
-					var la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var lb_ = context.Operators.Start(la_);
-					var lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
-					var ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
-					var lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> ku_ = context.Operators.SortBy<Encounter>(ks_, kt_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter kv_ = context.Operators.Last<Encounter>(ku_);
+					Period kw_ = kv_?.Period;
+					CqlInterval<CqlDateTime> kx_ = FHIRHelpers_4_3_000.ToInterval(kw_);
+					CqlDateTime ky_ = context.Operators.Start(kx_);
+					CqlInterval<CqlDateTime> la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime lb_ = context.Operators.Start(la_);
+					CqlInterval<CqlDateTime> lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
+					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
+					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? lg_(Encounter LastObs)
 					{
-						var nu_ = LastObs?.StatusElement;
-						var nv_ = nu_?.Value;
-						var nw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nv_);
-						var nx_ = context.Operators.Equal(nw_, "finished");
-						var ny_ = LastObs?.Period;
-						var nz_ = FHIRHelpers_4_3_000.ToInterval(ny_);
-						var oa_ = context.Operators.End(nz_);
-						var ob_ = Visit?.Period;
-						var oc_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var od_ = context.Operators.Start(oc_);
-						var oe_ = context.Operators.Quantity(1m, "hour");
-						var of_ = context.Operators.Subtract(od_, oe_);
-						var oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var oi_ = context.Operators.Start(oh_);
-						var oj_ = context.Operators.Interval(of_, oi_, true, true);
-						var ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
-						var om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var on_ = context.Operators.Start(om_);
-						var oo_ = context.Operators.Not((bool?)(on_ is null));
-						var op_ = context.Operators.And(ok_, oo_);
-						var oq_ = context.Operators.And(nx_, op_);
+						Code<Encounter.EncounterStatus> nu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? nv_ = nu_?.Value;
+						Code<Encounter.EncounterStatus> nw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nv_);
+						bool? nx_ = context.Operators.Equal(nw_, "finished");
+						Period ny_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> nz_ = FHIRHelpers_4_3_000.ToInterval(ny_);
+						CqlDateTime oa_ = context.Operators.End(nz_);
+						Period ob_ = Visit?.Period;
+						CqlInterval<CqlDateTime> oc_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime od_ = context.Operators.Start(oc_);
+						CqlQuantity oe_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime of_ = context.Operators.Subtract(od_, oe_);
+						CqlInterval<CqlDateTime> oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime oi_ = context.Operators.Start(oh_);
+						CqlInterval<CqlDateTime> oj_ = context.Operators.Interval(of_, oi_, true, true);
+						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
+						CqlInterval<CqlDateTime> om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime on_ = context.Operators.Start(om_);
+						bool? oo_ = context.Operators.Not((bool?)(on_ is null));
+						bool? op_ = context.Operators.And(ok_, oo_);
+						bool? oq_ = context.Operators.And(nx_, op_);
 
 						return oq_;
 					};
-					var lh_ = context.Operators.Where<Encounter>(lf_, lg_);
+					IEnumerable<Encounter> lh_ = context.Operators.Where<Encounter>(lf_, lg_);
 					object li_(Encounter @this)
 					{
-						var or_ = @this?.Period;
-						var os_ = FHIRHelpers_4_3_000.ToInterval(or_);
-						var ot_ = context.Operators.End(os_);
+						Period or_ = @this?.Period;
+						CqlInterval<CqlDateTime> os_ = FHIRHelpers_4_3_000.ToInterval(or_);
+						CqlDateTime ot_ = context.Operators.End(os_);
 
 						return ot_;
 					};
-					var lj_ = context.Operators.SortBy<Encounter>(lh_, li_, System.ComponentModel.ListSortDirection.Ascending);
-					var lk_ = context.Operators.Last<Encounter>(lj_);
-					var ll_ = lk_?.Period;
-					var lm_ = FHIRHelpers_4_3_000.ToInterval(ll_);
-					var ln_ = context.Operators.Start(lm_);
-					var lp_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var lq_ = context.Operators.Start(lp_);
-					var lr_ = context.Operators.Not((bool?)((ln_ ?? lq_) is null));
-					var ls_ = context.Operators.And(ld_, lr_);
-					var lt_ = context.Operators.And(jw_, ls_);
+					IEnumerable<Encounter> lj_ = context.Operators.SortBy<Encounter>(lh_, li_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter lk_ = context.Operators.Last<Encounter>(lj_);
+					Period ll_ = lk_?.Period;
+					CqlInterval<CqlDateTime> lm_ = FHIRHelpers_4_3_000.ToInterval(ll_);
+					CqlDateTime ln_ = context.Operators.Start(lm_);
+					CqlInterval<CqlDateTime> lp_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime lq_ = context.Operators.Start(lp_);
+					bool? lr_ = context.Operators.Not((bool?)((ln_ ?? lq_) is null));
+					bool? ls_ = context.Operators.And(ld_, lr_);
+					bool? lt_ = context.Operators.And(jw_, ls_);
 
 					return lt_;
 				};
-				var bu_ = context.Operators.Where<Encounter>(bs_, bt_);
+				IEnumerable<Encounter> bu_ = context.Operators.Where<Encounter>(bs_, bt_);
 				object bv_(Encounter @this)
 				{
-					var ou_ = @this?.Period;
-					var ov_ = FHIRHelpers_4_3_000.ToInterval(ou_);
-					var ow_ = context.Operators.End(ov_);
+					Period ou_ = @this?.Period;
+					CqlInterval<CqlDateTime> ov_ = FHIRHelpers_4_3_000.ToInterval(ou_);
+					CqlDateTime ow_ = context.Operators.End(ov_);
 
 					return ow_;
 				};
-				var bw_ = context.Operators.SortBy<Encounter>(bu_, bv_, System.ComponentModel.ListSortDirection.Ascending);
-				var bx_ = context.Operators.Last<Encounter>(bw_);
-				var by_ = bx_?.Period;
-				var bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
-				var ca_ = context.Operators.Start(bz_);
-				var cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> bw_ = context.Operators.SortBy<Encounter>(bu_, bv_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bx_ = context.Operators.Last<Encounter>(bw_);
+				Period by_ = bx_?.Period;
+				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
+				CqlDateTime ca_ = context.Operators.Start(bz_);
+				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? cd_(Encounter LastObs)
 				{
-					var ox_ = LastObs?.StatusElement;
-					var oy_ = ox_?.Value;
-					var oz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oy_);
-					var pa_ = context.Operators.Equal(oz_, "finished");
-					var pb_ = LastObs?.Period;
-					var pc_ = FHIRHelpers_4_3_000.ToInterval(pb_);
-					var pd_ = context.Operators.End(pc_);
-					var pe_ = Visit?.Period;
-					var pf_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pg_ = context.Operators.Start(pf_);
-					var ph_ = context.Operators.Quantity(1m, "hour");
-					var pi_ = context.Operators.Subtract(pg_, ph_);
-					var pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pl_ = context.Operators.Start(pk_);
-					var pm_ = context.Operators.Interval(pi_, pl_, true, true);
-					var pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
-					var pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pq_ = context.Operators.Start(pp_);
-					var pr_ = context.Operators.Not((bool?)(pq_ is null));
-					var ps_ = context.Operators.And(pn_, pr_);
-					var pt_ = context.Operators.And(pa_, ps_);
+					Code<Encounter.EncounterStatus> ox_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? oy_ = ox_?.Value;
+					Code<Encounter.EncounterStatus> oz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oy_);
+					bool? pa_ = context.Operators.Equal(oz_, "finished");
+					Period pb_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> pc_ = FHIRHelpers_4_3_000.ToInterval(pb_);
+					CqlDateTime pd_ = context.Operators.End(pc_);
+					Period pe_ = Visit?.Period;
+					CqlInterval<CqlDateTime> pf_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pg_ = context.Operators.Start(pf_);
+					CqlQuantity ph_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime pi_ = context.Operators.Subtract(pg_, ph_);
+					CqlInterval<CqlDateTime> pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pl_ = context.Operators.Start(pk_);
+					CqlInterval<CqlDateTime> pm_ = context.Operators.Interval(pi_, pl_, true, true);
+					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
+					CqlInterval<CqlDateTime> pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pq_ = context.Operators.Start(pp_);
+					bool? pr_ = context.Operators.Not((bool?)(pq_ is null));
+					bool? ps_ = context.Operators.And(pn_, pr_);
+					bool? pt_ = context.Operators.And(pa_, ps_);
 
 					return pt_;
 				};
-				var ce_ = context.Operators.Where<Encounter>(cc_, cd_);
+				IEnumerable<Encounter> ce_ = context.Operators.Where<Encounter>(cc_, cd_);
 				object cf_(Encounter @this)
 				{
-					var pu_ = @this?.Period;
-					var pv_ = FHIRHelpers_4_3_000.ToInterval(pu_);
-					var pw_ = context.Operators.End(pv_);
+					Period pu_ = @this?.Period;
+					CqlInterval<CqlDateTime> pv_ = FHIRHelpers_4_3_000.ToInterval(pu_);
+					CqlDateTime pw_ = context.Operators.End(pv_);
 
 					return pw_;
 				};
-				var cg_ = context.Operators.SortBy<Encounter>(ce_, cf_, System.ComponentModel.ListSortDirection.Ascending);
-				var ch_ = context.Operators.Last<Encounter>(cg_);
-				var ci_ = ch_?.Period;
-				var cj_ = FHIRHelpers_4_3_000.ToInterval(ci_);
-				var ck_ = context.Operators.Start(cj_);
-				var cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var cn_ = context.Operators.Start(cm_);
-				var co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
-				var cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
-				var cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> cg_ = context.Operators.SortBy<Encounter>(ce_, cf_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter ch_ = context.Operators.Last<Encounter>(cg_);
+				Period ci_ = ch_?.Period;
+				CqlInterval<CqlDateTime> cj_ = FHIRHelpers_4_3_000.ToInterval(ci_);
+				CqlDateTime ck_ = context.Operators.Start(cj_);
+				CqlInterval<CqlDateTime> cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime cn_ = context.Operators.Start(cm_);
+				CqlInterval<CqlDateTime> co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
+				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
+				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? cs_(Encounter LastED)
 				{
-					var px_ = LastED?.StatusElement;
-					var py_ = px_?.Value;
-					var pz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(py_);
-					var qa_ = context.Operators.Equal(pz_, "finished");
-					var qb_ = LastED?.Period;
-					var qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
-					var qd_ = context.Operators.End(qc_);
-					var qe_ = this.Observation_Services();
-					var qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					Code<Encounter.EncounterStatus> px_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? py_ = px_?.Value;
+					Code<Encounter.EncounterStatus> pz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(py_);
+					bool? qa_ = context.Operators.Equal(pz_, "finished");
+					Period qb_ = LastED?.Period;
+					CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
+					CqlDateTime qd_ = context.Operators.End(qc_);
+					CqlValueSet qe_ = this.Observation_Services();
+					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? qg_(Encounter LastObs)
 					{
-						var ry_ = LastObs?.StatusElement;
-						var rz_ = ry_?.Value;
-						var sa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rz_);
-						var sb_ = context.Operators.Equal(sa_, "finished");
-						var sc_ = LastObs?.Period;
-						var sd_ = FHIRHelpers_4_3_000.ToInterval(sc_);
-						var se_ = context.Operators.End(sd_);
-						var sf_ = Visit?.Period;
-						var sg_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sh_ = context.Operators.Start(sg_);
-						var si_ = context.Operators.Quantity(1m, "hour");
-						var sj_ = context.Operators.Subtract(sh_, si_);
-						var sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sm_ = context.Operators.Start(sl_);
-						var sn_ = context.Operators.Interval(sj_, sm_, true, true);
-						var so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
-						var sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sr_ = context.Operators.Start(sq_);
-						var ss_ = context.Operators.Not((bool?)(sr_ is null));
-						var st_ = context.Operators.And(so_, ss_);
-						var su_ = context.Operators.And(sb_, st_);
+						Code<Encounter.EncounterStatus> ry_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? rz_ = ry_?.Value;
+						Code<Encounter.EncounterStatus> sa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rz_);
+						bool? sb_ = context.Operators.Equal(sa_, "finished");
+						Period sc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> sd_ = FHIRHelpers_4_3_000.ToInterval(sc_);
+						CqlDateTime se_ = context.Operators.End(sd_);
+						Period sf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> sg_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sh_ = context.Operators.Start(sg_);
+						CqlQuantity si_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime sj_ = context.Operators.Subtract(sh_, si_);
+						CqlInterval<CqlDateTime> sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sm_ = context.Operators.Start(sl_);
+						CqlInterval<CqlDateTime> sn_ = context.Operators.Interval(sj_, sm_, true, true);
+						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
+						CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sr_ = context.Operators.Start(sq_);
+						bool? ss_ = context.Operators.Not((bool?)(sr_ is null));
+						bool? st_ = context.Operators.And(so_, ss_);
+						bool? su_ = context.Operators.And(sb_, st_);
 
 						return su_;
 					};
-					var qh_ = context.Operators.Where<Encounter>(qf_, qg_);
+					IEnumerable<Encounter> qh_ = context.Operators.Where<Encounter>(qf_, qg_);
 					object qi_(Encounter @this)
 					{
-						var sv_ = @this?.Period;
-						var sw_ = FHIRHelpers_4_3_000.ToInterval(sv_);
-						var sx_ = context.Operators.End(sw_);
+						Period sv_ = @this?.Period;
+						CqlInterval<CqlDateTime> sw_ = FHIRHelpers_4_3_000.ToInterval(sv_);
+						CqlDateTime sx_ = context.Operators.End(sw_);
 
 						return sx_;
 					};
-					var qj_ = context.Operators.SortBy<Encounter>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
-					var qk_ = context.Operators.Last<Encounter>(qj_);
-					var ql_ = qk_?.Period;
-					var qm_ = FHIRHelpers_4_3_000.ToInterval(ql_);
-					var qn_ = context.Operators.Start(qm_);
-					var qo_ = Visit?.Period;
-					var qp_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var qq_ = context.Operators.Start(qp_);
-					var qr_ = context.Operators.Quantity(1m, "hour");
-					var qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
-					var qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qj_ = context.Operators.SortBy<Encounter>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter qk_ = context.Operators.Last<Encounter>(qj_);
+					Period ql_ = qk_?.Period;
+					CqlInterval<CqlDateTime> qm_ = FHIRHelpers_4_3_000.ToInterval(ql_);
+					CqlDateTime qn_ = context.Operators.Start(qm_);
+					Period qo_ = Visit?.Period;
+					CqlInterval<CqlDateTime> qp_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime qq_ = context.Operators.Start(qp_);
+					CqlQuantity qr_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
+					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? qv_(Encounter LastObs)
 					{
-						var sy_ = LastObs?.StatusElement;
-						var sz_ = sy_?.Value;
-						var ta_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sz_);
-						var tb_ = context.Operators.Equal(ta_, "finished");
-						var tc_ = LastObs?.Period;
-						var td_ = FHIRHelpers_4_3_000.ToInterval(tc_);
-						var te_ = context.Operators.End(td_);
-						var tf_ = Visit?.Period;
-						var tg_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var th_ = context.Operators.Start(tg_);
-						var ti_ = context.Operators.Quantity(1m, "hour");
-						var tj_ = context.Operators.Subtract(th_, ti_);
-						var tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var tm_ = context.Operators.Start(tl_);
-						var tn_ = context.Operators.Interval(tj_, tm_, true, true);
-						var to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
-						var tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var tr_ = context.Operators.Start(tq_);
-						var ts_ = context.Operators.Not((bool?)(tr_ is null));
-						var tt_ = context.Operators.And(to_, ts_);
-						var tu_ = context.Operators.And(tb_, tt_);
+						Code<Encounter.EncounterStatus> sy_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? sz_ = sy_?.Value;
+						Code<Encounter.EncounterStatus> ta_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sz_);
+						bool? tb_ = context.Operators.Equal(ta_, "finished");
+						Period tc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> td_ = FHIRHelpers_4_3_000.ToInterval(tc_);
+						CqlDateTime te_ = context.Operators.End(td_);
+						Period tf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> tg_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime th_ = context.Operators.Start(tg_);
+						CqlQuantity ti_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime tj_ = context.Operators.Subtract(th_, ti_);
+						CqlInterval<CqlDateTime> tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime tm_ = context.Operators.Start(tl_);
+						CqlInterval<CqlDateTime> tn_ = context.Operators.Interval(tj_, tm_, true, true);
+						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
+						CqlInterval<CqlDateTime> tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime tr_ = context.Operators.Start(tq_);
+						bool? ts_ = context.Operators.Not((bool?)(tr_ is null));
+						bool? tt_ = context.Operators.And(to_, ts_);
+						bool? tu_ = context.Operators.And(tb_, tt_);
 
 						return tu_;
 					};
-					var qw_ = context.Operators.Where<Encounter>(qu_, qv_);
+					IEnumerable<Encounter> qw_ = context.Operators.Where<Encounter>(qu_, qv_);
 					object qx_(Encounter @this)
 					{
-						var tv_ = @this?.Period;
-						var tw_ = FHIRHelpers_4_3_000.ToInterval(tv_);
-						var tx_ = context.Operators.End(tw_);
+						Period tv_ = @this?.Period;
+						CqlInterval<CqlDateTime> tw_ = FHIRHelpers_4_3_000.ToInterval(tv_);
+						CqlDateTime tx_ = context.Operators.End(tw_);
 
 						return tx_;
 					};
-					var qy_ = context.Operators.SortBy<Encounter>(qw_, qx_, System.ComponentModel.ListSortDirection.Ascending);
-					var qz_ = context.Operators.Last<Encounter>(qy_);
-					var ra_ = qz_?.Period;
-					var rb_ = FHIRHelpers_4_3_000.ToInterval(ra_);
-					var rc_ = context.Operators.Start(rb_);
-					var re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var rf_ = context.Operators.Start(re_);
-					var rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
-					var rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
-					var rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qy_ = context.Operators.SortBy<Encounter>(qw_, qx_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter qz_ = context.Operators.Last<Encounter>(qy_);
+					Period ra_ = qz_?.Period;
+					CqlInterval<CqlDateTime> rb_ = FHIRHelpers_4_3_000.ToInterval(ra_);
+					CqlDateTime rc_ = context.Operators.Start(rb_);
+					CqlInterval<CqlDateTime> re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime rf_ = context.Operators.Start(re_);
+					CqlInterval<CqlDateTime> rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
+					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
+					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? rk_(Encounter LastObs)
 					{
-						var ty_ = LastObs?.StatusElement;
-						var tz_ = ty_?.Value;
-						var ua_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tz_);
-						var ub_ = context.Operators.Equal(ua_, "finished");
-						var uc_ = LastObs?.Period;
-						var ud_ = FHIRHelpers_4_3_000.ToInterval(uc_);
-						var ue_ = context.Operators.End(ud_);
-						var uf_ = Visit?.Period;
-						var ug_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var uh_ = context.Operators.Start(ug_);
-						var ui_ = context.Operators.Quantity(1m, "hour");
-						var uj_ = context.Operators.Subtract(uh_, ui_);
-						var ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var um_ = context.Operators.Start(ul_);
-						var un_ = context.Operators.Interval(uj_, um_, true, true);
-						var uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
-						var uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var ur_ = context.Operators.Start(uq_);
-						var us_ = context.Operators.Not((bool?)(ur_ is null));
-						var ut_ = context.Operators.And(uo_, us_);
-						var uu_ = context.Operators.And(ub_, ut_);
+						Code<Encounter.EncounterStatus> ty_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? tz_ = ty_?.Value;
+						Code<Encounter.EncounterStatus> ua_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tz_);
+						bool? ub_ = context.Operators.Equal(ua_, "finished");
+						Period uc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> ud_ = FHIRHelpers_4_3_000.ToInterval(uc_);
+						CqlDateTime ue_ = context.Operators.End(ud_);
+						Period uf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> ug_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime uh_ = context.Operators.Start(ug_);
+						CqlQuantity ui_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime uj_ = context.Operators.Subtract(uh_, ui_);
+						CqlInterval<CqlDateTime> ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime um_ = context.Operators.Start(ul_);
+						CqlInterval<CqlDateTime> un_ = context.Operators.Interval(uj_, um_, true, true);
+						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
+						CqlInterval<CqlDateTime> uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime ur_ = context.Operators.Start(uq_);
+						bool? us_ = context.Operators.Not((bool?)(ur_ is null));
+						bool? ut_ = context.Operators.And(uo_, us_);
+						bool? uu_ = context.Operators.And(ub_, ut_);
 
 						return uu_;
 					};
-					var rl_ = context.Operators.Where<Encounter>(rj_, rk_);
+					IEnumerable<Encounter> rl_ = context.Operators.Where<Encounter>(rj_, rk_);
 					object rm_(Encounter @this)
 					{
-						var uv_ = @this?.Period;
-						var uw_ = FHIRHelpers_4_3_000.ToInterval(uv_);
-						var ux_ = context.Operators.End(uw_);
+						Period uv_ = @this?.Period;
+						CqlInterval<CqlDateTime> uw_ = FHIRHelpers_4_3_000.ToInterval(uv_);
+						CqlDateTime ux_ = context.Operators.End(uw_);
 
 						return ux_;
 					};
-					var rn_ = context.Operators.SortBy<Encounter>(rl_, rm_, System.ComponentModel.ListSortDirection.Ascending);
-					var ro_ = context.Operators.Last<Encounter>(rn_);
-					var rp_ = ro_?.Period;
-					var rq_ = FHIRHelpers_4_3_000.ToInterval(rp_);
-					var rr_ = context.Operators.Start(rq_);
-					var rt_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var ru_ = context.Operators.Start(rt_);
-					var rv_ = context.Operators.Not((bool?)((rr_ ?? ru_) is null));
-					var rw_ = context.Operators.And(rh_, rv_);
-					var rx_ = context.Operators.And(qa_, rw_);
+					IEnumerable<Encounter> rn_ = context.Operators.SortBy<Encounter>(rl_, rm_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter ro_ = context.Operators.Last<Encounter>(rn_);
+					Period rp_ = ro_?.Period;
+					CqlInterval<CqlDateTime> rq_ = FHIRHelpers_4_3_000.ToInterval(rp_);
+					CqlDateTime rr_ = context.Operators.Start(rq_);
+					CqlInterval<CqlDateTime> rt_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime ru_ = context.Operators.Start(rt_);
+					bool? rv_ = context.Operators.Not((bool?)((rr_ ?? ru_) is null));
+					bool? rw_ = context.Operators.And(rh_, rv_);
+					bool? rx_ = context.Operators.And(qa_, rw_);
 
 					return rx_;
 				};
-				var ct_ = context.Operators.Where<Encounter>(cr_, cs_);
+				IEnumerable<Encounter> ct_ = context.Operators.Where<Encounter>(cr_, cs_);
 				object cu_(Encounter @this)
 				{
-					var uy_ = @this?.Period;
-					var uz_ = FHIRHelpers_4_3_000.ToInterval(uy_);
-					var va_ = context.Operators.End(uz_);
+					Period uy_ = @this?.Period;
+					CqlInterval<CqlDateTime> uz_ = FHIRHelpers_4_3_000.ToInterval(uy_);
+					CqlDateTime va_ = context.Operators.End(uz_);
 
 					return va_;
 				};
-				var cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
-				var cw_ = context.Operators.Last<Encounter>(cv_);
-				var cx_ = cw_?.Period;
-				var cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
-				var cz_ = context.Operators.Start(cy_);
-				var db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter cw_ = context.Operators.Last<Encounter>(cv_);
+				Period cx_ = cw_?.Period;
+				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
+				CqlDateTime cz_ = context.Operators.Start(cy_);
+				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? dc_(Encounter LastObs)
 				{
-					var vb_ = LastObs?.StatusElement;
-					var vc_ = vb_?.Value;
-					var vd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vc_);
-					var ve_ = context.Operators.Equal(vd_, "finished");
-					var vf_ = LastObs?.Period;
-					var vg_ = FHIRHelpers_4_3_000.ToInterval(vf_);
-					var vh_ = context.Operators.End(vg_);
-					var vi_ = Visit?.Period;
-					var vj_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vk_ = context.Operators.Start(vj_);
-					var vl_ = context.Operators.Quantity(1m, "hour");
-					var vm_ = context.Operators.Subtract(vk_, vl_);
-					var vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vp_ = context.Operators.Start(vo_);
-					var vq_ = context.Operators.Interval(vm_, vp_, true, true);
-					var vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
-					var vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vu_ = context.Operators.Start(vt_);
-					var vv_ = context.Operators.Not((bool?)(vu_ is null));
-					var vw_ = context.Operators.And(vr_, vv_);
-					var vx_ = context.Operators.And(ve_, vw_);
+					Code<Encounter.EncounterStatus> vb_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? vc_ = vb_?.Value;
+					Code<Encounter.EncounterStatus> vd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vc_);
+					bool? ve_ = context.Operators.Equal(vd_, "finished");
+					Period vf_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> vg_ = FHIRHelpers_4_3_000.ToInterval(vf_);
+					CqlDateTime vh_ = context.Operators.End(vg_);
+					Period vi_ = Visit?.Period;
+					CqlInterval<CqlDateTime> vj_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vk_ = context.Operators.Start(vj_);
+					CqlQuantity vl_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime vm_ = context.Operators.Subtract(vk_, vl_);
+					CqlInterval<CqlDateTime> vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vp_ = context.Operators.Start(vo_);
+					CqlInterval<CqlDateTime> vq_ = context.Operators.Interval(vm_, vp_, true, true);
+					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
+					CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vu_ = context.Operators.Start(vt_);
+					bool? vv_ = context.Operators.Not((bool?)(vu_ is null));
+					bool? vw_ = context.Operators.And(vr_, vv_);
+					bool? vx_ = context.Operators.And(ve_, vw_);
 
 					return vx_;
 				};
-				var dd_ = context.Operators.Where<Encounter>(db_, dc_);
+				IEnumerable<Encounter> dd_ = context.Operators.Where<Encounter>(db_, dc_);
 				object de_(Encounter @this)
 				{
-					var vy_ = @this?.Period;
-					var vz_ = FHIRHelpers_4_3_000.ToInterval(vy_);
-					var wa_ = context.Operators.End(vz_);
+					Period vy_ = @this?.Period;
+					CqlInterval<CqlDateTime> vz_ = FHIRHelpers_4_3_000.ToInterval(vy_);
+					CqlDateTime wa_ = context.Operators.End(vz_);
 
 					return wa_;
 				};
-				var df_ = context.Operators.SortBy<Encounter>(dd_, de_, System.ComponentModel.ListSortDirection.Ascending);
-				var dg_ = context.Operators.Last<Encounter>(df_);
-				var dh_ = dg_?.Period;
-				var di_ = FHIRHelpers_4_3_000.ToInterval(dh_);
-				var dj_ = context.Operators.Start(di_);
-				var dl_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var dm_ = context.Operators.Start(dl_);
-				var dn_ = context.Operators.Not((bool?)((cz_ ?? (dj_ ?? dm_)) is null));
-				var do_ = context.Operators.And(cp_, dn_);
+				IEnumerable<Encounter> df_ = context.Operators.SortBy<Encounter>(dd_, de_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter dg_ = context.Operators.Last<Encounter>(df_);
+				Period dh_ = dg_?.Period;
+				CqlInterval<CqlDateTime> di_ = FHIRHelpers_4_3_000.ToInterval(dh_);
+				CqlDateTime dj_ = context.Operators.Start(di_);
+				CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime dm_ = context.Operators.Start(dl_);
+				bool? dn_ = context.Operators.Not((bool?)((cz_ ?? (dj_ ?? dm_)) is null));
+				bool? do_ = context.Operators.And(cp_, dn_);
 
 				return do_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var wb_ = @this?.Period;
-				var wc_ = FHIRHelpers_4_3_000.ToInterval(wb_);
-				var wd_ = context.Operators.End(wc_);
+				Period wb_ = @this?.Period;
+				CqlInterval<CqlDateTime> wc_ = FHIRHelpers_4_3_000.ToInterval(wb_);
+				CqlDateTime wd_ = context.Operators.End(wc_);
 
 				return wd_;
 			};
-			var j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Encounter>(j_);
-			var l_ = k_?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Emergency_Department_Visit();
-			var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter k_ = context.Operators.Last<Encounter>(j_);
+			Period l_ = k_?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlValueSet o_ = this.Emergency_Department_Visit();
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
 			bool? q_(Encounter LastED)
 			{
-				var we_ = LastED?.StatusElement;
-				var wf_ = we_?.Value;
-				var wg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wf_);
-				var wh_ = context.Operators.Equal(wg_, "finished");
-				var wi_ = LastED?.Period;
-				var wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
-				var wk_ = context.Operators.End(wj_);
-				var wl_ = this.Observation_Services();
-				var wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				Code<Encounter.EncounterStatus> we_ = LastED?.StatusElement;
+				Encounter.EncounterStatus? wf_ = we_?.Value;
+				Code<Encounter.EncounterStatus> wg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wf_);
+				bool? wh_ = context.Operators.Equal(wg_, "finished");
+				Period wi_ = LastED?.Period;
+				CqlInterval<CqlDateTime> wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
+				CqlDateTime wk_ = context.Operators.End(wj_);
+				CqlValueSet wl_ = this.Observation_Services();
+				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? wn_(Encounter LastObs)
 				{
-					var yf_ = LastObs?.StatusElement;
-					var yg_ = yf_?.Value;
-					var yh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(yg_);
-					var yi_ = context.Operators.Equal(yh_, "finished");
-					var yj_ = LastObs?.Period;
-					var yk_ = FHIRHelpers_4_3_000.ToInterval(yj_);
-					var yl_ = context.Operators.End(yk_);
-					var ym_ = Visit?.Period;
-					var yn_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yo_ = context.Operators.Start(yn_);
-					var yp_ = context.Operators.Quantity(1m, "hour");
-					var yq_ = context.Operators.Subtract(yo_, yp_);
-					var ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yt_ = context.Operators.Start(ys_);
-					var yu_ = context.Operators.Interval(yq_, yt_, true, true);
-					var yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
-					var yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yy_ = context.Operators.Start(yx_);
-					var yz_ = context.Operators.Not((bool?)(yy_ is null));
-					var za_ = context.Operators.And(yv_, yz_);
-					var zb_ = context.Operators.And(yi_, za_);
+					Code<Encounter.EncounterStatus> yf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? yg_ = yf_?.Value;
+					Code<Encounter.EncounterStatus> yh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(yg_);
+					bool? yi_ = context.Operators.Equal(yh_, "finished");
+					Period yj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> yk_ = FHIRHelpers_4_3_000.ToInterval(yj_);
+					CqlDateTime yl_ = context.Operators.End(yk_);
+					Period ym_ = Visit?.Period;
+					CqlInterval<CqlDateTime> yn_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yo_ = context.Operators.Start(yn_);
+					CqlQuantity yp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime yq_ = context.Operators.Subtract(yo_, yp_);
+					CqlInterval<CqlDateTime> ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yt_ = context.Operators.Start(ys_);
+					CqlInterval<CqlDateTime> yu_ = context.Operators.Interval(yq_, yt_, true, true);
+					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
+					CqlInterval<CqlDateTime> yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yy_ = context.Operators.Start(yx_);
+					bool? yz_ = context.Operators.Not((bool?)(yy_ is null));
+					bool? za_ = context.Operators.And(yv_, yz_);
+					bool? zb_ = context.Operators.And(yi_, za_);
 
 					return zb_;
 				};
-				var wo_ = context.Operators.Where<Encounter>(wm_, wn_);
+				IEnumerable<Encounter> wo_ = context.Operators.Where<Encounter>(wm_, wn_);
 				object wp_(Encounter @this)
 				{
-					var zc_ = @this?.Period;
-					var zd_ = FHIRHelpers_4_3_000.ToInterval(zc_);
-					var ze_ = context.Operators.End(zd_);
+					Period zc_ = @this?.Period;
+					CqlInterval<CqlDateTime> zd_ = FHIRHelpers_4_3_000.ToInterval(zc_);
+					CqlDateTime ze_ = context.Operators.End(zd_);
 
 					return ze_;
 				};
-				var wq_ = context.Operators.SortBy<Encounter>(wo_, wp_, System.ComponentModel.ListSortDirection.Ascending);
-				var wr_ = context.Operators.Last<Encounter>(wq_);
-				var ws_ = wr_?.Period;
-				var wt_ = FHIRHelpers_4_3_000.ToInterval(ws_);
-				var wu_ = context.Operators.Start(wt_);
-				var wv_ = Visit?.Period;
-				var ww_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var wx_ = context.Operators.Start(ww_);
-				var wy_ = context.Operators.Quantity(1m, "hour");
-				var wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
-				var xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> wq_ = context.Operators.SortBy<Encounter>(wo_, wp_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter wr_ = context.Operators.Last<Encounter>(wq_);
+				Period ws_ = wr_?.Period;
+				CqlInterval<CqlDateTime> wt_ = FHIRHelpers_4_3_000.ToInterval(ws_);
+				CqlDateTime wu_ = context.Operators.Start(wt_);
+				Period wv_ = Visit?.Period;
+				CqlInterval<CqlDateTime> ww_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime wx_ = context.Operators.Start(ww_);
+				CqlQuantity wy_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
+				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? xc_(Encounter LastObs)
 				{
-					var zf_ = LastObs?.StatusElement;
-					var zg_ = zf_?.Value;
-					var zh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(zg_);
-					var zi_ = context.Operators.Equal(zh_, "finished");
-					var zj_ = LastObs?.Period;
-					var zk_ = FHIRHelpers_4_3_000.ToInterval(zj_);
-					var zl_ = context.Operators.End(zk_);
-					var zm_ = Visit?.Period;
-					var zn_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zo_ = context.Operators.Start(zn_);
-					var zp_ = context.Operators.Quantity(1m, "hour");
-					var zq_ = context.Operators.Subtract(zo_, zp_);
-					var zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zt_ = context.Operators.Start(zs_);
-					var zu_ = context.Operators.Interval(zq_, zt_, true, true);
-					var zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
-					var zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zy_ = context.Operators.Start(zx_);
-					var zz_ = context.Operators.Not((bool?)(zy_ is null));
-					var aza_ = context.Operators.And(zv_, zz_);
-					var azb_ = context.Operators.And(zi_, aza_);
+					Code<Encounter.EncounterStatus> zf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? zg_ = zf_?.Value;
+					Code<Encounter.EncounterStatus> zh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(zg_);
+					bool? zi_ = context.Operators.Equal(zh_, "finished");
+					Period zj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> zk_ = FHIRHelpers_4_3_000.ToInterval(zj_);
+					CqlDateTime zl_ = context.Operators.End(zk_);
+					Period zm_ = Visit?.Period;
+					CqlInterval<CqlDateTime> zn_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zo_ = context.Operators.Start(zn_);
+					CqlQuantity zp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime zq_ = context.Operators.Subtract(zo_, zp_);
+					CqlInterval<CqlDateTime> zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zt_ = context.Operators.Start(zs_);
+					CqlInterval<CqlDateTime> zu_ = context.Operators.Interval(zq_, zt_, true, true);
+					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
+					CqlInterval<CqlDateTime> zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zy_ = context.Operators.Start(zx_);
+					bool? zz_ = context.Operators.Not((bool?)(zy_ is null));
+					bool? aza_ = context.Operators.And(zv_, zz_);
+					bool? azb_ = context.Operators.And(zi_, aza_);
 
 					return azb_;
 				};
-				var xd_ = context.Operators.Where<Encounter>(xb_, xc_);
+				IEnumerable<Encounter> xd_ = context.Operators.Where<Encounter>(xb_, xc_);
 				object xe_(Encounter @this)
 				{
-					var azc_ = @this?.Period;
-					var azd_ = FHIRHelpers_4_3_000.ToInterval(azc_);
-					var aze_ = context.Operators.End(azd_);
+					Period azc_ = @this?.Period;
+					CqlInterval<CqlDateTime> azd_ = FHIRHelpers_4_3_000.ToInterval(azc_);
+					CqlDateTime aze_ = context.Operators.End(azd_);
 
 					return aze_;
 				};
-				var xf_ = context.Operators.SortBy<Encounter>(xd_, xe_, System.ComponentModel.ListSortDirection.Ascending);
-				var xg_ = context.Operators.Last<Encounter>(xf_);
-				var xh_ = xg_?.Period;
-				var xi_ = FHIRHelpers_4_3_000.ToInterval(xh_);
-				var xj_ = context.Operators.Start(xi_);
-				var xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var xm_ = context.Operators.Start(xl_);
-				var xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
-				var xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
-				var xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> xf_ = context.Operators.SortBy<Encounter>(xd_, xe_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter xg_ = context.Operators.Last<Encounter>(xf_);
+				Period xh_ = xg_?.Period;
+				CqlInterval<CqlDateTime> xi_ = FHIRHelpers_4_3_000.ToInterval(xh_);
+				CqlDateTime xj_ = context.Operators.Start(xi_);
+				CqlInterval<CqlDateTime> xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime xm_ = context.Operators.Start(xl_);
+				CqlInterval<CqlDateTime> xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
+				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
+				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? xr_(Encounter LastObs)
 				{
-					var azf_ = LastObs?.StatusElement;
-					var azg_ = azf_?.Value;
-					var azh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(azg_);
-					var azi_ = context.Operators.Equal(azh_, "finished");
-					var azj_ = LastObs?.Period;
-					var azk_ = FHIRHelpers_4_3_000.ToInterval(azj_);
-					var azl_ = context.Operators.End(azk_);
-					var azm_ = Visit?.Period;
-					var azn_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azo_ = context.Operators.Start(azn_);
-					var azp_ = context.Operators.Quantity(1m, "hour");
-					var azq_ = context.Operators.Subtract(azo_, azp_);
-					var azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azt_ = context.Operators.Start(azs_);
-					var azu_ = context.Operators.Interval(azq_, azt_, true, true);
-					var azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
-					var azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azy_ = context.Operators.Start(azx_);
-					var azz_ = context.Operators.Not((bool?)(azy_ is null));
-					var bza_ = context.Operators.And(azv_, azz_);
-					var bzb_ = context.Operators.And(azi_, bza_);
+					Code<Encounter.EncounterStatus> azf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? azg_ = azf_?.Value;
+					Code<Encounter.EncounterStatus> azh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(azg_);
+					bool? azi_ = context.Operators.Equal(azh_, "finished");
+					Period azj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> azk_ = FHIRHelpers_4_3_000.ToInterval(azj_);
+					CqlDateTime azl_ = context.Operators.End(azk_);
+					Period azm_ = Visit?.Period;
+					CqlInterval<CqlDateTime> azn_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azo_ = context.Operators.Start(azn_);
+					CqlQuantity azp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime azq_ = context.Operators.Subtract(azo_, azp_);
+					CqlInterval<CqlDateTime> azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azt_ = context.Operators.Start(azs_);
+					CqlInterval<CqlDateTime> azu_ = context.Operators.Interval(azq_, azt_, true, true);
+					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
+					CqlInterval<CqlDateTime> azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azy_ = context.Operators.Start(azx_);
+					bool? azz_ = context.Operators.Not((bool?)(azy_ is null));
+					bool? bza_ = context.Operators.And(azv_, azz_);
+					bool? bzb_ = context.Operators.And(azi_, bza_);
 
 					return bzb_;
 				};
-				var xs_ = context.Operators.Where<Encounter>(xq_, xr_);
+				IEnumerable<Encounter> xs_ = context.Operators.Where<Encounter>(xq_, xr_);
 				object xt_(Encounter @this)
 				{
-					var bzc_ = @this?.Period;
-					var bzd_ = FHIRHelpers_4_3_000.ToInterval(bzc_);
-					var bze_ = context.Operators.End(bzd_);
+					Period bzc_ = @this?.Period;
+					CqlInterval<CqlDateTime> bzd_ = FHIRHelpers_4_3_000.ToInterval(bzc_);
+					CqlDateTime bze_ = context.Operators.End(bzd_);
 
 					return bze_;
 				};
-				var xu_ = context.Operators.SortBy<Encounter>(xs_, xt_, System.ComponentModel.ListSortDirection.Ascending);
-				var xv_ = context.Operators.Last<Encounter>(xu_);
-				var xw_ = xv_?.Period;
-				var xx_ = FHIRHelpers_4_3_000.ToInterval(xw_);
-				var xy_ = context.Operators.Start(xx_);
-				var ya_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var yb_ = context.Operators.Start(ya_);
-				var yc_ = context.Operators.Not((bool?)((xy_ ?? yb_) is null));
-				var yd_ = context.Operators.And(xo_, yc_);
-				var ye_ = context.Operators.And(wh_, yd_);
+				IEnumerable<Encounter> xu_ = context.Operators.SortBy<Encounter>(xs_, xt_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter xv_ = context.Operators.Last<Encounter>(xu_);
+				Period xw_ = xv_?.Period;
+				CqlInterval<CqlDateTime> xx_ = FHIRHelpers_4_3_000.ToInterval(xw_);
+				CqlDateTime xy_ = context.Operators.Start(xx_);
+				CqlInterval<CqlDateTime> ya_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime yb_ = context.Operators.Start(ya_);
+				bool? yc_ = context.Operators.Not((bool?)((xy_ ?? yb_) is null));
+				bool? yd_ = context.Operators.And(xo_, yc_);
+				bool? ye_ = context.Operators.And(wh_, yd_);
 
 				return ye_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 			object s_(Encounter @this)
 			{
-				var bzf_ = @this?.Period;
-				var bzg_ = FHIRHelpers_4_3_000.ToInterval(bzf_);
-				var bzh_ = context.Operators.End(bzg_);
+				Period bzf_ = @this?.Period;
+				CqlInterval<CqlDateTime> bzg_ = FHIRHelpers_4_3_000.ToInterval(bzf_);
+				CqlDateTime bzh_ = context.Operators.End(bzg_);
 
 				return bzh_;
 			};
-			var t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.Last<Encounter>(t_);
-			var v_ = u_?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
-			var y_ = this.Observation_Services();
-			var z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
+			IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter u_ = context.Operators.Last<Encounter>(t_);
+			Period v_ = u_?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			CqlValueSet y_ = this.Observation_Services();
+			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
 			bool? aa_(Encounter LastObs)
 			{
-				var bzi_ = LastObs?.StatusElement;
-				var bzj_ = bzi_?.Value;
-				var bzk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bzj_);
-				var bzl_ = context.Operators.Equal(bzk_, "finished");
-				var bzm_ = LastObs?.Period;
-				var bzn_ = FHIRHelpers_4_3_000.ToInterval(bzm_);
-				var bzo_ = context.Operators.End(bzn_);
-				var bzp_ = Visit?.Period;
-				var bzq_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var bzr_ = context.Operators.Start(bzq_);
-				var bzs_ = context.Operators.Quantity(1m, "hour");
-				var bzt_ = context.Operators.Subtract(bzr_, bzs_);
-				var bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var bzw_ = context.Operators.Start(bzv_);
-				var bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
-				var bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
-				var cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var czb_ = context.Operators.Start(cza_);
-				var czc_ = context.Operators.Not((bool?)(czb_ is null));
-				var czd_ = context.Operators.And(bzy_, czc_);
-				var cze_ = context.Operators.And(bzl_, czd_);
+				Code<Encounter.EncounterStatus> bzi_ = LastObs?.StatusElement;
+				Encounter.EncounterStatus? bzj_ = bzi_?.Value;
+				Code<Encounter.EncounterStatus> bzk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bzj_);
+				bool? bzl_ = context.Operators.Equal(bzk_, "finished");
+				Period bzm_ = LastObs?.Period;
+				CqlInterval<CqlDateTime> bzn_ = FHIRHelpers_4_3_000.ToInterval(bzm_);
+				CqlDateTime bzo_ = context.Operators.End(bzn_);
+				Period bzp_ = Visit?.Period;
+				CqlInterval<CqlDateTime> bzq_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime bzr_ = context.Operators.Start(bzq_);
+				CqlQuantity bzs_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime bzt_ = context.Operators.Subtract(bzr_, bzs_);
+				CqlInterval<CqlDateTime> bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime bzw_ = context.Operators.Start(bzv_);
+				CqlInterval<CqlDateTime> bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
+				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
+				CqlInterval<CqlDateTime> cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime czb_ = context.Operators.Start(cza_);
+				bool? czc_ = context.Operators.Not((bool?)(czb_ is null));
+				bool? czd_ = context.Operators.And(bzy_, czc_);
+				bool? cze_ = context.Operators.And(bzl_, czd_);
 
 				return cze_;
 			};
-			var ab_ = context.Operators.Where<Encounter>(z_, aa_);
+			IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
 			object ac_(Encounter @this)
 			{
-				var czf_ = @this?.Period;
-				var czg_ = FHIRHelpers_4_3_000.ToInterval(czf_);
-				var czh_ = context.Operators.End(czg_);
+				Period czf_ = @this?.Period;
+				CqlInterval<CqlDateTime> czg_ = FHIRHelpers_4_3_000.ToInterval(czf_);
+				CqlDateTime czh_ = context.Operators.End(czg_);
 
 				return czh_;
 			};
-			var ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
-			var ae_ = context.Operators.Last<Encounter>(ad_);
-			var af_ = ae_?.Period;
-			var ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-			var ah_ = context.Operators.Start(ag_);
-			var ai_ = Visit?.Period;
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-			var ak_ = context.Operators.Start(aj_);
-			var am_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-			var an_ = context.Operators.End(am_);
-			var ao_ = context.Operators.Interval((n_ ?? (x_ ?? (ah_ ?? ak_))), an_, true, true);
+			IEnumerable<Encounter> ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter ae_ = context.Operators.Last<Encounter>(ad_);
+			Period af_ = ae_?.Period;
+			CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
+			CqlDateTime ah_ = context.Operators.Start(ag_);
+			Period ai_ = Visit?.Period;
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+			CqlDateTime an_ = context.Operators.End(am_);
+			CqlInterval<CqlDateTime> ao_ = context.Operators.Interval((n_ ?? (x_ ?? (ah_ ?? ak_))), an_, true, true);
 
 			return ao_;
 		};
-		var c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
+		CqlInterval<CqlDateTime> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
 
 		return d_;
 	}
@@ -1587,888 +1613,888 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Hospitalization with Observation and Outpatient Surgery Service returns the total interval from the start of any immediately prior emergency department visit, outpatient surgery visit or observation visit to the discharge of the given encounter.")]
 	public CqlInterval<CqlDateTime> hospitalizationWithObservationAndOutpatientSurgeryService(Encounter TheEncounter)
 	{
-		var a_ = new Encounter[]
+		Encounter[] a_ = new Encounter[]
 		{
 			TheEncounter,
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Outpatient_Surgery_Service();
-			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			CqlValueSet e_ = this.Outpatient_Surgery_Service();
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastSurgeryOP)
 			{
-				var ap_ = LastSurgeryOP?.Period;
-				var aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				var ar_ = context.Operators.End(aq_);
-				var as_ = this.Emergency_Department_Visit();
-				var at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				Period ap_ = LastSurgeryOP?.Period;
+				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
+				CqlDateTime ar_ = context.Operators.End(aq_);
+				CqlValueSet as_ = this.Emergency_Department_Visit();
+				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? au_(Encounter LastED)
 				{
-					var dp_ = LastED?.StatusElement;
-					var dq_ = dp_?.Value;
-					var dr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dq_);
-					var ds_ = context.Operators.Equal(dr_, "finished");
-					var dt_ = LastED?.Period;
-					var du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
-					var dv_ = context.Operators.End(du_);
-					var dw_ = this.Observation_Services();
-					var dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					Code<Encounter.EncounterStatus> dp_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? dq_ = dp_?.Value;
+					Code<Encounter.EncounterStatus> dr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dq_);
+					bool? ds_ = context.Operators.Equal(dr_, "finished");
+					Period dt_ = LastED?.Period;
+					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
+					CqlDateTime dv_ = context.Operators.End(du_);
+					CqlValueSet dw_ = this.Observation_Services();
+					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? dy_(Encounter LastObs)
 					{
-						var fq_ = LastObs?.StatusElement;
-						var fr_ = fq_?.Value;
-						var fs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fr_);
-						var ft_ = context.Operators.Equal(fs_, "finished");
-						var fu_ = LastObs?.Period;
-						var fv_ = FHIRHelpers_4_3_000.ToInterval(fu_);
-						var fw_ = context.Operators.End(fv_);
-						var fx_ = Visit?.Period;
-						var fy_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var fz_ = context.Operators.Start(fy_);
-						var ga_ = context.Operators.Quantity(1m, "hour");
-						var gb_ = context.Operators.Subtract(fz_, ga_);
-						var gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var ge_ = context.Operators.Start(gd_);
-						var gf_ = context.Operators.Interval(gb_, ge_, true, true);
-						var gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
-						var gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var gj_ = context.Operators.Start(gi_);
-						var gk_ = context.Operators.Not((bool?)(gj_ is null));
-						var gl_ = context.Operators.And(gg_, gk_);
-						var gm_ = context.Operators.And(ft_, gl_);
+						Code<Encounter.EncounterStatus> fq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? fr_ = fq_?.Value;
+						Code<Encounter.EncounterStatus> fs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fr_);
+						bool? ft_ = context.Operators.Equal(fs_, "finished");
+						Period fu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> fv_ = FHIRHelpers_4_3_000.ToInterval(fu_);
+						CqlDateTime fw_ = context.Operators.End(fv_);
+						Period fx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> fy_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime fz_ = context.Operators.Start(fy_);
+						CqlQuantity ga_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime gb_ = context.Operators.Subtract(fz_, ga_);
+						CqlInterval<CqlDateTime> gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime ge_ = context.Operators.Start(gd_);
+						CqlInterval<CqlDateTime> gf_ = context.Operators.Interval(gb_, ge_, true, true);
+						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
+						CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime gj_ = context.Operators.Start(gi_);
+						bool? gk_ = context.Operators.Not((bool?)(gj_ is null));
+						bool? gl_ = context.Operators.And(gg_, gk_);
+						bool? gm_ = context.Operators.And(ft_, gl_);
 
 						return gm_;
 					};
-					var dz_ = context.Operators.Where<Encounter>(dx_, dy_);
+					IEnumerable<Encounter> dz_ = context.Operators.Where<Encounter>(dx_, dy_);
 					object ea_(Encounter @this)
 					{
-						var gn_ = @this?.Period;
-						var go_ = FHIRHelpers_4_3_000.ToInterval(gn_);
-						var gp_ = context.Operators.End(go_);
+						Period gn_ = @this?.Period;
+						CqlInterval<CqlDateTime> go_ = FHIRHelpers_4_3_000.ToInterval(gn_);
+						CqlDateTime gp_ = context.Operators.End(go_);
 
 						return gp_;
 					};
-					var eb_ = context.Operators.SortBy<Encounter>(dz_, ea_, System.ComponentModel.ListSortDirection.Ascending);
-					var ec_ = context.Operators.Last<Encounter>(eb_);
-					var ed_ = ec_?.Period;
-					var ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
-					var ef_ = context.Operators.Start(ee_);
-					var eg_ = Visit?.Period;
-					var eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var ei_ = context.Operators.Start(eh_);
-					var ej_ = context.Operators.Quantity(1m, "hour");
-					var ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
-					var em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> eb_ = context.Operators.SortBy<Encounter>(dz_, ea_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter ec_ = context.Operators.Last<Encounter>(eb_);
+					Period ed_ = ec_?.Period;
+					CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
+					CqlDateTime ef_ = context.Operators.Start(ee_);
+					Period eg_ = Visit?.Period;
+					CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime ei_ = context.Operators.Start(eh_);
+					CqlQuantity ej_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
+					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? en_(Encounter LastObs)
 					{
-						var gq_ = LastObs?.StatusElement;
-						var gr_ = gq_?.Value;
-						var gs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gr_);
-						var gt_ = context.Operators.Equal(gs_, "finished");
-						var gu_ = LastObs?.Period;
-						var gv_ = FHIRHelpers_4_3_000.ToInterval(gu_);
-						var gw_ = context.Operators.End(gv_);
-						var gx_ = Visit?.Period;
-						var gy_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var gz_ = context.Operators.Start(gy_);
-						var ha_ = context.Operators.Quantity(1m, "hour");
-						var hb_ = context.Operators.Subtract(gz_, ha_);
-						var hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var he_ = context.Operators.Start(hd_);
-						var hf_ = context.Operators.Interval(hb_, he_, true, true);
-						var hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
-						var hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var hj_ = context.Operators.Start(hi_);
-						var hk_ = context.Operators.Not((bool?)(hj_ is null));
-						var hl_ = context.Operators.And(hg_, hk_);
-						var hm_ = context.Operators.And(gt_, hl_);
+						Code<Encounter.EncounterStatus> gq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? gr_ = gq_?.Value;
+						Code<Encounter.EncounterStatus> gs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gr_);
+						bool? gt_ = context.Operators.Equal(gs_, "finished");
+						Period gu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> gv_ = FHIRHelpers_4_3_000.ToInterval(gu_);
+						CqlDateTime gw_ = context.Operators.End(gv_);
+						Period gx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> gy_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime gz_ = context.Operators.Start(gy_);
+						CqlQuantity ha_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime hb_ = context.Operators.Subtract(gz_, ha_);
+						CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime he_ = context.Operators.Start(hd_);
+						CqlInterval<CqlDateTime> hf_ = context.Operators.Interval(hb_, he_, true, true);
+						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
+						CqlInterval<CqlDateTime> hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime hj_ = context.Operators.Start(hi_);
+						bool? hk_ = context.Operators.Not((bool?)(hj_ is null));
+						bool? hl_ = context.Operators.And(hg_, hk_);
+						bool? hm_ = context.Operators.And(gt_, hl_);
 
 						return hm_;
 					};
-					var eo_ = context.Operators.Where<Encounter>(em_, en_);
+					IEnumerable<Encounter> eo_ = context.Operators.Where<Encounter>(em_, en_);
 					object ep_(Encounter @this)
 					{
-						var hn_ = @this?.Period;
-						var ho_ = FHIRHelpers_4_3_000.ToInterval(hn_);
-						var hp_ = context.Operators.End(ho_);
+						Period hn_ = @this?.Period;
+						CqlInterval<CqlDateTime> ho_ = FHIRHelpers_4_3_000.ToInterval(hn_);
+						CqlDateTime hp_ = context.Operators.End(ho_);
 
 						return hp_;
 					};
-					var eq_ = context.Operators.SortBy<Encounter>(eo_, ep_, System.ComponentModel.ListSortDirection.Ascending);
-					var er_ = context.Operators.Last<Encounter>(eq_);
-					var es_ = er_?.Period;
-					var et_ = FHIRHelpers_4_3_000.ToInterval(es_);
-					var eu_ = context.Operators.Start(et_);
-					var ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var ex_ = context.Operators.Start(ew_);
-					var ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
-					var ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
-					var fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> eq_ = context.Operators.SortBy<Encounter>(eo_, ep_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter er_ = context.Operators.Last<Encounter>(eq_);
+					Period es_ = er_?.Period;
+					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(es_);
+					CqlDateTime eu_ = context.Operators.Start(et_);
+					CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime ex_ = context.Operators.Start(ew_);
+					CqlInterval<CqlDateTime> ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
+					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
+					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? fc_(Encounter LastObs)
 					{
-						var hq_ = LastObs?.StatusElement;
-						var hr_ = hq_?.Value;
-						var hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
-						var ht_ = context.Operators.Equal(hs_, "finished");
-						var hu_ = LastObs?.Period;
-						var hv_ = FHIRHelpers_4_3_000.ToInterval(hu_);
-						var hw_ = context.Operators.End(hv_);
-						var hx_ = Visit?.Period;
-						var hy_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var hz_ = context.Operators.Start(hy_);
-						var ia_ = context.Operators.Quantity(1m, "hour");
-						var ib_ = context.Operators.Subtract(hz_, ia_);
-						var id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var ie_ = context.Operators.Start(id_);
-						var if_ = context.Operators.Interval(ib_, ie_, true, true);
-						var ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
-						var ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var ij_ = context.Operators.Start(ii_);
-						var ik_ = context.Operators.Not((bool?)(ij_ is null));
-						var il_ = context.Operators.And(ig_, ik_);
-						var im_ = context.Operators.And(ht_, il_);
+						Code<Encounter.EncounterStatus> hq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? hr_ = hq_?.Value;
+						Code<Encounter.EncounterStatus> hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
+						bool? ht_ = context.Operators.Equal(hs_, "finished");
+						Period hu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> hv_ = FHIRHelpers_4_3_000.ToInterval(hu_);
+						CqlDateTime hw_ = context.Operators.End(hv_);
+						Period hx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> hy_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime hz_ = context.Operators.Start(hy_);
+						CqlQuantity ia_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime ib_ = context.Operators.Subtract(hz_, ia_);
+						CqlInterval<CqlDateTime> id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime ie_ = context.Operators.Start(id_);
+						CqlInterval<CqlDateTime> if_ = context.Operators.Interval(ib_, ie_, true, true);
+						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
+						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime ij_ = context.Operators.Start(ii_);
+						bool? ik_ = context.Operators.Not((bool?)(ij_ is null));
+						bool? il_ = context.Operators.And(ig_, ik_);
+						bool? im_ = context.Operators.And(ht_, il_);
 
 						return im_;
 					};
-					var fd_ = context.Operators.Where<Encounter>(fb_, fc_);
+					IEnumerable<Encounter> fd_ = context.Operators.Where<Encounter>(fb_, fc_);
 					object fe_(Encounter @this)
 					{
-						var in_ = @this?.Period;
-						var io_ = FHIRHelpers_4_3_000.ToInterval(in_);
-						var ip_ = context.Operators.End(io_);
+						Period in_ = @this?.Period;
+						CqlInterval<CqlDateTime> io_ = FHIRHelpers_4_3_000.ToInterval(in_);
+						CqlDateTime ip_ = context.Operators.End(io_);
 
 						return ip_;
 					};
-					var ff_ = context.Operators.SortBy<Encounter>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
-					var fg_ = context.Operators.Last<Encounter>(ff_);
-					var fh_ = fg_?.Period;
-					var fi_ = FHIRHelpers_4_3_000.ToInterval(fh_);
-					var fj_ = context.Operators.Start(fi_);
-					var fl_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var fm_ = context.Operators.Start(fl_);
-					var fn_ = context.Operators.Not((bool?)((fj_ ?? fm_) is null));
-					var fo_ = context.Operators.And(ez_, fn_);
-					var fp_ = context.Operators.And(ds_, fo_);
+					IEnumerable<Encounter> ff_ = context.Operators.SortBy<Encounter>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter fg_ = context.Operators.Last<Encounter>(ff_);
+					Period fh_ = fg_?.Period;
+					CqlInterval<CqlDateTime> fi_ = FHIRHelpers_4_3_000.ToInterval(fh_);
+					CqlDateTime fj_ = context.Operators.Start(fi_);
+					CqlInterval<CqlDateTime> fl_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime fm_ = context.Operators.Start(fl_);
+					bool? fn_ = context.Operators.Not((bool?)((fj_ ?? fm_) is null));
+					bool? fo_ = context.Operators.And(ez_, fn_);
+					bool? fp_ = context.Operators.And(ds_, fo_);
 
 					return fp_;
 				};
-				var av_ = context.Operators.Where<Encounter>(at_, au_);
+				IEnumerable<Encounter> av_ = context.Operators.Where<Encounter>(at_, au_);
 				object aw_(Encounter @this)
 				{
-					var iq_ = @this?.Period;
-					var ir_ = FHIRHelpers_4_3_000.ToInterval(iq_);
-					var is_ = context.Operators.End(ir_);
+					Period iq_ = @this?.Period;
+					CqlInterval<CqlDateTime> ir_ = FHIRHelpers_4_3_000.ToInterval(iq_);
+					CqlDateTime is_ = context.Operators.End(ir_);
 
 					return is_;
 				};
-				var ax_ = context.Operators.SortBy<Encounter>(av_, aw_, System.ComponentModel.ListSortDirection.Ascending);
-				var ay_ = context.Operators.Last<Encounter>(ax_);
-				var az_ = ay_?.Period;
-				var ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
-				var bb_ = context.Operators.Start(ba_);
-				var bc_ = this.Observation_Services();
-				var bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> ax_ = context.Operators.SortBy<Encounter>(av_, aw_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter ay_ = context.Operators.Last<Encounter>(ax_);
+				Period az_ = ay_?.Period;
+				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
+				CqlDateTime bb_ = context.Operators.Start(ba_);
+				CqlValueSet bc_ = this.Observation_Services();
+				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? be_(Encounter LastObs)
 				{
-					var it_ = LastObs?.StatusElement;
-					var iu_ = it_?.Value;
-					var iv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iu_);
-					var iw_ = context.Operators.Equal(iv_, "finished");
-					var ix_ = LastObs?.Period;
-					var iy_ = FHIRHelpers_4_3_000.ToInterval(ix_);
-					var iz_ = context.Operators.End(iy_);
-					var ja_ = Visit?.Period;
-					var jb_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jc_ = context.Operators.Start(jb_);
-					var jd_ = context.Operators.Quantity(1m, "hour");
-					var je_ = context.Operators.Subtract(jc_, jd_);
-					var jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jh_ = context.Operators.Start(jg_);
-					var ji_ = context.Operators.Interval(je_, jh_, true, true);
-					var jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
-					var jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jm_ = context.Operators.Start(jl_);
-					var jn_ = context.Operators.Not((bool?)(jm_ is null));
-					var jo_ = context.Operators.And(jj_, jn_);
-					var jp_ = context.Operators.And(iw_, jo_);
+					Code<Encounter.EncounterStatus> it_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? iu_ = it_?.Value;
+					Code<Encounter.EncounterStatus> iv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iu_);
+					bool? iw_ = context.Operators.Equal(iv_, "finished");
+					Period ix_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> iy_ = FHIRHelpers_4_3_000.ToInterval(ix_);
+					CqlDateTime iz_ = context.Operators.End(iy_);
+					Period ja_ = Visit?.Period;
+					CqlInterval<CqlDateTime> jb_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jc_ = context.Operators.Start(jb_);
+					CqlQuantity jd_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime je_ = context.Operators.Subtract(jc_, jd_);
+					CqlInterval<CqlDateTime> jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jh_ = context.Operators.Start(jg_);
+					CqlInterval<CqlDateTime> ji_ = context.Operators.Interval(je_, jh_, true, true);
+					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
+					CqlInterval<CqlDateTime> jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jm_ = context.Operators.Start(jl_);
+					bool? jn_ = context.Operators.Not((bool?)(jm_ is null));
+					bool? jo_ = context.Operators.And(jj_, jn_);
+					bool? jp_ = context.Operators.And(iw_, jo_);
 
 					return jp_;
 				};
-				var bf_ = context.Operators.Where<Encounter>(bd_, be_);
+				IEnumerable<Encounter> bf_ = context.Operators.Where<Encounter>(bd_, be_);
 				object bg_(Encounter @this)
 				{
-					var jq_ = @this?.Period;
-					var jr_ = FHIRHelpers_4_3_000.ToInterval(jq_);
-					var js_ = context.Operators.End(jr_);
+					Period jq_ = @this?.Period;
+					CqlInterval<CqlDateTime> jr_ = FHIRHelpers_4_3_000.ToInterval(jq_);
+					CqlDateTime js_ = context.Operators.End(jr_);
 
 					return js_;
 				};
-				var bh_ = context.Operators.SortBy<Encounter>(bf_, bg_, System.ComponentModel.ListSortDirection.Ascending);
-				var bi_ = context.Operators.Last<Encounter>(bh_);
-				var bj_ = bi_?.Period;
-				var bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
-				var bl_ = context.Operators.Start(bk_);
-				var bm_ = Visit?.Period;
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var bo_ = context.Operators.Start(bn_);
-				var bp_ = context.Operators.Quantity(1m, "hour");
-				var bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
-				var bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> bh_ = context.Operators.SortBy<Encounter>(bf_, bg_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bi_ = context.Operators.Last<Encounter>(bh_);
+				Period bj_ = bi_?.Period;
+				CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
+				CqlDateTime bl_ = context.Operators.Start(bk_);
+				Period bm_ = Visit?.Period;
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlQuantity bp_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
+				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? bt_(Encounter LastED)
 				{
-					var jt_ = LastED?.StatusElement;
-					var ju_ = jt_?.Value;
-					var jv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ju_);
-					var jw_ = context.Operators.Equal(jv_, "finished");
-					var jx_ = LastED?.Period;
-					var jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
-					var jz_ = context.Operators.End(jy_);
-					var ka_ = this.Observation_Services();
-					var kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					Code<Encounter.EncounterStatus> jt_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? ju_ = jt_?.Value;
+					Code<Encounter.EncounterStatus> jv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ju_);
+					bool? jw_ = context.Operators.Equal(jv_, "finished");
+					Period jx_ = LastED?.Period;
+					CqlInterval<CqlDateTime> jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
+					CqlDateTime jz_ = context.Operators.End(jy_);
+					CqlValueSet ka_ = this.Observation_Services();
+					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? kc_(Encounter LastObs)
 					{
-						var lu_ = LastObs?.StatusElement;
-						var lv_ = lu_?.Value;
-						var lw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lv_);
-						var lx_ = context.Operators.Equal(lw_, "finished");
-						var ly_ = LastObs?.Period;
-						var lz_ = FHIRHelpers_4_3_000.ToInterval(ly_);
-						var ma_ = context.Operators.End(lz_);
-						var mb_ = Visit?.Period;
-						var mc_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var md_ = context.Operators.Start(mc_);
-						var me_ = context.Operators.Quantity(1m, "hour");
-						var mf_ = context.Operators.Subtract(md_, me_);
-						var mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var mi_ = context.Operators.Start(mh_);
-						var mj_ = context.Operators.Interval(mf_, mi_, true, true);
-						var mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
-						var mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var mn_ = context.Operators.Start(mm_);
-						var mo_ = context.Operators.Not((bool?)(mn_ is null));
-						var mp_ = context.Operators.And(mk_, mo_);
-						var mq_ = context.Operators.And(lx_, mp_);
+						Code<Encounter.EncounterStatus> lu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? lv_ = lu_?.Value;
+						Code<Encounter.EncounterStatus> lw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lv_);
+						bool? lx_ = context.Operators.Equal(lw_, "finished");
+						Period ly_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> lz_ = FHIRHelpers_4_3_000.ToInterval(ly_);
+						CqlDateTime ma_ = context.Operators.End(lz_);
+						Period mb_ = Visit?.Period;
+						CqlInterval<CqlDateTime> mc_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime md_ = context.Operators.Start(mc_);
+						CqlQuantity me_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime mf_ = context.Operators.Subtract(md_, me_);
+						CqlInterval<CqlDateTime> mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime mi_ = context.Operators.Start(mh_);
+						CqlInterval<CqlDateTime> mj_ = context.Operators.Interval(mf_, mi_, true, true);
+						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
+						CqlInterval<CqlDateTime> mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime mn_ = context.Operators.Start(mm_);
+						bool? mo_ = context.Operators.Not((bool?)(mn_ is null));
+						bool? mp_ = context.Operators.And(mk_, mo_);
+						bool? mq_ = context.Operators.And(lx_, mp_);
 
 						return mq_;
 					};
-					var kd_ = context.Operators.Where<Encounter>(kb_, kc_);
+					IEnumerable<Encounter> kd_ = context.Operators.Where<Encounter>(kb_, kc_);
 					object ke_(Encounter @this)
 					{
-						var mr_ = @this?.Period;
-						var ms_ = FHIRHelpers_4_3_000.ToInterval(mr_);
-						var mt_ = context.Operators.End(ms_);
+						Period mr_ = @this?.Period;
+						CqlInterval<CqlDateTime> ms_ = FHIRHelpers_4_3_000.ToInterval(mr_);
+						CqlDateTime mt_ = context.Operators.End(ms_);
 
 						return mt_;
 					};
-					var kf_ = context.Operators.SortBy<Encounter>(kd_, ke_, System.ComponentModel.ListSortDirection.Ascending);
-					var kg_ = context.Operators.Last<Encounter>(kf_);
-					var kh_ = kg_?.Period;
-					var ki_ = FHIRHelpers_4_3_000.ToInterval(kh_);
-					var kj_ = context.Operators.Start(ki_);
-					var kk_ = Visit?.Period;
-					var kl_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var km_ = context.Operators.Start(kl_);
-					var kn_ = context.Operators.Quantity(1m, "hour");
-					var ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
-					var kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> kf_ = context.Operators.SortBy<Encounter>(kd_, ke_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter kg_ = context.Operators.Last<Encounter>(kf_);
+					Period kh_ = kg_?.Period;
+					CqlInterval<CqlDateTime> ki_ = FHIRHelpers_4_3_000.ToInterval(kh_);
+					CqlDateTime kj_ = context.Operators.Start(ki_);
+					Period kk_ = Visit?.Period;
+					CqlInterval<CqlDateTime> kl_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime km_ = context.Operators.Start(kl_);
+					CqlQuantity kn_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
+					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? kr_(Encounter LastObs)
 					{
-						var mu_ = LastObs?.StatusElement;
-						var mv_ = mu_?.Value;
-						var mw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mv_);
-						var mx_ = context.Operators.Equal(mw_, "finished");
-						var my_ = LastObs?.Period;
-						var mz_ = FHIRHelpers_4_3_000.ToInterval(my_);
-						var na_ = context.Operators.End(mz_);
-						var nb_ = Visit?.Period;
-						var nc_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var nd_ = context.Operators.Start(nc_);
-						var ne_ = context.Operators.Quantity(1m, "hour");
-						var nf_ = context.Operators.Subtract(nd_, ne_);
-						var nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var ni_ = context.Operators.Start(nh_);
-						var nj_ = context.Operators.Interval(nf_, ni_, true, true);
-						var nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
-						var nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var nn_ = context.Operators.Start(nm_);
-						var no_ = context.Operators.Not((bool?)(nn_ is null));
-						var np_ = context.Operators.And(nk_, no_);
-						var nq_ = context.Operators.And(mx_, np_);
+						Code<Encounter.EncounterStatus> mu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? mv_ = mu_?.Value;
+						Code<Encounter.EncounterStatus> mw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mv_);
+						bool? mx_ = context.Operators.Equal(mw_, "finished");
+						Period my_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> mz_ = FHIRHelpers_4_3_000.ToInterval(my_);
+						CqlDateTime na_ = context.Operators.End(mz_);
+						Period nb_ = Visit?.Period;
+						CqlInterval<CqlDateTime> nc_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime nd_ = context.Operators.Start(nc_);
+						CqlQuantity ne_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime nf_ = context.Operators.Subtract(nd_, ne_);
+						CqlInterval<CqlDateTime> nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime ni_ = context.Operators.Start(nh_);
+						CqlInterval<CqlDateTime> nj_ = context.Operators.Interval(nf_, ni_, true, true);
+						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
+						CqlInterval<CqlDateTime> nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime nn_ = context.Operators.Start(nm_);
+						bool? no_ = context.Operators.Not((bool?)(nn_ is null));
+						bool? np_ = context.Operators.And(nk_, no_);
+						bool? nq_ = context.Operators.And(mx_, np_);
 
 						return nq_;
 					};
-					var ks_ = context.Operators.Where<Encounter>(kq_, kr_);
+					IEnumerable<Encounter> ks_ = context.Operators.Where<Encounter>(kq_, kr_);
 					object kt_(Encounter @this)
 					{
-						var nr_ = @this?.Period;
-						var ns_ = FHIRHelpers_4_3_000.ToInterval(nr_);
-						var nt_ = context.Operators.End(ns_);
+						Period nr_ = @this?.Period;
+						CqlInterval<CqlDateTime> ns_ = FHIRHelpers_4_3_000.ToInterval(nr_);
+						CqlDateTime nt_ = context.Operators.End(ns_);
 
 						return nt_;
 					};
-					var ku_ = context.Operators.SortBy<Encounter>(ks_, kt_, System.ComponentModel.ListSortDirection.Ascending);
-					var kv_ = context.Operators.Last<Encounter>(ku_);
-					var kw_ = kv_?.Period;
-					var kx_ = FHIRHelpers_4_3_000.ToInterval(kw_);
-					var ky_ = context.Operators.Start(kx_);
-					var la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var lb_ = context.Operators.Start(la_);
-					var lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
-					var ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
-					var lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> ku_ = context.Operators.SortBy<Encounter>(ks_, kt_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter kv_ = context.Operators.Last<Encounter>(ku_);
+					Period kw_ = kv_?.Period;
+					CqlInterval<CqlDateTime> kx_ = FHIRHelpers_4_3_000.ToInterval(kw_);
+					CqlDateTime ky_ = context.Operators.Start(kx_);
+					CqlInterval<CqlDateTime> la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime lb_ = context.Operators.Start(la_);
+					CqlInterval<CqlDateTime> lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
+					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
+					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? lg_(Encounter LastObs)
 					{
-						var nu_ = LastObs?.StatusElement;
-						var nv_ = nu_?.Value;
-						var nw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nv_);
-						var nx_ = context.Operators.Equal(nw_, "finished");
-						var ny_ = LastObs?.Period;
-						var nz_ = FHIRHelpers_4_3_000.ToInterval(ny_);
-						var oa_ = context.Operators.End(nz_);
-						var ob_ = Visit?.Period;
-						var oc_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var od_ = context.Operators.Start(oc_);
-						var oe_ = context.Operators.Quantity(1m, "hour");
-						var of_ = context.Operators.Subtract(od_, oe_);
-						var oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var oi_ = context.Operators.Start(oh_);
-						var oj_ = context.Operators.Interval(of_, oi_, true, true);
-						var ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
-						var om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var on_ = context.Operators.Start(om_);
-						var oo_ = context.Operators.Not((bool?)(on_ is null));
-						var op_ = context.Operators.And(ok_, oo_);
-						var oq_ = context.Operators.And(nx_, op_);
+						Code<Encounter.EncounterStatus> nu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? nv_ = nu_?.Value;
+						Code<Encounter.EncounterStatus> nw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nv_);
+						bool? nx_ = context.Operators.Equal(nw_, "finished");
+						Period ny_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> nz_ = FHIRHelpers_4_3_000.ToInterval(ny_);
+						CqlDateTime oa_ = context.Operators.End(nz_);
+						Period ob_ = Visit?.Period;
+						CqlInterval<CqlDateTime> oc_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime od_ = context.Operators.Start(oc_);
+						CqlQuantity oe_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime of_ = context.Operators.Subtract(od_, oe_);
+						CqlInterval<CqlDateTime> oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime oi_ = context.Operators.Start(oh_);
+						CqlInterval<CqlDateTime> oj_ = context.Operators.Interval(of_, oi_, true, true);
+						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
+						CqlInterval<CqlDateTime> om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime on_ = context.Operators.Start(om_);
+						bool? oo_ = context.Operators.Not((bool?)(on_ is null));
+						bool? op_ = context.Operators.And(ok_, oo_);
+						bool? oq_ = context.Operators.And(nx_, op_);
 
 						return oq_;
 					};
-					var lh_ = context.Operators.Where<Encounter>(lf_, lg_);
+					IEnumerable<Encounter> lh_ = context.Operators.Where<Encounter>(lf_, lg_);
 					object li_(Encounter @this)
 					{
-						var or_ = @this?.Period;
-						var os_ = FHIRHelpers_4_3_000.ToInterval(or_);
-						var ot_ = context.Operators.End(os_);
+						Period or_ = @this?.Period;
+						CqlInterval<CqlDateTime> os_ = FHIRHelpers_4_3_000.ToInterval(or_);
+						CqlDateTime ot_ = context.Operators.End(os_);
 
 						return ot_;
 					};
-					var lj_ = context.Operators.SortBy<Encounter>(lh_, li_, System.ComponentModel.ListSortDirection.Ascending);
-					var lk_ = context.Operators.Last<Encounter>(lj_);
-					var ll_ = lk_?.Period;
-					var lm_ = FHIRHelpers_4_3_000.ToInterval(ll_);
-					var ln_ = context.Operators.Start(lm_);
-					var lp_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var lq_ = context.Operators.Start(lp_);
-					var lr_ = context.Operators.Not((bool?)((ln_ ?? lq_) is null));
-					var ls_ = context.Operators.And(ld_, lr_);
-					var lt_ = context.Operators.And(jw_, ls_);
+					IEnumerable<Encounter> lj_ = context.Operators.SortBy<Encounter>(lh_, li_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter lk_ = context.Operators.Last<Encounter>(lj_);
+					Period ll_ = lk_?.Period;
+					CqlInterval<CqlDateTime> lm_ = FHIRHelpers_4_3_000.ToInterval(ll_);
+					CqlDateTime ln_ = context.Operators.Start(lm_);
+					CqlInterval<CqlDateTime> lp_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime lq_ = context.Operators.Start(lp_);
+					bool? lr_ = context.Operators.Not((bool?)((ln_ ?? lq_) is null));
+					bool? ls_ = context.Operators.And(ld_, lr_);
+					bool? lt_ = context.Operators.And(jw_, ls_);
 
 					return lt_;
 				};
-				var bu_ = context.Operators.Where<Encounter>(bs_, bt_);
+				IEnumerable<Encounter> bu_ = context.Operators.Where<Encounter>(bs_, bt_);
 				object bv_(Encounter @this)
 				{
-					var ou_ = @this?.Period;
-					var ov_ = FHIRHelpers_4_3_000.ToInterval(ou_);
-					var ow_ = context.Operators.End(ov_);
+					Period ou_ = @this?.Period;
+					CqlInterval<CqlDateTime> ov_ = FHIRHelpers_4_3_000.ToInterval(ou_);
+					CqlDateTime ow_ = context.Operators.End(ov_);
 
 					return ow_;
 				};
-				var bw_ = context.Operators.SortBy<Encounter>(bu_, bv_, System.ComponentModel.ListSortDirection.Ascending);
-				var bx_ = context.Operators.Last<Encounter>(bw_);
-				var by_ = bx_?.Period;
-				var bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
-				var ca_ = context.Operators.Start(bz_);
-				var cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> bw_ = context.Operators.SortBy<Encounter>(bu_, bv_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bx_ = context.Operators.Last<Encounter>(bw_);
+				Period by_ = bx_?.Period;
+				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
+				CqlDateTime ca_ = context.Operators.Start(bz_);
+				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? cd_(Encounter LastObs)
 				{
-					var ox_ = LastObs?.StatusElement;
-					var oy_ = ox_?.Value;
-					var oz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oy_);
-					var pa_ = context.Operators.Equal(oz_, "finished");
-					var pb_ = LastObs?.Period;
-					var pc_ = FHIRHelpers_4_3_000.ToInterval(pb_);
-					var pd_ = context.Operators.End(pc_);
-					var pe_ = Visit?.Period;
-					var pf_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pg_ = context.Operators.Start(pf_);
-					var ph_ = context.Operators.Quantity(1m, "hour");
-					var pi_ = context.Operators.Subtract(pg_, ph_);
-					var pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pl_ = context.Operators.Start(pk_);
-					var pm_ = context.Operators.Interval(pi_, pl_, true, true);
-					var pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
-					var pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pq_ = context.Operators.Start(pp_);
-					var pr_ = context.Operators.Not((bool?)(pq_ is null));
-					var ps_ = context.Operators.And(pn_, pr_);
-					var pt_ = context.Operators.And(pa_, ps_);
+					Code<Encounter.EncounterStatus> ox_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? oy_ = ox_?.Value;
+					Code<Encounter.EncounterStatus> oz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oy_);
+					bool? pa_ = context.Operators.Equal(oz_, "finished");
+					Period pb_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> pc_ = FHIRHelpers_4_3_000.ToInterval(pb_);
+					CqlDateTime pd_ = context.Operators.End(pc_);
+					Period pe_ = Visit?.Period;
+					CqlInterval<CqlDateTime> pf_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pg_ = context.Operators.Start(pf_);
+					CqlQuantity ph_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime pi_ = context.Operators.Subtract(pg_, ph_);
+					CqlInterval<CqlDateTime> pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pl_ = context.Operators.Start(pk_);
+					CqlInterval<CqlDateTime> pm_ = context.Operators.Interval(pi_, pl_, true, true);
+					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
+					CqlInterval<CqlDateTime> pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pq_ = context.Operators.Start(pp_);
+					bool? pr_ = context.Operators.Not((bool?)(pq_ is null));
+					bool? ps_ = context.Operators.And(pn_, pr_);
+					bool? pt_ = context.Operators.And(pa_, ps_);
 
 					return pt_;
 				};
-				var ce_ = context.Operators.Where<Encounter>(cc_, cd_);
+				IEnumerable<Encounter> ce_ = context.Operators.Where<Encounter>(cc_, cd_);
 				object cf_(Encounter @this)
 				{
-					var pu_ = @this?.Period;
-					var pv_ = FHIRHelpers_4_3_000.ToInterval(pu_);
-					var pw_ = context.Operators.End(pv_);
+					Period pu_ = @this?.Period;
+					CqlInterval<CqlDateTime> pv_ = FHIRHelpers_4_3_000.ToInterval(pu_);
+					CqlDateTime pw_ = context.Operators.End(pv_);
 
 					return pw_;
 				};
-				var cg_ = context.Operators.SortBy<Encounter>(ce_, cf_, System.ComponentModel.ListSortDirection.Ascending);
-				var ch_ = context.Operators.Last<Encounter>(cg_);
-				var ci_ = ch_?.Period;
-				var cj_ = FHIRHelpers_4_3_000.ToInterval(ci_);
-				var ck_ = context.Operators.Start(cj_);
-				var cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var cn_ = context.Operators.Start(cm_);
-				var co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
-				var cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
-				var cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> cg_ = context.Operators.SortBy<Encounter>(ce_, cf_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter ch_ = context.Operators.Last<Encounter>(cg_);
+				Period ci_ = ch_?.Period;
+				CqlInterval<CqlDateTime> cj_ = FHIRHelpers_4_3_000.ToInterval(ci_);
+				CqlDateTime ck_ = context.Operators.Start(cj_);
+				CqlInterval<CqlDateTime> cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime cn_ = context.Operators.Start(cm_);
+				CqlInterval<CqlDateTime> co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
+				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
+				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? cs_(Encounter LastED)
 				{
-					var px_ = LastED?.StatusElement;
-					var py_ = px_?.Value;
-					var pz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(py_);
-					var qa_ = context.Operators.Equal(pz_, "finished");
-					var qb_ = LastED?.Period;
-					var qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
-					var qd_ = context.Operators.End(qc_);
-					var qe_ = this.Observation_Services();
-					var qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					Code<Encounter.EncounterStatus> px_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? py_ = px_?.Value;
+					Code<Encounter.EncounterStatus> pz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(py_);
+					bool? qa_ = context.Operators.Equal(pz_, "finished");
+					Period qb_ = LastED?.Period;
+					CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
+					CqlDateTime qd_ = context.Operators.End(qc_);
+					CqlValueSet qe_ = this.Observation_Services();
+					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? qg_(Encounter LastObs)
 					{
-						var ry_ = LastObs?.StatusElement;
-						var rz_ = ry_?.Value;
-						var sa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rz_);
-						var sb_ = context.Operators.Equal(sa_, "finished");
-						var sc_ = LastObs?.Period;
-						var sd_ = FHIRHelpers_4_3_000.ToInterval(sc_);
-						var se_ = context.Operators.End(sd_);
-						var sf_ = Visit?.Period;
-						var sg_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sh_ = context.Operators.Start(sg_);
-						var si_ = context.Operators.Quantity(1m, "hour");
-						var sj_ = context.Operators.Subtract(sh_, si_);
-						var sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sm_ = context.Operators.Start(sl_);
-						var sn_ = context.Operators.Interval(sj_, sm_, true, true);
-						var so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
-						var sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sr_ = context.Operators.Start(sq_);
-						var ss_ = context.Operators.Not((bool?)(sr_ is null));
-						var st_ = context.Operators.And(so_, ss_);
-						var su_ = context.Operators.And(sb_, st_);
+						Code<Encounter.EncounterStatus> ry_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? rz_ = ry_?.Value;
+						Code<Encounter.EncounterStatus> sa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rz_);
+						bool? sb_ = context.Operators.Equal(sa_, "finished");
+						Period sc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> sd_ = FHIRHelpers_4_3_000.ToInterval(sc_);
+						CqlDateTime se_ = context.Operators.End(sd_);
+						Period sf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> sg_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sh_ = context.Operators.Start(sg_);
+						CqlQuantity si_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime sj_ = context.Operators.Subtract(sh_, si_);
+						CqlInterval<CqlDateTime> sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sm_ = context.Operators.Start(sl_);
+						CqlInterval<CqlDateTime> sn_ = context.Operators.Interval(sj_, sm_, true, true);
+						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
+						CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sr_ = context.Operators.Start(sq_);
+						bool? ss_ = context.Operators.Not((bool?)(sr_ is null));
+						bool? st_ = context.Operators.And(so_, ss_);
+						bool? su_ = context.Operators.And(sb_, st_);
 
 						return su_;
 					};
-					var qh_ = context.Operators.Where<Encounter>(qf_, qg_);
+					IEnumerable<Encounter> qh_ = context.Operators.Where<Encounter>(qf_, qg_);
 					object qi_(Encounter @this)
 					{
-						var sv_ = @this?.Period;
-						var sw_ = FHIRHelpers_4_3_000.ToInterval(sv_);
-						var sx_ = context.Operators.End(sw_);
+						Period sv_ = @this?.Period;
+						CqlInterval<CqlDateTime> sw_ = FHIRHelpers_4_3_000.ToInterval(sv_);
+						CqlDateTime sx_ = context.Operators.End(sw_);
 
 						return sx_;
 					};
-					var qj_ = context.Operators.SortBy<Encounter>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
-					var qk_ = context.Operators.Last<Encounter>(qj_);
-					var ql_ = qk_?.Period;
-					var qm_ = FHIRHelpers_4_3_000.ToInterval(ql_);
-					var qn_ = context.Operators.Start(qm_);
-					var qo_ = Visit?.Period;
-					var qp_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var qq_ = context.Operators.Start(qp_);
-					var qr_ = context.Operators.Quantity(1m, "hour");
-					var qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
-					var qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qj_ = context.Operators.SortBy<Encounter>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter qk_ = context.Operators.Last<Encounter>(qj_);
+					Period ql_ = qk_?.Period;
+					CqlInterval<CqlDateTime> qm_ = FHIRHelpers_4_3_000.ToInterval(ql_);
+					CqlDateTime qn_ = context.Operators.Start(qm_);
+					Period qo_ = Visit?.Period;
+					CqlInterval<CqlDateTime> qp_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime qq_ = context.Operators.Start(qp_);
+					CqlQuantity qr_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
+					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? qv_(Encounter LastObs)
 					{
-						var sy_ = LastObs?.StatusElement;
-						var sz_ = sy_?.Value;
-						var ta_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sz_);
-						var tb_ = context.Operators.Equal(ta_, "finished");
-						var tc_ = LastObs?.Period;
-						var td_ = FHIRHelpers_4_3_000.ToInterval(tc_);
-						var te_ = context.Operators.End(td_);
-						var tf_ = Visit?.Period;
-						var tg_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var th_ = context.Operators.Start(tg_);
-						var ti_ = context.Operators.Quantity(1m, "hour");
-						var tj_ = context.Operators.Subtract(th_, ti_);
-						var tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var tm_ = context.Operators.Start(tl_);
-						var tn_ = context.Operators.Interval(tj_, tm_, true, true);
-						var to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
-						var tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var tr_ = context.Operators.Start(tq_);
-						var ts_ = context.Operators.Not((bool?)(tr_ is null));
-						var tt_ = context.Operators.And(to_, ts_);
-						var tu_ = context.Operators.And(tb_, tt_);
+						Code<Encounter.EncounterStatus> sy_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? sz_ = sy_?.Value;
+						Code<Encounter.EncounterStatus> ta_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sz_);
+						bool? tb_ = context.Operators.Equal(ta_, "finished");
+						Period tc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> td_ = FHIRHelpers_4_3_000.ToInterval(tc_);
+						CqlDateTime te_ = context.Operators.End(td_);
+						Period tf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> tg_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime th_ = context.Operators.Start(tg_);
+						CqlQuantity ti_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime tj_ = context.Operators.Subtract(th_, ti_);
+						CqlInterval<CqlDateTime> tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime tm_ = context.Operators.Start(tl_);
+						CqlInterval<CqlDateTime> tn_ = context.Operators.Interval(tj_, tm_, true, true);
+						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
+						CqlInterval<CqlDateTime> tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime tr_ = context.Operators.Start(tq_);
+						bool? ts_ = context.Operators.Not((bool?)(tr_ is null));
+						bool? tt_ = context.Operators.And(to_, ts_);
+						bool? tu_ = context.Operators.And(tb_, tt_);
 
 						return tu_;
 					};
-					var qw_ = context.Operators.Where<Encounter>(qu_, qv_);
+					IEnumerable<Encounter> qw_ = context.Operators.Where<Encounter>(qu_, qv_);
 					object qx_(Encounter @this)
 					{
-						var tv_ = @this?.Period;
-						var tw_ = FHIRHelpers_4_3_000.ToInterval(tv_);
-						var tx_ = context.Operators.End(tw_);
+						Period tv_ = @this?.Period;
+						CqlInterval<CqlDateTime> tw_ = FHIRHelpers_4_3_000.ToInterval(tv_);
+						CqlDateTime tx_ = context.Operators.End(tw_);
 
 						return tx_;
 					};
-					var qy_ = context.Operators.SortBy<Encounter>(qw_, qx_, System.ComponentModel.ListSortDirection.Ascending);
-					var qz_ = context.Operators.Last<Encounter>(qy_);
-					var ra_ = qz_?.Period;
-					var rb_ = FHIRHelpers_4_3_000.ToInterval(ra_);
-					var rc_ = context.Operators.Start(rb_);
-					var re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var rf_ = context.Operators.Start(re_);
-					var rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
-					var rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
-					var rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qy_ = context.Operators.SortBy<Encounter>(qw_, qx_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter qz_ = context.Operators.Last<Encounter>(qy_);
+					Period ra_ = qz_?.Period;
+					CqlInterval<CqlDateTime> rb_ = FHIRHelpers_4_3_000.ToInterval(ra_);
+					CqlDateTime rc_ = context.Operators.Start(rb_);
+					CqlInterval<CqlDateTime> re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime rf_ = context.Operators.Start(re_);
+					CqlInterval<CqlDateTime> rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
+					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
+					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? rk_(Encounter LastObs)
 					{
-						var ty_ = LastObs?.StatusElement;
-						var tz_ = ty_?.Value;
-						var ua_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tz_);
-						var ub_ = context.Operators.Equal(ua_, "finished");
-						var uc_ = LastObs?.Period;
-						var ud_ = FHIRHelpers_4_3_000.ToInterval(uc_);
-						var ue_ = context.Operators.End(ud_);
-						var uf_ = Visit?.Period;
-						var ug_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var uh_ = context.Operators.Start(ug_);
-						var ui_ = context.Operators.Quantity(1m, "hour");
-						var uj_ = context.Operators.Subtract(uh_, ui_);
-						var ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var um_ = context.Operators.Start(ul_);
-						var un_ = context.Operators.Interval(uj_, um_, true, true);
-						var uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
-						var uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var ur_ = context.Operators.Start(uq_);
-						var us_ = context.Operators.Not((bool?)(ur_ is null));
-						var ut_ = context.Operators.And(uo_, us_);
-						var uu_ = context.Operators.And(ub_, ut_);
+						Code<Encounter.EncounterStatus> ty_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? tz_ = ty_?.Value;
+						Code<Encounter.EncounterStatus> ua_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tz_);
+						bool? ub_ = context.Operators.Equal(ua_, "finished");
+						Period uc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> ud_ = FHIRHelpers_4_3_000.ToInterval(uc_);
+						CqlDateTime ue_ = context.Operators.End(ud_);
+						Period uf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> ug_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime uh_ = context.Operators.Start(ug_);
+						CqlQuantity ui_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime uj_ = context.Operators.Subtract(uh_, ui_);
+						CqlInterval<CqlDateTime> ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime um_ = context.Operators.Start(ul_);
+						CqlInterval<CqlDateTime> un_ = context.Operators.Interval(uj_, um_, true, true);
+						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
+						CqlInterval<CqlDateTime> uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime ur_ = context.Operators.Start(uq_);
+						bool? us_ = context.Operators.Not((bool?)(ur_ is null));
+						bool? ut_ = context.Operators.And(uo_, us_);
+						bool? uu_ = context.Operators.And(ub_, ut_);
 
 						return uu_;
 					};
-					var rl_ = context.Operators.Where<Encounter>(rj_, rk_);
+					IEnumerable<Encounter> rl_ = context.Operators.Where<Encounter>(rj_, rk_);
 					object rm_(Encounter @this)
 					{
-						var uv_ = @this?.Period;
-						var uw_ = FHIRHelpers_4_3_000.ToInterval(uv_);
-						var ux_ = context.Operators.End(uw_);
+						Period uv_ = @this?.Period;
+						CqlInterval<CqlDateTime> uw_ = FHIRHelpers_4_3_000.ToInterval(uv_);
+						CqlDateTime ux_ = context.Operators.End(uw_);
 
 						return ux_;
 					};
-					var rn_ = context.Operators.SortBy<Encounter>(rl_, rm_, System.ComponentModel.ListSortDirection.Ascending);
-					var ro_ = context.Operators.Last<Encounter>(rn_);
-					var rp_ = ro_?.Period;
-					var rq_ = FHIRHelpers_4_3_000.ToInterval(rp_);
-					var rr_ = context.Operators.Start(rq_);
-					var rt_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var ru_ = context.Operators.Start(rt_);
-					var rv_ = context.Operators.Not((bool?)((rr_ ?? ru_) is null));
-					var rw_ = context.Operators.And(rh_, rv_);
-					var rx_ = context.Operators.And(qa_, rw_);
+					IEnumerable<Encounter> rn_ = context.Operators.SortBy<Encounter>(rl_, rm_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter ro_ = context.Operators.Last<Encounter>(rn_);
+					Period rp_ = ro_?.Period;
+					CqlInterval<CqlDateTime> rq_ = FHIRHelpers_4_3_000.ToInterval(rp_);
+					CqlDateTime rr_ = context.Operators.Start(rq_);
+					CqlInterval<CqlDateTime> rt_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime ru_ = context.Operators.Start(rt_);
+					bool? rv_ = context.Operators.Not((bool?)((rr_ ?? ru_) is null));
+					bool? rw_ = context.Operators.And(rh_, rv_);
+					bool? rx_ = context.Operators.And(qa_, rw_);
 
 					return rx_;
 				};
-				var ct_ = context.Operators.Where<Encounter>(cr_, cs_);
+				IEnumerable<Encounter> ct_ = context.Operators.Where<Encounter>(cr_, cs_);
 				object cu_(Encounter @this)
 				{
-					var uy_ = @this?.Period;
-					var uz_ = FHIRHelpers_4_3_000.ToInterval(uy_);
-					var va_ = context.Operators.End(uz_);
+					Period uy_ = @this?.Period;
+					CqlInterval<CqlDateTime> uz_ = FHIRHelpers_4_3_000.ToInterval(uy_);
+					CqlDateTime va_ = context.Operators.End(uz_);
 
 					return va_;
 				};
-				var cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
-				var cw_ = context.Operators.Last<Encounter>(cv_);
-				var cx_ = cw_?.Period;
-				var cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
-				var cz_ = context.Operators.Start(cy_);
-				var db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter cw_ = context.Operators.Last<Encounter>(cv_);
+				Period cx_ = cw_?.Period;
+				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
+				CqlDateTime cz_ = context.Operators.Start(cy_);
+				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? dc_(Encounter LastObs)
 				{
-					var vb_ = LastObs?.StatusElement;
-					var vc_ = vb_?.Value;
-					var vd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vc_);
-					var ve_ = context.Operators.Equal(vd_, "finished");
-					var vf_ = LastObs?.Period;
-					var vg_ = FHIRHelpers_4_3_000.ToInterval(vf_);
-					var vh_ = context.Operators.End(vg_);
-					var vi_ = Visit?.Period;
-					var vj_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vk_ = context.Operators.Start(vj_);
-					var vl_ = context.Operators.Quantity(1m, "hour");
-					var vm_ = context.Operators.Subtract(vk_, vl_);
-					var vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vp_ = context.Operators.Start(vo_);
-					var vq_ = context.Operators.Interval(vm_, vp_, true, true);
-					var vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
-					var vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vu_ = context.Operators.Start(vt_);
-					var vv_ = context.Operators.Not((bool?)(vu_ is null));
-					var vw_ = context.Operators.And(vr_, vv_);
-					var vx_ = context.Operators.And(ve_, vw_);
+					Code<Encounter.EncounterStatus> vb_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? vc_ = vb_?.Value;
+					Code<Encounter.EncounterStatus> vd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vc_);
+					bool? ve_ = context.Operators.Equal(vd_, "finished");
+					Period vf_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> vg_ = FHIRHelpers_4_3_000.ToInterval(vf_);
+					CqlDateTime vh_ = context.Operators.End(vg_);
+					Period vi_ = Visit?.Period;
+					CqlInterval<CqlDateTime> vj_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vk_ = context.Operators.Start(vj_);
+					CqlQuantity vl_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime vm_ = context.Operators.Subtract(vk_, vl_);
+					CqlInterval<CqlDateTime> vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vp_ = context.Operators.Start(vo_);
+					CqlInterval<CqlDateTime> vq_ = context.Operators.Interval(vm_, vp_, true, true);
+					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
+					CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vu_ = context.Operators.Start(vt_);
+					bool? vv_ = context.Operators.Not((bool?)(vu_ is null));
+					bool? vw_ = context.Operators.And(vr_, vv_);
+					bool? vx_ = context.Operators.And(ve_, vw_);
 
 					return vx_;
 				};
-				var dd_ = context.Operators.Where<Encounter>(db_, dc_);
+				IEnumerable<Encounter> dd_ = context.Operators.Where<Encounter>(db_, dc_);
 				object de_(Encounter @this)
 				{
-					var vy_ = @this?.Period;
-					var vz_ = FHIRHelpers_4_3_000.ToInterval(vy_);
-					var wa_ = context.Operators.End(vz_);
+					Period vy_ = @this?.Period;
+					CqlInterval<CqlDateTime> vz_ = FHIRHelpers_4_3_000.ToInterval(vy_);
+					CqlDateTime wa_ = context.Operators.End(vz_);
 
 					return wa_;
 				};
-				var df_ = context.Operators.SortBy<Encounter>(dd_, de_, System.ComponentModel.ListSortDirection.Ascending);
-				var dg_ = context.Operators.Last<Encounter>(df_);
-				var dh_ = dg_?.Period;
-				var di_ = FHIRHelpers_4_3_000.ToInterval(dh_);
-				var dj_ = context.Operators.Start(di_);
-				var dl_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var dm_ = context.Operators.Start(dl_);
-				var dn_ = context.Operators.Not((bool?)((cz_ ?? (dj_ ?? dm_)) is null));
-				var do_ = context.Operators.And(cp_, dn_);
+				IEnumerable<Encounter> df_ = context.Operators.SortBy<Encounter>(dd_, de_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter dg_ = context.Operators.Last<Encounter>(df_);
+				Period dh_ = dg_?.Period;
+				CqlInterval<CqlDateTime> di_ = FHIRHelpers_4_3_000.ToInterval(dh_);
+				CqlDateTime dj_ = context.Operators.Start(di_);
+				CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime dm_ = context.Operators.Start(dl_);
+				bool? dn_ = context.Operators.Not((bool?)((cz_ ?? (dj_ ?? dm_)) is null));
+				bool? do_ = context.Operators.And(cp_, dn_);
 
 				return do_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var wb_ = @this?.Period;
-				var wc_ = FHIRHelpers_4_3_000.ToInterval(wb_);
-				var wd_ = context.Operators.End(wc_);
+				Period wb_ = @this?.Period;
+				CqlInterval<CqlDateTime> wc_ = FHIRHelpers_4_3_000.ToInterval(wb_);
+				CqlDateTime wd_ = context.Operators.End(wc_);
 
 				return wd_;
 			};
-			var j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Encounter>(j_);
-			var l_ = k_?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Emergency_Department_Visit();
-			var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter k_ = context.Operators.Last<Encounter>(j_);
+			Period l_ = k_?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlValueSet o_ = this.Emergency_Department_Visit();
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
 			bool? q_(Encounter LastED)
 			{
-				var we_ = LastED?.StatusElement;
-				var wf_ = we_?.Value;
-				var wg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wf_);
-				var wh_ = context.Operators.Equal(wg_, "finished");
-				var wi_ = LastED?.Period;
-				var wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
-				var wk_ = context.Operators.End(wj_);
-				var wl_ = this.Observation_Services();
-				var wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				Code<Encounter.EncounterStatus> we_ = LastED?.StatusElement;
+				Encounter.EncounterStatus? wf_ = we_?.Value;
+				Code<Encounter.EncounterStatus> wg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wf_);
+				bool? wh_ = context.Operators.Equal(wg_, "finished");
+				Period wi_ = LastED?.Period;
+				CqlInterval<CqlDateTime> wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
+				CqlDateTime wk_ = context.Operators.End(wj_);
+				CqlValueSet wl_ = this.Observation_Services();
+				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? wn_(Encounter LastObs)
 				{
-					var yf_ = LastObs?.StatusElement;
-					var yg_ = yf_?.Value;
-					var yh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(yg_);
-					var yi_ = context.Operators.Equal(yh_, "finished");
-					var yj_ = LastObs?.Period;
-					var yk_ = FHIRHelpers_4_3_000.ToInterval(yj_);
-					var yl_ = context.Operators.End(yk_);
-					var ym_ = Visit?.Period;
-					var yn_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yo_ = context.Operators.Start(yn_);
-					var yp_ = context.Operators.Quantity(1m, "hour");
-					var yq_ = context.Operators.Subtract(yo_, yp_);
-					var ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yt_ = context.Operators.Start(ys_);
-					var yu_ = context.Operators.Interval(yq_, yt_, true, true);
-					var yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
-					var yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yy_ = context.Operators.Start(yx_);
-					var yz_ = context.Operators.Not((bool?)(yy_ is null));
-					var za_ = context.Operators.And(yv_, yz_);
-					var zb_ = context.Operators.And(yi_, za_);
+					Code<Encounter.EncounterStatus> yf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? yg_ = yf_?.Value;
+					Code<Encounter.EncounterStatus> yh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(yg_);
+					bool? yi_ = context.Operators.Equal(yh_, "finished");
+					Period yj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> yk_ = FHIRHelpers_4_3_000.ToInterval(yj_);
+					CqlDateTime yl_ = context.Operators.End(yk_);
+					Period ym_ = Visit?.Period;
+					CqlInterval<CqlDateTime> yn_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yo_ = context.Operators.Start(yn_);
+					CqlQuantity yp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime yq_ = context.Operators.Subtract(yo_, yp_);
+					CqlInterval<CqlDateTime> ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yt_ = context.Operators.Start(ys_);
+					CqlInterval<CqlDateTime> yu_ = context.Operators.Interval(yq_, yt_, true, true);
+					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
+					CqlInterval<CqlDateTime> yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yy_ = context.Operators.Start(yx_);
+					bool? yz_ = context.Operators.Not((bool?)(yy_ is null));
+					bool? za_ = context.Operators.And(yv_, yz_);
+					bool? zb_ = context.Operators.And(yi_, za_);
 
 					return zb_;
 				};
-				var wo_ = context.Operators.Where<Encounter>(wm_, wn_);
+				IEnumerable<Encounter> wo_ = context.Operators.Where<Encounter>(wm_, wn_);
 				object wp_(Encounter @this)
 				{
-					var zc_ = @this?.Period;
-					var zd_ = FHIRHelpers_4_3_000.ToInterval(zc_);
-					var ze_ = context.Operators.End(zd_);
+					Period zc_ = @this?.Period;
+					CqlInterval<CqlDateTime> zd_ = FHIRHelpers_4_3_000.ToInterval(zc_);
+					CqlDateTime ze_ = context.Operators.End(zd_);
 
 					return ze_;
 				};
-				var wq_ = context.Operators.SortBy<Encounter>(wo_, wp_, System.ComponentModel.ListSortDirection.Ascending);
-				var wr_ = context.Operators.Last<Encounter>(wq_);
-				var ws_ = wr_?.Period;
-				var wt_ = FHIRHelpers_4_3_000.ToInterval(ws_);
-				var wu_ = context.Operators.Start(wt_);
-				var wv_ = Visit?.Period;
-				var ww_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var wx_ = context.Operators.Start(ww_);
-				var wy_ = context.Operators.Quantity(1m, "hour");
-				var wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
-				var xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> wq_ = context.Operators.SortBy<Encounter>(wo_, wp_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter wr_ = context.Operators.Last<Encounter>(wq_);
+				Period ws_ = wr_?.Period;
+				CqlInterval<CqlDateTime> wt_ = FHIRHelpers_4_3_000.ToInterval(ws_);
+				CqlDateTime wu_ = context.Operators.Start(wt_);
+				Period wv_ = Visit?.Period;
+				CqlInterval<CqlDateTime> ww_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime wx_ = context.Operators.Start(ww_);
+				CqlQuantity wy_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
+				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? xc_(Encounter LastObs)
 				{
-					var zf_ = LastObs?.StatusElement;
-					var zg_ = zf_?.Value;
-					var zh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(zg_);
-					var zi_ = context.Operators.Equal(zh_, "finished");
-					var zj_ = LastObs?.Period;
-					var zk_ = FHIRHelpers_4_3_000.ToInterval(zj_);
-					var zl_ = context.Operators.End(zk_);
-					var zm_ = Visit?.Period;
-					var zn_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zo_ = context.Operators.Start(zn_);
-					var zp_ = context.Operators.Quantity(1m, "hour");
-					var zq_ = context.Operators.Subtract(zo_, zp_);
-					var zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zt_ = context.Operators.Start(zs_);
-					var zu_ = context.Operators.Interval(zq_, zt_, true, true);
-					var zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
-					var zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zy_ = context.Operators.Start(zx_);
-					var zz_ = context.Operators.Not((bool?)(zy_ is null));
-					var aza_ = context.Operators.And(zv_, zz_);
-					var azb_ = context.Operators.And(zi_, aza_);
+					Code<Encounter.EncounterStatus> zf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? zg_ = zf_?.Value;
+					Code<Encounter.EncounterStatus> zh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(zg_);
+					bool? zi_ = context.Operators.Equal(zh_, "finished");
+					Period zj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> zk_ = FHIRHelpers_4_3_000.ToInterval(zj_);
+					CqlDateTime zl_ = context.Operators.End(zk_);
+					Period zm_ = Visit?.Period;
+					CqlInterval<CqlDateTime> zn_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zo_ = context.Operators.Start(zn_);
+					CqlQuantity zp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime zq_ = context.Operators.Subtract(zo_, zp_);
+					CqlInterval<CqlDateTime> zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zt_ = context.Operators.Start(zs_);
+					CqlInterval<CqlDateTime> zu_ = context.Operators.Interval(zq_, zt_, true, true);
+					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
+					CqlInterval<CqlDateTime> zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zy_ = context.Operators.Start(zx_);
+					bool? zz_ = context.Operators.Not((bool?)(zy_ is null));
+					bool? aza_ = context.Operators.And(zv_, zz_);
+					bool? azb_ = context.Operators.And(zi_, aza_);
 
 					return azb_;
 				};
-				var xd_ = context.Operators.Where<Encounter>(xb_, xc_);
+				IEnumerable<Encounter> xd_ = context.Operators.Where<Encounter>(xb_, xc_);
 				object xe_(Encounter @this)
 				{
-					var azc_ = @this?.Period;
-					var azd_ = FHIRHelpers_4_3_000.ToInterval(azc_);
-					var aze_ = context.Operators.End(azd_);
+					Period azc_ = @this?.Period;
+					CqlInterval<CqlDateTime> azd_ = FHIRHelpers_4_3_000.ToInterval(azc_);
+					CqlDateTime aze_ = context.Operators.End(azd_);
 
 					return aze_;
 				};
-				var xf_ = context.Operators.SortBy<Encounter>(xd_, xe_, System.ComponentModel.ListSortDirection.Ascending);
-				var xg_ = context.Operators.Last<Encounter>(xf_);
-				var xh_ = xg_?.Period;
-				var xi_ = FHIRHelpers_4_3_000.ToInterval(xh_);
-				var xj_ = context.Operators.Start(xi_);
-				var xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var xm_ = context.Operators.Start(xl_);
-				var xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
-				var xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
-				var xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> xf_ = context.Operators.SortBy<Encounter>(xd_, xe_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter xg_ = context.Operators.Last<Encounter>(xf_);
+				Period xh_ = xg_?.Period;
+				CqlInterval<CqlDateTime> xi_ = FHIRHelpers_4_3_000.ToInterval(xh_);
+				CqlDateTime xj_ = context.Operators.Start(xi_);
+				CqlInterval<CqlDateTime> xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime xm_ = context.Operators.Start(xl_);
+				CqlInterval<CqlDateTime> xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
+				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
+				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? xr_(Encounter LastObs)
 				{
-					var azf_ = LastObs?.StatusElement;
-					var azg_ = azf_?.Value;
-					var azh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(azg_);
-					var azi_ = context.Operators.Equal(azh_, "finished");
-					var azj_ = LastObs?.Period;
-					var azk_ = FHIRHelpers_4_3_000.ToInterval(azj_);
-					var azl_ = context.Operators.End(azk_);
-					var azm_ = Visit?.Period;
-					var azn_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azo_ = context.Operators.Start(azn_);
-					var azp_ = context.Operators.Quantity(1m, "hour");
-					var azq_ = context.Operators.Subtract(azo_, azp_);
-					var azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azt_ = context.Operators.Start(azs_);
-					var azu_ = context.Operators.Interval(azq_, azt_, true, true);
-					var azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
-					var azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azy_ = context.Operators.Start(azx_);
-					var azz_ = context.Operators.Not((bool?)(azy_ is null));
-					var bza_ = context.Operators.And(azv_, azz_);
-					var bzb_ = context.Operators.And(azi_, bza_);
+					Code<Encounter.EncounterStatus> azf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? azg_ = azf_?.Value;
+					Code<Encounter.EncounterStatus> azh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(azg_);
+					bool? azi_ = context.Operators.Equal(azh_, "finished");
+					Period azj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> azk_ = FHIRHelpers_4_3_000.ToInterval(azj_);
+					CqlDateTime azl_ = context.Operators.End(azk_);
+					Period azm_ = Visit?.Period;
+					CqlInterval<CqlDateTime> azn_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azo_ = context.Operators.Start(azn_);
+					CqlQuantity azp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime azq_ = context.Operators.Subtract(azo_, azp_);
+					CqlInterval<CqlDateTime> azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azt_ = context.Operators.Start(azs_);
+					CqlInterval<CqlDateTime> azu_ = context.Operators.Interval(azq_, azt_, true, true);
+					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
+					CqlInterval<CqlDateTime> azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azy_ = context.Operators.Start(azx_);
+					bool? azz_ = context.Operators.Not((bool?)(azy_ is null));
+					bool? bza_ = context.Operators.And(azv_, azz_);
+					bool? bzb_ = context.Operators.And(azi_, bza_);
 
 					return bzb_;
 				};
-				var xs_ = context.Operators.Where<Encounter>(xq_, xr_);
+				IEnumerable<Encounter> xs_ = context.Operators.Where<Encounter>(xq_, xr_);
 				object xt_(Encounter @this)
 				{
-					var bzc_ = @this?.Period;
-					var bzd_ = FHIRHelpers_4_3_000.ToInterval(bzc_);
-					var bze_ = context.Operators.End(bzd_);
+					Period bzc_ = @this?.Period;
+					CqlInterval<CqlDateTime> bzd_ = FHIRHelpers_4_3_000.ToInterval(bzc_);
+					CqlDateTime bze_ = context.Operators.End(bzd_);
 
 					return bze_;
 				};
-				var xu_ = context.Operators.SortBy<Encounter>(xs_, xt_, System.ComponentModel.ListSortDirection.Ascending);
-				var xv_ = context.Operators.Last<Encounter>(xu_);
-				var xw_ = xv_?.Period;
-				var xx_ = FHIRHelpers_4_3_000.ToInterval(xw_);
-				var xy_ = context.Operators.Start(xx_);
-				var ya_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var yb_ = context.Operators.Start(ya_);
-				var yc_ = context.Operators.Not((bool?)((xy_ ?? yb_) is null));
-				var yd_ = context.Operators.And(xo_, yc_);
-				var ye_ = context.Operators.And(wh_, yd_);
+				IEnumerable<Encounter> xu_ = context.Operators.SortBy<Encounter>(xs_, xt_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter xv_ = context.Operators.Last<Encounter>(xu_);
+				Period xw_ = xv_?.Period;
+				CqlInterval<CqlDateTime> xx_ = FHIRHelpers_4_3_000.ToInterval(xw_);
+				CqlDateTime xy_ = context.Operators.Start(xx_);
+				CqlInterval<CqlDateTime> ya_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime yb_ = context.Operators.Start(ya_);
+				bool? yc_ = context.Operators.Not((bool?)((xy_ ?? yb_) is null));
+				bool? yd_ = context.Operators.And(xo_, yc_);
+				bool? ye_ = context.Operators.And(wh_, yd_);
 
 				return ye_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 			object s_(Encounter @this)
 			{
-				var bzf_ = @this?.Period;
-				var bzg_ = FHIRHelpers_4_3_000.ToInterval(bzf_);
-				var bzh_ = context.Operators.End(bzg_);
+				Period bzf_ = @this?.Period;
+				CqlInterval<CqlDateTime> bzg_ = FHIRHelpers_4_3_000.ToInterval(bzf_);
+				CqlDateTime bzh_ = context.Operators.End(bzg_);
 
 				return bzh_;
 			};
-			var t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.Last<Encounter>(t_);
-			var v_ = u_?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
-			var y_ = this.Observation_Services();
-			var z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
+			IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter u_ = context.Operators.Last<Encounter>(t_);
+			Period v_ = u_?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			CqlValueSet y_ = this.Observation_Services();
+			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
 			bool? aa_(Encounter LastObs)
 			{
-				var bzi_ = LastObs?.StatusElement;
-				var bzj_ = bzi_?.Value;
-				var bzk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bzj_);
-				var bzl_ = context.Operators.Equal(bzk_, "finished");
-				var bzm_ = LastObs?.Period;
-				var bzn_ = FHIRHelpers_4_3_000.ToInterval(bzm_);
-				var bzo_ = context.Operators.End(bzn_);
-				var bzp_ = Visit?.Period;
-				var bzq_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var bzr_ = context.Operators.Start(bzq_);
-				var bzs_ = context.Operators.Quantity(1m, "hour");
-				var bzt_ = context.Operators.Subtract(bzr_, bzs_);
-				var bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var bzw_ = context.Operators.Start(bzv_);
-				var bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
-				var bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
-				var cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var czb_ = context.Operators.Start(cza_);
-				var czc_ = context.Operators.Not((bool?)(czb_ is null));
-				var czd_ = context.Operators.And(bzy_, czc_);
-				var cze_ = context.Operators.And(bzl_, czd_);
+				Code<Encounter.EncounterStatus> bzi_ = LastObs?.StatusElement;
+				Encounter.EncounterStatus? bzj_ = bzi_?.Value;
+				Code<Encounter.EncounterStatus> bzk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bzj_);
+				bool? bzl_ = context.Operators.Equal(bzk_, "finished");
+				Period bzm_ = LastObs?.Period;
+				CqlInterval<CqlDateTime> bzn_ = FHIRHelpers_4_3_000.ToInterval(bzm_);
+				CqlDateTime bzo_ = context.Operators.End(bzn_);
+				Period bzp_ = Visit?.Period;
+				CqlInterval<CqlDateTime> bzq_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime bzr_ = context.Operators.Start(bzq_);
+				CqlQuantity bzs_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime bzt_ = context.Operators.Subtract(bzr_, bzs_);
+				CqlInterval<CqlDateTime> bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime bzw_ = context.Operators.Start(bzv_);
+				CqlInterval<CqlDateTime> bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
+				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
+				CqlInterval<CqlDateTime> cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime czb_ = context.Operators.Start(cza_);
+				bool? czc_ = context.Operators.Not((bool?)(czb_ is null));
+				bool? czd_ = context.Operators.And(bzy_, czc_);
+				bool? cze_ = context.Operators.And(bzl_, czd_);
 
 				return cze_;
 			};
-			var ab_ = context.Operators.Where<Encounter>(z_, aa_);
+			IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
 			object ac_(Encounter @this)
 			{
-				var czf_ = @this?.Period;
-				var czg_ = FHIRHelpers_4_3_000.ToInterval(czf_);
-				var czh_ = context.Operators.End(czg_);
+				Period czf_ = @this?.Period;
+				CqlInterval<CqlDateTime> czg_ = FHIRHelpers_4_3_000.ToInterval(czf_);
+				CqlDateTime czh_ = context.Operators.End(czg_);
 
 				return czh_;
 			};
-			var ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
-			var ae_ = context.Operators.Last<Encounter>(ad_);
-			var af_ = ae_?.Period;
-			var ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-			var ah_ = context.Operators.Start(ag_);
-			var ai_ = Visit?.Period;
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-			var ak_ = context.Operators.Start(aj_);
-			var am_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-			var an_ = context.Operators.End(am_);
-			var ao_ = context.Operators.Interval((n_ ?? (x_ ?? (ah_ ?? ak_))), an_, true, true);
+			IEnumerable<Encounter> ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter ae_ = context.Operators.Last<Encounter>(ad_);
+			Period af_ = ae_?.Period;
+			CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
+			CqlDateTime ah_ = context.Operators.Start(ag_);
+			Period ai_ = Visit?.Period;
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+			CqlDateTime an_ = context.Operators.End(am_);
+			CqlInterval<CqlDateTime> ao_ = context.Operators.Interval((n_ ?? (x_ ?? (ah_ ?? ak_))), an_, true, true);
 
 			return ao_;
 		};
-		var c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
+		CqlInterval<CqlDateTime> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
 
 		return d_;
 	}
@@ -2478,231 +2504,231 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationWithObservation()` instead.")]
 	public CqlInterval<CqlDateTime> HospitalizationWithObservation(Encounter TheEncounter)
 	{
-		var a_ = new Encounter[]
+		Encounter[] a_ = new Encounter[]
 		{
 			TheEncounter,
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Emergency_Department_Visit();
-			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			CqlValueSet e_ = this.Emergency_Department_Visit();
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastED)
 			{
-				var af_ = LastED?.StatusElement;
-				var ag_ = af_?.Value;
-				var ah_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ag_);
-				var ai_ = context.Operators.Equal(ah_, "finished");
-				var aj_ = LastED?.Period;
-				var ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
-				var al_ = context.Operators.End(ak_);
-				var am_ = this.Observation_Services();
-				var an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				Code<Encounter.EncounterStatus> af_ = LastED?.StatusElement;
+				Encounter.EncounterStatus? ag_ = af_?.Value;
+				Code<Encounter.EncounterStatus> ah_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ag_);
+				bool? ai_ = context.Operators.Equal(ah_, "finished");
+				Period aj_ = LastED?.Period;
+				CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
+				CqlDateTime al_ = context.Operators.End(ak_);
+				CqlValueSet am_ = this.Observation_Services();
+				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? ao_(Encounter LastObs)
 				{
-					var cg_ = LastObs?.StatusElement;
-					var ch_ = cg_?.Value;
-					var ci_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ch_);
-					var cj_ = context.Operators.Equal(ci_, "finished");
-					var ck_ = LastObs?.Period;
-					var cl_ = FHIRHelpers_4_3_000.ToInterval(ck_);
-					var cm_ = context.Operators.End(cl_);
-					var cn_ = Visit?.Period;
-					var co_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cp_ = context.Operators.Start(co_);
-					var cq_ = context.Operators.Quantity(1m, "hour");
-					var cr_ = context.Operators.Subtract(cp_, cq_);
-					var ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cu_ = context.Operators.Start(ct_);
-					var cv_ = context.Operators.Interval(cr_, cu_, true, true);
-					var cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
-					var cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cz_ = context.Operators.Start(cy_);
-					var da_ = context.Operators.Not((bool?)(cz_ is null));
-					var db_ = context.Operators.And(cw_, da_);
-					var dc_ = context.Operators.And(cj_, db_);
+					Code<Encounter.EncounterStatus> cg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? ch_ = cg_?.Value;
+					Code<Encounter.EncounterStatus> ci_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ch_);
+					bool? cj_ = context.Operators.Equal(ci_, "finished");
+					Period ck_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> cl_ = FHIRHelpers_4_3_000.ToInterval(ck_);
+					CqlDateTime cm_ = context.Operators.End(cl_);
+					Period cn_ = Visit?.Period;
+					CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cp_ = context.Operators.Start(co_);
+					CqlQuantity cq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime cr_ = context.Operators.Subtract(cp_, cq_);
+					CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cu_ = context.Operators.Start(ct_);
+					CqlInterval<CqlDateTime> cv_ = context.Operators.Interval(cr_, cu_, true, true);
+					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
+					CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cz_ = context.Operators.Start(cy_);
+					bool? da_ = context.Operators.Not((bool?)(cz_ is null));
+					bool? db_ = context.Operators.And(cw_, da_);
+					bool? dc_ = context.Operators.And(cj_, db_);
 
 					return dc_;
 				};
-				var ap_ = context.Operators.Where<Encounter>(an_, ao_);
+				IEnumerable<Encounter> ap_ = context.Operators.Where<Encounter>(an_, ao_);
 				object aq_(Encounter @this)
 				{
-					var dd_ = @this?.Period;
-					var de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
-					var df_ = context.Operators.End(de_);
+					Period dd_ = @this?.Period;
+					CqlInterval<CqlDateTime> de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
+					CqlDateTime df_ = context.Operators.End(de_);
 
 					return df_;
 				};
-				var ar_ = context.Operators.SortBy<Encounter>(ap_, aq_, System.ComponentModel.ListSortDirection.Ascending);
-				var as_ = context.Operators.Last<Encounter>(ar_);
-				var at_ = as_?.Period;
-				var au_ = FHIRHelpers_4_3_000.ToInterval(at_);
-				var av_ = context.Operators.Start(au_);
-				var aw_ = Visit?.Period;
-				var ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var ay_ = context.Operators.Start(ax_);
-				var az_ = context.Operators.Quantity(1m, "hour");
-				var ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
-				var bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> ar_ = context.Operators.SortBy<Encounter>(ap_, aq_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter as_ = context.Operators.Last<Encounter>(ar_);
+				Period at_ = as_?.Period;
+				CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_3_000.ToInterval(at_);
+				CqlDateTime av_ = context.Operators.Start(au_);
+				Period aw_ = Visit?.Period;
+				CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime ay_ = context.Operators.Start(ax_);
+				CqlQuantity az_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
+				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? bd_(Encounter LastObs)
 				{
-					var dg_ = LastObs?.StatusElement;
-					var dh_ = dg_?.Value;
-					var di_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dh_);
-					var dj_ = context.Operators.Equal(di_, "finished");
-					var dk_ = LastObs?.Period;
-					var dl_ = FHIRHelpers_4_3_000.ToInterval(dk_);
-					var dm_ = context.Operators.End(dl_);
-					var dn_ = Visit?.Period;
-					var do_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var dp_ = context.Operators.Start(do_);
-					var dq_ = context.Operators.Quantity(1m, "hour");
-					var dr_ = context.Operators.Subtract(dp_, dq_);
-					var dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var du_ = context.Operators.Start(dt_);
-					var dv_ = context.Operators.Interval(dr_, du_, true, true);
-					var dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
-					var dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var dz_ = context.Operators.Start(dy_);
-					var ea_ = context.Operators.Not((bool?)(dz_ is null));
-					var eb_ = context.Operators.And(dw_, ea_);
-					var ec_ = context.Operators.And(dj_, eb_);
+					Code<Encounter.EncounterStatus> dg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? dh_ = dg_?.Value;
+					Code<Encounter.EncounterStatus> di_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dh_);
+					bool? dj_ = context.Operators.Equal(di_, "finished");
+					Period dk_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_3_000.ToInterval(dk_);
+					CqlDateTime dm_ = context.Operators.End(dl_);
+					Period dn_ = Visit?.Period;
+					CqlInterval<CqlDateTime> do_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime dp_ = context.Operators.Start(do_);
+					CqlQuantity dq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime dr_ = context.Operators.Subtract(dp_, dq_);
+					CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime du_ = context.Operators.Start(dt_);
+					CqlInterval<CqlDateTime> dv_ = context.Operators.Interval(dr_, du_, true, true);
+					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
+					CqlInterval<CqlDateTime> dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime dz_ = context.Operators.Start(dy_);
+					bool? ea_ = context.Operators.Not((bool?)(dz_ is null));
+					bool? eb_ = context.Operators.And(dw_, ea_);
+					bool? ec_ = context.Operators.And(dj_, eb_);
 
 					return ec_;
 				};
-				var be_ = context.Operators.Where<Encounter>(bc_, bd_);
+				IEnumerable<Encounter> be_ = context.Operators.Where<Encounter>(bc_, bd_);
 				object bf_(Encounter @this)
 				{
-					var ed_ = @this?.Period;
-					var ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
-					var ef_ = context.Operators.End(ee_);
+					Period ed_ = @this?.Period;
+					CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
+					CqlDateTime ef_ = context.Operators.End(ee_);
 
 					return ef_;
 				};
-				var bg_ = context.Operators.SortBy<Encounter>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
-				var bh_ = context.Operators.Last<Encounter>(bg_);
-				var bi_ = bh_?.Period;
-				var bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
-				var bk_ = context.Operators.Start(bj_);
-				var bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var bn_ = context.Operators.Start(bm_);
-				var bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
-				var bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
-				var br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> bg_ = context.Operators.SortBy<Encounter>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bh_ = context.Operators.Last<Encounter>(bg_);
+				Period bi_ = bh_?.Period;
+				CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
+				CqlDateTime bk_ = context.Operators.Start(bj_);
+				CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime bn_ = context.Operators.Start(bm_);
+				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
+				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
+				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? bs_(Encounter LastObs)
 				{
-					var eg_ = LastObs?.StatusElement;
-					var eh_ = eg_?.Value;
-					var ei_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eh_);
-					var ej_ = context.Operators.Equal(ei_, "finished");
-					var ek_ = LastObs?.Period;
-					var el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
-					var em_ = context.Operators.End(el_);
-					var en_ = Visit?.Period;
-					var eo_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var ep_ = context.Operators.Start(eo_);
-					var eq_ = context.Operators.Quantity(1m, "hour");
-					var er_ = context.Operators.Subtract(ep_, eq_);
-					var et_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var eu_ = context.Operators.Start(et_);
-					var ev_ = context.Operators.Interval(er_, eu_, true, true);
-					var ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
-					var ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var ez_ = context.Operators.Start(ey_);
-					var fa_ = context.Operators.Not((bool?)(ez_ is null));
-					var fb_ = context.Operators.And(ew_, fa_);
-					var fc_ = context.Operators.And(ej_, fb_);
+					Code<Encounter.EncounterStatus> eg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? eh_ = eg_?.Value;
+					Code<Encounter.EncounterStatus> ei_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eh_);
+					bool? ej_ = context.Operators.Equal(ei_, "finished");
+					Period ek_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
+					CqlDateTime em_ = context.Operators.End(el_);
+					Period en_ = Visit?.Period;
+					CqlInterval<CqlDateTime> eo_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime ep_ = context.Operators.Start(eo_);
+					CqlQuantity eq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime er_ = context.Operators.Subtract(ep_, eq_);
+					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime eu_ = context.Operators.Start(et_);
+					CqlInterval<CqlDateTime> ev_ = context.Operators.Interval(er_, eu_, true, true);
+					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
+					CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime ez_ = context.Operators.Start(ey_);
+					bool? fa_ = context.Operators.Not((bool?)(ez_ is null));
+					bool? fb_ = context.Operators.And(ew_, fa_);
+					bool? fc_ = context.Operators.And(ej_, fb_);
 
 					return fc_;
 				};
-				var bt_ = context.Operators.Where<Encounter>(br_, bs_);
+				IEnumerable<Encounter> bt_ = context.Operators.Where<Encounter>(br_, bs_);
 				object bu_(Encounter @this)
 				{
-					var fd_ = @this?.Period;
-					var fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
-					var ff_ = context.Operators.End(fe_);
+					Period fd_ = @this?.Period;
+					CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
+					CqlDateTime ff_ = context.Operators.End(fe_);
 
 					return ff_;
 				};
-				var bv_ = context.Operators.SortBy<Encounter>(bt_, bu_, System.ComponentModel.ListSortDirection.Ascending);
-				var bw_ = context.Operators.Last<Encounter>(bv_);
-				var bx_ = bw_?.Period;
-				var by_ = FHIRHelpers_4_3_000.ToInterval(bx_);
-				var bz_ = context.Operators.Start(by_);
-				var cb_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var cc_ = context.Operators.Start(cb_);
-				var cd_ = context.Operators.Not((bool?)((bz_ ?? cc_) is null));
-				var ce_ = context.Operators.And(bp_, cd_);
-				var cf_ = context.Operators.And(ai_, ce_);
+				IEnumerable<Encounter> bv_ = context.Operators.SortBy<Encounter>(bt_, bu_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bw_ = context.Operators.Last<Encounter>(bv_);
+				Period bx_ = bw_?.Period;
+				CqlInterval<CqlDateTime> by_ = FHIRHelpers_4_3_000.ToInterval(bx_);
+				CqlDateTime bz_ = context.Operators.Start(by_);
+				CqlInterval<CqlDateTime> cb_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime cc_ = context.Operators.Start(cb_);
+				bool? cd_ = context.Operators.Not((bool?)((bz_ ?? cc_) is null));
+				bool? ce_ = context.Operators.And(bp_, cd_);
+				bool? cf_ = context.Operators.And(ai_, ce_);
 
 				return cf_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var fg_ = @this?.Period;
-				var fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
-				var fi_ = context.Operators.End(fh_);
+				Period fg_ = @this?.Period;
+				CqlInterval<CqlDateTime> fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
+				CqlDateTime fi_ = context.Operators.End(fh_);
 
 				return fi_;
 			};
-			var j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Encounter>(j_);
-			var l_ = k_?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Observation_Services();
-			var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter k_ = context.Operators.Last<Encounter>(j_);
+			Period l_ = k_?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlValueSet o_ = this.Observation_Services();
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
 			bool? q_(Encounter LastObs)
 			{
-				var fj_ = LastObs?.StatusElement;
-				var fk_ = fj_?.Value;
-				var fl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fk_);
-				var fm_ = context.Operators.Equal(fl_, "finished");
-				var fn_ = LastObs?.Period;
-				var fo_ = FHIRHelpers_4_3_000.ToInterval(fn_);
-				var fp_ = context.Operators.End(fo_);
-				var fq_ = Visit?.Period;
-				var fr_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var fs_ = context.Operators.Start(fr_);
-				var ft_ = context.Operators.Quantity(1m, "hour");
-				var fu_ = context.Operators.Subtract(fs_, ft_);
-				var fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var fx_ = context.Operators.Start(fw_);
-				var fy_ = context.Operators.Interval(fu_, fx_, true, true);
-				var fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
-				var gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var gc_ = context.Operators.Start(gb_);
-				var gd_ = context.Operators.Not((bool?)(gc_ is null));
-				var ge_ = context.Operators.And(fz_, gd_);
-				var gf_ = context.Operators.And(fm_, ge_);
+				Code<Encounter.EncounterStatus> fj_ = LastObs?.StatusElement;
+				Encounter.EncounterStatus? fk_ = fj_?.Value;
+				Code<Encounter.EncounterStatus> fl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fk_);
+				bool? fm_ = context.Operators.Equal(fl_, "finished");
+				Period fn_ = LastObs?.Period;
+				CqlInterval<CqlDateTime> fo_ = FHIRHelpers_4_3_000.ToInterval(fn_);
+				CqlDateTime fp_ = context.Operators.End(fo_);
+				Period fq_ = Visit?.Period;
+				CqlInterval<CqlDateTime> fr_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime fs_ = context.Operators.Start(fr_);
+				CqlQuantity ft_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime fu_ = context.Operators.Subtract(fs_, ft_);
+				CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime fx_ = context.Operators.Start(fw_);
+				CqlInterval<CqlDateTime> fy_ = context.Operators.Interval(fu_, fx_, true, true);
+				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
+				CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime gc_ = context.Operators.Start(gb_);
+				bool? gd_ = context.Operators.Not((bool?)(gc_ is null));
+				bool? ge_ = context.Operators.And(fz_, gd_);
+				bool? gf_ = context.Operators.And(fm_, ge_);
 
 				return gf_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 			object s_(Encounter @this)
 			{
-				var gg_ = @this?.Period;
-				var gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
-				var gi_ = context.Operators.End(gh_);
+				Period gg_ = @this?.Period;
+				CqlInterval<CqlDateTime> gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
+				CqlDateTime gi_ = context.Operators.End(gh_);
 
 				return gi_;
 			};
-			var t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.Last<Encounter>(t_);
-			var v_ = u_?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
-			var y_ = Visit?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = context.Operators.Start(z_);
-			var ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var ad_ = context.Operators.End(ac_);
-			var ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
+			IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter u_ = context.Operators.Last<Encounter>(t_);
+			Period v_ = u_?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			Period y_ = Visit?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime aa_ = context.Operators.Start(z_);
+			CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime ad_ = context.Operators.End(ac_);
+			CqlInterval<CqlDateTime> ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
 
 			return ae_;
 		};
-		var c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
+		CqlInterval<CqlDateTime> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
 
 		return d_;
 	}
@@ -2711,231 +2737,231 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Hospitalization with Observation returns the total interval from the start of any immediately prior emergency department visit through the observation visit to the discharge of the given encounter")]
 	public CqlInterval<CqlDateTime> hospitalizationWithObservation(Encounter TheEncounter)
 	{
-		var a_ = new Encounter[]
+		Encounter[] a_ = new Encounter[]
 		{
 			TheEncounter,
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Emergency_Department_Visit();
-			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			CqlValueSet e_ = this.Emergency_Department_Visit();
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastED)
 			{
-				var af_ = LastED?.StatusElement;
-				var ag_ = af_?.Value;
-				var ah_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ag_);
-				var ai_ = context.Operators.Equal(ah_, "finished");
-				var aj_ = LastED?.Period;
-				var ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
-				var al_ = context.Operators.End(ak_);
-				var am_ = this.Observation_Services();
-				var an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				Code<Encounter.EncounterStatus> af_ = LastED?.StatusElement;
+				Encounter.EncounterStatus? ag_ = af_?.Value;
+				Code<Encounter.EncounterStatus> ah_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ag_);
+				bool? ai_ = context.Operators.Equal(ah_, "finished");
+				Period aj_ = LastED?.Period;
+				CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
+				CqlDateTime al_ = context.Operators.End(ak_);
+				CqlValueSet am_ = this.Observation_Services();
+				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? ao_(Encounter LastObs)
 				{
-					var cg_ = LastObs?.StatusElement;
-					var ch_ = cg_?.Value;
-					var ci_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ch_);
-					var cj_ = context.Operators.Equal(ci_, "finished");
-					var ck_ = LastObs?.Period;
-					var cl_ = FHIRHelpers_4_3_000.ToInterval(ck_);
-					var cm_ = context.Operators.End(cl_);
-					var cn_ = Visit?.Period;
-					var co_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cp_ = context.Operators.Start(co_);
-					var cq_ = context.Operators.Quantity(1m, "hour");
-					var cr_ = context.Operators.Subtract(cp_, cq_);
-					var ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cu_ = context.Operators.Start(ct_);
-					var cv_ = context.Operators.Interval(cr_, cu_, true, true);
-					var cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
-					var cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cz_ = context.Operators.Start(cy_);
-					var da_ = context.Operators.Not((bool?)(cz_ is null));
-					var db_ = context.Operators.And(cw_, da_);
-					var dc_ = context.Operators.And(cj_, db_);
+					Code<Encounter.EncounterStatus> cg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? ch_ = cg_?.Value;
+					Code<Encounter.EncounterStatus> ci_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ch_);
+					bool? cj_ = context.Operators.Equal(ci_, "finished");
+					Period ck_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> cl_ = FHIRHelpers_4_3_000.ToInterval(ck_);
+					CqlDateTime cm_ = context.Operators.End(cl_);
+					Period cn_ = Visit?.Period;
+					CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cp_ = context.Operators.Start(co_);
+					CqlQuantity cq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime cr_ = context.Operators.Subtract(cp_, cq_);
+					CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cu_ = context.Operators.Start(ct_);
+					CqlInterval<CqlDateTime> cv_ = context.Operators.Interval(cr_, cu_, true, true);
+					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
+					CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cz_ = context.Operators.Start(cy_);
+					bool? da_ = context.Operators.Not((bool?)(cz_ is null));
+					bool? db_ = context.Operators.And(cw_, da_);
+					bool? dc_ = context.Operators.And(cj_, db_);
 
 					return dc_;
 				};
-				var ap_ = context.Operators.Where<Encounter>(an_, ao_);
+				IEnumerable<Encounter> ap_ = context.Operators.Where<Encounter>(an_, ao_);
 				object aq_(Encounter @this)
 				{
-					var dd_ = @this?.Period;
-					var de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
-					var df_ = context.Operators.End(de_);
+					Period dd_ = @this?.Period;
+					CqlInterval<CqlDateTime> de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
+					CqlDateTime df_ = context.Operators.End(de_);
 
 					return df_;
 				};
-				var ar_ = context.Operators.SortBy<Encounter>(ap_, aq_, System.ComponentModel.ListSortDirection.Ascending);
-				var as_ = context.Operators.Last<Encounter>(ar_);
-				var at_ = as_?.Period;
-				var au_ = FHIRHelpers_4_3_000.ToInterval(at_);
-				var av_ = context.Operators.Start(au_);
-				var aw_ = Visit?.Period;
-				var ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var ay_ = context.Operators.Start(ax_);
-				var az_ = context.Operators.Quantity(1m, "hour");
-				var ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
-				var bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> ar_ = context.Operators.SortBy<Encounter>(ap_, aq_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter as_ = context.Operators.Last<Encounter>(ar_);
+				Period at_ = as_?.Period;
+				CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_3_000.ToInterval(at_);
+				CqlDateTime av_ = context.Operators.Start(au_);
+				Period aw_ = Visit?.Period;
+				CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime ay_ = context.Operators.Start(ax_);
+				CqlQuantity az_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
+				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? bd_(Encounter LastObs)
 				{
-					var dg_ = LastObs?.StatusElement;
-					var dh_ = dg_?.Value;
-					var di_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dh_);
-					var dj_ = context.Operators.Equal(di_, "finished");
-					var dk_ = LastObs?.Period;
-					var dl_ = FHIRHelpers_4_3_000.ToInterval(dk_);
-					var dm_ = context.Operators.End(dl_);
-					var dn_ = Visit?.Period;
-					var do_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var dp_ = context.Operators.Start(do_);
-					var dq_ = context.Operators.Quantity(1m, "hour");
-					var dr_ = context.Operators.Subtract(dp_, dq_);
-					var dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var du_ = context.Operators.Start(dt_);
-					var dv_ = context.Operators.Interval(dr_, du_, true, true);
-					var dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
-					var dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var dz_ = context.Operators.Start(dy_);
-					var ea_ = context.Operators.Not((bool?)(dz_ is null));
-					var eb_ = context.Operators.And(dw_, ea_);
-					var ec_ = context.Operators.And(dj_, eb_);
+					Code<Encounter.EncounterStatus> dg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? dh_ = dg_?.Value;
+					Code<Encounter.EncounterStatus> di_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dh_);
+					bool? dj_ = context.Operators.Equal(di_, "finished");
+					Period dk_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_3_000.ToInterval(dk_);
+					CqlDateTime dm_ = context.Operators.End(dl_);
+					Period dn_ = Visit?.Period;
+					CqlInterval<CqlDateTime> do_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime dp_ = context.Operators.Start(do_);
+					CqlQuantity dq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime dr_ = context.Operators.Subtract(dp_, dq_);
+					CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime du_ = context.Operators.Start(dt_);
+					CqlInterval<CqlDateTime> dv_ = context.Operators.Interval(dr_, du_, true, true);
+					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
+					CqlInterval<CqlDateTime> dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime dz_ = context.Operators.Start(dy_);
+					bool? ea_ = context.Operators.Not((bool?)(dz_ is null));
+					bool? eb_ = context.Operators.And(dw_, ea_);
+					bool? ec_ = context.Operators.And(dj_, eb_);
 
 					return ec_;
 				};
-				var be_ = context.Operators.Where<Encounter>(bc_, bd_);
+				IEnumerable<Encounter> be_ = context.Operators.Where<Encounter>(bc_, bd_);
 				object bf_(Encounter @this)
 				{
-					var ed_ = @this?.Period;
-					var ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
-					var ef_ = context.Operators.End(ee_);
+					Period ed_ = @this?.Period;
+					CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
+					CqlDateTime ef_ = context.Operators.End(ee_);
 
 					return ef_;
 				};
-				var bg_ = context.Operators.SortBy<Encounter>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
-				var bh_ = context.Operators.Last<Encounter>(bg_);
-				var bi_ = bh_?.Period;
-				var bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
-				var bk_ = context.Operators.Start(bj_);
-				var bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var bn_ = context.Operators.Start(bm_);
-				var bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
-				var bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
-				var br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> bg_ = context.Operators.SortBy<Encounter>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bh_ = context.Operators.Last<Encounter>(bg_);
+				Period bi_ = bh_?.Period;
+				CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
+				CqlDateTime bk_ = context.Operators.Start(bj_);
+				CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime bn_ = context.Operators.Start(bm_);
+				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
+				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
+				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? bs_(Encounter LastObs)
 				{
-					var eg_ = LastObs?.StatusElement;
-					var eh_ = eg_?.Value;
-					var ei_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eh_);
-					var ej_ = context.Operators.Equal(ei_, "finished");
-					var ek_ = LastObs?.Period;
-					var el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
-					var em_ = context.Operators.End(el_);
-					var en_ = Visit?.Period;
-					var eo_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var ep_ = context.Operators.Start(eo_);
-					var eq_ = context.Operators.Quantity(1m, "hour");
-					var er_ = context.Operators.Subtract(ep_, eq_);
-					var et_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var eu_ = context.Operators.Start(et_);
-					var ev_ = context.Operators.Interval(er_, eu_, true, true);
-					var ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
-					var ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var ez_ = context.Operators.Start(ey_);
-					var fa_ = context.Operators.Not((bool?)(ez_ is null));
-					var fb_ = context.Operators.And(ew_, fa_);
-					var fc_ = context.Operators.And(ej_, fb_);
+					Code<Encounter.EncounterStatus> eg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? eh_ = eg_?.Value;
+					Code<Encounter.EncounterStatus> ei_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eh_);
+					bool? ej_ = context.Operators.Equal(ei_, "finished");
+					Period ek_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
+					CqlDateTime em_ = context.Operators.End(el_);
+					Period en_ = Visit?.Period;
+					CqlInterval<CqlDateTime> eo_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime ep_ = context.Operators.Start(eo_);
+					CqlQuantity eq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime er_ = context.Operators.Subtract(ep_, eq_);
+					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime eu_ = context.Operators.Start(et_);
+					CqlInterval<CqlDateTime> ev_ = context.Operators.Interval(er_, eu_, true, true);
+					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
+					CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime ez_ = context.Operators.Start(ey_);
+					bool? fa_ = context.Operators.Not((bool?)(ez_ is null));
+					bool? fb_ = context.Operators.And(ew_, fa_);
+					bool? fc_ = context.Operators.And(ej_, fb_);
 
 					return fc_;
 				};
-				var bt_ = context.Operators.Where<Encounter>(br_, bs_);
+				IEnumerable<Encounter> bt_ = context.Operators.Where<Encounter>(br_, bs_);
 				object bu_(Encounter @this)
 				{
-					var fd_ = @this?.Period;
-					var fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
-					var ff_ = context.Operators.End(fe_);
+					Period fd_ = @this?.Period;
+					CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
+					CqlDateTime ff_ = context.Operators.End(fe_);
 
 					return ff_;
 				};
-				var bv_ = context.Operators.SortBy<Encounter>(bt_, bu_, System.ComponentModel.ListSortDirection.Ascending);
-				var bw_ = context.Operators.Last<Encounter>(bv_);
-				var bx_ = bw_?.Period;
-				var by_ = FHIRHelpers_4_3_000.ToInterval(bx_);
-				var bz_ = context.Operators.Start(by_);
-				var cb_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var cc_ = context.Operators.Start(cb_);
-				var cd_ = context.Operators.Not((bool?)((bz_ ?? cc_) is null));
-				var ce_ = context.Operators.And(bp_, cd_);
-				var cf_ = context.Operators.And(ai_, ce_);
+				IEnumerable<Encounter> bv_ = context.Operators.SortBy<Encounter>(bt_, bu_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bw_ = context.Operators.Last<Encounter>(bv_);
+				Period bx_ = bw_?.Period;
+				CqlInterval<CqlDateTime> by_ = FHIRHelpers_4_3_000.ToInterval(bx_);
+				CqlDateTime bz_ = context.Operators.Start(by_);
+				CqlInterval<CqlDateTime> cb_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime cc_ = context.Operators.Start(cb_);
+				bool? cd_ = context.Operators.Not((bool?)((bz_ ?? cc_) is null));
+				bool? ce_ = context.Operators.And(bp_, cd_);
+				bool? cf_ = context.Operators.And(ai_, ce_);
 
 				return cf_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var fg_ = @this?.Period;
-				var fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
-				var fi_ = context.Operators.End(fh_);
+				Period fg_ = @this?.Period;
+				CqlInterval<CqlDateTime> fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
+				CqlDateTime fi_ = context.Operators.End(fh_);
 
 				return fi_;
 			};
-			var j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Encounter>(j_);
-			var l_ = k_?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Observation_Services();
-			var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter k_ = context.Operators.Last<Encounter>(j_);
+			Period l_ = k_?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlValueSet o_ = this.Observation_Services();
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
 			bool? q_(Encounter LastObs)
 			{
-				var fj_ = LastObs?.StatusElement;
-				var fk_ = fj_?.Value;
-				var fl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fk_);
-				var fm_ = context.Operators.Equal(fl_, "finished");
-				var fn_ = LastObs?.Period;
-				var fo_ = FHIRHelpers_4_3_000.ToInterval(fn_);
-				var fp_ = context.Operators.End(fo_);
-				var fq_ = Visit?.Period;
-				var fr_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var fs_ = context.Operators.Start(fr_);
-				var ft_ = context.Operators.Quantity(1m, "hour");
-				var fu_ = context.Operators.Subtract(fs_, ft_);
-				var fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var fx_ = context.Operators.Start(fw_);
-				var fy_ = context.Operators.Interval(fu_, fx_, true, true);
-				var fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
-				var gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var gc_ = context.Operators.Start(gb_);
-				var gd_ = context.Operators.Not((bool?)(gc_ is null));
-				var ge_ = context.Operators.And(fz_, gd_);
-				var gf_ = context.Operators.And(fm_, ge_);
+				Code<Encounter.EncounterStatus> fj_ = LastObs?.StatusElement;
+				Encounter.EncounterStatus? fk_ = fj_?.Value;
+				Code<Encounter.EncounterStatus> fl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fk_);
+				bool? fm_ = context.Operators.Equal(fl_, "finished");
+				Period fn_ = LastObs?.Period;
+				CqlInterval<CqlDateTime> fo_ = FHIRHelpers_4_3_000.ToInterval(fn_);
+				CqlDateTime fp_ = context.Operators.End(fo_);
+				Period fq_ = Visit?.Period;
+				CqlInterval<CqlDateTime> fr_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime fs_ = context.Operators.Start(fr_);
+				CqlQuantity ft_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime fu_ = context.Operators.Subtract(fs_, ft_);
+				CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime fx_ = context.Operators.Start(fw_);
+				CqlInterval<CqlDateTime> fy_ = context.Operators.Interval(fu_, fx_, true, true);
+				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
+				CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime gc_ = context.Operators.Start(gb_);
+				bool? gd_ = context.Operators.Not((bool?)(gc_ is null));
+				bool? ge_ = context.Operators.And(fz_, gd_);
+				bool? gf_ = context.Operators.And(fm_, ge_);
 
 				return gf_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 			object s_(Encounter @this)
 			{
-				var gg_ = @this?.Period;
-				var gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
-				var gi_ = context.Operators.End(gh_);
+				Period gg_ = @this?.Period;
+				CqlInterval<CqlDateTime> gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
+				CqlDateTime gi_ = context.Operators.End(gh_);
 
 				return gi_;
 			};
-			var t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.Last<Encounter>(t_);
-			var v_ = u_?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
-			var y_ = Visit?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = context.Operators.Start(z_);
-			var ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var ad_ = context.Operators.End(ac_);
-			var ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
+			IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter u_ = context.Operators.Last<Encounter>(t_);
+			Period v_ = u_?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			Period y_ = Visit?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime aa_ = context.Operators.Start(z_);
+			CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime ad_ = context.Operators.End(ac_);
+			CqlInterval<CqlDateTime> ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
 
 			return ae_;
 		};
-		var c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
+		CqlInterval<CqlDateTime> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
 
 		return d_;
 	}
@@ -2945,8 +2971,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationWithObservationLengthofStay()` instead.")]
 	public int? HospitalizationWithObservationLengthofStay(Encounter TheEncounter)
 	{
-		var a_ = this.HospitalizationWithObservation(TheEncounter);
-		var b_ = this.LengthInDays(a_);
+		CqlInterval<CqlDateTime> a_ = this.HospitalizationWithObservation(TheEncounter);
+		int? b_ = this.LengthInDays(a_);
 
 		return b_;
 	}
@@ -2955,8 +2981,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Hospitalization with Observation Length of Stay returns the length in days from the start of any immediately prior emergency department visit through the observation visit to the discharge of the given encounter")]
 	public int? hospitalizationWithObservationLengthofStay(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalizationWithObservation(TheEncounter);
-		var b_ = this.lengthInDays(a_);
+		CqlInterval<CqlDateTime> a_ = this.hospitalizationWithObservation(TheEncounter);
+		int? b_ = this.lengthInDays(a_);
 
 		return b_;
 	}
@@ -2966,84 +2992,86 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `firstInpatientIntensiveCareUnit()` instead.")]
 	public Encounter.LocationComponent FirstInpatientIntensiveCareUnit(Encounter Encounter)
 	{
-		bool? a_(Encounter.LocationComponent HospitalLocation)
+		List<Encounter.LocationComponent> a_ = Encounter?.Location;
+		bool? b_(Encounter.LocationComponent HospitalLocation)
 		{
-			var f_ = HospitalLocation?.Location;
-			var g_ = this.GetLocation(f_);
-			var h_ = g_?.Type;
-			CqlConcept i_(CodeableConcept @this)
+			ResourceReference g_ = HospitalLocation?.Location;
+			Location h_ = this.GetLocation(g_);
+			List<CodeableConcept> i_ = h_?.Type;
+			CqlConcept j_(CodeableConcept @this)
 			{
-				var s_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept t_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-				return s_;
+				return t_;
 			};
-			var j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
-			var k_ = this.Intensive_Care_Unit();
-			var l_ = context.Operators.ConceptsInValueSet(j_, k_);
-			var m_ = Encounter?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = HospitalLocation?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, p_, null);
-			var r_ = context.Operators.And(l_, q_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			CqlValueSet l_ = this.Intensive_Care_Unit();
+			bool? m_ = context.Operators.ConceptsInValueSet(k_, l_);
+			Period n_ = Encounter?.Period;
+			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+			Period p_ = HospitalLocation?.Period;
+			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, null);
+			bool? s_ = context.Operators.And(m_, r_);
 
-			return r_;
+			return s_;
 		};
-		var b_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)Encounter?.Location, a_);
-		object c_(Encounter.LocationComponent @this)
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
+		object d_(Encounter.LocationComponent @this)
 		{
-			var t_ = @this?.Period;
-			var u_ = FHIRHelpers_4_3_000.ToInterval(t_);
-			var v_ = context.Operators.Start(u_);
+			Period u_ = @this?.Period;
+			CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(u_);
+			CqlDateTime w_ = context.Operators.Start(v_);
 
-			return v_;
+			return w_;
 		};
-		var d_ = context.Operators.SortBy<Encounter.LocationComponent>(b_, c_, System.ComponentModel.ListSortDirection.Ascending);
-		var e_ = context.Operators.First<Encounter.LocationComponent>(d_);
+		IEnumerable<Encounter.LocationComponent> e_ = context.Operators.SortBy<Encounter.LocationComponent>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent f_ = context.Operators.First<Encounter.LocationComponent>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("firstInpatientIntensiveCareUnit")]
     [CqlTag("description", "First Inpatient Intensive Care Unit returns the first intensive care unit for the given encounter, without considering any immediately prior emergency department visit.")]
 	public Encounter.LocationComponent firstInpatientIntensiveCareUnit(Encounter Encounter)
 	{
-		bool? a_(Encounter.LocationComponent HospitalLocation)
+		List<Encounter.LocationComponent> a_ = Encounter?.Location;
+		bool? b_(Encounter.LocationComponent HospitalLocation)
 		{
-			var f_ = HospitalLocation?.Location;
-			var g_ = this.GetLocation(f_);
-			var h_ = g_?.Type;
-			CqlConcept i_(CodeableConcept @this)
+			ResourceReference g_ = HospitalLocation?.Location;
+			Location h_ = this.GetLocation(g_);
+			List<CodeableConcept> i_ = h_?.Type;
+			CqlConcept j_(CodeableConcept @this)
 			{
-				var s_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept t_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-				return s_;
+				return t_;
 			};
-			var j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
-			var k_ = this.Intensive_Care_Unit();
-			var l_ = context.Operators.ConceptsInValueSet(j_, k_);
-			var m_ = Encounter?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = HospitalLocation?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, p_, null);
-			var r_ = context.Operators.And(l_, q_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			CqlValueSet l_ = this.Intensive_Care_Unit();
+			bool? m_ = context.Operators.ConceptsInValueSet(k_, l_);
+			Period n_ = Encounter?.Period;
+			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+			Period p_ = HospitalLocation?.Period;
+			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, null);
+			bool? s_ = context.Operators.And(m_, r_);
 
-			return r_;
+			return s_;
 		};
-		var b_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)Encounter?.Location, a_);
-		object c_(Encounter.LocationComponent @this)
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
+		object d_(Encounter.LocationComponent @this)
 		{
-			var t_ = @this?.Period;
-			var u_ = FHIRHelpers_4_3_000.ToInterval(t_);
-			var v_ = context.Operators.Start(u_);
+			Period u_ = @this?.Period;
+			CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(u_);
+			CqlDateTime w_ = context.Operators.Start(v_);
 
-			return v_;
+			return w_;
 		};
-		var d_ = context.Operators.SortBy<Encounter.LocationComponent>(b_, c_, System.ComponentModel.ListSortDirection.Ascending);
-		var e_ = context.Operators.First<Encounter.LocationComponent>(d_);
+		IEnumerable<Encounter.LocationComponent> e_ = context.Operators.SortBy<Encounter.LocationComponent>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent f_ = context.Operators.First<Encounter.LocationComponent>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("EncounterDiagnosis")]
@@ -3051,58 +3079,60 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `encounterDiagnosis()` instead.")]
 	public IEnumerable<Condition> EncounterDiagnosis(Encounter Encounter)
 	{
-		Condition a_(Encounter.DiagnosisComponent D)
+		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
+		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			var c_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-			bool? d_(Condition C)
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? e_(Condition C)
 			{
-				var g_ = C?.IdElement;
-				var h_ = g_?.Value;
-				var i_ = D?.Condition;
-				var j_ = i_?.ReferenceElement;
-				var k_ = j_?.Value;
-				var l_ = QICoreCommon_2_0_000.getId(k_);
-				var m_ = context.Operators.Equal(h_, l_);
+				Id h_ = C?.IdElement;
+				string i_ = h_?.Value;
+				ResourceReference j_ = D?.Condition;
+				FhirString k_ = j_?.ReferenceElement;
+				string l_ = k_?.Value;
+				string m_ = QICoreCommon_2_0_000.getId(l_);
+				bool? n_ = context.Operators.Equal(i_, m_);
 
-				return m_;
+				return n_;
 			};
-			var e_ = context.Operators.Where<Condition>(c_, d_);
-			var f_ = context.Operators.SingletonFrom<Condition>(e_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+			Condition g_ = context.Operators.SingletonFrom<Condition>(f_);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>((IEnumerable<Encounter.DiagnosisComponent>)Encounter?.Diagnosis, a_);
+		IEnumerable<Condition> c_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 
-		return b_;
+		return c_;
 	}
 
     [CqlDeclaration("encounterDiagnosis")]
     [CqlTag("description", "Returns the Condition resources referenced by the diagnosis element of the Encounter")]
 	public IEnumerable<Condition> encounterDiagnosis(Encounter Encounter)
 	{
-		Condition a_(Encounter.DiagnosisComponent D)
+		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
+		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			var c_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-			bool? d_(Condition C)
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? e_(Condition C)
 			{
-				var g_ = C?.IdElement;
-				var h_ = g_?.Value;
-				var i_ = D?.Condition;
-				var j_ = i_?.ReferenceElement;
-				var k_ = j_?.Value;
-				var l_ = QICoreCommon_2_0_000.getId(k_);
-				var m_ = context.Operators.Equal(h_, l_);
+				Id h_ = C?.IdElement;
+				string i_ = h_?.Value;
+				ResourceReference j_ = D?.Condition;
+				FhirString k_ = j_?.ReferenceElement;
+				string l_ = k_?.Value;
+				string m_ = QICoreCommon_2_0_000.getId(l_);
+				bool? n_ = context.Operators.Equal(i_, m_);
 
-				return m_;
+				return n_;
 			};
-			var e_ = context.Operators.Where<Condition>(c_, d_);
-			var f_ = context.Operators.SingletonFrom<Condition>(e_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+			Condition g_ = context.Operators.SingletonFrom<Condition>(f_);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>((IEnumerable<Encounter.DiagnosisComponent>)Encounter?.Diagnosis, a_);
+		IEnumerable<Condition> c_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 
-		return b_;
+		return c_;
 	}
 
     [CqlDeclaration("GetCondition")]
@@ -3110,20 +3140,20 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getCondition()` instead")]
 	public Condition GetCondition(ResourceReference reference)
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
 		bool? b_(Condition C)
 		{
-			var e_ = C?.IdElement;
-			var f_ = e_?.Value;
-			var g_ = reference?.ReferenceElement;
-			var h_ = g_?.Value;
-			var i_ = QICoreCommon_2_0_000.getId(h_);
-			var j_ = context.Operators.Equal(f_, i_);
+			Id e_ = C?.IdElement;
+			string f_ = e_?.Value;
+			FhirString g_ = reference?.ReferenceElement;
+			string h_ = g_?.Value;
+			string i_ = QICoreCommon_2_0_000.getId(h_);
+			bool? j_ = context.Operators.Equal(f_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Condition>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Condition>(c_);
+		IEnumerable<Condition> c_ = context.Operators.Where<Condition>(a_, b_);
+		Condition d_ = context.Operators.SingletonFrom<Condition>(c_);
 
 		return d_;
 	}
@@ -3132,20 +3162,20 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the Condition resource for the given reference")]
 	public Condition getCondition(ResourceReference reference)
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
 		bool? b_(Condition C)
 		{
-			var e_ = C?.IdElement;
-			var f_ = e_?.Value;
-			var g_ = reference?.ReferenceElement;
-			var h_ = g_?.Value;
-			var i_ = QICoreCommon_2_0_000.getId(h_);
-			var j_ = context.Operators.Equal(f_, i_);
+			Id e_ = C?.IdElement;
+			string f_ = e_?.Value;
+			FhirString g_ = reference?.ReferenceElement;
+			string h_ = g_?.Value;
+			string i_ = QICoreCommon_2_0_000.getId(h_);
+			bool? j_ = context.Operators.Equal(f_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Condition>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Condition>(c_);
+		IEnumerable<Condition> c_ = context.Operators.Where<Condition>(a_, b_);
+		Condition d_ = context.Operators.SingletonFrom<Condition>(c_);
 
 		return d_;
 	}
@@ -3155,98 +3185,100 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `principalDiagnosis()` instead.")]
 	public Condition PrincipalDiagnosis(Encounter Encounter)
 	{
-		bool? a_(Encounter.DiagnosisComponent D)
+		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
+		bool? b_(Encounter.DiagnosisComponent D)
 		{
-			var f_ = D?.RankElement;
-			var g_ = f_?.Value;
-			var h_ = context.Operators.Equal(g_, 1);
+			PositiveInt g_ = D?.RankElement;
+			int? h_ = g_?.Value;
+			bool? i_ = context.Operators.Equal(h_, 1);
 
-			return h_;
+			return i_;
 		};
-		var b_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)Encounter?.Diagnosis, a_);
-		Condition c_(Encounter.DiagnosisComponent PD)
+		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
+		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			var i_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-			bool? j_(Condition C)
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? k_(Condition C)
 			{
-				var m_ = C?.IdElement;
-				var n_ = m_?.Value;
-				var o_ = PD?.Condition;
-				var p_ = o_?.ReferenceElement;
-				var q_ = p_?.Value;
-				var r_ = QICoreCommon_2_0_000.getId(q_);
-				var s_ = context.Operators.Equal(n_, r_);
+				Id n_ = C?.IdElement;
+				string o_ = n_?.Value;
+				ResourceReference p_ = PD?.Condition;
+				FhirString q_ = p_?.ReferenceElement;
+				string r_ = q_?.Value;
+				string s_ = QICoreCommon_2_0_000.getId(r_);
+				bool? t_ = context.Operators.Equal(o_, s_);
 
-				return s_;
+				return t_;
 			};
-			var k_ = context.Operators.Where<Condition>(i_, j_);
-			var l_ = context.Operators.SingletonFrom<Condition>(k_);
+			IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
+			Condition m_ = context.Operators.SingletonFrom<Condition>(l_);
 
-			return l_;
+			return m_;
 		};
-		var d_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<Condition>(d_);
+		IEnumerable<Condition> e_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(c_, d_);
+		Condition f_ = context.Operators.SingletonFrom<Condition>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("principalDiagnosis")]
     [CqlTag("description", "Returns the condition that is specified as the principal diagnosis for the encounter")]
 	public Condition principalDiagnosis(Encounter Encounter)
 	{
-		bool? a_(Encounter.DiagnosisComponent D)
+		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
+		bool? b_(Encounter.DiagnosisComponent D)
 		{
-			var f_ = D?.RankElement;
-			var g_ = f_?.Value;
-			var h_ = context.Operators.Equal(g_, 1);
+			PositiveInt g_ = D?.RankElement;
+			int? h_ = g_?.Value;
+			bool? i_ = context.Operators.Equal(h_, 1);
 
-			return h_;
+			return i_;
 		};
-		var b_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)Encounter?.Diagnosis, a_);
-		Condition c_(Encounter.DiagnosisComponent PD)
+		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
+		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			var i_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-			bool? j_(Condition C)
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? k_(Condition C)
 			{
-				var m_ = C?.IdElement;
-				var n_ = m_?.Value;
-				var o_ = PD?.Condition;
-				var p_ = o_?.ReferenceElement;
-				var q_ = p_?.Value;
-				var r_ = QICoreCommon_2_0_000.getId(q_);
-				var s_ = context.Operators.Equal(n_, r_);
+				Id n_ = C?.IdElement;
+				string o_ = n_?.Value;
+				ResourceReference p_ = PD?.Condition;
+				FhirString q_ = p_?.ReferenceElement;
+				string r_ = q_?.Value;
+				string s_ = QICoreCommon_2_0_000.getId(r_);
+				bool? t_ = context.Operators.Equal(o_, s_);
 
-				return s_;
+				return t_;
 			};
-			var k_ = context.Operators.Where<Condition>(i_, j_);
-			var l_ = context.Operators.SingletonFrom<Condition>(k_);
+			IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
+			Condition m_ = context.Operators.SingletonFrom<Condition>(l_);
 
-			return l_;
+			return m_;
 		};
-		var d_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<Condition>(d_);
+		IEnumerable<Condition> e_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(c_, d_);
+		Condition f_ = context.Operators.SingletonFrom<Condition>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("getLocation")]
     [CqlTag("description", "Returns the Location resource specified by the given reference.")]
 	public Location getLocation(ResourceReference reference)
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
 		bool? b_(Location L)
 		{
-			var e_ = L?.IdElement;
-			var f_ = e_?.Value;
-			var g_ = reference?.ReferenceElement;
-			var h_ = g_?.Value;
-			var i_ = QICoreCommon_2_0_000.getId(h_);
-			var j_ = context.Operators.Equal(f_, i_);
+			Id e_ = L?.IdElement;
+			string f_ = e_?.Value;
+			FhirString g_ = reference?.ReferenceElement;
+			string h_ = g_?.Value;
+			string i_ = QICoreCommon_2_0_000.getId(h_);
+			bool? j_ = context.Operators.Equal(f_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Location>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Location>(c_);
+		IEnumerable<Location> c_ = context.Operators.Where<Location>(a_, b_);
+		Location d_ = context.Operators.SingletonFrom<Location>(c_);
 
 		return d_;
 	}
@@ -3260,40 +3292,41 @@ public class CQMCommon_2_0_000
 		{
 			bool b_()
 			{
-				var c_ = request?.Medication;
-				var d_ = FHIRHelpers_4_3_000.ToValue(c_);
-				var e_ = d_ is CqlConcept;
+				DataType c_ = request?.Medication;
+				object d_ = FHIRHelpers_4_3_000.ToValue(c_);
+				bool e_ = d_ is CqlConcept;
 
 				return e_;
 			};
 			if (b_())
 			{
-				var f_ = request?.Medication;
-				var g_ = FHIRHelpers_4_3_000.ToValue(f_);
+				DataType f_ = request?.Medication;
+				object g_ = FHIRHelpers_4_3_000.ToValue(f_);
 
 				return (g_ as CqlConcept);
 			}
 			else
 			{
-				var h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
+				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
 				bool? i_(Medication M)
 				{
-					var m_ = M?.IdElement;
-					var n_ = m_?.Value;
-					var o_ = request?.Medication;
-					var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-					var q_ = (p_ as ResourceReference)?.ReferenceElement;
-					var r_ = q_?.Value;
-					var s_ = QICoreCommon_2_0_000.getId(r_);
-					var t_ = context.Operators.Equal(n_, s_);
+					Id n_ = M?.IdElement;
+					string o_ = n_?.Value;
+					DataType p_ = request?.Medication;
+					object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+					FhirString r_ = (q_ as ResourceReference)?.ReferenceElement;
+					string s_ = r_?.Value;
+					string t_ = QICoreCommon_2_0_000.getId(s_);
+					bool? u_ = context.Operators.Equal(o_, t_);
 
-					return t_;
+					return u_;
 				};
-				var j_ = context.Operators.Where<Medication>(h_, i_);
-				var k_ = context.Operators.SingletonFrom<Medication>(j_);
-				var l_ = FHIRHelpers_4_3_000.ToConcept(k_?.Code);
+				IEnumerable<Medication> j_ = context.Operators.Where<Medication>(h_, i_);
+				Medication k_ = context.Operators.SingletonFrom<Medication>(j_);
+				CodeableConcept l_ = k_?.Code;
+				CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
 
-				return l_;
+				return m_;
 			}
 		};
 
@@ -3308,40 +3341,41 @@ public class CQMCommon_2_0_000
 		{
 			bool b_()
 			{
-				var c_ = request?.Medication;
-				var d_ = FHIRHelpers_4_3_000.ToValue(c_);
-				var e_ = d_ is CqlConcept;
+				DataType c_ = request?.Medication;
+				object d_ = FHIRHelpers_4_3_000.ToValue(c_);
+				bool e_ = d_ is CqlConcept;
 
 				return e_;
 			};
 			if (b_())
 			{
-				var f_ = request?.Medication;
-				var g_ = FHIRHelpers_4_3_000.ToValue(f_);
+				DataType f_ = request?.Medication;
+				object g_ = FHIRHelpers_4_3_000.ToValue(f_);
 
 				return (g_ as CqlConcept);
 			}
 			else
 			{
-				var h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
+				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
 				bool? i_(Medication M)
 				{
-					var m_ = M?.IdElement;
-					var n_ = m_?.Value;
-					var o_ = request?.Medication;
-					var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-					var q_ = (p_ as ResourceReference)?.ReferenceElement;
-					var r_ = q_?.Value;
-					var s_ = QICoreCommon_2_0_000.getId(r_);
-					var t_ = context.Operators.Equal(n_, s_);
+					Id n_ = M?.IdElement;
+					string o_ = n_?.Value;
+					DataType p_ = request?.Medication;
+					object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+					FhirString r_ = (q_ as ResourceReference)?.ReferenceElement;
+					string s_ = r_?.Value;
+					string t_ = QICoreCommon_2_0_000.getId(s_);
+					bool? u_ = context.Operators.Equal(o_, t_);
 
-					return t_;
+					return u_;
 				};
-				var j_ = context.Operators.Where<Medication>(h_, i_);
-				var k_ = context.Operators.SingletonFrom<Medication>(j_);
-				var l_ = FHIRHelpers_4_3_000.ToConcept(k_?.Code);
+				IEnumerable<Medication> j_ = context.Operators.Where<Medication>(h_, i_);
+				Medication k_ = context.Operators.SingletonFrom<Medication>(j_);
+				CodeableConcept l_ = k_?.Code;
+				CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
 
-				return l_;
+				return m_;
 			}
 		};
 

--- a/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
@@ -80,182 +80,205 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 
     #endregion
 
+    /// <seealso cref="Consultant_Report"/>
 	private CqlValueSet Consultant_Report_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006", null);
 
+    /// <seealso cref="Consultant_Report_Value"/>
     [CqlDeclaration("Consultant Report")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006")]
 	public CqlValueSet Consultant_Report() => 
 		__Consultant_Report.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Ophthalmological_Services"/>
 	private CqlValueSet Ophthalmological_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
 
+    /// <seealso cref="Ophthalmological_Services_Value"/>
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
 	public CqlValueSet Ophthalmological_Services() => 
 		__Ophthalmological_Services.Value;
 
+    /// <seealso cref="Preventive_Care_Services___Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
 	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
 	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Referral"/>
 	private CqlValueSet Referral_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046", null);
 
+    /// <seealso cref="Referral_Value"/>
     [CqlDeclaration("Referral")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046")]
 	public CqlValueSet Referral() => 
 		__Referral.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("CRLReceiptofSpecialistReportFHIR-0.2.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("CRLReceiptofSpecialistReportFHIR-0.2.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Has_Encounter_during_Measurement_Period"/>
 	private bool? Has_Encounter_during_Measurement_Period_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Ophthalmological_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Ophthalmological_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		bool? r_(Encounter Encounter)
 		{
-			var u_ = Encounter?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
-			var x_ = context.Operators.Equal(w_, "finished");
-			var y_ = this.Measurement_Period();
-			var z_ = Encounter?.Period;
-			var aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-			var ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, "day");
-			var ac_ = context.Operators.And(x_, ab_);
+			Code<Encounter.EncounterStatus> u_ = Encounter?.StatusElement;
+			Encounter.EncounterStatus? v_ = u_?.Value;
+			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+			bool? x_ = context.Operators.Equal(w_, "finished");
+			CqlInterval<CqlDateTime> y_ = this.Measurement_Period();
+			Period z_ = Encounter?.Period;
+			CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, "day");
+			bool? ac_ = context.Operators.And(x_, ab_);
 
 			return ac_;
 		};
-		var s_ = context.Operators.Where<Encounter>(q_, r_);
-		var t_ = context.Operators.Exists<Encounter>(s_);
+		IEnumerable<Encounter> s_ = context.Operators.Where<Encounter>(q_, r_);
+		bool? t_ = context.Operators.Exists<Encounter>(s_);
 
 		return t_;
 	}
 
+    /// <seealso cref="Has_Encounter_during_Measurement_Period_Value"/>
     [CqlDeclaration("Has Encounter during Measurement Period")]
 	public bool? Has_Encounter_during_Measurement_Period() => 
 		__Has_Encounter_during_Measurement_Period.Value;
 
+    /// <seealso cref="First_Referral_during_First_10_Months_of_Measurement_Period"/>
 	private Tuple_BLEMZbHGbhMbZiIgCJaASVTUS First_Referral_during_First_10_Months_of_Measurement_Period_Value()
 	{
-		var a_ = this.Referral();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		CqlValueSet a_ = this.Referral();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
 		bool? c_(ServiceRequest ReferralOrder)
 		{
-			var j_ = ReferralOrder?.StatusElement;
-			var k_ = j_?.Value;
-			var l_ = context.Operators.Convert<Code<RequestStatus>>(k_);
-			var m_ = context.Operators.Convert<string>(l_);
-			var n_ = new string[]
+			Code<RequestStatus> j_ = ReferralOrder?.StatusElement;
+			RequestStatus? k_ = j_?.Value;
+			Code<RequestStatus> l_ = context.Operators.Convert<Code<RequestStatus>>(k_);
+			string m_ = context.Operators.Convert<string>(l_);
+			string[] n_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var o_ = context.Operators.In<string>(m_, (n_ as IEnumerable<string>));
-			var p_ = ReferralOrder?.IntentElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<RequestIntent>>(q_);
-			var s_ = context.Operators.Equal(r_, "order");
-			var t_ = context.Operators.And(o_, s_);
-			var u_ = ReferralOrder?.AuthoredOnElement;
-			var v_ = context.Operators.Convert<CqlDateTime>(u_);
-			var w_ = this.Measurement_Period();
-			var x_ = context.Operators.Start(w_);
-			var z_ = context.Operators.Start(w_);
-			var aa_ = context.Operators.DateTimeComponentFrom(z_, "year");
-			var ab_ = context.Operators.Date(aa_, 10, 31);
-			var ac_ = context.Operators.ConvertDateToDateTime(ab_);
-			var ad_ = context.Operators.Interval(x_, ac_, true, true);
-			var ae_ = context.Operators.In<CqlDateTime>(v_, ad_, "day");
-			var af_ = context.Operators.And(t_, ae_);
+			bool? o_ = context.Operators.In<string>(m_, (n_ as IEnumerable<string>));
+			Code<RequestIntent> p_ = ReferralOrder?.IntentElement;
+			RequestIntent? q_ = p_?.Value;
+			Code<RequestIntent> r_ = context.Operators.Convert<Code<RequestIntent>>(q_);
+			bool? s_ = context.Operators.Equal(r_, "order");
+			bool? t_ = context.Operators.And(o_, s_);
+			FhirDateTime u_ = ReferralOrder?.AuthoredOnElement;
+			CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
+			CqlDateTime x_ = context.Operators.Start(w_);
+			CqlDateTime z_ = context.Operators.Start(w_);
+			int? aa_ = context.Operators.DateTimeComponentFrom(z_, "year");
+			CqlDate ab_ = context.Operators.Date(aa_, 10, 31);
+			CqlDateTime ac_ = context.Operators.ConvertDateToDateTime(ab_);
+			CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
+			bool? ae_ = context.Operators.In<CqlDateTime>(v_, ad_, "day");
+			bool? af_ = context.Operators.And(t_, ae_);
 
 			return af_;
 		};
-		var d_ = context.Operators.Where<ServiceRequest>(b_, c_);
+		IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
 		Tuple_BLEMZbHGbhMbZiIgCJaASVTUS e_(ServiceRequest ReferralOrder)
 		{
-			var ag_ = ReferralOrder?.IdElement;
-			var ah_ = ag_?.Value;
-			var ai_ = ReferralOrder?.AuthoredOnElement;
-			var aj_ = context.Operators.Convert<CqlDateTime>(ai_);
-			var ak_ = new Tuple_BLEMZbHGbhMbZiIgCJaASVTUS
+			Id ag_ = ReferralOrder?.IdElement;
+			string ah_ = ag_?.Value;
+			FhirDateTime ai_ = ReferralOrder?.AuthoredOnElement;
+			CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(ai_);
+			Tuple_BLEMZbHGbhMbZiIgCJaASVTUS ak_ = new Tuple_BLEMZbHGbhMbZiIgCJaASVTUS
 			{
 				ID = ah_,
 				AuthorDate = aj_,
@@ -263,88 +286,101 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 
 			return ak_;
 		};
-		var f_ = context.Operators.Select<ServiceRequest, Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>(d_, e_);
+		IEnumerable<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS> f_ = context.Operators.Select<ServiceRequest, Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>(d_, e_);
 		object g_(Tuple_BLEMZbHGbhMbZiIgCJaASVTUS @this)
 		{
-			var al_ = @this?.AuthorDate;
+			CqlDateTime al_ = @this?.AuthorDate;
 
 			return al_;
 		};
-		var h_ = context.Operators.SortBy<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
-		var i_ = context.Operators.First<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>(h_);
+		IEnumerable<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS> h_ = context.Operators.SortBy<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+		Tuple_BLEMZbHGbhMbZiIgCJaASVTUS i_ = context.Operators.First<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>(h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="First_Referral_during_First_10_Months_of_Measurement_Period_Value"/>
     [CqlDeclaration("First Referral during First 10 Months of Measurement Period")]
 	public Tuple_BLEMZbHGbhMbZiIgCJaASVTUS First_Referral_during_First_10_Months_of_Measurement_Period() => 
 		__First_Referral_during_First_10_Months_of_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Has_Encounter_during_Measurement_Period();
-		var b_ = this.First_Referral_during_First_10_Months_of_Measurement_Period();
-		var c_ = context.Operators.Not((bool?)(b_ is null));
-		var d_ = context.Operators.And(a_, c_);
+		bool? a_ = this.Has_Encounter_during_Measurement_Period();
+		Tuple_BLEMZbHGbhMbZiIgCJaASVTUS b_ = this.First_Referral_during_First_10_Months_of_Measurement_Period();
+		bool? c_ = context.Operators.Not((bool?)(b_ is null));
+		bool? d_ = context.Operators.And(a_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
@@ -352,78 +388,83 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
     [CqlDeclaration("TaskGetRequestID")]
 	public IEnumerable<string> TaskGetRequestID(Task task)
 	{
-		string a_(ResourceReference Task)
+		List<ResourceReference> a_ = task?.BasedOn;
+		string b_(ResourceReference Task)
 		{
-			var c_ = Task?.ReferenceElement;
-			var d_ = c_?.Value;
-			var e_ = QICoreCommon_2_0_000.GetId(d_);
+			FhirString d_ = Task?.ReferenceElement;
+			string e_ = d_?.Value;
+			string f_ = QICoreCommon_2_0_000.GetId(e_);
 
-			return e_;
+			return f_;
 		};
-		var b_ = context.Operators.Select<ResourceReference, string>((IEnumerable<ResourceReference>)task?.BasedOn, a_);
+		IEnumerable<string> c_ = context.Operators.Select<ResourceReference, string>((IEnumerable<ResourceReference>)a_, b_);
 
-		return b_;
+		return c_;
 	}
 
+    /// <seealso cref="Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop"/>
 	private bool? Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop_Value()
 	{
-		var a_ = this.Consultant_Report();
-		var b_ = context.Operators.RetrieveByValueSet<Task>(a_, null);
+		CqlValueSet a_ = this.Consultant_Report();
+		IEnumerable<Task> b_ = context.Operators.RetrieveByValueSet<Task>(a_, null);
 		IEnumerable<Task> c_(Task ConsultantReportObtained)
 		{
-			var f_ = this.First_Referral_during_First_10_Months_of_Measurement_Period();
-			var g_ = new Tuple_BLEMZbHGbhMbZiIgCJaASVTUS[]
+			Tuple_BLEMZbHGbhMbZiIgCJaASVTUS f_ = this.First_Referral_during_First_10_Months_of_Measurement_Period();
+			Tuple_BLEMZbHGbhMbZiIgCJaASVTUS[] g_ = new Tuple_BLEMZbHGbhMbZiIgCJaASVTUS[]
 			{
 				f_,
 			};
 			bool? h_(Tuple_BLEMZbHGbhMbZiIgCJaASVTUS FirstReferral)
 			{
-				var l_ = FirstReferral?.ID;
-				var m_ = this.TaskGetRequestID(ConsultantReportObtained);
-				var n_ = context.Operators.In<string>(l_, m_);
-				var o_ = ConsultantReportObtained?.ExecutionPeriod;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = context.Operators.End(p_);
-				var r_ = FirstReferral?.AuthorDate;
-				var s_ = context.Operators.After(q_, r_, null);
-				var t_ = context.Operators.And(n_, s_);
-				var u_ = ConsultantReportObtained?.StatusElement;
-				var v_ = u_?.Value;
-				var w_ = context.Operators.Convert<Code<Task.TaskStatus>>(v_);
-				var x_ = context.Operators.Equal(w_, "completed");
-				var y_ = context.Operators.And(t_, x_);
-				var aa_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var ab_ = context.Operators.End(aa_);
-				var ac_ = this.Measurement_Period();
-				var ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, "day");
-				var ae_ = context.Operators.And(y_, ad_);
+				string l_ = FirstReferral?.ID;
+				IEnumerable<string> m_ = this.TaskGetRequestID(ConsultantReportObtained);
+				bool? n_ = context.Operators.In<string>(l_, m_);
+				Period o_ = ConsultantReportObtained?.ExecutionPeriod;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				CqlDateTime q_ = context.Operators.End(p_);
+				CqlDateTime r_ = FirstReferral?.AuthorDate;
+				bool? s_ = context.Operators.After(q_, r_, null);
+				bool? t_ = context.Operators.And(n_, s_);
+				Code<Task.TaskStatus> u_ = ConsultantReportObtained?.StatusElement;
+				Task.TaskStatus? v_ = u_?.Value;
+				Code<Task.TaskStatus> w_ = context.Operators.Convert<Code<Task.TaskStatus>>(v_);
+				bool? x_ = context.Operators.Equal(w_, "completed");
+				bool? y_ = context.Operators.And(t_, x_);
+				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				CqlDateTime ab_ = context.Operators.End(aa_);
+				CqlInterval<CqlDateTime> ac_ = this.Measurement_Period();
+				bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, "day");
+				bool? ae_ = context.Operators.And(y_, ad_);
 
 				return ae_;
 			};
-			var i_ = context.Operators.Where<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>((IEnumerable<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>)g_, h_);
+			IEnumerable<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS> i_ = context.Operators.Where<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>((IEnumerable<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS>)g_, h_);
 			Task j_(Tuple_BLEMZbHGbhMbZiIgCJaASVTUS FirstReferral) => 
 				ConsultantReportObtained;
-			var k_ = context.Operators.Select<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS, Task>(i_, j_);
+			IEnumerable<Task> k_ = context.Operators.Select<Tuple_BLEMZbHGbhMbZiIgCJaASVTUS, Task>(i_, j_);
 
 			return k_;
 		};
-		var d_ = context.Operators.SelectMany<Task, Task>(b_, c_);
-		var e_ = context.Operators.Exists<Task>(d_);
+		IEnumerable<Task> d_ = context.Operators.SelectMany<Task, Task>(b_, c_);
+		bool? e_ = context.Operators.Exists<Task>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop_Value"/>
     [CqlDeclaration("Referring Clinician Receives Consultant Report to Close Referral Loop")]
 	public bool? Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop() => 
 		__Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop();
+		bool? a_ = this.Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop();
 
 		return a_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
@@ -182,480 +182,599 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Acute_and_Subacute_Iridocyclitis"/>
 	private CqlValueSet Acute_and_Subacute_Iridocyclitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241", null);
 
+    /// <seealso cref="Acute_and_Subacute_Iridocyclitis_Value"/>
     [CqlDeclaration("Acute and Subacute Iridocyclitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241")]
 	public CqlValueSet Acute_and_Subacute_Iridocyclitis() => 
 		__Acute_and_Subacute_Iridocyclitis.Value;
 
+    /// <seealso cref="Amblyopia"/>
 	private CqlValueSet Amblyopia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448", null);
 
+    /// <seealso cref="Amblyopia_Value"/>
     [CqlDeclaration("Amblyopia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448")]
 	public CqlValueSet Amblyopia() => 
 		__Amblyopia.Value;
 
+    /// <seealso cref="Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart"/>
 	private CqlValueSet Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560", null);
 
+    /// <seealso cref="Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart_Value"/>
     [CqlDeclaration("Best Corrected Visual Acuity Exam Using Snellen Chart")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560")]
 	public CqlValueSet Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart() => 
 		__Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart.Value;
 
+    /// <seealso cref="Burn_Confined_to_Eye_and_Adnexa"/>
 	private CqlValueSet Burn_Confined_to_Eye_and_Adnexa_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409", null);
 
+    /// <seealso cref="Burn_Confined_to_Eye_and_Adnexa_Value"/>
     [CqlDeclaration("Burn Confined to Eye and Adnexa")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409")]
 	public CqlValueSet Burn_Confined_to_Eye_and_Adnexa() => 
 		__Burn_Confined_to_Eye_and_Adnexa.Value;
 
+    /// <seealso cref="Cataract_Congenital"/>
 	private CqlValueSet Cataract_Congenital_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412", null);
 
+    /// <seealso cref="Cataract_Congenital_Value"/>
     [CqlDeclaration("Cataract Congenital")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412")]
 	public CqlValueSet Cataract_Congenital() => 
 		__Cataract_Congenital.Value;
 
+    /// <seealso cref="Cataract_Mature_or_Hypermature"/>
 	private CqlValueSet Cataract_Mature_or_Hypermature_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413", null);
 
+    /// <seealso cref="Cataract_Mature_or_Hypermature_Value"/>
     [CqlDeclaration("Cataract Mature or Hypermature")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413")]
 	public CqlValueSet Cataract_Mature_or_Hypermature() => 
 		__Cataract_Mature_or_Hypermature.Value;
 
+    /// <seealso cref="Cataract_Posterior_Polar"/>
 	private CqlValueSet Cataract_Posterior_Polar_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414", null);
 
+    /// <seealso cref="Cataract_Posterior_Polar_Value"/>
     [CqlDeclaration("Cataract Posterior Polar")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414")]
 	public CqlValueSet Cataract_Posterior_Polar() => 
 		__Cataract_Posterior_Polar.Value;
 
+    /// <seealso cref="Cataract_Secondary_to_Ocular_Disorders"/>
 	private CqlValueSet Cataract_Secondary_to_Ocular_Disorders_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410", null);
 
+    /// <seealso cref="Cataract_Secondary_to_Ocular_Disorders_Value"/>
     [CqlDeclaration("Cataract Secondary to Ocular Disorders")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410")]
 	public CqlValueSet Cataract_Secondary_to_Ocular_Disorders() => 
 		__Cataract_Secondary_to_Ocular_Disorders.Value;
 
+    /// <seealso cref="Cataract_Surgery"/>
 	private CqlValueSet Cataract_Surgery_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411", null);
 
+    /// <seealso cref="Cataract_Surgery_Value"/>
     [CqlDeclaration("Cataract Surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411")]
 	public CqlValueSet Cataract_Surgery() => 
 		__Cataract_Surgery.Value;
 
+    /// <seealso cref="Central_Corneal_Ulcer"/>
 	private CqlValueSet Central_Corneal_Ulcer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428", null);
 
+    /// <seealso cref="Central_Corneal_Ulcer_Value"/>
     [CqlDeclaration("Central Corneal Ulcer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428")]
 	public CqlValueSet Central_Corneal_Ulcer() => 
 		__Central_Corneal_Ulcer.Value;
 
+    /// <seealso cref="Certain_Types_of_Iridocyclitis"/>
 	private CqlValueSet Certain_Types_of_Iridocyclitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415", null);
 
+    /// <seealso cref="Certain_Types_of_Iridocyclitis_Value"/>
     [CqlDeclaration("Certain Types of Iridocyclitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415")]
 	public CqlValueSet Certain_Types_of_Iridocyclitis() => 
 		__Certain_Types_of_Iridocyclitis.Value;
 
+    /// <seealso cref="Choroidal_Degenerations"/>
 	private CqlValueSet Choroidal_Degenerations_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450", null);
 
+    /// <seealso cref="Choroidal_Degenerations_Value"/>
     [CqlDeclaration("Choroidal Degenerations")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450")]
 	public CqlValueSet Choroidal_Degenerations() => 
 		__Choroidal_Degenerations.Value;
 
+    /// <seealso cref="Choroidal_Detachment"/>
 	private CqlValueSet Choroidal_Detachment_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451", null);
 
+    /// <seealso cref="Choroidal_Detachment_Value"/>
     [CqlDeclaration("Choroidal Detachment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451")]
 	public CqlValueSet Choroidal_Detachment() => 
 		__Choroidal_Detachment.Value;
 
+    /// <seealso cref="Choroidal_Hemorrhage_and_Rupture"/>
 	private CqlValueSet Choroidal_Hemorrhage_and_Rupture_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452", null);
 
+    /// <seealso cref="Choroidal_Hemorrhage_and_Rupture_Value"/>
     [CqlDeclaration("Choroidal Hemorrhage and Rupture")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452")]
 	public CqlValueSet Choroidal_Hemorrhage_and_Rupture() => 
 		__Choroidal_Hemorrhage_and_Rupture.Value;
 
+    /// <seealso cref="Chronic_Iridocyclitis"/>
 	private CqlValueSet Chronic_Iridocyclitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416", null);
 
+    /// <seealso cref="Chronic_Iridocyclitis_Value"/>
     [CqlDeclaration("Chronic Iridocyclitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416")]
 	public CqlValueSet Chronic_Iridocyclitis() => 
 		__Chronic_Iridocyclitis.Value;
 
+    /// <seealso cref="Cloudy_Cornea"/>
 	private CqlValueSet Cloudy_Cornea_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417", null);
 
+    /// <seealso cref="Cloudy_Cornea_Value"/>
     [CqlDeclaration("Cloudy Cornea")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417")]
 	public CqlValueSet Cloudy_Cornea() => 
 		__Cloudy_Cornea.Value;
 
+    /// <seealso cref="Corneal_Edema"/>
 	private CqlValueSet Corneal_Edema_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418", null);
 
+    /// <seealso cref="Corneal_Edema_Value"/>
     [CqlDeclaration("Corneal Edema")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418")]
 	public CqlValueSet Corneal_Edema() => 
 		__Corneal_Edema.Value;
 
+    /// <seealso cref="Degeneration_of_Macula_and_Posterior_Pole"/>
 	private CqlValueSet Degeneration_of_Macula_and_Posterior_Pole_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453", null);
 
+    /// <seealso cref="Degeneration_of_Macula_and_Posterior_Pole_Value"/>
     [CqlDeclaration("Degeneration of Macula and Posterior Pole")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453")]
 	public CqlValueSet Degeneration_of_Macula_and_Posterior_Pole() => 
 		__Degeneration_of_Macula_and_Posterior_Pole.Value;
 
+    /// <seealso cref="Degenerative_Disorders_of_Globe"/>
 	private CqlValueSet Degenerative_Disorders_of_Globe_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454", null);
 
+    /// <seealso cref="Degenerative_Disorders_of_Globe_Value"/>
     [CqlDeclaration("Degenerative Disorders of Globe")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454")]
 	public CqlValueSet Degenerative_Disorders_of_Globe() => 
 		__Degenerative_Disorders_of_Globe.Value;
 
+    /// <seealso cref="Diabetic_Macular_Edema"/>
 	private CqlValueSet Diabetic_Macular_Edema_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455", null);
 
+    /// <seealso cref="Diabetic_Macular_Edema_Value"/>
     [CqlDeclaration("Diabetic Macular Edema")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455")]
 	public CqlValueSet Diabetic_Macular_Edema() => 
 		__Diabetic_Macular_Edema.Value;
 
+    /// <seealso cref="Diabetic_Retinopathy"/>
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
 
+    /// <seealso cref="Diabetic_Retinopathy_Value"/>
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
 	public CqlValueSet Diabetic_Retinopathy() => 
 		__Diabetic_Retinopathy.Value;
 
+    /// <seealso cref="Disorders_of_Cornea_Including_Corneal_Opacity"/>
 	private CqlValueSet Disorders_of_Cornea_Including_Corneal_Opacity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419", null);
 
+    /// <seealso cref="Disorders_of_Cornea_Including_Corneal_Opacity_Value"/>
     [CqlDeclaration("Disorders of Cornea Including Corneal Opacity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419")]
 	public CqlValueSet Disorders_of_Cornea_Including_Corneal_Opacity() => 
 		__Disorders_of_Cornea_Including_Corneal_Opacity.Value;
 
+    /// <seealso cref="Disorders_of_Optic_Chiasm"/>
 	private CqlValueSet Disorders_of_Optic_Chiasm_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457", null);
 
+    /// <seealso cref="Disorders_of_Optic_Chiasm_Value"/>
     [CqlDeclaration("Disorders of Optic Chiasm")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457")]
 	public CqlValueSet Disorders_of_Optic_Chiasm() => 
 		__Disorders_of_Optic_Chiasm.Value;
 
+    /// <seealso cref="Disorders_of_Visual_Cortex"/>
 	private CqlValueSet Disorders_of_Visual_Cortex_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458", null);
 
+    /// <seealso cref="Disorders_of_Visual_Cortex_Value"/>
     [CqlDeclaration("Disorders of Visual Cortex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458")]
 	public CqlValueSet Disorders_of_Visual_Cortex() => 
 		__Disorders_of_Visual_Cortex.Value;
 
+    /// <seealso cref="Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis"/>
 	private CqlValueSet Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459", null);
 
+    /// <seealso cref="Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis_Value"/>
     [CqlDeclaration("Disseminated Chorioretinitis and Disseminated Retinochoroiditis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459")]
 	public CqlValueSet Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis() => 
 		__Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis.Value;
 
+    /// <seealso cref="Focal_Chorioretinitis_and_Focal_Retinochoroiditis"/>
 	private CqlValueSet Focal_Chorioretinitis_and_Focal_Retinochoroiditis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460", null);
 
+    /// <seealso cref="Focal_Chorioretinitis_and_Focal_Retinochoroiditis_Value"/>
     [CqlDeclaration("Focal Chorioretinitis and Focal Retinochoroiditis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460")]
 	public CqlValueSet Focal_Chorioretinitis_and_Focal_Retinochoroiditis() => 
 		__Focal_Chorioretinitis_and_Focal_Retinochoroiditis.Value;
 
+    /// <seealso cref="Glaucoma"/>
 	private CqlValueSet Glaucoma_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423", null);
 
+    /// <seealso cref="Glaucoma_Value"/>
     [CqlDeclaration("Glaucoma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423")]
 	public CqlValueSet Glaucoma() => 
 		__Glaucoma.Value;
 
+    /// <seealso cref="Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes"/>
 	private CqlValueSet Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461", null);
 
+    /// <seealso cref="Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes_Value"/>
     [CqlDeclaration("Glaucoma Associated with Congenital Anomalies and Dystrophies and Systemic Syndromes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461")]
 	public CqlValueSet Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes() => 
 		__Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes.Value;
 
+    /// <seealso cref="Hereditary_Choroidal_Dystrophies"/>
 	private CqlValueSet Hereditary_Choroidal_Dystrophies_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462", null);
 
+    /// <seealso cref="Hereditary_Choroidal_Dystrophies_Value"/>
     [CqlDeclaration("Hereditary Choroidal Dystrophies")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462")]
 	public CqlValueSet Hereditary_Choroidal_Dystrophies() => 
 		__Hereditary_Choroidal_Dystrophies.Value;
 
+    /// <seealso cref="Hereditary_Corneal_Dystrophies"/>
 	private CqlValueSet Hereditary_Corneal_Dystrophies_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424", null);
 
+    /// <seealso cref="Hereditary_Corneal_Dystrophies_Value"/>
     [CqlDeclaration("Hereditary Corneal Dystrophies")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424")]
 	public CqlValueSet Hereditary_Corneal_Dystrophies() => 
 		__Hereditary_Corneal_Dystrophies.Value;
 
+    /// <seealso cref="Hereditary_Retinal_Dystrophies"/>
 	private CqlValueSet Hereditary_Retinal_Dystrophies_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463", null);
 
+    /// <seealso cref="Hereditary_Retinal_Dystrophies_Value"/>
     [CqlDeclaration("Hereditary Retinal Dystrophies")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463")]
 	public CqlValueSet Hereditary_Retinal_Dystrophies() => 
 		__Hereditary_Retinal_Dystrophies.Value;
 
+    /// <seealso cref="Hypotony_of_Eye"/>
 	private CqlValueSet Hypotony_of_Eye_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426", null);
 
+    /// <seealso cref="Hypotony_of_Eye_Value"/>
     [CqlDeclaration("Hypotony of Eye")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426")]
 	public CqlValueSet Hypotony_of_Eye() => 
 		__Hypotony_of_Eye.Value;
 
+    /// <seealso cref="Injury_to_Optic_Nerve_and_Pathways"/>
 	private CqlValueSet Injury_to_Optic_Nerve_and_Pathways_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427", null);
 
+    /// <seealso cref="Injury_to_Optic_Nerve_and_Pathways_Value"/>
     [CqlDeclaration("Injury to Optic Nerve and Pathways")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427")]
 	public CqlValueSet Injury_to_Optic_Nerve_and_Pathways() => 
 		__Injury_to_Optic_Nerve_and_Pathways.Value;
 
+    /// <seealso cref="Macular_Scar_of_Posterior_Polar"/>
 	private CqlValueSet Macular_Scar_of_Posterior_Polar_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559", null);
 
+    /// <seealso cref="Macular_Scar_of_Posterior_Polar_Value"/>
     [CqlDeclaration("Macular Scar of Posterior Polar")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559")]
 	public CqlValueSet Macular_Scar_of_Posterior_Polar() => 
 		__Macular_Scar_of_Posterior_Polar.Value;
 
+    /// <seealso cref="Morgagnian_Cataract"/>
 	private CqlValueSet Morgagnian_Cataract_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558", null);
 
+    /// <seealso cref="Morgagnian_Cataract_Value"/>
     [CqlDeclaration("Morgagnian Cataract")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558")]
 	public CqlValueSet Morgagnian_Cataract() => 
 		__Morgagnian_Cataract.Value;
 
+    /// <seealso cref="Nystagmus_and_Other_Irregular_Eye_Movements"/>
 	private CqlValueSet Nystagmus_and_Other_Irregular_Eye_Movements_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465", null);
 
+    /// <seealso cref="Nystagmus_and_Other_Irregular_Eye_Movements_Value"/>
     [CqlDeclaration("Nystagmus and Other Irregular Eye Movements")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465")]
 	public CqlValueSet Nystagmus_and_Other_Irregular_Eye_Movements() => 
 		__Nystagmus_and_Other_Irregular_Eye_Movements.Value;
 
+    /// <seealso cref="Open_Wound_of_Eyeball"/>
 	private CqlValueSet Open_Wound_of_Eyeball_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430", null);
 
+    /// <seealso cref="Open_Wound_of_Eyeball_Value"/>
     [CqlDeclaration("Open Wound of Eyeball")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430")]
 	public CqlValueSet Open_Wound_of_Eyeball() => 
 		__Open_Wound_of_Eyeball.Value;
 
+    /// <seealso cref="Optic_Atrophy"/>
 	private CqlValueSet Optic_Atrophy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466", null);
 
+    /// <seealso cref="Optic_Atrophy_Value"/>
     [CqlDeclaration("Optic Atrophy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466")]
 	public CqlValueSet Optic_Atrophy() => 
 		__Optic_Atrophy.Value;
 
+    /// <seealso cref="Optic_Neuritis"/>
 	private CqlValueSet Optic_Neuritis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467", null);
 
+    /// <seealso cref="Optic_Neuritis_Value"/>
     [CqlDeclaration("Optic Neuritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467")]
 	public CqlValueSet Optic_Neuritis() => 
 		__Optic_Neuritis.Value;
 
+    /// <seealso cref="Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis"/>
 	private CqlValueSet Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468", null);
 
+    /// <seealso cref="Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis_Value"/>
     [CqlDeclaration("Other and Unspecified Forms of Chorioretinitis and Retinochoroiditis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468")]
 	public CqlValueSet Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis() => 
 		__Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis.Value;
 
+    /// <seealso cref="Other_Background_Retinopathy_and_Retinal_Vascular_Changes"/>
 	private CqlValueSet Other_Background_Retinopathy_and_Retinal_Vascular_Changes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469", null);
 
+    /// <seealso cref="Other_Background_Retinopathy_and_Retinal_Vascular_Changes_Value"/>
     [CqlDeclaration("Other Background Retinopathy and Retinal Vascular Changes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469")]
 	public CqlValueSet Other_Background_Retinopathy_and_Retinal_Vascular_Changes() => 
 		__Other_Background_Retinopathy_and_Retinal_Vascular_Changes.Value;
 
+    /// <seealso cref="Other_Disorders_of_Optic_Nerve"/>
 	private CqlValueSet Other_Disorders_of_Optic_Nerve_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471", null);
 
+    /// <seealso cref="Other_Disorders_of_Optic_Nerve_Value"/>
     [CqlDeclaration("Other Disorders of Optic Nerve")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471")]
 	public CqlValueSet Other_Disorders_of_Optic_Nerve() => 
 		__Other_Disorders_of_Optic_Nerve.Value;
 
+    /// <seealso cref="Other_Endophthalmitis"/>
 	private CqlValueSet Other_Endophthalmitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473", null);
 
+    /// <seealso cref="Other_Endophthalmitis_Value"/>
     [CqlDeclaration("Other Endophthalmitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473")]
 	public CqlValueSet Other_Endophthalmitis() => 
 		__Other_Endophthalmitis.Value;
 
+    /// <seealso cref="Other_Proliferative_Retinopathy"/>
 	private CqlValueSet Other_Proliferative_Retinopathy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480", null);
 
+    /// <seealso cref="Other_Proliferative_Retinopathy_Value"/>
     [CqlDeclaration("Other Proliferative Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480")]
 	public CqlValueSet Other_Proliferative_Retinopathy() => 
 		__Other_Proliferative_Retinopathy.Value;
 
+    /// <seealso cref="Pathologic_Myopia"/>
 	private CqlValueSet Pathologic_Myopia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432", null);
 
+    /// <seealso cref="Pathologic_Myopia_Value"/>
     [CqlDeclaration("Pathologic Myopia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432")]
 	public CqlValueSet Pathologic_Myopia() => 
 		__Pathologic_Myopia.Value;
 
+    /// <seealso cref="Posterior_Lenticonus"/>
 	private CqlValueSet Posterior_Lenticonus_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433", null);
 
+    /// <seealso cref="Posterior_Lenticonus_Value"/>
     [CqlDeclaration("Posterior Lenticonus")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433")]
 	public CqlValueSet Posterior_Lenticonus() => 
 		__Posterior_Lenticonus.Value;
 
+    /// <seealso cref="Prior_Penetrating_Keratoplasty"/>
 	private CqlValueSet Prior_Penetrating_Keratoplasty_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475", null);
 
+    /// <seealso cref="Prior_Penetrating_Keratoplasty_Value"/>
     [CqlDeclaration("Prior Penetrating Keratoplasty")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475")]
 	public CqlValueSet Prior_Penetrating_Keratoplasty() => 
 		__Prior_Penetrating_Keratoplasty.Value;
 
+    /// <seealso cref="Purulent_Endophthalmitis"/>
 	private CqlValueSet Purulent_Endophthalmitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477", null);
 
+    /// <seealso cref="Purulent_Endophthalmitis_Value"/>
     [CqlDeclaration("Purulent Endophthalmitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477")]
 	public CqlValueSet Purulent_Endophthalmitis() => 
 		__Purulent_Endophthalmitis.Value;
 
+    /// <seealso cref="Retinal_Detachment_with_Retinal_Defect"/>
 	private CqlValueSet Retinal_Detachment_with_Retinal_Defect_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478", null);
 
+    /// <seealso cref="Retinal_Detachment_with_Retinal_Defect_Value"/>
     [CqlDeclaration("Retinal Detachment with Retinal Defect")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478")]
 	public CqlValueSet Retinal_Detachment_with_Retinal_Defect() => 
 		__Retinal_Detachment_with_Retinal_Defect.Value;
 
+    /// <seealso cref="Retinal_Vascular_Occlusion"/>
 	private CqlValueSet Retinal_Vascular_Occlusion_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479", null);
 
+    /// <seealso cref="Retinal_Vascular_Occlusion_Value"/>
     [CqlDeclaration("Retinal Vascular Occlusion")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479")]
 	public CqlValueSet Retinal_Vascular_Occlusion() => 
 		__Retinal_Vascular_Occlusion.Value;
 
+    /// <seealso cref="Retrolental_Fibroplasias"/>
 	private CqlValueSet Retrolental_Fibroplasias_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438", null);
 
+    /// <seealso cref="Retrolental_Fibroplasias_Value"/>
     [CqlDeclaration("Retrolental Fibroplasias")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438")]
 	public CqlValueSet Retrolental_Fibroplasias() => 
 		__Retrolental_Fibroplasias.Value;
 
+    /// <seealso cref="Scleritis"/>
 	private CqlValueSet Scleritis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1", null);
 
+    /// <seealso cref="Scleritis_Value"/>
     [CqlDeclaration("Scleritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1")]
 	public CqlValueSet Scleritis() => 
 		__Scleritis.Value;
 
+    /// <seealso cref="Separation_of_Retinal_Layers"/>
 	private CqlValueSet Separation_of_Retinal_Layers_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482", null);
 
+    /// <seealso cref="Separation_of_Retinal_Layers_Value"/>
     [CqlDeclaration("Separation of Retinal Layers")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482")]
 	public CqlValueSet Separation_of_Retinal_Layers() => 
 		__Separation_of_Retinal_Layers.Value;
 
+    /// <seealso cref="Traumatic_Cataract"/>
 	private CqlValueSet Traumatic_Cataract_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443", null);
 
+    /// <seealso cref="Traumatic_Cataract_Value"/>
     [CqlDeclaration("Traumatic Cataract")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443")]
 	public CqlValueSet Traumatic_Cataract() => 
 		__Traumatic_Cataract.Value;
 
+    /// <seealso cref="Uveitis"/>
 	private CqlValueSet Uveitis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444", null);
 
+    /// <seealso cref="Uveitis_Value"/>
     [CqlDeclaration("Uveitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444")]
 	public CqlValueSet Uveitis() => 
 		__Uveitis.Value;
 
+    /// <seealso cref="Vascular_Disorders_of_Iris_and_Ciliary_Body"/>
 	private CqlValueSet Vascular_Disorders_of_Iris_and_Ciliary_Body_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445", null);
 
+    /// <seealso cref="Vascular_Disorders_of_Iris_and_Ciliary_Body_Value"/>
     [CqlDeclaration("Vascular Disorders of Iris and Ciliary Body")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445")]
 	public CqlValueSet Vascular_Disorders_of_Iris_and_Ciliary_Body() => 
 		__Vascular_Disorders_of_Iris_and_Ciliary_Body.Value;
 
+    /// <seealso cref="Visual_Acuity_20_40_or_Better"/>
 	private CqlValueSet Visual_Acuity_20_40_or_Better_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483", null);
 
+    /// <seealso cref="Visual_Acuity_20_40_or_Better_Value"/>
     [CqlDeclaration("Visual Acuity 20/40 or Better")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483")]
 	public CqlValueSet Visual_Acuity_20_40_or_Better() => 
 		__Visual_Acuity_20_40_or_Better.Value;
 
+    /// <seealso cref="Visual_Field_Defects"/>
 	private CqlValueSet Visual_Field_Defects_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446", null);
 
+    /// <seealso cref="Visual_Field_Defects_Value"/>
     [CqlDeclaration("Visual Field Defects")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446")]
 	public CqlValueSet Visual_Field_Defects() => 
 		__Visual_Field_Defects.Value;
 
+    /// <seealso cref="Best_corrected_visual_acuity__observable_entity_"/>
 	private CqlCode Best_corrected_visual_acuity__observable_entity__Value() => 
 		new CqlCode("419775003", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Best_corrected_visual_acuity__observable_entity__Value"/>
     [CqlDeclaration("Best corrected visual acuity (observable entity)")]
 	public CqlCode Best_corrected_visual_acuity__observable_entity_() => 
 		__Best_corrected_visual_acuity__observable_entity_.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("419775003", "http://snomed.info/sct", null, null),
 		};
@@ -663,416 +782,439 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("Cataracts2040BCVAwithin90DaysFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("Cataracts2040BCVAwithin90DaysFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Cataract_Surgery_Between_January_and_September_of_Measurement_Period"/>
 	private IEnumerable<Procedure> Cataract_Surgery_Between_January_and_September_of_Measurement_Period_Value()
 	{
-		var a_ = this.Cataract_Surgery();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		CqlValueSet a_ = this.Cataract_Surgery();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure CataractSurgery)
 		{
-			var e_ = this.Measurement_Period();
-			var f_ = CataractSurgery?.Performed;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.toInterval(g_);
-			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, null);
-			var k_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var l_ = QICoreCommon_2_0_000.toInterval(k_);
-			var m_ = context.Operators.Start(l_);
-			var o_ = context.Operators.End(e_);
-			var p_ = context.Operators.Quantity(92m, "days");
-			var q_ = context.Operators.Subtract(o_, p_);
-			var r_ = context.Operators.SameOrBefore(m_, q_, null);
-			var s_ = context.Operators.And(i_, r_);
-			var t_ = CataractSurgery?.StatusElement;
-			var u_ = t_?.Value;
-			var v_ = context.Operators.Convert<string>(u_);
-			var w_ = context.Operators.Equal(v_, "completed");
-			var x_ = context.Operators.And(s_, w_);
+			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+			DataType f_ = CataractSurgery?.Performed;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.toInterval(g_);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, null);
+			object k_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
+			CqlDateTime m_ = context.Operators.Start(l_);
+			CqlDateTime o_ = context.Operators.End(e_);
+			CqlQuantity p_ = context.Operators.Quantity(92m, "days");
+			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
+			bool? r_ = context.Operators.SameOrBefore(m_, q_, null);
+			bool? s_ = context.Operators.And(i_, r_);
+			Code<EventStatus> t_ = CataractSurgery?.StatusElement;
+			EventStatus? u_ = t_?.Value;
+			string v_ = context.Operators.Convert<string>(u_);
+			bool? w_ = context.Operators.Equal(v_, "completed");
+			bool? x_ = context.Operators.And(s_, w_);
 
 			return x_;
 		};
-		var d_ = context.Operators.Where<Procedure>(b_, c_);
+		IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Cataract_Surgery_Between_January_and_September_of_Measurement_Period_Value"/>
     [CqlDeclaration("Cataract Surgery Between January and September of Measurement Period")]
 	public IEnumerable<Procedure> Cataract_Surgery_Between_January_and_September_of_Measurement_Period() => 
 		__Cataract_Surgery_Between_January_and_September_of_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Procedure> Initial_Population_Value()
 	{
-		var a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period();
+		IEnumerable<Procedure> a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period();
 		bool? b_(Procedure CataractSurgeryPerformed)
 		{
-			var d_ = this.Patient();
-			var e_ = d_?.BirthDateElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.Convert<CqlDate>(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.Start(h_);
-			var j_ = context.Operators.DateFrom(i_);
-			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
-			var l_ = context.Operators.GreaterOrEqual(k_, 18);
+			Patient d_ = this.Patient();
+			Date e_ = d_?.BirthDateElement;
+			string f_ = e_?.Value;
+			CqlDate g_ = context.Operators.Convert<CqlDate>(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.Start(h_);
+			CqlDate j_ = context.Operators.DateFrom(i_);
+			int? k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			bool? l_ = context.Operators.GreaterOrEqual(k_, 18);
 
 			return l_;
 		};
-		var c_ = context.Operators.Where<Procedure>(a_, b_);
+		IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Procedure> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Procedure> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Procedure> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Procedure> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private IEnumerable<Procedure> Denominator_Exclusions_Value()
 	{
-		var a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period();
+		IEnumerable<Procedure> a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period();
 		IEnumerable<Procedure> b_(Procedure CataractSurgeryPerformed)
 		{
-			var d_ = this.Acute_and_Subacute_Iridocyclitis();
-			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
-			var f_ = this.Amblyopia();
-			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
-			var h_ = context.Operators.Union<Condition>(e_, g_);
-			var i_ = this.Burn_Confined_to_Eye_and_Adnexa();
-			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
-			var k_ = this.Cataract_Secondary_to_Ocular_Disorders();
-			var l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
-			var m_ = context.Operators.Union<Condition>(j_, l_);
-			var n_ = context.Operators.Union<Condition>(h_, m_);
-			var o_ = this.Cataract_Congenital();
-			var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
-			var q_ = this.Cataract_Mature_or_Hypermature();
-			var r_ = context.Operators.RetrieveByValueSet<Condition>(q_, null);
-			var s_ = context.Operators.Union<Condition>(p_, r_);
-			var t_ = context.Operators.Union<Condition>(n_, s_);
-			var u_ = this.Cataract_Posterior_Polar();
-			var v_ = context.Operators.RetrieveByValueSet<Condition>(u_, null);
-			var w_ = this.Central_Corneal_Ulcer();
-			var x_ = context.Operators.RetrieveByValueSet<Condition>(w_, null);
-			var y_ = context.Operators.Union<Condition>(v_, x_);
-			var z_ = context.Operators.Union<Condition>(t_, y_);
-			var aa_ = this.Certain_Types_of_Iridocyclitis();
-			var ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, null);
-			var ac_ = this.Choroidal_Degenerations();
-			var ad_ = context.Operators.RetrieveByValueSet<Condition>(ac_, null);
-			var ae_ = context.Operators.Union<Condition>(ab_, ad_);
-			var af_ = context.Operators.Union<Condition>(z_, ae_);
-			var ag_ = this.Choroidal_Detachment();
-			var ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, null);
-			var ai_ = this.Choroidal_Hemorrhage_and_Rupture();
-			var aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, null);
-			var ak_ = context.Operators.Union<Condition>(ah_, aj_);
-			var al_ = context.Operators.Union<Condition>(af_, ak_);
-			var am_ = this.Chronic_Iridocyclitis();
-			var an_ = context.Operators.RetrieveByValueSet<Condition>(am_, null);
-			var ao_ = this.Cloudy_Cornea();
-			var ap_ = context.Operators.RetrieveByValueSet<Condition>(ao_, null);
-			var aq_ = context.Operators.Union<Condition>(an_, ap_);
-			var ar_ = context.Operators.Union<Condition>(al_, aq_);
-			var as_ = this.Corneal_Edema();
-			var at_ = context.Operators.RetrieveByValueSet<Condition>(as_, null);
-			var au_ = this.Disorders_of_Cornea_Including_Corneal_Opacity();
-			var av_ = context.Operators.RetrieveByValueSet<Condition>(au_, null);
-			var aw_ = context.Operators.Union<Condition>(at_, av_);
-			var ax_ = context.Operators.Union<Condition>(ar_, aw_);
-			var ay_ = this.Degeneration_of_Macula_and_Posterior_Pole();
-			var az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, null);
-			var ba_ = this.Degenerative_Disorders_of_Globe();
-			var bb_ = context.Operators.RetrieveByValueSet<Condition>(ba_, null);
-			var bc_ = context.Operators.Union<Condition>(az_, bb_);
-			var bd_ = context.Operators.Union<Condition>(ax_, bc_);
-			var be_ = this.Diabetic_Macular_Edema();
-			var bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, null);
-			var bg_ = this.Diabetic_Retinopathy();
-			var bh_ = context.Operators.RetrieveByValueSet<Condition>(bg_, null);
-			var bi_ = context.Operators.Union<Condition>(bf_, bh_);
-			var bj_ = context.Operators.Union<Condition>(bd_, bi_);
-			var bk_ = this.Disorders_of_Optic_Chiasm();
-			var bl_ = context.Operators.RetrieveByValueSet<Condition>(bk_, null);
-			var bm_ = this.Disorders_of_Visual_Cortex();
-			var bn_ = context.Operators.RetrieveByValueSet<Condition>(bm_, null);
-			var bo_ = context.Operators.Union<Condition>(bl_, bn_);
-			var bp_ = context.Operators.Union<Condition>(bj_, bo_);
-			var bq_ = this.Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis();
-			var br_ = context.Operators.RetrieveByValueSet<Condition>(bq_, null);
-			var bs_ = this.Focal_Chorioretinitis_and_Focal_Retinochoroiditis();
-			var bt_ = context.Operators.RetrieveByValueSet<Condition>(bs_, null);
-			var bu_ = context.Operators.Union<Condition>(br_, bt_);
-			var bv_ = context.Operators.Union<Condition>(bp_, bu_);
-			var bw_ = this.Glaucoma();
-			var bx_ = context.Operators.RetrieveByValueSet<Condition>(bw_, null);
-			var by_ = this.Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes();
-			var bz_ = context.Operators.RetrieveByValueSet<Condition>(by_, null);
-			var ca_ = context.Operators.Union<Condition>(bx_, bz_);
-			var cb_ = context.Operators.Union<Condition>(bv_, ca_);
-			var cc_ = this.Hereditary_Choroidal_Dystrophies();
-			var cd_ = context.Operators.RetrieveByValueSet<Condition>(cc_, null);
-			var ce_ = this.Hereditary_Corneal_Dystrophies();
-			var cf_ = context.Operators.RetrieveByValueSet<Condition>(ce_, null);
-			var cg_ = context.Operators.Union<Condition>(cd_, cf_);
-			var ch_ = context.Operators.Union<Condition>(cb_, cg_);
-			var ci_ = this.Hereditary_Retinal_Dystrophies();
-			var cj_ = context.Operators.RetrieveByValueSet<Condition>(ci_, null);
-			var ck_ = this.Hypotony_of_Eye();
-			var cl_ = context.Operators.RetrieveByValueSet<Condition>(ck_, null);
-			var cm_ = context.Operators.Union<Condition>(cj_, cl_);
-			var cn_ = context.Operators.Union<Condition>(ch_, cm_);
-			var co_ = this.Injury_to_Optic_Nerve_and_Pathways();
-			var cp_ = context.Operators.RetrieveByValueSet<Condition>(co_, null);
-			var cq_ = this.Macular_Scar_of_Posterior_Polar();
-			var cr_ = context.Operators.RetrieveByValueSet<Condition>(cq_, null);
-			var cs_ = context.Operators.Union<Condition>(cp_, cr_);
-			var ct_ = context.Operators.Union<Condition>(cn_, cs_);
-			var cu_ = this.Morgagnian_Cataract();
-			var cv_ = context.Operators.RetrieveByValueSet<Condition>(cu_, null);
-			var cw_ = this.Nystagmus_and_Other_Irregular_Eye_Movements();
-			var cx_ = context.Operators.RetrieveByValueSet<Condition>(cw_, null);
-			var cy_ = context.Operators.Union<Condition>(cv_, cx_);
-			var cz_ = context.Operators.Union<Condition>(ct_, cy_);
-			var da_ = this.Open_Wound_of_Eyeball();
-			var db_ = context.Operators.RetrieveByValueSet<Condition>(da_, null);
-			var dc_ = this.Optic_Atrophy();
-			var dd_ = context.Operators.RetrieveByValueSet<Condition>(dc_, null);
-			var de_ = context.Operators.Union<Condition>(db_, dd_);
-			var df_ = context.Operators.Union<Condition>(cz_, de_);
-			var dg_ = this.Optic_Neuritis();
-			var dh_ = context.Operators.RetrieveByValueSet<Condition>(dg_, null);
-			var di_ = this.Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis();
-			var dj_ = context.Operators.RetrieveByValueSet<Condition>(di_, null);
-			var dk_ = context.Operators.Union<Condition>(dh_, dj_);
-			var dl_ = context.Operators.Union<Condition>(df_, dk_);
-			var dm_ = this.Other_Background_Retinopathy_and_Retinal_Vascular_Changes();
-			var dn_ = context.Operators.RetrieveByValueSet<Condition>(dm_, null);
-			var do_ = this.Other_Disorders_of_Optic_Nerve();
-			var dp_ = context.Operators.RetrieveByValueSet<Condition>(do_, null);
-			var dq_ = context.Operators.Union<Condition>(dn_, dp_);
-			var dr_ = context.Operators.Union<Condition>(dl_, dq_);
-			var ds_ = this.Other_Endophthalmitis();
-			var dt_ = context.Operators.RetrieveByValueSet<Condition>(ds_, null);
-			var du_ = this.Other_Proliferative_Retinopathy();
-			var dv_ = context.Operators.RetrieveByValueSet<Condition>(du_, null);
-			var dw_ = context.Operators.Union<Condition>(dt_, dv_);
-			var dx_ = context.Operators.Union<Condition>(dr_, dw_);
-			var dy_ = this.Pathologic_Myopia();
-			var dz_ = context.Operators.RetrieveByValueSet<Condition>(dy_, null);
-			var ea_ = this.Posterior_Lenticonus();
-			var eb_ = context.Operators.RetrieveByValueSet<Condition>(ea_, null);
-			var ec_ = context.Operators.Union<Condition>(dz_, eb_);
-			var ed_ = context.Operators.Union<Condition>(dx_, ec_);
-			var ee_ = this.Prior_Penetrating_Keratoplasty();
-			var ef_ = context.Operators.RetrieveByValueSet<Condition>(ee_, null);
-			var eg_ = this.Purulent_Endophthalmitis();
-			var eh_ = context.Operators.RetrieveByValueSet<Condition>(eg_, null);
-			var ei_ = context.Operators.Union<Condition>(ef_, eh_);
-			var ej_ = context.Operators.Union<Condition>(ed_, ei_);
-			var ek_ = this.Retinal_Detachment_with_Retinal_Defect();
-			var el_ = context.Operators.RetrieveByValueSet<Condition>(ek_, null);
-			var em_ = this.Retinal_Vascular_Occlusion();
-			var en_ = context.Operators.RetrieveByValueSet<Condition>(em_, null);
-			var eo_ = context.Operators.Union<Condition>(el_, en_);
-			var ep_ = context.Operators.Union<Condition>(ej_, eo_);
-			var eq_ = this.Retrolental_Fibroplasias();
-			var er_ = context.Operators.RetrieveByValueSet<Condition>(eq_, null);
-			var es_ = this.Scleritis();
-			var et_ = context.Operators.RetrieveByValueSet<Condition>(es_, null);
-			var eu_ = context.Operators.Union<Condition>(er_, et_);
-			var ev_ = context.Operators.Union<Condition>(ep_, eu_);
-			var ew_ = this.Separation_of_Retinal_Layers();
-			var ex_ = context.Operators.RetrieveByValueSet<Condition>(ew_, null);
-			var ey_ = this.Traumatic_Cataract();
-			var ez_ = context.Operators.RetrieveByValueSet<Condition>(ey_, null);
-			var fa_ = context.Operators.Union<Condition>(ex_, ez_);
-			var fb_ = context.Operators.Union<Condition>(ev_, fa_);
-			var fc_ = this.Uveitis();
-			var fd_ = context.Operators.RetrieveByValueSet<Condition>(fc_, null);
-			var fe_ = this.Vascular_Disorders_of_Iris_and_Ciliary_Body();
-			var ff_ = context.Operators.RetrieveByValueSet<Condition>(fe_, null);
-			var fg_ = context.Operators.Union<Condition>(fd_, ff_);
-			var fh_ = context.Operators.Union<Condition>(fb_, fg_);
-			var fi_ = this.Visual_Field_Defects();
-			var fj_ = context.Operators.RetrieveByValueSet<Condition>(fi_, null);
-			var fk_ = context.Operators.Union<Condition>(fh_, fj_);
+			CqlValueSet d_ = this.Acute_and_Subacute_Iridocyclitis();
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			CqlValueSet f_ = this.Amblyopia();
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
+			CqlValueSet i_ = this.Burn_Confined_to_Eye_and_Adnexa();
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			CqlValueSet k_ = this.Cataract_Secondary_to_Ocular_Disorders();
+			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+			IEnumerable<Condition> m_ = context.Operators.Union<Condition>(j_, l_);
+			IEnumerable<Condition> n_ = context.Operators.Union<Condition>(h_, m_);
+			CqlValueSet o_ = this.Cataract_Congenital();
+			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+			CqlValueSet q_ = this.Cataract_Mature_or_Hypermature();
+			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, null);
+			IEnumerable<Condition> s_ = context.Operators.Union<Condition>(p_, r_);
+			IEnumerable<Condition> t_ = context.Operators.Union<Condition>(n_, s_);
+			CqlValueSet u_ = this.Cataract_Posterior_Polar();
+			IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, null);
+			CqlValueSet w_ = this.Central_Corneal_Ulcer();
+			IEnumerable<Condition> x_ = context.Operators.RetrieveByValueSet<Condition>(w_, null);
+			IEnumerable<Condition> y_ = context.Operators.Union<Condition>(v_, x_);
+			IEnumerable<Condition> z_ = context.Operators.Union<Condition>(t_, y_);
+			CqlValueSet aa_ = this.Certain_Types_of_Iridocyclitis();
+			IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, null);
+			CqlValueSet ac_ = this.Choroidal_Degenerations();
+			IEnumerable<Condition> ad_ = context.Operators.RetrieveByValueSet<Condition>(ac_, null);
+			IEnumerable<Condition> ae_ = context.Operators.Union<Condition>(ab_, ad_);
+			IEnumerable<Condition> af_ = context.Operators.Union<Condition>(z_, ae_);
+			CqlValueSet ag_ = this.Choroidal_Detachment();
+			IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, null);
+			CqlValueSet ai_ = this.Choroidal_Hemorrhage_and_Rupture();
+			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, null);
+			IEnumerable<Condition> ak_ = context.Operators.Union<Condition>(ah_, aj_);
+			IEnumerable<Condition> al_ = context.Operators.Union<Condition>(af_, ak_);
+			CqlValueSet am_ = this.Chronic_Iridocyclitis();
+			IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, null);
+			CqlValueSet ao_ = this.Cloudy_Cornea();
+			IEnumerable<Condition> ap_ = context.Operators.RetrieveByValueSet<Condition>(ao_, null);
+			IEnumerable<Condition> aq_ = context.Operators.Union<Condition>(an_, ap_);
+			IEnumerable<Condition> ar_ = context.Operators.Union<Condition>(al_, aq_);
+			CqlValueSet as_ = this.Corneal_Edema();
+			IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, null);
+			CqlValueSet au_ = this.Disorders_of_Cornea_Including_Corneal_Opacity();
+			IEnumerable<Condition> av_ = context.Operators.RetrieveByValueSet<Condition>(au_, null);
+			IEnumerable<Condition> aw_ = context.Operators.Union<Condition>(at_, av_);
+			IEnumerable<Condition> ax_ = context.Operators.Union<Condition>(ar_, aw_);
+			CqlValueSet ay_ = this.Degeneration_of_Macula_and_Posterior_Pole();
+			IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, null);
+			CqlValueSet ba_ = this.Degenerative_Disorders_of_Globe();
+			IEnumerable<Condition> bb_ = context.Operators.RetrieveByValueSet<Condition>(ba_, null);
+			IEnumerable<Condition> bc_ = context.Operators.Union<Condition>(az_, bb_);
+			IEnumerable<Condition> bd_ = context.Operators.Union<Condition>(ax_, bc_);
+			CqlValueSet be_ = this.Diabetic_Macular_Edema();
+			IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, null);
+			CqlValueSet bg_ = this.Diabetic_Retinopathy();
+			IEnumerable<Condition> bh_ = context.Operators.RetrieveByValueSet<Condition>(bg_, null);
+			IEnumerable<Condition> bi_ = context.Operators.Union<Condition>(bf_, bh_);
+			IEnumerable<Condition> bj_ = context.Operators.Union<Condition>(bd_, bi_);
+			CqlValueSet bk_ = this.Disorders_of_Optic_Chiasm();
+			IEnumerable<Condition> bl_ = context.Operators.RetrieveByValueSet<Condition>(bk_, null);
+			CqlValueSet bm_ = this.Disorders_of_Visual_Cortex();
+			IEnumerable<Condition> bn_ = context.Operators.RetrieveByValueSet<Condition>(bm_, null);
+			IEnumerable<Condition> bo_ = context.Operators.Union<Condition>(bl_, bn_);
+			IEnumerable<Condition> bp_ = context.Operators.Union<Condition>(bj_, bo_);
+			CqlValueSet bq_ = this.Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis();
+			IEnumerable<Condition> br_ = context.Operators.RetrieveByValueSet<Condition>(bq_, null);
+			CqlValueSet bs_ = this.Focal_Chorioretinitis_and_Focal_Retinochoroiditis();
+			IEnumerable<Condition> bt_ = context.Operators.RetrieveByValueSet<Condition>(bs_, null);
+			IEnumerable<Condition> bu_ = context.Operators.Union<Condition>(br_, bt_);
+			IEnumerable<Condition> bv_ = context.Operators.Union<Condition>(bp_, bu_);
+			CqlValueSet bw_ = this.Glaucoma();
+			IEnumerable<Condition> bx_ = context.Operators.RetrieveByValueSet<Condition>(bw_, null);
+			CqlValueSet by_ = this.Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes();
+			IEnumerable<Condition> bz_ = context.Operators.RetrieveByValueSet<Condition>(by_, null);
+			IEnumerable<Condition> ca_ = context.Operators.Union<Condition>(bx_, bz_);
+			IEnumerable<Condition> cb_ = context.Operators.Union<Condition>(bv_, ca_);
+			CqlValueSet cc_ = this.Hereditary_Choroidal_Dystrophies();
+			IEnumerable<Condition> cd_ = context.Operators.RetrieveByValueSet<Condition>(cc_, null);
+			CqlValueSet ce_ = this.Hereditary_Corneal_Dystrophies();
+			IEnumerable<Condition> cf_ = context.Operators.RetrieveByValueSet<Condition>(ce_, null);
+			IEnumerable<Condition> cg_ = context.Operators.Union<Condition>(cd_, cf_);
+			IEnumerable<Condition> ch_ = context.Operators.Union<Condition>(cb_, cg_);
+			CqlValueSet ci_ = this.Hereditary_Retinal_Dystrophies();
+			IEnumerable<Condition> cj_ = context.Operators.RetrieveByValueSet<Condition>(ci_, null);
+			CqlValueSet ck_ = this.Hypotony_of_Eye();
+			IEnumerable<Condition> cl_ = context.Operators.RetrieveByValueSet<Condition>(ck_, null);
+			IEnumerable<Condition> cm_ = context.Operators.Union<Condition>(cj_, cl_);
+			IEnumerable<Condition> cn_ = context.Operators.Union<Condition>(ch_, cm_);
+			CqlValueSet co_ = this.Injury_to_Optic_Nerve_and_Pathways();
+			IEnumerable<Condition> cp_ = context.Operators.RetrieveByValueSet<Condition>(co_, null);
+			CqlValueSet cq_ = this.Macular_Scar_of_Posterior_Polar();
+			IEnumerable<Condition> cr_ = context.Operators.RetrieveByValueSet<Condition>(cq_, null);
+			IEnumerable<Condition> cs_ = context.Operators.Union<Condition>(cp_, cr_);
+			IEnumerable<Condition> ct_ = context.Operators.Union<Condition>(cn_, cs_);
+			CqlValueSet cu_ = this.Morgagnian_Cataract();
+			IEnumerable<Condition> cv_ = context.Operators.RetrieveByValueSet<Condition>(cu_, null);
+			CqlValueSet cw_ = this.Nystagmus_and_Other_Irregular_Eye_Movements();
+			IEnumerable<Condition> cx_ = context.Operators.RetrieveByValueSet<Condition>(cw_, null);
+			IEnumerable<Condition> cy_ = context.Operators.Union<Condition>(cv_, cx_);
+			IEnumerable<Condition> cz_ = context.Operators.Union<Condition>(ct_, cy_);
+			CqlValueSet da_ = this.Open_Wound_of_Eyeball();
+			IEnumerable<Condition> db_ = context.Operators.RetrieveByValueSet<Condition>(da_, null);
+			CqlValueSet dc_ = this.Optic_Atrophy();
+			IEnumerable<Condition> dd_ = context.Operators.RetrieveByValueSet<Condition>(dc_, null);
+			IEnumerable<Condition> de_ = context.Operators.Union<Condition>(db_, dd_);
+			IEnumerable<Condition> df_ = context.Operators.Union<Condition>(cz_, de_);
+			CqlValueSet dg_ = this.Optic_Neuritis();
+			IEnumerable<Condition> dh_ = context.Operators.RetrieveByValueSet<Condition>(dg_, null);
+			CqlValueSet di_ = this.Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis();
+			IEnumerable<Condition> dj_ = context.Operators.RetrieveByValueSet<Condition>(di_, null);
+			IEnumerable<Condition> dk_ = context.Operators.Union<Condition>(dh_, dj_);
+			IEnumerable<Condition> dl_ = context.Operators.Union<Condition>(df_, dk_);
+			CqlValueSet dm_ = this.Other_Background_Retinopathy_and_Retinal_Vascular_Changes();
+			IEnumerable<Condition> dn_ = context.Operators.RetrieveByValueSet<Condition>(dm_, null);
+			CqlValueSet do_ = this.Other_Disorders_of_Optic_Nerve();
+			IEnumerable<Condition> dp_ = context.Operators.RetrieveByValueSet<Condition>(do_, null);
+			IEnumerable<Condition> dq_ = context.Operators.Union<Condition>(dn_, dp_);
+			IEnumerable<Condition> dr_ = context.Operators.Union<Condition>(dl_, dq_);
+			CqlValueSet ds_ = this.Other_Endophthalmitis();
+			IEnumerable<Condition> dt_ = context.Operators.RetrieveByValueSet<Condition>(ds_, null);
+			CqlValueSet du_ = this.Other_Proliferative_Retinopathy();
+			IEnumerable<Condition> dv_ = context.Operators.RetrieveByValueSet<Condition>(du_, null);
+			IEnumerable<Condition> dw_ = context.Operators.Union<Condition>(dt_, dv_);
+			IEnumerable<Condition> dx_ = context.Operators.Union<Condition>(dr_, dw_);
+			CqlValueSet dy_ = this.Pathologic_Myopia();
+			IEnumerable<Condition> dz_ = context.Operators.RetrieveByValueSet<Condition>(dy_, null);
+			CqlValueSet ea_ = this.Posterior_Lenticonus();
+			IEnumerable<Condition> eb_ = context.Operators.RetrieveByValueSet<Condition>(ea_, null);
+			IEnumerable<Condition> ec_ = context.Operators.Union<Condition>(dz_, eb_);
+			IEnumerable<Condition> ed_ = context.Operators.Union<Condition>(dx_, ec_);
+			CqlValueSet ee_ = this.Prior_Penetrating_Keratoplasty();
+			IEnumerable<Condition> ef_ = context.Operators.RetrieveByValueSet<Condition>(ee_, null);
+			CqlValueSet eg_ = this.Purulent_Endophthalmitis();
+			IEnumerable<Condition> eh_ = context.Operators.RetrieveByValueSet<Condition>(eg_, null);
+			IEnumerable<Condition> ei_ = context.Operators.Union<Condition>(ef_, eh_);
+			IEnumerable<Condition> ej_ = context.Operators.Union<Condition>(ed_, ei_);
+			CqlValueSet ek_ = this.Retinal_Detachment_with_Retinal_Defect();
+			IEnumerable<Condition> el_ = context.Operators.RetrieveByValueSet<Condition>(ek_, null);
+			CqlValueSet em_ = this.Retinal_Vascular_Occlusion();
+			IEnumerable<Condition> en_ = context.Operators.RetrieveByValueSet<Condition>(em_, null);
+			IEnumerable<Condition> eo_ = context.Operators.Union<Condition>(el_, en_);
+			IEnumerable<Condition> ep_ = context.Operators.Union<Condition>(ej_, eo_);
+			CqlValueSet eq_ = this.Retrolental_Fibroplasias();
+			IEnumerable<Condition> er_ = context.Operators.RetrieveByValueSet<Condition>(eq_, null);
+			CqlValueSet es_ = this.Scleritis();
+			IEnumerable<Condition> et_ = context.Operators.RetrieveByValueSet<Condition>(es_, null);
+			IEnumerable<Condition> eu_ = context.Operators.Union<Condition>(er_, et_);
+			IEnumerable<Condition> ev_ = context.Operators.Union<Condition>(ep_, eu_);
+			CqlValueSet ew_ = this.Separation_of_Retinal_Layers();
+			IEnumerable<Condition> ex_ = context.Operators.RetrieveByValueSet<Condition>(ew_, null);
+			CqlValueSet ey_ = this.Traumatic_Cataract();
+			IEnumerable<Condition> ez_ = context.Operators.RetrieveByValueSet<Condition>(ey_, null);
+			IEnumerable<Condition> fa_ = context.Operators.Union<Condition>(ex_, ez_);
+			IEnumerable<Condition> fb_ = context.Operators.Union<Condition>(ev_, fa_);
+			CqlValueSet fc_ = this.Uveitis();
+			IEnumerable<Condition> fd_ = context.Operators.RetrieveByValueSet<Condition>(fc_, null);
+			CqlValueSet fe_ = this.Vascular_Disorders_of_Iris_and_Ciliary_Body();
+			IEnumerable<Condition> ff_ = context.Operators.RetrieveByValueSet<Condition>(fe_, null);
+			IEnumerable<Condition> fg_ = context.Operators.Union<Condition>(fd_, ff_);
+			IEnumerable<Condition> fh_ = context.Operators.Union<Condition>(fb_, fg_);
+			CqlValueSet fi_ = this.Visual_Field_Defects();
+			IEnumerable<Condition> fj_ = context.Operators.RetrieveByValueSet<Condition>(fi_, null);
+			IEnumerable<Condition> fk_ = context.Operators.Union<Condition>(fh_, fj_);
 			bool? fl_(Condition ComorbidDiagnosis)
 			{
-				var fp_ = QICoreCommon_2_0_000.prevalenceInterval(ComorbidDiagnosis);
-				var fq_ = CataractSurgeryPerformed?.Performed;
-				var fr_ = FHIRHelpers_4_3_000.ToValue(fq_);
-				var fs_ = QICoreCommon_2_0_000.toInterval(fr_);
-				var ft_ = context.Operators.OverlapsBefore(fp_, fs_, null);
-				var fu_ = QICoreCommon_2_0_000.isActive(ComorbidDiagnosis);
-				var fv_ = context.Operators.And(ft_, fu_);
+				CqlInterval<CqlDateTime> fp_ = QICoreCommon_2_0_000.prevalenceInterval(ComorbidDiagnosis);
+				DataType fq_ = CataractSurgeryPerformed?.Performed;
+				object fr_ = FHIRHelpers_4_3_000.ToValue(fq_);
+				CqlInterval<CqlDateTime> fs_ = QICoreCommon_2_0_000.toInterval(fr_);
+				bool? ft_ = context.Operators.OverlapsBefore(fp_, fs_, null);
+				bool? fu_ = QICoreCommon_2_0_000.isActive(ComorbidDiagnosis);
+				bool? fv_ = context.Operators.And(ft_, fu_);
 
 				return fv_;
 			};
-			var fm_ = context.Operators.Where<Condition>(fk_, fl_);
+			IEnumerable<Condition> fm_ = context.Operators.Where<Condition>(fk_, fl_);
 			Procedure fn_(Condition ComorbidDiagnosis) => 
 				CataractSurgeryPerformed;
-			var fo_ = context.Operators.Select<Condition, Procedure>(fm_, fn_);
+			IEnumerable<Procedure> fo_ = context.Operators.Select<Condition, Procedure>(fm_, fn_);
 
 			return fo_;
 		};
-		var c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
+		IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public IEnumerable<Procedure> Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Procedure> Numerator_Value()
 	{
-		var a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period();
+		IEnumerable<Procedure> a_ = this.Cataract_Surgery_Between_January_and_September_of_Measurement_Period();
 		IEnumerable<Procedure> b_(Procedure CataractSurgeryPerformed)
 		{
-			var d_ = this.Best_corrected_visual_acuity__observable_entity_();
-			var e_ = context.Operators.ToList<CqlCode>(d_);
-			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
-			var g_ = this.Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart();
-			var h_ = context.Operators.RetrieveByValueSet<Observation>(g_, null);
-			var i_ = context.Operators.Union<Observation>(f_, h_);
+			CqlCode d_ = this.Best_corrected_visual_acuity__observable_entity_();
+			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			CqlValueSet g_ = this.Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart();
+			IEnumerable<Observation> h_ = context.Operators.RetrieveByValueSet<Observation>(g_, null);
+			IEnumerable<Observation> i_ = context.Operators.Union<Observation>(f_, h_);
 			bool? j_(Observation VisualAcuityExamPerformed)
 			{
-				var n_ = VisualAcuityExamPerformed?.Effective;
-				var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-				var p_ = QICoreCommon_2_0_000.toInterval(o_);
-				var q_ = context.Operators.Start(p_);
-				var r_ = CataractSurgeryPerformed?.Performed;
-				var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var t_ = QICoreCommon_2_0_000.toInterval(s_);
-				var u_ = context.Operators.End(t_);
-				var w_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var x_ = QICoreCommon_2_0_000.toInterval(w_);
-				var y_ = context.Operators.End(x_);
-				var z_ = context.Operators.Quantity(90m, "days");
-				var aa_ = context.Operators.Add(y_, z_);
-				var ab_ = context.Operators.Interval(u_, aa_, false, true);
-				var ac_ = context.Operators.In<CqlDateTime>(q_, ab_, "day");
-				var ae_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var af_ = QICoreCommon_2_0_000.toInterval(ae_);
-				var ag_ = context.Operators.End(af_);
-				var ah_ = context.Operators.Not((bool?)(ag_ is null));
-				var ai_ = context.Operators.And(ac_, ah_);
-				var aj_ = VisualAcuityExamPerformed?.StatusElement;
-				var ak_ = aj_?.Value;
-				var al_ = context.Operators.Convert<Code<ObservationStatus>>(ak_);
-				var am_ = context.Operators.Convert<string>(al_);
-				var an_ = new string[]
+				DataType n_ = VisualAcuityExamPerformed?.Effective;
+				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+				CqlDateTime q_ = context.Operators.Start(p_);
+				DataType r_ = CataractSurgeryPerformed?.Performed;
+				object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+				CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.toInterval(s_);
+				CqlDateTime u_ = context.Operators.End(t_);
+				object w_ = FHIRHelpers_4_3_000.ToValue(r_);
+				CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.toInterval(w_);
+				CqlDateTime y_ = context.Operators.End(x_);
+				CqlQuantity z_ = context.Operators.Quantity(90m, "days");
+				CqlDateTime aa_ = context.Operators.Add(y_, z_);
+				CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(u_, aa_, false, true);
+				bool? ac_ = context.Operators.In<CqlDateTime>(q_, ab_, "day");
+				object ae_ = FHIRHelpers_4_3_000.ToValue(r_);
+				CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.toInterval(ae_);
+				CqlDateTime ag_ = context.Operators.End(af_);
+				bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+				bool? ai_ = context.Operators.And(ac_, ah_);
+				Code<ObservationStatus> aj_ = VisualAcuityExamPerformed?.StatusElement;
+				ObservationStatus? ak_ = aj_?.Value;
+				Code<ObservationStatus> al_ = context.Operators.Convert<Code<ObservationStatus>>(ak_);
+				string am_ = context.Operators.Convert<string>(al_);
+				string[] an_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 					"preliminary",
 				};
-				var ao_ = context.Operators.In<string>(am_, (an_ as IEnumerable<string>));
-				var ap_ = context.Operators.And(ai_, ao_);
-				var aq_ = VisualAcuityExamPerformed?.Value;
-				var ar_ = FHIRHelpers_4_3_000.ToValue(aq_);
-				var as_ = this.Visual_Acuity_20_40_or_Better();
-				var at_ = context.Operators.ConceptInValueSet((ar_ as CqlConcept), as_);
-				var au_ = context.Operators.And(ap_, at_);
+				bool? ao_ = context.Operators.In<string>(am_, (an_ as IEnumerable<string>));
+				bool? ap_ = context.Operators.And(ai_, ao_);
+				DataType aq_ = VisualAcuityExamPerformed?.Value;
+				object ar_ = FHIRHelpers_4_3_000.ToValue(aq_);
+				CqlValueSet as_ = this.Visual_Acuity_20_40_or_Better();
+				bool? at_ = context.Operators.ConceptInValueSet((ar_ as CqlConcept), as_);
+				bool? au_ = context.Operators.And(ap_, at_);
 
 				return au_;
 			};
-			var k_ = context.Operators.Where<Observation>(i_, j_);
+			IEnumerable<Observation> k_ = context.Operators.Where<Observation>(i_, j_);
 			Procedure l_(Observation VisualAcuityExamPerformed) => 
 				CataractSurgeryPerformed;
-			var m_ = context.Operators.Select<Observation, Procedure>(k_, l_);
+			IEnumerable<Procedure> m_ = context.Operators.Select<Observation, Procedure>(k_, l_);
 
 			return m_;
 		};
-		var c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
+		IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Procedure> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
@@ -94,293 +94,332 @@ public class CervicalCancerScreeningFHIR_0_0_001
 
     #endregion
 
+    /// <seealso cref="Congenital_or_Acquired_Absence_of_Cervix"/>
 	private CqlValueSet Congenital_or_Acquired_Absence_of_Cervix_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", null);
 
+    /// <seealso cref="Congenital_or_Acquired_Absence_of_Cervix_Value"/>
     [CqlDeclaration("Congenital or Acquired Absence of Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016")]
 	public CqlValueSet Congenital_or_Acquired_Absence_of_Cervix() => 
 		__Congenital_or_Acquired_Absence_of_Cervix.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="HPV_Test"/>
 	private CqlValueSet HPV_Test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", null);
 
+    /// <seealso cref="HPV_Test_Value"/>
     [CqlDeclaration("HPV Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059")]
 	public CqlValueSet HPV_Test() => 
 		__HPV_Test.Value;
 
+    /// <seealso cref="Hysterectomy_with_No_Residual_Cervix"/>
 	private CqlValueSet Hysterectomy_with_No_Residual_Cervix_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", null);
 
+    /// <seealso cref="Hysterectomy_with_No_Residual_Cervix_Value"/>
     [CqlDeclaration("Hysterectomy with No Residual Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014")]
 	public CqlValueSet Hysterectomy_with_No_Residual_Cervix() => 
 		__Hysterectomy_with_No_Residual_Cervix.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Pap_Test"/>
 	private CqlValueSet Pap_Test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", null);
 
+    /// <seealso cref="Pap_Test_Value"/>
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
 	public CqlValueSet Pap_Test() => 
 		__Pap_Test.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("CervicalCancerScreeningFHIR-0.0.001", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("CervicalCancerScreeningFHIR-0.0.001", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Home_Healthcare_Services();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Telephone_Visits();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Online_Assessments();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = Status_1_6_000.isEncounterPerformed(q_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Telephone_Visits();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Online_Assessments();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		IEnumerable<Encounter> r_ = Status_1_6_000.isEncounterPerformed(q_);
 		bool? s_(Encounter ValidEncounters)
 		{
-			var u_ = this.Measurement_Period();
-			var v_ = ValidEncounters?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = QICoreCommon_2_0_000.toInterval((w_ as object));
-			var y_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, x_, "day");
+			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
+			Period v_ = ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.toInterval((w_ as object));
+			bool? y_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, x_, "day");
 
 			return y_;
 		};
-		var t_ = context.Operators.Where<Encounter>(r_, s_);
+		IEnumerable<Encounter> t_ = context.Operators.Where<Encounter>(r_, s_);
 
 		return t_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(24, 64, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var j_ = context.Operators.Convert<string>(a_?.GenderElement?.Value);
-		var k_ = context.Operators.Equal(j_, "female");
-		var l_ = context.Operators.And(h_, k_);
-		var m_ = this.Qualifying_Encounters();
-		var n_ = context.Operators.Exists<Encounter>(m_);
-		var o_ = context.Operators.And(l_, n_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(24, 64, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		Code<AdministrativeGender> l_ = a_?.GenderElement;
+		AdministrativeGender? m_ = l_?.Value;
+		string n_ = context.Operators.Convert<string>(m_);
+		bool? o_ = context.Operators.Equal(n_, "female");
+		bool? p_ = context.Operators.And(j_, o_);
+		IEnumerable<Encounter> q_ = this.Qualifying_Encounters();
+		bool? r_ = context.Operators.Exists<Encounter>(q_);
+		bool? s_ = context.Operators.And(p_, r_);
 
-		return o_;
+		return s_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Absence_of_Cervix"/>
 	private IEnumerable<object> Absence_of_Cervix_Value()
 	{
-		var a_ = this.Hysterectomy_with_No_Residual_Cervix();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.isProcedurePerformed(b_);
+		CqlValueSet a_ = this.Hysterectomy_with_No_Residual_Cervix();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		bool? d_(Procedure NoCervixProcedure)
 		{
-			var k_ = NoCervixProcedure?.Performed;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = QICoreCommon_2_0_000.toInterval(l_);
-			var n_ = context.Operators.End(m_);
-			var o_ = this.Measurement_Period();
-			var p_ = context.Operators.End(o_);
-			var q_ = context.Operators.SameOrBefore(n_, p_, null);
+			DataType k_ = NoCervixProcedure?.Performed;
+			object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+			CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.toInterval(l_);
+			CqlDateTime n_ = context.Operators.End(m_);
+			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
+			CqlDateTime p_ = context.Operators.End(o_);
+			bool? q_ = context.Operators.SameOrBefore(n_, p_, null);
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
-		var f_ = this.Congenital_or_Acquired_Absence_of_Cervix();
-		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
+		CqlValueSet f_ = this.Congenital_or_Acquired_Absence_of_Cervix();
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
 		bool? h_(Condition NoCervixDiagnosis)
 		{
-			var r_ = QICoreCommon_2_0_000.prevalenceInterval(NoCervixDiagnosis);
-			var s_ = context.Operators.Start(r_);
-			var t_ = this.Measurement_Period();
-			var u_ = context.Operators.End(t_);
-			var v_ = context.Operators.SameOrBefore(s_, u_, null);
+			CqlInterval<CqlDateTime> r_ = QICoreCommon_2_0_000.prevalenceInterval(NoCervixDiagnosis);
+			CqlDateTime s_ = context.Operators.Start(r_);
+			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
+			CqlDateTime u_ = context.Operators.End(t_);
+			bool? v_ = context.Operators.SameOrBefore(s_, u_, null);
 
 			return v_;
 		};
-		var i_ = context.Operators.Where<Condition>(g_, h_);
-		var j_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (i_ as IEnumerable<object>));
+		IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
+		IEnumerable<object> j_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (i_ as IEnumerable<object>));
 
 		return j_;
 	}
 
+    /// <seealso cref="Absence_of_Cervix_Value"/>
     [CqlDeclaration("Absence of Cervix")]
 	public IEnumerable<object> Absence_of_Cervix() => 
 		__Absence_of_Cervix.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = this.Absence_of_Cervix();
-		var c_ = context.Operators.Exists<object>(b_);
-		var d_ = context.Operators.Or(a_, c_);
-		var e_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
-		var f_ = context.Operators.Or(d_, e_);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		IEnumerable<object> b_ = this.Absence_of_Cervix();
+		bool? c_ = context.Operators.Exists<object>(b_);
+		bool? d_ = context.Operators.Or(a_, c_);
+		bool? e_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		bool? f_ = context.Operators.Or(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Cervical_Cytology_Within_3_Years"/>
 	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years_Value()
 	{
-		var a_ = this.Pap_Test();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
+		CqlValueSet a_ = this.Pap_Test();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation CervicalCytology)
 		{
 			object f_()
 			{
 				bool t_()
 				{
-					var w_ = CervicalCytology?.Effective;
-					var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-					var y_ = x_ is CqlDateTime;
+					DataType w_ = CervicalCytology?.Effective;
+					object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+					bool y_ = x_ is CqlDateTime;
 
 					return y_;
 				};
 				bool u_()
 				{
-					var z_ = CervicalCytology?.Effective;
-					var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
-					var ab_ = aa_ is CqlInterval<CqlDateTime>;
+					DataType z_ = CervicalCytology?.Effective;
+					object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+					bool ab_ = aa_ is CqlInterval<CqlDateTime>;
 
 					return ab_;
 				};
 				bool v_()
 				{
-					var ac_ = CervicalCytology?.Effective;
-					var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-					var ae_ = ad_ is CqlDateTime;
+					DataType ac_ = CervicalCytology?.Effective;
+					object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+					bool ae_ = ad_ is CqlDateTime;
 
 					return ae_;
 				};
 				if (t_())
 				{
-					var af_ = CervicalCytology?.Effective;
-					var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+					DataType af_ = CervicalCytology?.Effective;
+					object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
 
 					return ((ag_ as CqlDateTime) as object);
 				}
 				else if (u_())
 				{
-					var ah_ = CervicalCytology?.Effective;
-					var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+					DataType ah_ = CervicalCytology?.Effective;
+					object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
 
 					return ((ai_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (v_())
 				{
-					var aj_ = CervicalCytology?.Effective;
-					var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+					DataType aj_ = CervicalCytology?.Effective;
+					object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
 
 					return ((ak_ as CqlDateTime) as object);
 				}
@@ -389,85 +428,87 @@ public class CervicalCancerScreeningFHIR_0_0_001
 					return null;
 				}
 			};
-			var g_ = QICoreCommon_2_0_000.latest(f_());
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.Start(h_);
-			var j_ = context.Operators.Quantity(2m, "years");
-			var k_ = context.Operators.Subtract(i_, j_);
-			var m_ = context.Operators.End(h_);
-			var n_ = context.Operators.Interval(k_, m_, true, true);
-			var o_ = context.Operators.In<CqlDateTime>(g_, n_, "day");
-			var p_ = CervicalCytology?.Value;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = context.Operators.Not((bool?)(q_ is null));
-			var s_ = context.Operators.And(o_, r_);
+			CqlDateTime g_ = QICoreCommon_2_0_000.latest(f_());
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.Start(h_);
+			CqlQuantity j_ = context.Operators.Quantity(2m, "years");
+			CqlDateTime k_ = context.Operators.Subtract(i_, j_);
+			CqlDateTime m_ = context.Operators.End(h_);
+			CqlInterval<CqlDateTime> n_ = context.Operators.Interval(k_, m_, true, true);
+			bool? o_ = context.Operators.In<CqlDateTime>(g_, n_, "day");
+			DataType p_ = CervicalCytology?.Value;
+			object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+			bool? r_ = context.Operators.Not((bool?)(q_ is null));
+			bool? s_ = context.Operators.And(o_, r_);
 
 			return s_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Cervical_Cytology_Within_3_Years_Value"/>
     [CqlDeclaration("Cervical Cytology Within 3 Years")]
 	public IEnumerable<Observation> Cervical_Cytology_Within_3_Years() => 
 		__Cervical_Cytology_Within_3_Years.Value;
 
+    /// <seealso cref="HPV_Test_Within_5_Years_for_Women_Age_30_and_Older"/>
 	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value()
 	{
-		var a_ = this.HPV_Test();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
+		CqlValueSet a_ = this.HPV_Test();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation HPVTest)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
 			object j_()
 			{
 				bool ad_()
 				{
-					var ag_ = HPVTest?.Effective;
-					var ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
-					var ai_ = ah_ is CqlDateTime;
+					DataType ag_ = HPVTest?.Effective;
+					object ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
+					bool ai_ = ah_ is CqlDateTime;
 
 					return ai_;
 				};
 				bool ae_()
 				{
-					var aj_ = HPVTest?.Effective;
-					var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-					var al_ = ak_ is CqlInterval<CqlDateTime>;
+					DataType aj_ = HPVTest?.Effective;
+					object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+					bool al_ = ak_ is CqlInterval<CqlDateTime>;
 
 					return al_;
 				};
 				bool af_()
 				{
-					var am_ = HPVTest?.Effective;
-					var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-					var ao_ = an_ is CqlDateTime;
+					DataType am_ = HPVTest?.Effective;
+					object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+					bool ao_ = an_ is CqlDateTime;
 
 					return ao_;
 				};
 				if (ad_())
 				{
-					var ap_ = HPVTest?.Effective;
-					var aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+					DataType ap_ = HPVTest?.Effective;
+					object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
 
 					return ((aq_ as CqlDateTime) as object);
 				}
 				else if (ae_())
 				{
-					var ar_ = HPVTest?.Effective;
-					var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+					DataType ar_ = HPVTest?.Effective;
+					object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
 
 					return ((as_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (af_())
 				{
-					var at_ = HPVTest?.Effective;
-					var au_ = FHIRHelpers_4_3_000.ToValue(at_);
+					DataType at_ = HPVTest?.Effective;
+					object au_ = FHIRHelpers_4_3_000.ToValue(at_);
 
 					return ((au_ as CqlDateTime) as object);
 				}
@@ -476,54 +517,54 @@ public class CervicalCancerScreeningFHIR_0_0_001
 					return null;
 				}
 			};
-			var k_ = QICoreCommon_2_0_000.latest(j_());
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-			var n_ = context.Operators.GreaterOrEqual(m_, 30);
+			CqlDateTime k_ = QICoreCommon_2_0_000.latest(j_());
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			bool? n_ = context.Operators.GreaterOrEqual(m_, 30);
 			object o_()
 			{
 				bool av_()
 				{
-					var ay_ = HPVTest?.Effective;
-					var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-					var ba_ = az_ is CqlDateTime;
+					DataType ay_ = HPVTest?.Effective;
+					object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+					bool ba_ = az_ is CqlDateTime;
 
 					return ba_;
 				};
 				bool aw_()
 				{
-					var bb_ = HPVTest?.Effective;
-					var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
-					var bd_ = bc_ is CqlInterval<CqlDateTime>;
+					DataType bb_ = HPVTest?.Effective;
+					object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+					bool bd_ = bc_ is CqlInterval<CqlDateTime>;
 
 					return bd_;
 				};
 				bool ax_()
 				{
-					var be_ = HPVTest?.Effective;
-					var bf_ = FHIRHelpers_4_3_000.ToValue(be_);
-					var bg_ = bf_ is CqlDateTime;
+					DataType be_ = HPVTest?.Effective;
+					object bf_ = FHIRHelpers_4_3_000.ToValue(be_);
+					bool bg_ = bf_ is CqlDateTime;
 
 					return bg_;
 				};
 				if (av_())
 				{
-					var bh_ = HPVTest?.Effective;
-					var bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
+					DataType bh_ = HPVTest?.Effective;
+					object bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
 
 					return ((bi_ as CqlDateTime) as object);
 				}
 				else if (aw_())
 				{
-					var bj_ = HPVTest?.Effective;
-					var bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+					DataType bj_ = HPVTest?.Effective;
+					object bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
 
 					return ((bk_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (ax_())
 				{
-					var bl_ = HPVTest?.Effective;
-					var bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
+					DataType bl_ = HPVTest?.Effective;
+					object bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
 
 					return ((bm_ as CqlDateTime) as object);
 				}
@@ -532,86 +573,97 @@ public class CervicalCancerScreeningFHIR_0_0_001
 					return null;
 				}
 			};
-			var p_ = QICoreCommon_2_0_000.latest(o_());
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.Start(q_);
-			var s_ = context.Operators.Quantity(4m, "years");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var v_ = context.Operators.End(q_);
-			var w_ = context.Operators.Interval(t_, v_, true, true);
-			var x_ = context.Operators.In<CqlDateTime>(p_, w_, "day");
-			var y_ = context.Operators.And(n_, x_);
-			var z_ = HPVTest?.Value;
-			var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
-			var ab_ = context.Operators.Not((bool?)(aa_ is null));
-			var ac_ = context.Operators.And(y_, ab_);
+			CqlDateTime p_ = QICoreCommon_2_0_000.latest(o_());
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.Start(q_);
+			CqlQuantity s_ = context.Operators.Quantity(4m, "years");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			CqlDateTime v_ = context.Operators.End(q_);
+			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(t_, v_, true, true);
+			bool? x_ = context.Operators.In<CqlDateTime>(p_, w_, "day");
+			bool? y_ = context.Operators.And(n_, x_);
+			DataType z_ = HPVTest?.Value;
+			object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+			bool? ac_ = context.Operators.And(y_, ab_);
 
 			return ac_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value"/>
     [CqlDeclaration("HPV Test Within 5 Years for Women Age 30 and Older")]
 	public IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older() => 
 		__HPV_Test_Within_5_Years_for_Women_Age_30_and_Older.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Cervical_Cytology_Within_3_Years();
-		var b_ = context.Operators.Exists<Observation>(a_);
-		var c_ = this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older();
-		var d_ = context.Operators.Exists<Observation>(c_);
-		var e_ = context.Operators.Or(b_, d_);
+		IEnumerable<Observation> a_ = this.Cervical_Cytology_Within_3_Years();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> c_ = this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older();
+		bool? d_ = context.Operators.Exists<Observation>(c_);
+		bool? e_ = context.Operators.Or(b_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
@@ -114,108 +114,135 @@ public class CesareanBirthFHIR_0_2_000
 
     #endregion
 
+    /// <seealso cref="Abnormal_Presentation"/>
 	private CqlValueSet Abnormal_Presentation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105", null);
 
+    /// <seealso cref="Abnormal_Presentation_Value"/>
     [CqlDeclaration("Abnormal Presentation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105")]
 	public CqlValueSet Abnormal_Presentation() => 
 		__Abnormal_Presentation.Value;
 
+    /// <seealso cref="Cesarean_Birth"/>
 	private CqlValueSet Cesarean_Birth_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282", null);
 
+    /// <seealso cref="Cesarean_Birth_Value"/>
     [CqlDeclaration("Cesarean Birth")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282")]
 	public CqlValueSet Cesarean_Birth() => 
 		__Cesarean_Birth.Value;
 
+    /// <seealso cref="Delivery_of_Singleton"/>
 	private CqlValueSet Delivery_of_Singleton_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99", null);
 
+    /// <seealso cref="Delivery_of_Singleton_Value"/>
     [CqlDeclaration("Delivery of Singleton")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99")]
 	public CqlValueSet Delivery_of_Singleton() => 
 		__Delivery_of_Singleton.Value;
 
+    /// <seealso cref="Delivery_Procedures"/>
 	private CqlValueSet Delivery_Procedures_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", null);
 
+    /// <seealso cref="Delivery_Procedures_Value"/>
     [CqlDeclaration("Delivery Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
 	public CqlValueSet Delivery_Procedures() => 
 		__Delivery_Procedures.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Genital_Herpes"/>
 	private CqlValueSet Genital_Herpes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049", null);
 
+    /// <seealso cref="Genital_Herpes_Value"/>
     [CqlDeclaration("Genital Herpes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049")]
 	public CqlValueSet Genital_Herpes() => 
 		__Genital_Herpes.Value;
 
+    /// <seealso cref="Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa"/>
 	private CqlValueSet Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37", null);
 
+    /// <seealso cref="Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa_Value"/>
     [CqlDeclaration("Placenta Previa Accreta Increta Percreta or Vasa Previa")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37")]
 	public CqlValueSet Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa() => 
 		__Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa.Value;
 
+    /// <seealso cref="_37_to_42_Plus_Weeks_Gestation"/>
 	private CqlValueSet _37_to_42_Plus_Weeks_Gestation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68", null);
 
+    /// <seealso cref="_37_to_42_Plus_Weeks_Gestation_Value"/>
     [CqlDeclaration("37 to 42 Plus Weeks Gestation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68")]
 	public CqlValueSet _37_to_42_Plus_Weeks_Gestation() => 
 		___37_to_42_Plus_Weeks_Gestation.Value;
 
+    /// <seealso cref="____Births_preterm"/>
 	private CqlCode ____Births_preterm_Value() => 
 		new CqlCode("11637-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="____Births_preterm_Value"/>
     [CqlDeclaration("[#] Births.preterm")]
 	public CqlCode ____Births_preterm() => 
 		______Births_preterm.Value;
 
+    /// <seealso cref="____Births_term"/>
 	private CqlCode ____Births_term_Value() => 
 		new CqlCode("11639-2", "http://loinc.org", null, null);
 
+    /// <seealso cref="____Births_term_Value"/>
     [CqlDeclaration("[#] Births.term")]
 	public CqlCode ____Births_term() => 
 		______Births_term.Value;
 
+    /// <seealso cref="____Parity"/>
 	private CqlCode ____Parity_Value() => 
 		new CqlCode("11977-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="____Parity_Value"/>
     [CqlDeclaration("[#] Parity")]
 	public CqlCode ____Parity() => 
 		______Parity.Value;
 
+    /// <seealso cref="____Pregnancies"/>
 	private CqlCode ____Pregnancies_Value() => 
 		new CqlCode("11996-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="____Pregnancies_Value"/>
     [CqlDeclaration("[#] Pregnancies")]
 	public CqlCode ____Pregnancies() => 
 		______Pregnancies.Value;
 
+    /// <seealso cref="Date_and_time_of_obstetric_delivery"/>
 	private CqlCode Date_and_time_of_obstetric_delivery_Value() => 
 		new CqlCode("93857-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="Date_and_time_of_obstetric_delivery_Value"/>
     [CqlDeclaration("Date and time of obstetric delivery")]
 	public CqlCode Date_and_time_of_obstetric_delivery() => 
 		__Date_and_time_of_obstetric_delivery.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("11637-6", "http://loinc.org", null, null),
 			new CqlCode("11639-2", "http://loinc.org", null, null),
@@ -227,150 +254,165 @@ public class CesareanBirthFHIR_0_2_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("CesareanBirthFHIR-0.2.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("CesareanBirthFHIR-0.2.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Delivery_Encounter_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks"/>
 	private IEnumerable<Encounter> Delivery_Encounter_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 		bool? b_(Encounter DeliveryEncounter)
 		{
-			var d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
-			var e_ = context.Operators.GreaterOrEqual(d_, 37);
+			int? d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			bool? e_ = context.Operators.GreaterOrEqual(d_, 37);
 
 			return e_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounter_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Value"/>
     [CqlDeclaration("Delivery Encounter with Calculated Gestational Age Greater than or Equal to 37 Weeks")]
 	public IEnumerable<Encounter> Delivery_Encounter_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks() => 
 		__Delivery_Encounter_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks.Value;
 
+    /// <seealso cref="Delivery_Encounter_with_Estimated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks"/>
 	private IEnumerable<Encounter> Delivery_Encounter_with_Estimated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 		bool? b_(Encounter DeliveryEncounter)
 		{
-			var d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
-			var e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
-			var f_ = context.Operators.Quantity(37m, "weeks");
-			var g_ = context.Operators.GreaterOrEqual(e_, f_);
-			var h_ = context.Operators.And((bool?)(d_ is null), g_);
+			int? d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			CqlQuantity e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			CqlQuantity f_ = context.Operators.Quantity(37m, "weeks");
+			bool? g_ = context.Operators.GreaterOrEqual(e_, f_);
+			bool? h_ = context.Operators.And((bool?)(d_ is null), g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounter_with_Estimated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Value"/>
     [CqlDeclaration("Delivery Encounter with Estimated Gestational Age Greater than or Equal to 37 Weeks")]
 	public IEnumerable<Encounter> Delivery_Encounter_with_Estimated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks() => 
 		__Delivery_Encounter_with_Estimated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks.Value;
 
+    /// <seealso cref="Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Based_on_Coding"/>
 	private IEnumerable<Encounter> Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Based_on_Coding_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 		bool? b_(Encounter DeliveryEncounter)
 		{
-			var d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
-			var e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
-			var f_ = context.Operators.And((bool?)(d_ is null), (bool?)(e_ is null));
-			var g_ = CQMCommon_2_0_000.encounterDiagnosis(DeliveryEncounter);
+			int? d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			CqlQuantity e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			bool? f_ = context.Operators.And((bool?)(d_ is null), (bool?)(e_ is null));
+			IEnumerable<Condition> g_ = CQMCommon_2_0_000.encounterDiagnosis(DeliveryEncounter);
 			bool? h_(Condition EncounterDiagnosis)
 			{
-				var l_ = EncounterDiagnosis?.Code;
-				var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-				var n_ = this._37_to_42_Plus_Weeks_Gestation();
-				var o_ = context.Operators.ConceptInValueSet(m_, n_);
+				CodeableConcept l_ = EncounterDiagnosis?.Code;
+				CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+				CqlValueSet n_ = this._37_to_42_Plus_Weeks_Gestation();
+				bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
 
 				return o_;
 			};
-			var i_ = context.Operators.Where<Condition>(g_, h_);
-			var j_ = context.Operators.Exists<Condition>(i_);
-			var k_ = context.Operators.And(f_, j_);
+			IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
+			bool? j_ = context.Operators.Exists<Condition>(i_);
+			bool? k_ = context.Operators.And(f_, j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Based_on_Coding_Value"/>
     [CqlDeclaration("Delivery Encounter with Gestational Age Greater than or Equal to 37 Weeks Based on Coding")]
 	public IEnumerable<Encounter> Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Based_on_Coding() => 
 		__Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Based_on_Coding.Value;
 
+    /// <seealso cref="Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks"/>
 	private IEnumerable<Encounter> Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Value()
 	{
-		var a_ = this.Delivery_Encounter_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks();
-		var b_ = this.Delivery_Encounter_with_Estimated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
-		var d_ = this.Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Based_on_Coding();
-		var e_ = context.Operators.Union<Encounter>(c_, d_);
+		IEnumerable<Encounter> a_ = this.Delivery_Encounter_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks();
+		IEnumerable<Encounter> b_ = this.Delivery_Encounter_with_Estimated_Gestational_Age_Greater_than_or_Equal_to_37_Weeks();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Based_on_Coding();
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks_Value"/>
     [CqlDeclaration("Delivery Encounter with Gestational Age Greater than or Equal to 37 Weeks")]
 	public IEnumerable<Encounter> Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks() => 
 		__Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks.Value;
 
+    /// <seealso cref="Encounter_with_Singleton_Delivery"/>
 	private IEnumerable<Encounter> Encounter_with_Singleton_Delivery_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 		bool? b_(Encounter DeliveryEncounter)
 		{
-			var d_ = CQMCommon_2_0_000.encounterDiagnosis(DeliveryEncounter);
+			IEnumerable<Condition> d_ = CQMCommon_2_0_000.encounterDiagnosis(DeliveryEncounter);
 			bool? e_(Condition EncounterDiagnosis)
 			{
-				var h_ = EncounterDiagnosis?.Code;
-				var i_ = FHIRHelpers_4_3_000.ToConcept(h_);
-				var j_ = this.Delivery_of_Singleton();
-				var k_ = context.Operators.ConceptInValueSet(i_, j_);
+				CodeableConcept h_ = EncounterDiagnosis?.Code;
+				CqlConcept i_ = FHIRHelpers_4_3_000.ToConcept(h_);
+				CqlValueSet j_ = this.Delivery_of_Singleton();
+				bool? k_ = context.Operators.ConceptInValueSet(i_, j_);
 
 				return k_;
 			};
-			var f_ = context.Operators.Where<Condition>(d_, e_);
-			var g_ = context.Operators.Exists<Condition>(f_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+			bool? g_ = context.Operators.Exists<Condition>(f_);
 
 			return g_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Singleton_Delivery_Value"/>
     [CqlDeclaration("Encounter with Singleton Delivery")]
 	public IEnumerable<Encounter> Encounter_with_Singleton_Delivery() => 
 		__Encounter_with_Singleton_Delivery.Value;
@@ -378,702 +420,709 @@ public class CesareanBirthFHIR_0_2_000
     [CqlDeclaration("lastGravida")]
 	public int? lastGravida(Encounter TheEncounter)
 	{
-		var a_ = this.____Pregnancies();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.____Pregnancies();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation Gravida)
 		{
-			var j_ = Gravida?.Value;
-			var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-			var l_ = context.Operators.Not((bool?)(k_ is null));
-			var m_ = Gravida?.StatusElement;
-			var n_ = m_?.Value;
-			var o_ = context.Operators.Convert<Code<ObservationStatus>>(n_);
-			var p_ = context.Operators.Convert<string>(o_);
-			var q_ = new string[]
+			DataType k_ = Gravida?.Value;
+			object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+			bool? m_ = context.Operators.Not((bool?)(l_ is null));
+			Code<ObservationStatus> n_ = Gravida?.StatusElement;
+			ObservationStatus? o_ = n_?.Value;
+			Code<ObservationStatus> p_ = context.Operators.Convert<Code<ObservationStatus>>(o_);
+			string q_ = context.Operators.Convert<string>(p_);
+			string[] r_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var r_ = context.Operators.In<string>(p_, (q_ as IEnumerable<string>));
-			var s_ = context.Operators.And(l_, r_);
-			object t_()
+			bool? s_ = context.Operators.In<string>(q_, (r_ as IEnumerable<string>));
+			bool? t_ = context.Operators.And(m_, s_);
+			object u_()
 			{
-				bool af_()
-				{
-					var ai_ = Gravida?.Effective;
-					var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-					var ak_ = aj_ is CqlDateTime;
-
-					return ak_;
-				};
 				bool ag_()
 				{
-					var al_ = Gravida?.Effective;
-					var am_ = FHIRHelpers_4_3_000.ToValue(al_);
-					var an_ = am_ is CqlInterval<CqlDateTime>;
+					DataType aj_ = Gravida?.Effective;
+					object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+					bool al_ = ak_ is CqlDateTime;
 
-					return an_;
+					return al_;
 				};
 				bool ah_()
 				{
-					var ao_ = Gravida?.Effective;
-					var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-					var aq_ = ap_ is CqlDateTime;
+					DataType am_ = Gravida?.Effective;
+					object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+					bool ao_ = an_ is CqlInterval<CqlDateTime>;
 
-					return aq_;
+					return ao_;
 				};
-				if (af_())
+				bool ai_()
 				{
-					var ar_ = Gravida?.Effective;
-					var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+					DataType ap_ = Gravida?.Effective;
+					object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+					bool ar_ = aq_ is CqlDateTime;
 
-					return ((as_ as CqlDateTime) as object);
-				}
-				else if (ag_())
+					return ar_;
+				};
+				if (ag_())
 				{
-					var at_ = Gravida?.Effective;
-					var au_ = FHIRHelpers_4_3_000.ToValue(at_);
+					DataType as_ = Gravida?.Effective;
+					object at_ = FHIRHelpers_4_3_000.ToValue(as_);
 
-					return ((au_ as CqlInterval<CqlDateTime>) as object);
+					return ((at_ as CqlDateTime) as object);
 				}
 				else if (ah_())
 				{
-					var av_ = Gravida?.Effective;
-					var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+					DataType au_ = Gravida?.Effective;
+					object av_ = FHIRHelpers_4_3_000.ToValue(au_);
 
-					return ((aw_ as CqlDateTime) as object);
+					return ((av_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (ai_())
+				{
+					DataType aw_ = Gravida?.Effective;
+					object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+
+					return ((ax_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var u_ = QICoreCommon_2_0_000.earliest(t_());
-			var v_ = PCMaternal_5_16_000.lastTimeOfDelivery(TheEncounter);
-			var w_ = context.Operators.Quantity(42m, "weeks");
-			var x_ = context.Operators.Subtract(v_, w_);
-			var z_ = context.Operators.Interval(x_, v_, true, false);
-			var aa_ = context.Operators.In<CqlDateTime>(u_, z_, null);
-			var ac_ = context.Operators.Not((bool?)(v_ is null));
-			var ad_ = context.Operators.And(aa_, ac_);
-			var ae_ = context.Operators.And(s_, ad_);
+			CqlDateTime v_ = QICoreCommon_2_0_000.earliest(u_());
+			CqlDateTime w_ = PCMaternal_5_16_000.lastTimeOfDelivery(TheEncounter);
+			CqlQuantity x_ = context.Operators.Quantity(42m, "weeks");
+			CqlDateTime y_ = context.Operators.Subtract(w_, x_);
+			CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(y_, w_, true, false);
+			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, null);
+			bool? ad_ = context.Operators.Not((bool?)(w_ is null));
+			bool? ae_ = context.Operators.And(ab_, ad_);
+			bool? af_ = context.Operators.And(t_, ae_);
 
-			return ae_;
+			return af_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			object ax_()
+			object ay_()
 			{
-				bool az_()
-				{
-					var bc_ = @this?.Effective;
-					var bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
-					var be_ = bd_ is CqlDateTime;
-
-					return be_;
-				};
 				bool ba_()
 				{
-					var bf_ = @this?.Effective;
-					var bg_ = FHIRHelpers_4_3_000.ToValue(bf_);
-					var bh_ = bg_ is CqlInterval<CqlDateTime>;
+					DataType bd_ = @this?.Effective;
+					object be_ = FHIRHelpers_4_3_000.ToValue(bd_);
+					bool bf_ = be_ is CqlDateTime;
 
-					return bh_;
+					return bf_;
 				};
 				bool bb_()
 				{
-					var bi_ = @this?.Effective;
-					var bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
-					var bk_ = bj_ is CqlDateTime;
+					DataType bg_ = @this?.Effective;
+					object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+					bool bi_ = bh_ is CqlInterval<CqlDateTime>;
 
-					return bk_;
+					return bi_;
 				};
-				if (az_())
+				bool bc_()
 				{
-					var bl_ = @this?.Effective;
-					var bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
+					DataType bj_ = @this?.Effective;
+					object bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+					bool bl_ = bk_ is CqlDateTime;
 
-					return ((bm_ as CqlDateTime) as object);
-				}
-				else if (ba_())
+					return bl_;
+				};
+				if (ba_())
 				{
-					var bn_ = @this?.Effective;
-					var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+					DataType bm_ = @this?.Effective;
+					object bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
 
-					return ((bo_ as CqlInterval<CqlDateTime>) as object);
+					return ((bn_ as CqlDateTime) as object);
 				}
 				else if (bb_())
 				{
-					var bp_ = @this?.Effective;
-					var bq_ = FHIRHelpers_4_3_000.ToValue(bp_);
+					DataType bo_ = @this?.Effective;
+					object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
 
-					return ((bq_ as CqlDateTime) as object);
+					return ((bp_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (bc_())
+				{
+					DataType bq_ = @this?.Effective;
+					object br_ = FHIRHelpers_4_3_000.ToValue(bq_);
+
+					return ((br_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var ay_ = QICoreCommon_2_0_000.earliest(ax_());
+			CqlDateTime az_ = QICoreCommon_2_0_000.earliest(ay_());
 
-			return ay_;
+			return az_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = FHIRHelpers_4_3_000.ToValue(h_?.Value);
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		DataType i_ = h_?.Value;
+		object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 
-		return (int?)i_;
+		return (int?)j_;
 	}
 
     [CqlDeclaration("lastParity")]
 	public int? lastParity(Encounter TheEncounter)
 	{
-		var a_ = this.____Parity();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.____Parity();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation Parity)
 		{
-			object j_()
+			object k_()
 			{
-				bool af_()
-				{
-					var ai_ = Parity?.Effective;
-					var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-					var ak_ = aj_ is CqlDateTime;
-
-					return ak_;
-				};
 				bool ag_()
 				{
-					var al_ = Parity?.Effective;
-					var am_ = FHIRHelpers_4_3_000.ToValue(al_);
-					var an_ = am_ is CqlInterval<CqlDateTime>;
+					DataType aj_ = Parity?.Effective;
+					object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+					bool al_ = ak_ is CqlDateTime;
 
-					return an_;
+					return al_;
 				};
 				bool ah_()
 				{
-					var ao_ = Parity?.Effective;
-					var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-					var aq_ = ap_ is CqlDateTime;
+					DataType am_ = Parity?.Effective;
+					object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+					bool ao_ = an_ is CqlInterval<CqlDateTime>;
 
-					return aq_;
+					return ao_;
 				};
-				if (af_())
+				bool ai_()
 				{
-					var ar_ = Parity?.Effective;
-					var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+					DataType ap_ = Parity?.Effective;
+					object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+					bool ar_ = aq_ is CqlDateTime;
 
-					return ((as_ as CqlDateTime) as object);
-				}
-				else if (ag_())
+					return ar_;
+				};
+				if (ag_())
 				{
-					var at_ = Parity?.Effective;
-					var au_ = FHIRHelpers_4_3_000.ToValue(at_);
+					DataType as_ = Parity?.Effective;
+					object at_ = FHIRHelpers_4_3_000.ToValue(as_);
 
-					return ((au_ as CqlInterval<CqlDateTime>) as object);
+					return ((at_ as CqlDateTime) as object);
 				}
 				else if (ah_())
 				{
-					var av_ = Parity?.Effective;
-					var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+					DataType au_ = Parity?.Effective;
+					object av_ = FHIRHelpers_4_3_000.ToValue(au_);
 
-					return ((aw_ as CqlDateTime) as object);
+					return ((av_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (ai_())
+				{
+					DataType aw_ = Parity?.Effective;
+					object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+
+					return ((ax_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var k_ = QICoreCommon_2_0_000.earliest(j_());
-			var l_ = PCMaternal_5_16_000.lastTimeOfDelivery(TheEncounter);
-			var m_ = context.Operators.Quantity(42m, "weeks");
-			var n_ = context.Operators.Subtract(l_, m_);
-			var p_ = context.Operators.Interval(n_, l_, true, false);
-			var q_ = context.Operators.In<CqlDateTime>(k_, p_, null);
-			var s_ = context.Operators.Not((bool?)(l_ is null));
-			var t_ = context.Operators.And(q_, s_);
-			var u_ = Parity?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
-			var x_ = context.Operators.Convert<string>(w_);
-			var y_ = new string[]
+			CqlDateTime l_ = QICoreCommon_2_0_000.earliest(k_());
+			CqlDateTime m_ = PCMaternal_5_16_000.lastTimeOfDelivery(TheEncounter);
+			CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
+			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
+			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
+			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, null);
+			bool? t_ = context.Operators.Not((bool?)(m_ is null));
+			bool? u_ = context.Operators.And(r_, t_);
+			Code<ObservationStatus> v_ = Parity?.StatusElement;
+			ObservationStatus? w_ = v_?.Value;
+			Code<ObservationStatus> x_ = context.Operators.Convert<Code<ObservationStatus>>(w_);
+			string y_ = context.Operators.Convert<string>(x_);
+			string[] z_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
-			var aa_ = context.Operators.And(t_, z_);
-			var ab_ = Parity?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
+			bool? aa_ = context.Operators.In<string>(y_, (z_ as IEnumerable<string>));
+			bool? ab_ = context.Operators.And(u_, aa_);
+			DataType ac_ = Parity?.Value;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+			bool? af_ = context.Operators.And(ab_, ae_);
 
-			return ae_;
+			return af_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			object ax_()
+			object ay_()
 			{
-				bool az_()
-				{
-					var bc_ = @this?.Effective;
-					var bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
-					var be_ = bd_ is CqlDateTime;
-
-					return be_;
-				};
 				bool ba_()
 				{
-					var bf_ = @this?.Effective;
-					var bg_ = FHIRHelpers_4_3_000.ToValue(bf_);
-					var bh_ = bg_ is CqlInterval<CqlDateTime>;
+					DataType bd_ = @this?.Effective;
+					object be_ = FHIRHelpers_4_3_000.ToValue(bd_);
+					bool bf_ = be_ is CqlDateTime;
 
-					return bh_;
+					return bf_;
 				};
 				bool bb_()
 				{
-					var bi_ = @this?.Effective;
-					var bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
-					var bk_ = bj_ is CqlDateTime;
+					DataType bg_ = @this?.Effective;
+					object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+					bool bi_ = bh_ is CqlInterval<CqlDateTime>;
 
-					return bk_;
+					return bi_;
 				};
-				if (az_())
+				bool bc_()
 				{
-					var bl_ = @this?.Effective;
-					var bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
+					DataType bj_ = @this?.Effective;
+					object bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+					bool bl_ = bk_ is CqlDateTime;
 
-					return ((bm_ as CqlDateTime) as object);
-				}
-				else if (ba_())
+					return bl_;
+				};
+				if (ba_())
 				{
-					var bn_ = @this?.Effective;
-					var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+					DataType bm_ = @this?.Effective;
+					object bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
 
-					return ((bo_ as CqlInterval<CqlDateTime>) as object);
+					return ((bn_ as CqlDateTime) as object);
 				}
 				else if (bb_())
 				{
-					var bp_ = @this?.Effective;
-					var bq_ = FHIRHelpers_4_3_000.ToValue(bp_);
+					DataType bo_ = @this?.Effective;
+					object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
 
-					return ((bq_ as CqlDateTime) as object);
+					return ((bp_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (bc_())
+				{
+					DataType bq_ = @this?.Effective;
+					object br_ = FHIRHelpers_4_3_000.ToValue(bq_);
+
+					return ((br_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var ay_ = QICoreCommon_2_0_000.earliest(ax_());
+			CqlDateTime az_ = QICoreCommon_2_0_000.earliest(ay_());
 
-			return ay_;
+			return az_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = FHIRHelpers_4_3_000.ToValue(h_?.Value);
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		DataType i_ = h_?.Value;
+		object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 
-		return (int?)i_;
+		return (int?)j_;
 	}
 
     [CqlDeclaration("lastHistoryPretermBirth")]
 	public int? lastHistoryPretermBirth(Encounter TheEncounter)
 	{
-		var a_ = this.____Births_preterm();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.____Births_preterm();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation PretermBirth)
 		{
-			object j_()
+			object k_()
 			{
-				bool af_()
-				{
-					var ai_ = PretermBirth?.Effective;
-					var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-					var ak_ = aj_ is CqlDateTime;
-
-					return ak_;
-				};
 				bool ag_()
 				{
-					var al_ = PretermBirth?.Effective;
-					var am_ = FHIRHelpers_4_3_000.ToValue(al_);
-					var an_ = am_ is CqlInterval<CqlDateTime>;
+					DataType aj_ = PretermBirth?.Effective;
+					object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+					bool al_ = ak_ is CqlDateTime;
 
-					return an_;
+					return al_;
 				};
 				bool ah_()
 				{
-					var ao_ = PretermBirth?.Effective;
-					var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-					var aq_ = ap_ is CqlDateTime;
+					DataType am_ = PretermBirth?.Effective;
+					object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+					bool ao_ = an_ is CqlInterval<CqlDateTime>;
 
-					return aq_;
+					return ao_;
 				};
-				if (af_())
+				bool ai_()
 				{
-					var ar_ = PretermBirth?.Effective;
-					var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+					DataType ap_ = PretermBirth?.Effective;
+					object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+					bool ar_ = aq_ is CqlDateTime;
 
-					return ((as_ as CqlDateTime) as object);
-				}
-				else if (ag_())
+					return ar_;
+				};
+				if (ag_())
 				{
-					var at_ = PretermBirth?.Effective;
-					var au_ = FHIRHelpers_4_3_000.ToValue(at_);
+					DataType as_ = PretermBirth?.Effective;
+					object at_ = FHIRHelpers_4_3_000.ToValue(as_);
 
-					return ((au_ as CqlInterval<CqlDateTime>) as object);
+					return ((at_ as CqlDateTime) as object);
 				}
 				else if (ah_())
 				{
-					var av_ = PretermBirth?.Effective;
-					var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+					DataType au_ = PretermBirth?.Effective;
+					object av_ = FHIRHelpers_4_3_000.ToValue(au_);
 
-					return ((aw_ as CqlDateTime) as object);
+					return ((av_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (ai_())
+				{
+					DataType aw_ = PretermBirth?.Effective;
+					object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+
+					return ((ax_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var k_ = QICoreCommon_2_0_000.earliest(j_());
-			var l_ = PCMaternal_5_16_000.lastTimeOfDelivery(TheEncounter);
-			var m_ = context.Operators.Quantity(42m, "weeks");
-			var n_ = context.Operators.Subtract(l_, m_);
-			var p_ = context.Operators.Interval(n_, l_, true, false);
-			var q_ = context.Operators.In<CqlDateTime>(k_, p_, null);
-			var s_ = context.Operators.Not((bool?)(l_ is null));
-			var t_ = context.Operators.And(q_, s_);
-			var u_ = PretermBirth?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
-			var x_ = context.Operators.Convert<string>(w_);
-			var y_ = new string[]
+			CqlDateTime l_ = QICoreCommon_2_0_000.earliest(k_());
+			CqlDateTime m_ = PCMaternal_5_16_000.lastTimeOfDelivery(TheEncounter);
+			CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
+			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
+			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
+			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, null);
+			bool? t_ = context.Operators.Not((bool?)(m_ is null));
+			bool? u_ = context.Operators.And(r_, t_);
+			Code<ObservationStatus> v_ = PretermBirth?.StatusElement;
+			ObservationStatus? w_ = v_?.Value;
+			Code<ObservationStatus> x_ = context.Operators.Convert<Code<ObservationStatus>>(w_);
+			string y_ = context.Operators.Convert<string>(x_);
+			string[] z_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
-			var aa_ = context.Operators.And(t_, z_);
-			var ab_ = PretermBirth?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
+			bool? aa_ = context.Operators.In<string>(y_, (z_ as IEnumerable<string>));
+			bool? ab_ = context.Operators.And(u_, aa_);
+			DataType ac_ = PretermBirth?.Value;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+			bool? af_ = context.Operators.And(ab_, ae_);
 
-			return ae_;
+			return af_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			object ax_()
+			object ay_()
 			{
-				bool az_()
-				{
-					var bc_ = @this?.Effective;
-					var bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
-					var be_ = bd_ is CqlDateTime;
-
-					return be_;
-				};
 				bool ba_()
 				{
-					var bf_ = @this?.Effective;
-					var bg_ = FHIRHelpers_4_3_000.ToValue(bf_);
-					var bh_ = bg_ is CqlInterval<CqlDateTime>;
+					DataType bd_ = @this?.Effective;
+					object be_ = FHIRHelpers_4_3_000.ToValue(bd_);
+					bool bf_ = be_ is CqlDateTime;
 
-					return bh_;
+					return bf_;
 				};
 				bool bb_()
 				{
-					var bi_ = @this?.Effective;
-					var bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
-					var bk_ = bj_ is CqlDateTime;
+					DataType bg_ = @this?.Effective;
+					object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+					bool bi_ = bh_ is CqlInterval<CqlDateTime>;
 
-					return bk_;
+					return bi_;
 				};
-				if (az_())
+				bool bc_()
 				{
-					var bl_ = @this?.Effective;
-					var bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
+					DataType bj_ = @this?.Effective;
+					object bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+					bool bl_ = bk_ is CqlDateTime;
 
-					return ((bm_ as CqlDateTime) as object);
-				}
-				else if (ba_())
+					return bl_;
+				};
+				if (ba_())
 				{
-					var bn_ = @this?.Effective;
-					var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+					DataType bm_ = @this?.Effective;
+					object bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
 
-					return ((bo_ as CqlInterval<CqlDateTime>) as object);
+					return ((bn_ as CqlDateTime) as object);
 				}
 				else if (bb_())
 				{
-					var bp_ = @this?.Effective;
-					var bq_ = FHIRHelpers_4_3_000.ToValue(bp_);
+					DataType bo_ = @this?.Effective;
+					object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
 
-					return ((bq_ as CqlDateTime) as object);
+					return ((bp_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (bc_())
+				{
+					DataType bq_ = @this?.Effective;
+					object br_ = FHIRHelpers_4_3_000.ToValue(bq_);
+
+					return ((br_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var ay_ = QICoreCommon_2_0_000.earliest(ax_());
+			CqlDateTime az_ = QICoreCommon_2_0_000.earliest(ay_());
 
-			return ay_;
+			return az_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = FHIRHelpers_4_3_000.ToValue(h_?.Value);
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		DataType i_ = h_?.Value;
+		object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 
-		return (int?)i_;
+		return (int?)j_;
 	}
 
     [CqlDeclaration("lastHistoryTermBirth")]
 	public int? lastHistoryTermBirth(Encounter TheEncounter)
 	{
-		var a_ = this.____Births_term();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.____Births_term();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation TermBirth)
 		{
-			object j_()
+			object k_()
 			{
-				bool af_()
-				{
-					var ai_ = TermBirth?.Effective;
-					var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-					var ak_ = aj_ is CqlDateTime;
-
-					return ak_;
-				};
 				bool ag_()
 				{
-					var al_ = TermBirth?.Effective;
-					var am_ = FHIRHelpers_4_3_000.ToValue(al_);
-					var an_ = am_ is CqlInterval<CqlDateTime>;
+					DataType aj_ = TermBirth?.Effective;
+					object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+					bool al_ = ak_ is CqlDateTime;
 
-					return an_;
+					return al_;
 				};
 				bool ah_()
 				{
-					var ao_ = TermBirth?.Effective;
-					var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-					var aq_ = ap_ is CqlDateTime;
+					DataType am_ = TermBirth?.Effective;
+					object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+					bool ao_ = an_ is CqlInterval<CqlDateTime>;
 
-					return aq_;
+					return ao_;
 				};
-				if (af_())
+				bool ai_()
 				{
-					var ar_ = TermBirth?.Effective;
-					var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+					DataType ap_ = TermBirth?.Effective;
+					object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+					bool ar_ = aq_ is CqlDateTime;
 
-					return ((as_ as CqlDateTime) as object);
-				}
-				else if (ag_())
+					return ar_;
+				};
+				if (ag_())
 				{
-					var at_ = TermBirth?.Effective;
-					var au_ = FHIRHelpers_4_3_000.ToValue(at_);
+					DataType as_ = TermBirth?.Effective;
+					object at_ = FHIRHelpers_4_3_000.ToValue(as_);
 
-					return ((au_ as CqlInterval<CqlDateTime>) as object);
+					return ((at_ as CqlDateTime) as object);
 				}
 				else if (ah_())
 				{
-					var av_ = TermBirth?.Effective;
-					var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+					DataType au_ = TermBirth?.Effective;
+					object av_ = FHIRHelpers_4_3_000.ToValue(au_);
 
-					return ((aw_ as CqlDateTime) as object);
+					return ((av_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (ai_())
+				{
+					DataType aw_ = TermBirth?.Effective;
+					object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+
+					return ((ax_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var k_ = QICoreCommon_2_0_000.earliest(j_());
-			var l_ = PCMaternal_5_16_000.lastTimeOfDelivery(TheEncounter);
-			var m_ = context.Operators.Quantity(42m, "weeks");
-			var n_ = context.Operators.Subtract(l_, m_);
-			var p_ = context.Operators.Interval(n_, l_, true, false);
-			var q_ = context.Operators.In<CqlDateTime>(k_, p_, null);
-			var s_ = context.Operators.Not((bool?)(l_ is null));
-			var t_ = context.Operators.And(q_, s_);
-			var u_ = TermBirth?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
-			var x_ = context.Operators.Convert<string>(w_);
-			var y_ = new string[]
+			CqlDateTime l_ = QICoreCommon_2_0_000.earliest(k_());
+			CqlDateTime m_ = PCMaternal_5_16_000.lastTimeOfDelivery(TheEncounter);
+			CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
+			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
+			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
+			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, null);
+			bool? t_ = context.Operators.Not((bool?)(m_ is null));
+			bool? u_ = context.Operators.And(r_, t_);
+			Code<ObservationStatus> v_ = TermBirth?.StatusElement;
+			ObservationStatus? w_ = v_?.Value;
+			Code<ObservationStatus> x_ = context.Operators.Convert<Code<ObservationStatus>>(w_);
+			string y_ = context.Operators.Convert<string>(x_);
+			string[] z_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
-			var aa_ = context.Operators.And(t_, z_);
-			var ab_ = TermBirth?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
+			bool? aa_ = context.Operators.In<string>(y_, (z_ as IEnumerable<string>));
+			bool? ab_ = context.Operators.And(u_, aa_);
+			DataType ac_ = TermBirth?.Value;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+			bool? af_ = context.Operators.And(ab_, ae_);
 
-			return ae_;
+			return af_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			object ax_()
+			object ay_()
 			{
-				bool az_()
-				{
-					var bc_ = @this?.Effective;
-					var bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
-					var be_ = bd_ is CqlDateTime;
-
-					return be_;
-				};
 				bool ba_()
 				{
-					var bf_ = @this?.Effective;
-					var bg_ = FHIRHelpers_4_3_000.ToValue(bf_);
-					var bh_ = bg_ is CqlInterval<CqlDateTime>;
+					DataType bd_ = @this?.Effective;
+					object be_ = FHIRHelpers_4_3_000.ToValue(bd_);
+					bool bf_ = be_ is CqlDateTime;
 
-					return bh_;
+					return bf_;
 				};
 				bool bb_()
 				{
-					var bi_ = @this?.Effective;
-					var bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
-					var bk_ = bj_ is CqlDateTime;
+					DataType bg_ = @this?.Effective;
+					object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+					bool bi_ = bh_ is CqlInterval<CqlDateTime>;
 
-					return bk_;
+					return bi_;
 				};
-				if (az_())
+				bool bc_()
 				{
-					var bl_ = @this?.Effective;
-					var bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
+					DataType bj_ = @this?.Effective;
+					object bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+					bool bl_ = bk_ is CqlDateTime;
 
-					return ((bm_ as CqlDateTime) as object);
-				}
-				else if (ba_())
+					return bl_;
+				};
+				if (ba_())
 				{
-					var bn_ = @this?.Effective;
-					var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+					DataType bm_ = @this?.Effective;
+					object bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
 
-					return ((bo_ as CqlInterval<CqlDateTime>) as object);
+					return ((bn_ as CqlDateTime) as object);
 				}
 				else if (bb_())
 				{
-					var bp_ = @this?.Effective;
-					var bq_ = FHIRHelpers_4_3_000.ToValue(bp_);
+					DataType bo_ = @this?.Effective;
+					object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
 
-					return ((bq_ as CqlDateTime) as object);
+					return ((bp_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (bc_())
+				{
+					DataType bq_ = @this?.Effective;
+					object br_ = FHIRHelpers_4_3_000.ToValue(bq_);
+
+					return ((br_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var ay_ = QICoreCommon_2_0_000.earliest(ax_());
+			CqlDateTime az_ = QICoreCommon_2_0_000.earliest(ay_());
 
-			return ay_;
+			return az_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = FHIRHelpers_4_3_000.ToValue(h_?.Value);
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		DataType i_ = h_?.Value;
+		object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 
-		return (int?)i_;
+		return (int?)j_;
 	}
 
+    /// <seealso cref="Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births"/>
 	private IEnumerable<Encounter> Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births_Value()
 	{
-		var a_ = this.Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks();
-		var b_ = this.Encounter_with_Singleton_Delivery();
-		var c_ = context.Operators.Intersect<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Delivery_Encounter_with_Gestational_Age_Greater_than_or_Equal_to_37_Weeks();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Singleton_Delivery();
+		IEnumerable<Encounter> c_ = context.Operators.Intersect<Encounter>(a_, b_);
 		bool? d_(Encounter SingletonEncounterGE37Weeks)
 		{
-			var f_ = this.lastGravida(SingletonEncounterGE37Weeks);
-			var g_ = context.Operators.Equal(f_, 1);
-			var h_ = this.lastParity(SingletonEncounterGE37Weeks);
-			var i_ = context.Operators.Equal(h_, 0);
-			var j_ = context.Operators.Or(g_, i_);
-			var k_ = this.lastHistoryPretermBirth(SingletonEncounterGE37Weeks);
-			var l_ = context.Operators.Equal(k_, 0);
-			var m_ = this.lastHistoryTermBirth(SingletonEncounterGE37Weeks);
-			var n_ = context.Operators.Equal(m_, 0);
-			var o_ = context.Operators.And(l_, n_);
-			var p_ = context.Operators.Or(j_, o_);
+			int? f_ = this.lastGravida(SingletonEncounterGE37Weeks);
+			bool? g_ = context.Operators.Equal(f_, 1);
+			int? h_ = this.lastParity(SingletonEncounterGE37Weeks);
+			bool? i_ = context.Operators.Equal(h_, 0);
+			bool? j_ = context.Operators.Or(g_, i_);
+			int? k_ = this.lastHistoryPretermBirth(SingletonEncounterGE37Weeks);
+			bool? l_ = context.Operators.Equal(k_, 0);
+			int? m_ = this.lastHistoryTermBirth(SingletonEncounterGE37Weeks);
+			bool? n_ = context.Operators.Equal(m_, 0);
+			bool? o_ = context.Operators.And(l_, n_);
+			bool? p_ = context.Operators.Or(j_, o_);
 
 			return p_;
 		};
-		var e_ = context.Operators.Where<Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births_Value"/>
     [CqlDeclaration("Singleton Delivery Encounters at 37 Plus Weeks Gravida 1 Parity 0, No Previous Births")]
 	public IEnumerable<Encounter> Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births() => 
 		__Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births.Value;
 
+    /// <seealso cref="Encounter_with_Abnormal_Presentation"/>
 	private IEnumerable<Encounter> Encounter_with_Abnormal_Presentation_Value()
 	{
-		var a_ = this.Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births();
+		IEnumerable<Encounter> a_ = this.Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births();
 		bool? b_(Encounter ThirtysevenWeeksPlusEncounter)
 		{
 			object d_()
 			{
 				bool n_()
 				{
-					var q_ = this.Abnormal_Presentation();
-					var r_ = context.Operators.RetrieveByValueSet<Observation>(q_, null);
+					CqlValueSet q_ = this.Abnormal_Presentation();
+					IEnumerable<Observation> r_ = context.Operators.RetrieveByValueSet<Observation>(q_, null);
 					bool? s_(Observation AbnormalPresentation)
 					{
 						object aa_()
 						{
 							bool al_()
 							{
-								var ao_ = AbnormalPresentation?.Effective;
-								var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-								var aq_ = ap_ is CqlDateTime;
+								DataType ao_ = AbnormalPresentation?.Effective;
+								object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+								bool aq_ = ap_ is CqlDateTime;
 
 								return aq_;
 							};
 							bool am_()
 							{
-								var ar_ = AbnormalPresentation?.Effective;
-								var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
-								var at_ = as_ is CqlInterval<CqlDateTime>;
+								DataType ar_ = AbnormalPresentation?.Effective;
+								object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+								bool at_ = as_ is CqlInterval<CqlDateTime>;
 
 								return at_;
 							};
 							bool an_()
 							{
-								var au_ = AbnormalPresentation?.Effective;
-								var av_ = FHIRHelpers_4_3_000.ToValue(au_);
-								var aw_ = av_ is CqlDateTime;
+								DataType au_ = AbnormalPresentation?.Effective;
+								object av_ = FHIRHelpers_4_3_000.ToValue(au_);
+								bool aw_ = av_ is CqlDateTime;
 
 								return aw_;
 							};
 							if (al_())
 							{
-								var ax_ = AbnormalPresentation?.Effective;
-								var ay_ = FHIRHelpers_4_3_000.ToValue(ax_);
+								DataType ax_ = AbnormalPresentation?.Effective;
+								object ay_ = FHIRHelpers_4_3_000.ToValue(ax_);
 
 								return ((ay_ as CqlDateTime) as object);
 							}
 							else if (am_())
 							{
-								var az_ = AbnormalPresentation?.Effective;
-								var ba_ = FHIRHelpers_4_3_000.ToValue(az_);
+								DataType az_ = AbnormalPresentation?.Effective;
+								object ba_ = FHIRHelpers_4_3_000.ToValue(az_);
 
 								return ((ba_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (an_())
 							{
-								var bb_ = AbnormalPresentation?.Effective;
-								var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+								DataType bb_ = AbnormalPresentation?.Effective;
+								object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
 
 								return ((bc_ as CqlDateTime) as object);
 							}
@@ -1082,71 +1131,71 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var ab_ = QICoreCommon_2_0_000.earliest(aa_());
-						var ac_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						var ad_ = context.Operators.SameOrBefore(ab_, ac_, null);
-						var ae_ = AbnormalPresentation?.StatusElement;
-						var af_ = ae_?.Value;
-						var ag_ = context.Operators.Convert<Code<ObservationStatus>>(af_);
-						var ah_ = context.Operators.Convert<string>(ag_);
-						var ai_ = new string[]
+						CqlDateTime ab_ = QICoreCommon_2_0_000.earliest(aa_());
+						CqlDateTime ac_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
+						bool? ad_ = context.Operators.SameOrBefore(ab_, ac_, null);
+						Code<ObservationStatus> ae_ = AbnormalPresentation?.StatusElement;
+						ObservationStatus? af_ = ae_?.Value;
+						Code<ObservationStatus> ag_ = context.Operators.Convert<Code<ObservationStatus>>(af_);
+						string ah_ = context.Operators.Convert<string>(ag_);
+						string[] ai_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var aj_ = context.Operators.In<string>(ah_, (ai_ as IEnumerable<string>));
-						var ak_ = context.Operators.And(ad_, aj_);
+						bool? aj_ = context.Operators.In<string>(ah_, (ai_ as IEnumerable<string>));
+						bool? ak_ = context.Operators.And(ad_, aj_);
 
 						return ak_;
 					};
-					var t_ = context.Operators.Where<Observation>(r_, s_);
+					IEnumerable<Observation> t_ = context.Operators.Where<Observation>(r_, s_);
 					object u_(Observation @this)
 					{
 						object bd_()
 						{
 							bool bf_()
 							{
-								var bi_ = @this?.Effective;
-								var bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
-								var bk_ = bj_ is CqlDateTime;
+								DataType bi_ = @this?.Effective;
+								object bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
+								bool bk_ = bj_ is CqlDateTime;
 
 								return bk_;
 							};
 							bool bg_()
 							{
-								var bl_ = @this?.Effective;
-								var bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
-								var bn_ = bm_ is CqlInterval<CqlDateTime>;
+								DataType bl_ = @this?.Effective;
+								object bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
+								bool bn_ = bm_ is CqlInterval<CqlDateTime>;
 
 								return bn_;
 							};
 							bool bh_()
 							{
-								var bo_ = @this?.Effective;
-								var bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
-								var bq_ = bp_ is CqlDateTime;
+								DataType bo_ = @this?.Effective;
+								object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
+								bool bq_ = bp_ is CqlDateTime;
 
 								return bq_;
 							};
 							if (bf_())
 							{
-								var br_ = @this?.Effective;
-								var bs_ = FHIRHelpers_4_3_000.ToValue(br_);
+								DataType br_ = @this?.Effective;
+								object bs_ = FHIRHelpers_4_3_000.ToValue(br_);
 
 								return ((bs_ as CqlDateTime) as object);
 							}
 							else if (bg_())
 							{
-								var bt_ = @this?.Effective;
-								var bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
+								DataType bt_ = @this?.Effective;
+								object bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
 
 								return ((bu_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (bh_())
 							{
-								var bv_ = @this?.Effective;
-								var bw_ = FHIRHelpers_4_3_000.ToValue(bv_);
+								DataType bv_ = @this?.Effective;
+								object bw_ = FHIRHelpers_4_3_000.ToValue(bv_);
 
 								return ((bw_ as CqlDateTime) as object);
 							}
@@ -1155,68 +1204,68 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var be_ = QICoreCommon_2_0_000.earliest(bd_());
+						CqlDateTime be_ = QICoreCommon_2_0_000.earliest(bd_());
 
 						return be_;
 					};
-					var v_ = context.Operators.SortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
-					var w_ = context.Operators.Last<Observation>(v_);
-					var x_ = w_?.Effective;
-					var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-					var z_ = y_ is CqlDateTime;
+					IEnumerable<Observation> v_ = context.Operators.SortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation w_ = context.Operators.Last<Observation>(v_);
+					DataType x_ = w_?.Effective;
+					object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+					bool z_ = y_ is CqlDateTime;
 
 					return z_;
 				};
 				bool o_()
 				{
-					var bx_ = this.Abnormal_Presentation();
-					var by_ = context.Operators.RetrieveByValueSet<Observation>(bx_, null);
+					CqlValueSet bx_ = this.Abnormal_Presentation();
+					IEnumerable<Observation> by_ = context.Operators.RetrieveByValueSet<Observation>(bx_, null);
 					bool? bz_(Observation AbnormalPresentation)
 					{
 						object ch_()
 						{
 							bool cs_()
 							{
-								var cv_ = AbnormalPresentation?.Effective;
-								var cw_ = FHIRHelpers_4_3_000.ToValue(cv_);
-								var cx_ = cw_ is CqlDateTime;
+								DataType cv_ = AbnormalPresentation?.Effective;
+								object cw_ = FHIRHelpers_4_3_000.ToValue(cv_);
+								bool cx_ = cw_ is CqlDateTime;
 
 								return cx_;
 							};
 							bool ct_()
 							{
-								var cy_ = AbnormalPresentation?.Effective;
-								var cz_ = FHIRHelpers_4_3_000.ToValue(cy_);
-								var da_ = cz_ is CqlInterval<CqlDateTime>;
+								DataType cy_ = AbnormalPresentation?.Effective;
+								object cz_ = FHIRHelpers_4_3_000.ToValue(cy_);
+								bool da_ = cz_ is CqlInterval<CqlDateTime>;
 
 								return da_;
 							};
 							bool cu_()
 							{
-								var db_ = AbnormalPresentation?.Effective;
-								var dc_ = FHIRHelpers_4_3_000.ToValue(db_);
-								var dd_ = dc_ is CqlDateTime;
+								DataType db_ = AbnormalPresentation?.Effective;
+								object dc_ = FHIRHelpers_4_3_000.ToValue(db_);
+								bool dd_ = dc_ is CqlDateTime;
 
 								return dd_;
 							};
 							if (cs_())
 							{
-								var de_ = AbnormalPresentation?.Effective;
-								var df_ = FHIRHelpers_4_3_000.ToValue(de_);
+								DataType de_ = AbnormalPresentation?.Effective;
+								object df_ = FHIRHelpers_4_3_000.ToValue(de_);
 
 								return ((df_ as CqlDateTime) as object);
 							}
 							else if (ct_())
 							{
-								var dg_ = AbnormalPresentation?.Effective;
-								var dh_ = FHIRHelpers_4_3_000.ToValue(dg_);
+								DataType dg_ = AbnormalPresentation?.Effective;
+								object dh_ = FHIRHelpers_4_3_000.ToValue(dg_);
 
 								return ((dh_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (cu_())
 							{
-								var di_ = AbnormalPresentation?.Effective;
-								var dj_ = FHIRHelpers_4_3_000.ToValue(di_);
+								DataType di_ = AbnormalPresentation?.Effective;
+								object dj_ = FHIRHelpers_4_3_000.ToValue(di_);
 
 								return ((dj_ as CqlDateTime) as object);
 							}
@@ -1225,71 +1274,71 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var ci_ = QICoreCommon_2_0_000.earliest(ch_());
-						var cj_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						var ck_ = context.Operators.SameOrBefore(ci_, cj_, null);
-						var cl_ = AbnormalPresentation?.StatusElement;
-						var cm_ = cl_?.Value;
-						var cn_ = context.Operators.Convert<Code<ObservationStatus>>(cm_);
-						var co_ = context.Operators.Convert<string>(cn_);
-						var cp_ = new string[]
+						CqlDateTime ci_ = QICoreCommon_2_0_000.earliest(ch_());
+						CqlDateTime cj_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
+						bool? ck_ = context.Operators.SameOrBefore(ci_, cj_, null);
+						Code<ObservationStatus> cl_ = AbnormalPresentation?.StatusElement;
+						ObservationStatus? cm_ = cl_?.Value;
+						Code<ObservationStatus> cn_ = context.Operators.Convert<Code<ObservationStatus>>(cm_);
+						string co_ = context.Operators.Convert<string>(cn_);
+						string[] cp_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var cq_ = context.Operators.In<string>(co_, (cp_ as IEnumerable<string>));
-						var cr_ = context.Operators.And(ck_, cq_);
+						bool? cq_ = context.Operators.In<string>(co_, (cp_ as IEnumerable<string>));
+						bool? cr_ = context.Operators.And(ck_, cq_);
 
 						return cr_;
 					};
-					var ca_ = context.Operators.Where<Observation>(by_, bz_);
+					IEnumerable<Observation> ca_ = context.Operators.Where<Observation>(by_, bz_);
 					object cb_(Observation @this)
 					{
 						object dk_()
 						{
 							bool dm_()
 							{
-								var dp_ = @this?.Effective;
-								var dq_ = FHIRHelpers_4_3_000.ToValue(dp_);
-								var dr_ = dq_ is CqlDateTime;
+								DataType dp_ = @this?.Effective;
+								object dq_ = FHIRHelpers_4_3_000.ToValue(dp_);
+								bool dr_ = dq_ is CqlDateTime;
 
 								return dr_;
 							};
 							bool dn_()
 							{
-								var ds_ = @this?.Effective;
-								var dt_ = FHIRHelpers_4_3_000.ToValue(ds_);
-								var du_ = dt_ is CqlInterval<CqlDateTime>;
+								DataType ds_ = @this?.Effective;
+								object dt_ = FHIRHelpers_4_3_000.ToValue(ds_);
+								bool du_ = dt_ is CqlInterval<CqlDateTime>;
 
 								return du_;
 							};
 							bool do_()
 							{
-								var dv_ = @this?.Effective;
-								var dw_ = FHIRHelpers_4_3_000.ToValue(dv_);
-								var dx_ = dw_ is CqlDateTime;
+								DataType dv_ = @this?.Effective;
+								object dw_ = FHIRHelpers_4_3_000.ToValue(dv_);
+								bool dx_ = dw_ is CqlDateTime;
 
 								return dx_;
 							};
 							if (dm_())
 							{
-								var dy_ = @this?.Effective;
-								var dz_ = FHIRHelpers_4_3_000.ToValue(dy_);
+								DataType dy_ = @this?.Effective;
+								object dz_ = FHIRHelpers_4_3_000.ToValue(dy_);
 
 								return ((dz_ as CqlDateTime) as object);
 							}
 							else if (dn_())
 							{
-								var ea_ = @this?.Effective;
-								var eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
+								DataType ea_ = @this?.Effective;
+								object eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
 
 								return ((eb_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (do_())
 							{
-								var ec_ = @this?.Effective;
-								var ed_ = FHIRHelpers_4_3_000.ToValue(ec_);
+								DataType ec_ = @this?.Effective;
+								object ed_ = FHIRHelpers_4_3_000.ToValue(ec_);
 
 								return ((ed_ as CqlDateTime) as object);
 							}
@@ -1298,68 +1347,68 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var dl_ = QICoreCommon_2_0_000.earliest(dk_());
+						CqlDateTime dl_ = QICoreCommon_2_0_000.earliest(dk_());
 
 						return dl_;
 					};
-					var cc_ = context.Operators.SortBy<Observation>(ca_, cb_, System.ComponentModel.ListSortDirection.Ascending);
-					var cd_ = context.Operators.Last<Observation>(cc_);
-					var ce_ = cd_?.Effective;
-					var cf_ = FHIRHelpers_4_3_000.ToValue(ce_);
-					var cg_ = cf_ is CqlInterval<CqlDateTime>;
+					IEnumerable<Observation> cc_ = context.Operators.SortBy<Observation>(ca_, cb_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation cd_ = context.Operators.Last<Observation>(cc_);
+					DataType ce_ = cd_?.Effective;
+					object cf_ = FHIRHelpers_4_3_000.ToValue(ce_);
+					bool cg_ = cf_ is CqlInterval<CqlDateTime>;
 
 					return cg_;
 				};
 				bool p_()
 				{
-					var ee_ = this.Abnormal_Presentation();
-					var ef_ = context.Operators.RetrieveByValueSet<Observation>(ee_, null);
+					CqlValueSet ee_ = this.Abnormal_Presentation();
+					IEnumerable<Observation> ef_ = context.Operators.RetrieveByValueSet<Observation>(ee_, null);
 					bool? eg_(Observation AbnormalPresentation)
 					{
 						object eo_()
 						{
 							bool ez_()
 							{
-								var fc_ = AbnormalPresentation?.Effective;
-								var fd_ = FHIRHelpers_4_3_000.ToValue(fc_);
-								var fe_ = fd_ is CqlDateTime;
+								DataType fc_ = AbnormalPresentation?.Effective;
+								object fd_ = FHIRHelpers_4_3_000.ToValue(fc_);
+								bool fe_ = fd_ is CqlDateTime;
 
 								return fe_;
 							};
 							bool fa_()
 							{
-								var ff_ = AbnormalPresentation?.Effective;
-								var fg_ = FHIRHelpers_4_3_000.ToValue(ff_);
-								var fh_ = fg_ is CqlInterval<CqlDateTime>;
+								DataType ff_ = AbnormalPresentation?.Effective;
+								object fg_ = FHIRHelpers_4_3_000.ToValue(ff_);
+								bool fh_ = fg_ is CqlInterval<CqlDateTime>;
 
 								return fh_;
 							};
 							bool fb_()
 							{
-								var fi_ = AbnormalPresentation?.Effective;
-								var fj_ = FHIRHelpers_4_3_000.ToValue(fi_);
-								var fk_ = fj_ is CqlDateTime;
+								DataType fi_ = AbnormalPresentation?.Effective;
+								object fj_ = FHIRHelpers_4_3_000.ToValue(fi_);
+								bool fk_ = fj_ is CqlDateTime;
 
 								return fk_;
 							};
 							if (ez_())
 							{
-								var fl_ = AbnormalPresentation?.Effective;
-								var fm_ = FHIRHelpers_4_3_000.ToValue(fl_);
+								DataType fl_ = AbnormalPresentation?.Effective;
+								object fm_ = FHIRHelpers_4_3_000.ToValue(fl_);
 
 								return ((fm_ as CqlDateTime) as object);
 							}
 							else if (fa_())
 							{
-								var fn_ = AbnormalPresentation?.Effective;
-								var fo_ = FHIRHelpers_4_3_000.ToValue(fn_);
+								DataType fn_ = AbnormalPresentation?.Effective;
+								object fo_ = FHIRHelpers_4_3_000.ToValue(fn_);
 
 								return ((fo_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (fb_())
 							{
-								var fp_ = AbnormalPresentation?.Effective;
-								var fq_ = FHIRHelpers_4_3_000.ToValue(fp_);
+								DataType fp_ = AbnormalPresentation?.Effective;
+								object fq_ = FHIRHelpers_4_3_000.ToValue(fp_);
 
 								return ((fq_ as CqlDateTime) as object);
 							}
@@ -1368,71 +1417,71 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var ep_ = QICoreCommon_2_0_000.earliest(eo_());
-						var eq_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						var er_ = context.Operators.SameOrBefore(ep_, eq_, null);
-						var es_ = AbnormalPresentation?.StatusElement;
-						var et_ = es_?.Value;
-						var eu_ = context.Operators.Convert<Code<ObservationStatus>>(et_);
-						var ev_ = context.Operators.Convert<string>(eu_);
-						var ew_ = new string[]
+						CqlDateTime ep_ = QICoreCommon_2_0_000.earliest(eo_());
+						CqlDateTime eq_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
+						bool? er_ = context.Operators.SameOrBefore(ep_, eq_, null);
+						Code<ObservationStatus> es_ = AbnormalPresentation?.StatusElement;
+						ObservationStatus? et_ = es_?.Value;
+						Code<ObservationStatus> eu_ = context.Operators.Convert<Code<ObservationStatus>>(et_);
+						string ev_ = context.Operators.Convert<string>(eu_);
+						string[] ew_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var ex_ = context.Operators.In<string>(ev_, (ew_ as IEnumerable<string>));
-						var ey_ = context.Operators.And(er_, ex_);
+						bool? ex_ = context.Operators.In<string>(ev_, (ew_ as IEnumerable<string>));
+						bool? ey_ = context.Operators.And(er_, ex_);
 
 						return ey_;
 					};
-					var eh_ = context.Operators.Where<Observation>(ef_, eg_);
+					IEnumerable<Observation> eh_ = context.Operators.Where<Observation>(ef_, eg_);
 					object ei_(Observation @this)
 					{
 						object fr_()
 						{
 							bool ft_()
 							{
-								var fw_ = @this?.Effective;
-								var fx_ = FHIRHelpers_4_3_000.ToValue(fw_);
-								var fy_ = fx_ is CqlDateTime;
+								DataType fw_ = @this?.Effective;
+								object fx_ = FHIRHelpers_4_3_000.ToValue(fw_);
+								bool fy_ = fx_ is CqlDateTime;
 
 								return fy_;
 							};
 							bool fu_()
 							{
-								var fz_ = @this?.Effective;
-								var ga_ = FHIRHelpers_4_3_000.ToValue(fz_);
-								var gb_ = ga_ is CqlInterval<CqlDateTime>;
+								DataType fz_ = @this?.Effective;
+								object ga_ = FHIRHelpers_4_3_000.ToValue(fz_);
+								bool gb_ = ga_ is CqlInterval<CqlDateTime>;
 
 								return gb_;
 							};
 							bool fv_()
 							{
-								var gc_ = @this?.Effective;
-								var gd_ = FHIRHelpers_4_3_000.ToValue(gc_);
-								var ge_ = gd_ is CqlDateTime;
+								DataType gc_ = @this?.Effective;
+								object gd_ = FHIRHelpers_4_3_000.ToValue(gc_);
+								bool ge_ = gd_ is CqlDateTime;
 
 								return ge_;
 							};
 							if (ft_())
 							{
-								var gf_ = @this?.Effective;
-								var gg_ = FHIRHelpers_4_3_000.ToValue(gf_);
+								DataType gf_ = @this?.Effective;
+								object gg_ = FHIRHelpers_4_3_000.ToValue(gf_);
 
 								return ((gg_ as CqlDateTime) as object);
 							}
 							else if (fu_())
 							{
-								var gh_ = @this?.Effective;
-								var gi_ = FHIRHelpers_4_3_000.ToValue(gh_);
+								DataType gh_ = @this?.Effective;
+								object gi_ = FHIRHelpers_4_3_000.ToValue(gh_);
 
 								return ((gi_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (fv_())
 							{
-								var gj_ = @this?.Effective;
-								var gk_ = FHIRHelpers_4_3_000.ToValue(gj_);
+								DataType gj_ = @this?.Effective;
+								object gk_ = FHIRHelpers_4_3_000.ToValue(gj_);
 
 								return ((gk_ as CqlDateTime) as object);
 							}
@@ -1441,68 +1490,68 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var fs_ = QICoreCommon_2_0_000.earliest(fr_());
+						CqlDateTime fs_ = QICoreCommon_2_0_000.earliest(fr_());
 
 						return fs_;
 					};
-					var ej_ = context.Operators.SortBy<Observation>(eh_, ei_, System.ComponentModel.ListSortDirection.Ascending);
-					var ek_ = context.Operators.Last<Observation>(ej_);
-					var el_ = ek_?.Effective;
-					var em_ = FHIRHelpers_4_3_000.ToValue(el_);
-					var en_ = em_ is CqlDateTime;
+					IEnumerable<Observation> ej_ = context.Operators.SortBy<Observation>(eh_, ei_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation ek_ = context.Operators.Last<Observation>(ej_);
+					DataType el_ = ek_?.Effective;
+					object em_ = FHIRHelpers_4_3_000.ToValue(el_);
+					bool en_ = em_ is CqlDateTime;
 
 					return en_;
 				};
 				if (n_())
 				{
-					var gl_ = this.Abnormal_Presentation();
-					var gm_ = context.Operators.RetrieveByValueSet<Observation>(gl_, null);
+					CqlValueSet gl_ = this.Abnormal_Presentation();
+					IEnumerable<Observation> gm_ = context.Operators.RetrieveByValueSet<Observation>(gl_, null);
 					bool? gn_(Observation AbnormalPresentation)
 					{
 						object gu_()
 						{
 							bool hf_()
 							{
-								var hi_ = AbnormalPresentation?.Effective;
-								var hj_ = FHIRHelpers_4_3_000.ToValue(hi_);
-								var hk_ = hj_ is CqlDateTime;
+								DataType hi_ = AbnormalPresentation?.Effective;
+								object hj_ = FHIRHelpers_4_3_000.ToValue(hi_);
+								bool hk_ = hj_ is CqlDateTime;
 
 								return hk_;
 							};
 							bool hg_()
 							{
-								var hl_ = AbnormalPresentation?.Effective;
-								var hm_ = FHIRHelpers_4_3_000.ToValue(hl_);
-								var hn_ = hm_ is CqlInterval<CqlDateTime>;
+								DataType hl_ = AbnormalPresentation?.Effective;
+								object hm_ = FHIRHelpers_4_3_000.ToValue(hl_);
+								bool hn_ = hm_ is CqlInterval<CqlDateTime>;
 
 								return hn_;
 							};
 							bool hh_()
 							{
-								var ho_ = AbnormalPresentation?.Effective;
-								var hp_ = FHIRHelpers_4_3_000.ToValue(ho_);
-								var hq_ = hp_ is CqlDateTime;
+								DataType ho_ = AbnormalPresentation?.Effective;
+								object hp_ = FHIRHelpers_4_3_000.ToValue(ho_);
+								bool hq_ = hp_ is CqlDateTime;
 
 								return hq_;
 							};
 							if (hf_())
 							{
-								var hr_ = AbnormalPresentation?.Effective;
-								var hs_ = FHIRHelpers_4_3_000.ToValue(hr_);
+								DataType hr_ = AbnormalPresentation?.Effective;
+								object hs_ = FHIRHelpers_4_3_000.ToValue(hr_);
 
 								return ((hs_ as CqlDateTime) as object);
 							}
 							else if (hg_())
 							{
-								var ht_ = AbnormalPresentation?.Effective;
-								var hu_ = FHIRHelpers_4_3_000.ToValue(ht_);
+								DataType ht_ = AbnormalPresentation?.Effective;
+								object hu_ = FHIRHelpers_4_3_000.ToValue(ht_);
 
 								return ((hu_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (hh_())
 							{
-								var hv_ = AbnormalPresentation?.Effective;
-								var hw_ = FHIRHelpers_4_3_000.ToValue(hv_);
+								DataType hv_ = AbnormalPresentation?.Effective;
+								object hw_ = FHIRHelpers_4_3_000.ToValue(hv_);
 
 								return ((hw_ as CqlDateTime) as object);
 							}
@@ -1511,71 +1560,71 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var gv_ = QICoreCommon_2_0_000.earliest(gu_());
-						var gw_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						var gx_ = context.Operators.SameOrBefore(gv_, gw_, null);
-						var gy_ = AbnormalPresentation?.StatusElement;
-						var gz_ = gy_?.Value;
-						var ha_ = context.Operators.Convert<Code<ObservationStatus>>(gz_);
-						var hb_ = context.Operators.Convert<string>(ha_);
-						var hc_ = new string[]
+						CqlDateTime gv_ = QICoreCommon_2_0_000.earliest(gu_());
+						CqlDateTime gw_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
+						bool? gx_ = context.Operators.SameOrBefore(gv_, gw_, null);
+						Code<ObservationStatus> gy_ = AbnormalPresentation?.StatusElement;
+						ObservationStatus? gz_ = gy_?.Value;
+						Code<ObservationStatus> ha_ = context.Operators.Convert<Code<ObservationStatus>>(gz_);
+						string hb_ = context.Operators.Convert<string>(ha_);
+						string[] hc_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var hd_ = context.Operators.In<string>(hb_, (hc_ as IEnumerable<string>));
-						var he_ = context.Operators.And(gx_, hd_);
+						bool? hd_ = context.Operators.In<string>(hb_, (hc_ as IEnumerable<string>));
+						bool? he_ = context.Operators.And(gx_, hd_);
 
 						return he_;
 					};
-					var go_ = context.Operators.Where<Observation>(gm_, gn_);
+					IEnumerable<Observation> go_ = context.Operators.Where<Observation>(gm_, gn_);
 					object gp_(Observation @this)
 					{
 						object hx_()
 						{
 							bool hz_()
 							{
-								var ic_ = @this?.Effective;
-								var id_ = FHIRHelpers_4_3_000.ToValue(ic_);
-								var ie_ = id_ is CqlDateTime;
+								DataType ic_ = @this?.Effective;
+								object id_ = FHIRHelpers_4_3_000.ToValue(ic_);
+								bool ie_ = id_ is CqlDateTime;
 
 								return ie_;
 							};
 							bool ia_()
 							{
-								var if_ = @this?.Effective;
-								var ig_ = FHIRHelpers_4_3_000.ToValue(if_);
-								var ih_ = ig_ is CqlInterval<CqlDateTime>;
+								DataType if_ = @this?.Effective;
+								object ig_ = FHIRHelpers_4_3_000.ToValue(if_);
+								bool ih_ = ig_ is CqlInterval<CqlDateTime>;
 
 								return ih_;
 							};
 							bool ib_()
 							{
-								var ii_ = @this?.Effective;
-								var ij_ = FHIRHelpers_4_3_000.ToValue(ii_);
-								var ik_ = ij_ is CqlDateTime;
+								DataType ii_ = @this?.Effective;
+								object ij_ = FHIRHelpers_4_3_000.ToValue(ii_);
+								bool ik_ = ij_ is CqlDateTime;
 
 								return ik_;
 							};
 							if (hz_())
 							{
-								var il_ = @this?.Effective;
-								var im_ = FHIRHelpers_4_3_000.ToValue(il_);
+								DataType il_ = @this?.Effective;
+								object im_ = FHIRHelpers_4_3_000.ToValue(il_);
 
 								return ((im_ as CqlDateTime) as object);
 							}
 							else if (ia_())
 							{
-								var in_ = @this?.Effective;
-								var io_ = FHIRHelpers_4_3_000.ToValue(in_);
+								DataType in_ = @this?.Effective;
+								object io_ = FHIRHelpers_4_3_000.ToValue(in_);
 
 								return ((io_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ib_())
 							{
-								var ip_ = @this?.Effective;
-								var iq_ = FHIRHelpers_4_3_000.ToValue(ip_);
+								DataType ip_ = @this?.Effective;
+								object iq_ = FHIRHelpers_4_3_000.ToValue(ip_);
 
 								return ((iq_ as CqlDateTime) as object);
 							}
@@ -1584,67 +1633,67 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var hy_ = QICoreCommon_2_0_000.earliest(hx_());
+						CqlDateTime hy_ = QICoreCommon_2_0_000.earliest(hx_());
 
 						return hy_;
 					};
-					var gq_ = context.Operators.SortBy<Observation>(go_, gp_, System.ComponentModel.ListSortDirection.Ascending);
-					var gr_ = context.Operators.Last<Observation>(gq_);
-					var gs_ = gr_?.Effective;
-					var gt_ = FHIRHelpers_4_3_000.ToValue(gs_);
+					IEnumerable<Observation> gq_ = context.Operators.SortBy<Observation>(go_, gp_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation gr_ = context.Operators.Last<Observation>(gq_);
+					DataType gs_ = gr_?.Effective;
+					object gt_ = FHIRHelpers_4_3_000.ToValue(gs_);
 
 					return ((gt_ as CqlDateTime) as object);
 				}
 				else if (o_())
 				{
-					var ir_ = this.Abnormal_Presentation();
-					var is_ = context.Operators.RetrieveByValueSet<Observation>(ir_, null);
+					CqlValueSet ir_ = this.Abnormal_Presentation();
+					IEnumerable<Observation> is_ = context.Operators.RetrieveByValueSet<Observation>(ir_, null);
 					bool? it_(Observation AbnormalPresentation)
 					{
 						object ja_()
 						{
 							bool jl_()
 							{
-								var jo_ = AbnormalPresentation?.Effective;
-								var jp_ = FHIRHelpers_4_3_000.ToValue(jo_);
-								var jq_ = jp_ is CqlDateTime;
+								DataType jo_ = AbnormalPresentation?.Effective;
+								object jp_ = FHIRHelpers_4_3_000.ToValue(jo_);
+								bool jq_ = jp_ is CqlDateTime;
 
 								return jq_;
 							};
 							bool jm_()
 							{
-								var jr_ = AbnormalPresentation?.Effective;
-								var js_ = FHIRHelpers_4_3_000.ToValue(jr_);
-								var jt_ = js_ is CqlInterval<CqlDateTime>;
+								DataType jr_ = AbnormalPresentation?.Effective;
+								object js_ = FHIRHelpers_4_3_000.ToValue(jr_);
+								bool jt_ = js_ is CqlInterval<CqlDateTime>;
 
 								return jt_;
 							};
 							bool jn_()
 							{
-								var ju_ = AbnormalPresentation?.Effective;
-								var jv_ = FHIRHelpers_4_3_000.ToValue(ju_);
-								var jw_ = jv_ is CqlDateTime;
+								DataType ju_ = AbnormalPresentation?.Effective;
+								object jv_ = FHIRHelpers_4_3_000.ToValue(ju_);
+								bool jw_ = jv_ is CqlDateTime;
 
 								return jw_;
 							};
 							if (jl_())
 							{
-								var jx_ = AbnormalPresentation?.Effective;
-								var jy_ = FHIRHelpers_4_3_000.ToValue(jx_);
+								DataType jx_ = AbnormalPresentation?.Effective;
+								object jy_ = FHIRHelpers_4_3_000.ToValue(jx_);
 
 								return ((jy_ as CqlDateTime) as object);
 							}
 							else if (jm_())
 							{
-								var jz_ = AbnormalPresentation?.Effective;
-								var ka_ = FHIRHelpers_4_3_000.ToValue(jz_);
+								DataType jz_ = AbnormalPresentation?.Effective;
+								object ka_ = FHIRHelpers_4_3_000.ToValue(jz_);
 
 								return ((ka_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (jn_())
 							{
-								var kb_ = AbnormalPresentation?.Effective;
-								var kc_ = FHIRHelpers_4_3_000.ToValue(kb_);
+								DataType kb_ = AbnormalPresentation?.Effective;
+								object kc_ = FHIRHelpers_4_3_000.ToValue(kb_);
 
 								return ((kc_ as CqlDateTime) as object);
 							}
@@ -1653,71 +1702,71 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var jb_ = QICoreCommon_2_0_000.earliest(ja_());
-						var jc_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						var jd_ = context.Operators.SameOrBefore(jb_, jc_, null);
-						var je_ = AbnormalPresentation?.StatusElement;
-						var jf_ = je_?.Value;
-						var jg_ = context.Operators.Convert<Code<ObservationStatus>>(jf_);
-						var jh_ = context.Operators.Convert<string>(jg_);
-						var ji_ = new string[]
+						CqlDateTime jb_ = QICoreCommon_2_0_000.earliest(ja_());
+						CqlDateTime jc_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
+						bool? jd_ = context.Operators.SameOrBefore(jb_, jc_, null);
+						Code<ObservationStatus> je_ = AbnormalPresentation?.StatusElement;
+						ObservationStatus? jf_ = je_?.Value;
+						Code<ObservationStatus> jg_ = context.Operators.Convert<Code<ObservationStatus>>(jf_);
+						string jh_ = context.Operators.Convert<string>(jg_);
+						string[] ji_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var jj_ = context.Operators.In<string>(jh_, (ji_ as IEnumerable<string>));
-						var jk_ = context.Operators.And(jd_, jj_);
+						bool? jj_ = context.Operators.In<string>(jh_, (ji_ as IEnumerable<string>));
+						bool? jk_ = context.Operators.And(jd_, jj_);
 
 						return jk_;
 					};
-					var iu_ = context.Operators.Where<Observation>(is_, it_);
+					IEnumerable<Observation> iu_ = context.Operators.Where<Observation>(is_, it_);
 					object iv_(Observation @this)
 					{
 						object kd_()
 						{
 							bool kf_()
 							{
-								var ki_ = @this?.Effective;
-								var kj_ = FHIRHelpers_4_3_000.ToValue(ki_);
-								var kk_ = kj_ is CqlDateTime;
+								DataType ki_ = @this?.Effective;
+								object kj_ = FHIRHelpers_4_3_000.ToValue(ki_);
+								bool kk_ = kj_ is CqlDateTime;
 
 								return kk_;
 							};
 							bool kg_()
 							{
-								var kl_ = @this?.Effective;
-								var km_ = FHIRHelpers_4_3_000.ToValue(kl_);
-								var kn_ = km_ is CqlInterval<CqlDateTime>;
+								DataType kl_ = @this?.Effective;
+								object km_ = FHIRHelpers_4_3_000.ToValue(kl_);
+								bool kn_ = km_ is CqlInterval<CqlDateTime>;
 
 								return kn_;
 							};
 							bool kh_()
 							{
-								var ko_ = @this?.Effective;
-								var kp_ = FHIRHelpers_4_3_000.ToValue(ko_);
-								var kq_ = kp_ is CqlDateTime;
+								DataType ko_ = @this?.Effective;
+								object kp_ = FHIRHelpers_4_3_000.ToValue(ko_);
+								bool kq_ = kp_ is CqlDateTime;
 
 								return kq_;
 							};
 							if (kf_())
 							{
-								var kr_ = @this?.Effective;
-								var ks_ = FHIRHelpers_4_3_000.ToValue(kr_);
+								DataType kr_ = @this?.Effective;
+								object ks_ = FHIRHelpers_4_3_000.ToValue(kr_);
 
 								return ((ks_ as CqlDateTime) as object);
 							}
 							else if (kg_())
 							{
-								var kt_ = @this?.Effective;
-								var ku_ = FHIRHelpers_4_3_000.ToValue(kt_);
+								DataType kt_ = @this?.Effective;
+								object ku_ = FHIRHelpers_4_3_000.ToValue(kt_);
 
 								return ((ku_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (kh_())
 							{
-								var kv_ = @this?.Effective;
-								var kw_ = FHIRHelpers_4_3_000.ToValue(kv_);
+								DataType kv_ = @this?.Effective;
+								object kw_ = FHIRHelpers_4_3_000.ToValue(kv_);
 
 								return ((kw_ as CqlDateTime) as object);
 							}
@@ -1726,67 +1775,67 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var ke_ = QICoreCommon_2_0_000.earliest(kd_());
+						CqlDateTime ke_ = QICoreCommon_2_0_000.earliest(kd_());
 
 						return ke_;
 					};
-					var iw_ = context.Operators.SortBy<Observation>(iu_, iv_, System.ComponentModel.ListSortDirection.Ascending);
-					var ix_ = context.Operators.Last<Observation>(iw_);
-					var iy_ = ix_?.Effective;
-					var iz_ = FHIRHelpers_4_3_000.ToValue(iy_);
+					IEnumerable<Observation> iw_ = context.Operators.SortBy<Observation>(iu_, iv_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation ix_ = context.Operators.Last<Observation>(iw_);
+					DataType iy_ = ix_?.Effective;
+					object iz_ = FHIRHelpers_4_3_000.ToValue(iy_);
 
 					return ((iz_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (p_())
 				{
-					var kx_ = this.Abnormal_Presentation();
-					var ky_ = context.Operators.RetrieveByValueSet<Observation>(kx_, null);
+					CqlValueSet kx_ = this.Abnormal_Presentation();
+					IEnumerable<Observation> ky_ = context.Operators.RetrieveByValueSet<Observation>(kx_, null);
 					bool? kz_(Observation AbnormalPresentation)
 					{
 						object lg_()
 						{
 							bool lr_()
 							{
-								var lu_ = AbnormalPresentation?.Effective;
-								var lv_ = FHIRHelpers_4_3_000.ToValue(lu_);
-								var lw_ = lv_ is CqlDateTime;
+								DataType lu_ = AbnormalPresentation?.Effective;
+								object lv_ = FHIRHelpers_4_3_000.ToValue(lu_);
+								bool lw_ = lv_ is CqlDateTime;
 
 								return lw_;
 							};
 							bool ls_()
 							{
-								var lx_ = AbnormalPresentation?.Effective;
-								var ly_ = FHIRHelpers_4_3_000.ToValue(lx_);
-								var lz_ = ly_ is CqlInterval<CqlDateTime>;
+								DataType lx_ = AbnormalPresentation?.Effective;
+								object ly_ = FHIRHelpers_4_3_000.ToValue(lx_);
+								bool lz_ = ly_ is CqlInterval<CqlDateTime>;
 
 								return lz_;
 							};
 							bool lt_()
 							{
-								var ma_ = AbnormalPresentation?.Effective;
-								var mb_ = FHIRHelpers_4_3_000.ToValue(ma_);
-								var mc_ = mb_ is CqlDateTime;
+								DataType ma_ = AbnormalPresentation?.Effective;
+								object mb_ = FHIRHelpers_4_3_000.ToValue(ma_);
+								bool mc_ = mb_ is CqlDateTime;
 
 								return mc_;
 							};
 							if (lr_())
 							{
-								var md_ = AbnormalPresentation?.Effective;
-								var me_ = FHIRHelpers_4_3_000.ToValue(md_);
+								DataType md_ = AbnormalPresentation?.Effective;
+								object me_ = FHIRHelpers_4_3_000.ToValue(md_);
 
 								return ((me_ as CqlDateTime) as object);
 							}
 							else if (ls_())
 							{
-								var mf_ = AbnormalPresentation?.Effective;
-								var mg_ = FHIRHelpers_4_3_000.ToValue(mf_);
+								DataType mf_ = AbnormalPresentation?.Effective;
+								object mg_ = FHIRHelpers_4_3_000.ToValue(mf_);
 
 								return ((mg_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (lt_())
 							{
-								var mh_ = AbnormalPresentation?.Effective;
-								var mi_ = FHIRHelpers_4_3_000.ToValue(mh_);
+								DataType mh_ = AbnormalPresentation?.Effective;
+								object mi_ = FHIRHelpers_4_3_000.ToValue(mh_);
 
 								return ((mi_ as CqlDateTime) as object);
 							}
@@ -1795,71 +1844,71 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var lh_ = QICoreCommon_2_0_000.earliest(lg_());
-						var li_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						var lj_ = context.Operators.SameOrBefore(lh_, li_, null);
-						var lk_ = AbnormalPresentation?.StatusElement;
-						var ll_ = lk_?.Value;
-						var lm_ = context.Operators.Convert<Code<ObservationStatus>>(ll_);
-						var ln_ = context.Operators.Convert<string>(lm_);
-						var lo_ = new string[]
+						CqlDateTime lh_ = QICoreCommon_2_0_000.earliest(lg_());
+						CqlDateTime li_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
+						bool? lj_ = context.Operators.SameOrBefore(lh_, li_, null);
+						Code<ObservationStatus> lk_ = AbnormalPresentation?.StatusElement;
+						ObservationStatus? ll_ = lk_?.Value;
+						Code<ObservationStatus> lm_ = context.Operators.Convert<Code<ObservationStatus>>(ll_);
+						string ln_ = context.Operators.Convert<string>(lm_);
+						string[] lo_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var lp_ = context.Operators.In<string>(ln_, (lo_ as IEnumerable<string>));
-						var lq_ = context.Operators.And(lj_, lp_);
+						bool? lp_ = context.Operators.In<string>(ln_, (lo_ as IEnumerable<string>));
+						bool? lq_ = context.Operators.And(lj_, lp_);
 
 						return lq_;
 					};
-					var la_ = context.Operators.Where<Observation>(ky_, kz_);
+					IEnumerable<Observation> la_ = context.Operators.Where<Observation>(ky_, kz_);
 					object lb_(Observation @this)
 					{
 						object mj_()
 						{
 							bool ml_()
 							{
-								var mo_ = @this?.Effective;
-								var mp_ = FHIRHelpers_4_3_000.ToValue(mo_);
-								var mq_ = mp_ is CqlDateTime;
+								DataType mo_ = @this?.Effective;
+								object mp_ = FHIRHelpers_4_3_000.ToValue(mo_);
+								bool mq_ = mp_ is CqlDateTime;
 
 								return mq_;
 							};
 							bool mm_()
 							{
-								var mr_ = @this?.Effective;
-								var ms_ = FHIRHelpers_4_3_000.ToValue(mr_);
-								var mt_ = ms_ is CqlInterval<CqlDateTime>;
+								DataType mr_ = @this?.Effective;
+								object ms_ = FHIRHelpers_4_3_000.ToValue(mr_);
+								bool mt_ = ms_ is CqlInterval<CqlDateTime>;
 
 								return mt_;
 							};
 							bool mn_()
 							{
-								var mu_ = @this?.Effective;
-								var mv_ = FHIRHelpers_4_3_000.ToValue(mu_);
-								var mw_ = mv_ is CqlDateTime;
+								DataType mu_ = @this?.Effective;
+								object mv_ = FHIRHelpers_4_3_000.ToValue(mu_);
+								bool mw_ = mv_ is CqlDateTime;
 
 								return mw_;
 							};
 							if (ml_())
 							{
-								var mx_ = @this?.Effective;
-								var my_ = FHIRHelpers_4_3_000.ToValue(mx_);
+								DataType mx_ = @this?.Effective;
+								object my_ = FHIRHelpers_4_3_000.ToValue(mx_);
 
 								return ((my_ as CqlDateTime) as object);
 							}
 							else if (mm_())
 							{
-								var mz_ = @this?.Effective;
-								var na_ = FHIRHelpers_4_3_000.ToValue(mz_);
+								DataType mz_ = @this?.Effective;
+								object na_ = FHIRHelpers_4_3_000.ToValue(mz_);
 
 								return ((na_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (mn_())
 							{
-								var nb_ = @this?.Effective;
-								var nc_ = FHIRHelpers_4_3_000.ToValue(nb_);
+								DataType nb_ = @this?.Effective;
+								object nc_ = FHIRHelpers_4_3_000.ToValue(nb_);
 
 								return ((nc_ as CqlDateTime) as object);
 							}
@@ -1868,14 +1917,14 @@ public class CesareanBirthFHIR_0_2_000
 								return null;
 							}
 						};
-						var mk_ = QICoreCommon_2_0_000.earliest(mj_());
+						CqlDateTime mk_ = QICoreCommon_2_0_000.earliest(mj_());
 
 						return mk_;
 					};
-					var lc_ = context.Operators.SortBy<Observation>(la_, lb_, System.ComponentModel.ListSortDirection.Ascending);
-					var ld_ = context.Operators.Last<Observation>(lc_);
-					var le_ = ld_?.Effective;
-					var lf_ = FHIRHelpers_4_3_000.ToValue(le_);
+					IEnumerable<Observation> lc_ = context.Operators.SortBy<Observation>(la_, lb_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation ld_ = context.Operators.Last<Observation>(lc_);
+					DataType le_ = ld_?.Effective;
+					object lf_ = FHIRHelpers_4_3_000.ToValue(le_);
 
 					return ((lf_ as CqlDateTime) as object);
 				}
@@ -1884,214 +1933,239 @@ public class CesareanBirthFHIR_0_2_000
 					return null;
 				}
 			};
-			var e_ = QICoreCommon_2_0_000.earliest(d_());
-			var f_ = ThirtysevenWeeksPlusEncounter?.Period;
-			var g_ = FHIRHelpers_4_3_000.ToInterval(f_);
-			var h_ = context.Operators.In<CqlDateTime>(e_, g_, null);
-			var i_ = CQMCommon_2_0_000.encounterDiagnosis(ThirtysevenWeeksPlusEncounter);
+			CqlDateTime e_ = QICoreCommon_2_0_000.earliest(d_());
+			Period f_ = ThirtysevenWeeksPlusEncounter?.Period;
+			CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_3_000.ToInterval(f_);
+			bool? h_ = context.Operators.In<CqlDateTime>(e_, g_, null);
+			IEnumerable<Condition> i_ = CQMCommon_2_0_000.encounterDiagnosis(ThirtysevenWeeksPlusEncounter);
 			bool? j_(Condition EncounterDiagnosis)
 			{
-				var nd_ = EncounterDiagnosis?.Code;
-				var ne_ = FHIRHelpers_4_3_000.ToConcept(nd_);
-				var nf_ = this.Abnormal_Presentation();
-				var ng_ = context.Operators.ConceptInValueSet(ne_, nf_);
+				CodeableConcept nd_ = EncounterDiagnosis?.Code;
+				CqlConcept ne_ = FHIRHelpers_4_3_000.ToConcept(nd_);
+				CqlValueSet nf_ = this.Abnormal_Presentation();
+				bool? ng_ = context.Operators.ConceptInValueSet(ne_, nf_);
 
 				return ng_;
 			};
-			var k_ = context.Operators.Where<Condition>(i_, j_);
-			var l_ = context.Operators.Exists<Condition>(k_);
-			var m_ = context.Operators.Or(h_, l_);
+			IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
+			bool? l_ = context.Operators.Exists<Condition>(k_);
+			bool? m_ = context.Operators.Or(h_, l_);
 
 			return m_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Abnormal_Presentation_Value"/>
     [CqlDeclaration("Encounter with Abnormal Presentation")]
 	public IEnumerable<Encounter> Encounter_with_Abnormal_Presentation() => 
 		__Encounter_with_Abnormal_Presentation.Value;
 
+    /// <seealso cref="Encounter_with_Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum"/>
 	private IEnumerable<Encounter> Encounter_with_Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum_Value()
 	{
-		var a_ = this.Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births();
+		IEnumerable<Encounter> a_ = this.Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births();
 		bool? b_(Encounter ThirtysevenWeeksPlusEncounter)
 		{
-			var d_ = CQMCommon_2_0_000.encounterDiagnosis(ThirtysevenWeeksPlusEncounter);
+			IEnumerable<Condition> d_ = CQMCommon_2_0_000.encounterDiagnosis(ThirtysevenWeeksPlusEncounter);
 			bool? e_(Condition EncounterDiagnosis)
 			{
-				var h_ = EncounterDiagnosis?.Code;
-				var i_ = FHIRHelpers_4_3_000.ToConcept(h_);
-				var j_ = this.Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa();
-				var k_ = context.Operators.ConceptInValueSet(i_, j_);
-				var m_ = FHIRHelpers_4_3_000.ToConcept(h_);
-				var n_ = this.Genital_Herpes();
-				var o_ = context.Operators.ConceptInValueSet(m_, n_);
-				var p_ = context.Operators.Or(k_, o_);
+				CodeableConcept h_ = EncounterDiagnosis?.Code;
+				CqlConcept i_ = FHIRHelpers_4_3_000.ToConcept(h_);
+				CqlValueSet j_ = this.Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa();
+				bool? k_ = context.Operators.ConceptInValueSet(i_, j_);
+				CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(h_);
+				CqlValueSet n_ = this.Genital_Herpes();
+				bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+				bool? p_ = context.Operators.Or(k_, o_);
 
 				return p_;
 			};
-			var f_ = context.Operators.Where<Condition>(d_, e_);
-			var g_ = context.Operators.Exists<Condition>(f_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+			bool? g_ = context.Operators.Exists<Condition>(f_);
 
 			return g_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum_Value"/>
     [CqlDeclaration("Encounter with Genital Herpes, Placenta Previa, Vasa Previa or Placenta Accreta Spectrum")]
 	public IEnumerable<Encounter> Encounter_with_Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum() => 
 		__Encounter_with_Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum.Value;
 
+    /// <seealso cref="Delivery_Encounter_with_Abnormal_Presentation__Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum"/>
 	private IEnumerable<Encounter> Delivery_Encounter_with_Abnormal_Presentation__Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum_Value()
 	{
-		var a_ = this.Encounter_with_Abnormal_Presentation();
-		var b_ = this.Encounter_with_Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_Abnormal_Presentation();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounter_with_Abnormal_Presentation__Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum_Value"/>
     [CqlDeclaration("Delivery Encounter with Abnormal Presentation, Genital Herpes, Placenta Previa, Vasa Previa or Placenta Accreta Spectrum")]
 	public IEnumerable<Encounter> Delivery_Encounter_with_Abnormal_Presentation__Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum() => 
 		__Delivery_Encounter_with_Abnormal_Presentation__Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births();
+		IEnumerable<Encounter> a_ = this.Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private IEnumerable<Encounter> Denominator_Exclusions_Value()
 	{
-		var a_ = this.Delivery_Encounter_with_Abnormal_Presentation__Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounter_with_Abnormal_Presentation__Genital_Herpes__Placenta_Previa__Vasa_Previa_or_Placenta_Accreta_Spectrum();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public IEnumerable<Encounter> Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Delivery_Encounter_with_Cesarean_Birth"/>
 	private IEnumerable<Encounter> Delivery_Encounter_with_Cesarean_Birth_Value()
 	{
-		var a_ = this.Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births();
+		IEnumerable<Encounter> a_ = this.Singleton_Delivery_Encounters_at_37_Plus_Weeks_Gravida_1_Parity_0__No_Previous_Births();
 		IEnumerable<Encounter> b_(Encounter ThirtysevenWeeksPlusEncounter)
 		{
-			var d_ = this.Cesarean_Birth();
-			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			CqlValueSet d_ = this.Cesarean_Birth();
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
 			bool? f_(Procedure CSection)
 			{
-				var j_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(ThirtysevenWeeksPlusEncounter);
-				var k_ = CSection?.Performed;
-				var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-				var m_ = QICoreCommon_2_0_000.toInterval(l_);
-				var n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, null);
-				var o_ = CSection?.StatusElement;
-				var p_ = o_?.Value;
-				var q_ = context.Operators.Convert<string>(p_);
-				var r_ = context.Operators.Equal(q_, "completed");
-				var s_ = context.Operators.And(n_, r_);
+				CqlInterval<CqlDateTime> j_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(ThirtysevenWeeksPlusEncounter);
+				DataType k_ = CSection?.Performed;
+				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.toInterval(l_);
+				bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, null);
+				Code<EventStatus> o_ = CSection?.StatusElement;
+				EventStatus? p_ = o_?.Value;
+				string q_ = context.Operators.Convert<string>(p_);
+				bool? r_ = context.Operators.Equal(q_, "completed");
+				bool? s_ = context.Operators.And(n_, r_);
 
 				return s_;
 			};
-			var g_ = context.Operators.Where<Procedure>(e_, f_);
+			IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
 			Encounter h_(Procedure CSection) => 
 				ThirtysevenWeeksPlusEncounter;
-			var i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounter_with_Cesarean_Birth_Value"/>
     [CqlDeclaration("Delivery Encounter with Cesarean Birth")]
 	public IEnumerable<Encounter> Delivery_Encounter_with_Cesarean_Birth() => 
 		__Delivery_Encounter_with_Cesarean_Birth.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Delivery_Encounter_with_Cesarean_Birth();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounter_with_Cesarean_Birth();
 
 		return a_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Variable_Calculated_Gestational_Age"/>
 	private IEnumerable<Tuple_QRZgNJCaGQEYIeOSBhjLZNSO> Variable_Calculated_Gestational_Age_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Variable_Calculated_Gestational_Age();
+		IEnumerable<Tuple_QRZgNJCaGQEYIeOSBhjLZNSO> a_ = PCMaternal_5_16_000.Variable_Calculated_Gestational_Age();
 
 		return a_;
 	}
 
+    /// <seealso cref="Variable_Calculated_Gestational_Age_Value"/>
     [CqlDeclaration("Variable Calculated Gestational Age")]
 	public IEnumerable<Tuple_QRZgNJCaGQEYIeOSBhjLZNSO> Variable_Calculated_Gestational_Age() => 
 		__Variable_Calculated_Gestational_Age.Value;

--- a/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
@@ -94,102 +94,127 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 
     #endregion
 
+    /// <seealso cref="Group_Psychotherapy"/>
 	private CqlValueSet Group_Psychotherapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187", null);
 
+    /// <seealso cref="Group_Psychotherapy_Value"/>
     [CqlDeclaration("Group Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187")]
 	public CqlValueSet Group_Psychotherapy() => 
 		__Group_Psychotherapy.Value;
 
+    /// <seealso cref="Major_Depressive_Disorder_Active"/>
 	private CqlValueSet Major_Depressive_Disorder_Active_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491", null);
 
+    /// <seealso cref="Major_Depressive_Disorder_Active_Value"/>
     [CqlDeclaration("Major Depressive Disorder Active")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491")]
 	public CqlValueSet Major_Depressive_Disorder_Active() => 
 		__Major_Depressive_Disorder_Active.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation"/>
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation_Value"/>
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
 	public CqlValueSet Psych_Visit_Diagnostic_Evaluation() => 
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
+    /// <seealso cref="Psych_Visit_for_Family_Psychotherapy"/>
 	private CqlValueSet Psych_Visit_for_Family_Psychotherapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018", null);
 
+    /// <seealso cref="Psych_Visit_for_Family_Psychotherapy_Value"/>
     [CqlDeclaration("Psych Visit for Family Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018")]
 	public CqlValueSet Psych_Visit_for_Family_Psychotherapy() => 
 		__Psych_Visit_for_Family_Psychotherapy.Value;
 
+    /// <seealso cref="Psych_Visit_Psychotherapy"/>
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
 
+    /// <seealso cref="Psych_Visit_Psychotherapy_Value"/>
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
 	public CqlValueSet Psych_Visit_Psychotherapy() => 
 		__Psych_Visit_Psychotherapy.Value;
 
+    /// <seealso cref="Psychoanalysis"/>
 	private CqlValueSet Psychoanalysis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", null);
 
+    /// <seealso cref="Psychoanalysis_Value"/>
     [CqlDeclaration("Psychoanalysis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141")]
 	public CqlValueSet Psychoanalysis() => 
 		__Psychoanalysis.Value;
 
+    /// <seealso cref="Telehealth_Services"/>
 	private CqlValueSet Telehealth_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", null);
 
+    /// <seealso cref="Telehealth_Services_Value"/>
     [CqlDeclaration("Telehealth Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031")]
 	public CqlValueSet Telehealth_Services() => 
 		__Telehealth_Services.Value;
 
+    /// <seealso cref="Birth_date"/>
 	private CqlCode Birth_date_Value() => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Birth_date_Value"/>
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
+    /// <seealso cref="Suicide_risk_assessment__procedure_"/>
 	private CqlCode Suicide_risk_assessment__procedure__Value() => 
 		new CqlCode("225337009", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Suicide_risk_assessment__procedure__Value"/>
     [CqlDeclaration("Suicide risk assessment (procedure)")]
 	public CqlCode Suicide_risk_assessment__procedure_() => 
 		__Suicide_risk_assessment__procedure_.Value;
 
+    /// <seealso cref="AMB"/>
 	private CqlCode AMB_Value() => 
 		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="AMB_Value"/>
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
 		__AMB.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("21112-8", "http://loinc.org", null, null),
 		};
@@ -197,13 +222,15 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("225337009", "http://snomed.info/sct", null, null),
 		};
@@ -211,13 +238,15 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 		};
@@ -225,245 +254,268 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="ICD10CM"/>
 	private CqlCode[] ICD10CM_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="ICD10CM_Value"/>
     [CqlDeclaration("ICD10CM")]
 	public CqlCode[] ICD10CM() => 
 		__ICD10CM.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Major_Depressive_Disorder_Encounter"/>
 	private IEnumerable<Encounter> Major_Depressive_Disorder_Encounter_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Outpatient_Consultation();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Psych_Visit_Diagnostic_Evaluation();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Psych_Visit_for_Family_Psychotherapy();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Psych_Visit_Psychotherapy();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Psychoanalysis();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Group_Psychotherapy();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Telehealth_Services();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Psych_Visit_Diagnostic_Evaluation();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Psych_Visit_for_Family_Psychotherapy();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Psych_Visit_Psychotherapy();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Psychoanalysis();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Group_Psychotherapy();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Telehealth_Services();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		bool? x_(Encounter ValidEncounter)
 		{
-			var z_ = ValidEncounter?.StatusElement;
-			var aa_ = z_?.Value;
-			var ab_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(aa_);
-			var ac_ = context.Operators.Equal(ab_, "finished");
-			var ad_ = ValidEncounter?.ReasonCode;
+			Code<Encounter.EncounterStatus> z_ = ValidEncounter?.StatusElement;
+			Encounter.EncounterStatus? aa_ = z_?.Value;
+			Code<Encounter.EncounterStatus> ab_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(aa_);
+			bool? ac_ = context.Operators.Equal(ab_, "finished");
+			List<CodeableConcept> ad_ = ValidEncounter?.ReasonCode;
 			CqlConcept ae_(CodeableConcept @this)
 			{
-				var at_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept at_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return at_;
 			};
-			var af_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ad_, ae_);
-			var ag_ = this.Major_Depressive_Disorder_Active();
-			var ah_ = context.Operators.ConceptsInValueSet(af_, ag_);
-			var ai_ = CQMCommon_2_0_000.EncounterDiagnosis(ValidEncounter);
+			IEnumerable<CqlConcept> af_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ad_, ae_);
+			CqlValueSet ag_ = this.Major_Depressive_Disorder_Active();
+			bool? ah_ = context.Operators.ConceptsInValueSet(af_, ag_);
+			IEnumerable<Condition> ai_ = CQMCommon_2_0_000.EncounterDiagnosis(ValidEncounter);
 			bool? aj_(Condition EncounterDiagnosis)
 			{
-				var au_ = EncounterDiagnosis?.Code;
-				var av_ = FHIRHelpers_4_3_000.ToConcept(au_);
-				var aw_ = this.Major_Depressive_Disorder_Active();
-				var ax_ = context.Operators.ConceptInValueSet(av_, aw_);
+				CodeableConcept au_ = EncounterDiagnosis?.Code;
+				CqlConcept av_ = FHIRHelpers_4_3_000.ToConcept(au_);
+				CqlValueSet aw_ = this.Major_Depressive_Disorder_Active();
+				bool? ax_ = context.Operators.ConceptInValueSet(av_, aw_);
 
 				return ax_;
 			};
-			var ak_ = context.Operators.Where<Condition>(ai_, aj_);
-			var al_ = context.Operators.Exists<Condition>(ak_);
-			var am_ = context.Operators.Or(ah_, al_);
-			var an_ = context.Operators.And(ac_, am_);
-			var ao_ = this.Measurement_Period();
-			var ap_ = ValidEncounter?.Period;
-			var aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-			var ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, null);
-			var as_ = context.Operators.And(an_, ar_);
+			IEnumerable<Condition> ak_ = context.Operators.Where<Condition>(ai_, aj_);
+			bool? al_ = context.Operators.Exists<Condition>(ak_);
+			bool? am_ = context.Operators.Or(ah_, al_);
+			bool? an_ = context.Operators.And(ac_, am_);
+			CqlInterval<CqlDateTime> ao_ = this.Measurement_Period();
+			Period ap_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
+			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, null);
+			bool? as_ = context.Operators.And(an_, ar_);
 
 			return as_;
 		};
-		var y_ = context.Operators.Where<Encounter>(w_, x_);
+		IEnumerable<Encounter> y_ = context.Operators.Where<Encounter>(w_, x_);
 
 		return y_;
 	}
 
+    /// <seealso cref="Major_Depressive_Disorder_Encounter_Value"/>
     [CqlDeclaration("Major Depressive Disorder Encounter")]
 	public IEnumerable<Encounter> Major_Depressive_Disorder_Encounter() => 
 		__Major_Depressive_Disorder_Encounter.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Major_Depressive_Disorder_Encounter();
+		IEnumerable<Encounter> a_ = this.Major_Depressive_Disorder_Encounter();
 		bool? b_(Encounter MDDEncounter)
 		{
-			var d_ = this.Patient();
-			var e_ = d_?.BirthDateElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.Convert<CqlDate>(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.Start(h_);
-			var j_ = context.Operators.DateFrom(i_);
-			var k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
-			var l_ = context.Operators.GreaterOrEqual(k_, 6);
-			var n_ = d_?.BirthDateElement;
-			var o_ = n_?.Value;
-			var p_ = context.Operators.Convert<CqlDate>(o_);
-			var r_ = context.Operators.Start(h_);
-			var s_ = context.Operators.DateFrom(r_);
-			var t_ = context.Operators.CalculateAgeAt(p_, s_, "year");
-			var u_ = context.Operators.LessOrEqual(t_, 16);
-			var v_ = context.Operators.And(l_, u_);
+			Patient d_ = this.Patient();
+			Date e_ = d_?.BirthDateElement;
+			string f_ = e_?.Value;
+			CqlDate g_ = context.Operators.Convert<CqlDate>(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.Start(h_);
+			CqlDate j_ = context.Operators.DateFrom(i_);
+			int? k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			bool? l_ = context.Operators.GreaterOrEqual(k_, 6);
+			Date n_ = d_?.BirthDateElement;
+			string o_ = n_?.Value;
+			CqlDate p_ = context.Operators.Convert<CqlDate>(o_);
+			CqlDateTime r_ = context.Operators.Start(h_);
+			CqlDate s_ = context.Operators.DateFrom(r_);
+			int? t_ = context.Operators.CalculateAgeAt(p_, s_, "year");
+			bool? u_ = context.Operators.LessOrEqual(t_, 16);
+			bool? v_ = context.Operators.And(l_, u_);
 
 			return v_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Major_Depressive_Disorder_Encounter();
+		IEnumerable<Encounter> a_ = this.Major_Depressive_Disorder_Encounter();
 		IEnumerable<Encounter> b_(Encounter MDDEncounter)
 		{
-			var d_ = this.Suicide_risk_assessment__procedure_();
-			var e_ = context.Operators.ToList<CqlCode>(d_);
-			var f_ = context.Operators.RetrieveByCodes<Procedure>(e_, null);
+			CqlCode d_ = this.Suicide_risk_assessment__procedure_();
+			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, null);
 			bool? g_(Procedure SuicideRiskAssessment)
 			{
-				var k_ = SuicideRiskAssessment?.StatusElement;
-				var l_ = k_?.Value;
-				var m_ = context.Operators.Convert<string>(l_);
-				var n_ = context.Operators.Equal(m_, "completed");
-				var o_ = MDDEncounter?.Period;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = SuicideRiskAssessment?.Performed;
-				var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-				var s_ = QICoreCommon_2_0_000.ToInterval(r_);
-				var t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, null);
-				var u_ = context.Operators.And(n_, t_);
+				Code<EventStatus> k_ = SuicideRiskAssessment?.StatusElement;
+				EventStatus? l_ = k_?.Value;
+				string m_ = context.Operators.Convert<string>(l_);
+				bool? n_ = context.Operators.Equal(m_, "completed");
+				Period o_ = MDDEncounter?.Period;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				DataType q_ = SuicideRiskAssessment?.Performed;
+				object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+				CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
+				bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, null);
+				bool? u_ = context.Operators.And(n_, t_);
 
 				return u_;
 			};
-			var h_ = context.Operators.Where<Procedure>(f_, g_);
+			IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
 			Encounter i_(Procedure SuicideRiskAssessment) => 
 				MDDEncounter;
-			var j_ = context.Operators.Select<Procedure, Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Select<Procedure, Encounter>(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
@@ -296,469 +296,588 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Anaphylactic_Reaction_to_DTaP_Vaccine"/>
 	private CqlValueSet Anaphylactic_Reaction_to_DTaP_Vaccine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031", null);
 
+    /// <seealso cref="Anaphylactic_Reaction_to_DTaP_Vaccine_Value"/>
     [CqlDeclaration("Anaphylactic Reaction to DTaP Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031")]
 	public CqlValueSet Anaphylactic_Reaction_to_DTaP_Vaccine() => 
 		__Anaphylactic_Reaction_to_DTaP_Vaccine.Value;
 
+    /// <seealso cref="Disorders_of_the_Immune_System"/>
 	private CqlValueSet Disorders_of_the_Immune_System_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001", null);
 
+    /// <seealso cref="Disorders_of_the_Immune_System_Value"/>
     [CqlDeclaration("Disorders of the Immune System")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001")]
 	public CqlValueSet Disorders_of_the_Immune_System() => 
 		__Disorders_of_the_Immune_System.Value;
 
+    /// <seealso cref="DTaP_Vaccine"/>
 	private CqlValueSet DTaP_Vaccine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214", null);
 
+    /// <seealso cref="DTaP_Vaccine_Value"/>
     [CqlDeclaration("DTaP Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214")]
 	public CqlValueSet DTaP_Vaccine() => 
 		__DTaP_Vaccine.Value;
 
+    /// <seealso cref="DTaP_Vaccine_Administered"/>
 	private CqlValueSet DTaP_Vaccine_Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022", null);
 
+    /// <seealso cref="DTaP_Vaccine_Administered_Value"/>
     [CqlDeclaration("DTaP Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022")]
 	public CqlValueSet DTaP_Vaccine_Administered() => 
 		__DTaP_Vaccine_Administered.Value;
 
+    /// <seealso cref="Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine"/>
 	private CqlValueSet Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164", null);
 
+    /// <seealso cref="Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine_Value"/>
     [CqlDeclaration("Encephalitis Due to Diphtheria, Tetanus or Pertussis Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164")]
 	public CqlValueSet Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine() => 
 		__Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered"/>
 	private CqlValueSet Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043", null);
 
+    /// <seealso cref="Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered_Value"/>
     [CqlDeclaration("Haemophilus Influenzae Type B (Hib) Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043")]
 	public CqlValueSet Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered() => 
 		__Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered.Value;
 
+    /// <seealso cref="Hepatitis_A"/>
 	private CqlValueSet Hepatitis_A_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", null);
 
+    /// <seealso cref="Hepatitis_A_Value"/>
     [CqlDeclaration("Hepatitis A")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024")]
 	public CqlValueSet Hepatitis_A() => 
 		__Hepatitis_A.Value;
 
+    /// <seealso cref="Hepatitis_A_Vaccine"/>
 	private CqlValueSet Hepatitis_A_Vaccine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215", null);
 
+    /// <seealso cref="Hepatitis_A_Vaccine_Value"/>
     [CqlDeclaration("Hepatitis A Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215")]
 	public CqlValueSet Hepatitis_A_Vaccine() => 
 		__Hepatitis_A_Vaccine.Value;
 
+    /// <seealso cref="Hepatitis_A_Vaccine_Administered"/>
 	private CqlValueSet Hepatitis_A_Vaccine_Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041", null);
 
+    /// <seealso cref="Hepatitis_A_Vaccine_Administered_Value"/>
     [CqlDeclaration("Hepatitis A Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041")]
 	public CqlValueSet Hepatitis_A_Vaccine_Administered() => 
 		__Hepatitis_A_Vaccine_Administered.Value;
 
+    /// <seealso cref="Hepatitis_B"/>
 	private CqlValueSet Hepatitis_B_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025", null);
 
+    /// <seealso cref="Hepatitis_B_Value"/>
     [CqlDeclaration("Hepatitis B")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025")]
 	public CqlValueSet Hepatitis_B() => 
 		__Hepatitis_B.Value;
 
+    /// <seealso cref="Hepatitis_B_Vaccine"/>
 	private CqlValueSet Hepatitis_B_Vaccine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216", null);
 
+    /// <seealso cref="Hepatitis_B_Vaccine_Value"/>
     [CqlDeclaration("Hepatitis B Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216")]
 	public CqlValueSet Hepatitis_B_Vaccine() => 
 		__Hepatitis_B_Vaccine.Value;
 
+    /// <seealso cref="Hepatitis_B_Vaccine_Administered"/>
 	private CqlValueSet Hepatitis_B_Vaccine_Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042", null);
 
+    /// <seealso cref="Hepatitis_B_Vaccine_Administered_Value"/>
     [CqlDeclaration("Hepatitis B Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042")]
 	public CqlValueSet Hepatitis_B_Vaccine_Administered() => 
 		__Hepatitis_B_Vaccine_Administered.Value;
 
+    /// <seealso cref="Hib_Vaccine__3_dose_schedule_"/>
 	private CqlValueSet Hib_Vaccine__3_dose_schedule__Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083", null);
 
+    /// <seealso cref="Hib_Vaccine__3_dose_schedule__Value"/>
     [CqlDeclaration("Hib Vaccine (3 dose schedule)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083")]
 	public CqlValueSet Hib_Vaccine__3_dose_schedule_() => 
 		__Hib_Vaccine__3_dose_schedule_.Value;
 
+    /// <seealso cref="Hib_Vaccine__3_dose_schedule__Administered"/>
 	private CqlValueSet Hib_Vaccine__3_dose_schedule__Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084", null);
 
+    /// <seealso cref="Hib_Vaccine__3_dose_schedule__Administered_Value"/>
     [CqlDeclaration("Hib Vaccine (3 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084")]
 	public CqlValueSet Hib_Vaccine__3_dose_schedule__Administered() => 
 		__Hib_Vaccine__3_dose_schedule__Administered.Value;
 
+    /// <seealso cref="Hib_Vaccine__4_dose_schedule_"/>
 	private CqlValueSet Hib_Vaccine__4_dose_schedule__Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085", null);
 
+    /// <seealso cref="Hib_Vaccine__4_dose_schedule__Value"/>
     [CqlDeclaration("Hib Vaccine (4 dose schedule)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085")]
 	public CqlValueSet Hib_Vaccine__4_dose_schedule_() => 
 		__Hib_Vaccine__4_dose_schedule_.Value;
 
+    /// <seealso cref="Hib_Vaccine__4_dose_schedule__Administered"/>
 	private CqlValueSet Hib_Vaccine__4_dose_schedule__Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086", null);
 
+    /// <seealso cref="Hib_Vaccine__4_dose_schedule__Administered_Value"/>
     [CqlDeclaration("Hib Vaccine (4 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086")]
 	public CqlValueSet Hib_Vaccine__4_dose_schedule__Administered() => 
 		__Hib_Vaccine__4_dose_schedule__Administered.Value;
 
+    /// <seealso cref="HIV"/>
 	private CqlValueSet HIV_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
 
+    /// <seealso cref="HIV_Value"/>
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
 	public CqlValueSet HIV() => 
 		__HIV.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Hospice_care_ambulatory"/>
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
 
+    /// <seealso cref="Hospice_care_ambulatory_Value"/>
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
 	public CqlValueSet Hospice_care_ambulatory() => 
 		__Hospice_care_ambulatory.Value;
 
+    /// <seealso cref="Inactivated_Polio_Vaccine__IPV_"/>
 	private CqlValueSet Inactivated_Polio_Vaccine__IPV__Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219", null);
 
+    /// <seealso cref="Inactivated_Polio_Vaccine__IPV__Value"/>
     [CqlDeclaration("Inactivated Polio Vaccine (IPV)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219")]
 	public CqlValueSet Inactivated_Polio_Vaccine__IPV_() => 
 		__Inactivated_Polio_Vaccine__IPV_.Value;
 
+    /// <seealso cref="Inactivated_Polio_Vaccine__IPV__Administered"/>
 	private CqlValueSet Inactivated_Polio_Vaccine__IPV__Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045", null);
 
+    /// <seealso cref="Inactivated_Polio_Vaccine__IPV__Administered_Value"/>
     [CqlDeclaration("Inactivated Polio Vaccine (IPV) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045")]
 	public CqlValueSet Inactivated_Polio_Vaccine__IPV__Administered() => 
 		__Inactivated_Polio_Vaccine__IPV__Administered.Value;
 
+    /// <seealso cref="Child_Influenza_Immunization_Administered"/>
 	private CqlValueSet Child_Influenza_Immunization_Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218", null);
 
+    /// <seealso cref="Child_Influenza_Immunization_Administered_Value"/>
     [CqlDeclaration("Child Influenza Immunization Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218")]
 	public CqlValueSet Child_Influenza_Immunization_Administered() => 
 		__Child_Influenza_Immunization_Administered.Value;
 
+    /// <seealso cref="Child_Influenza_Vaccine_Administered"/>
 	private CqlValueSet Child_Influenza_Vaccine_Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044", null);
 
+    /// <seealso cref="Child_Influenza_Vaccine_Administered_Value"/>
     [CqlDeclaration("Child Influenza Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044")]
 	public CqlValueSet Child_Influenza_Vaccine_Administered() => 
 		__Child_Influenza_Vaccine_Administered.Value;
 
+    /// <seealso cref="Influenza_Virus_LAIV_Immunization"/>
 	private CqlValueSet Influenza_Virus_LAIV_Immunization_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087", null);
 
+    /// <seealso cref="Influenza_Virus_LAIV_Immunization_Value"/>
     [CqlDeclaration("Influenza Virus LAIV Immunization")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087")]
 	public CqlValueSet Influenza_Virus_LAIV_Immunization() => 
 		__Influenza_Virus_LAIV_Immunization.Value;
 
+    /// <seealso cref="Influenza_Virus_LAIV_Procedure"/>
 	private CqlValueSet Influenza_Virus_LAIV_Procedure_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088", null);
 
+    /// <seealso cref="Influenza_Virus_LAIV_Procedure_Value"/>
     [CqlDeclaration("Influenza Virus LAIV Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088")]
 	public CqlValueSet Influenza_Virus_LAIV_Procedure() => 
 		__Influenza_Virus_LAIV_Procedure.Value;
 
+    /// <seealso cref="Intussusception"/>
 	private CqlValueSet Intussusception_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056", null);
 
+    /// <seealso cref="Intussusception_Value"/>
     [CqlDeclaration("Intussusception")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056")]
 	public CqlValueSet Intussusception() => 
 		__Intussusception.Value;
 
+    /// <seealso cref="Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue"/>
 	private CqlValueSet Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009", null);
 
+    /// <seealso cref="Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue_Value"/>
     [CqlDeclaration("Malignant Neoplasm of Lymphatic and Hematopoietic Tissue")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009")]
 	public CqlValueSet Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue() => 
 		__Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue.Value;
 
+    /// <seealso cref="Measles"/>
 	private CqlValueSet Measles_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053", null);
 
+    /// <seealso cref="Measles_Value"/>
     [CqlDeclaration("Measles")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053")]
 	public CqlValueSet Measles() => 
 		__Measles.Value;
 
+    /// <seealso cref="Measles__Mumps_and_Rubella__MMR__Vaccine"/>
 	private CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224", null);
 
+    /// <seealso cref="Measles__Mumps_and_Rubella__MMR__Vaccine_Value"/>
     [CqlDeclaration("Measles, Mumps and Rubella (MMR) Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224")]
 	public CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine() => 
 		__Measles__Mumps_and_Rubella__MMR__Vaccine.Value;
 
+    /// <seealso cref="Measles__Mumps_and_Rubella__MMR__Vaccine_Administered"/>
 	private CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031", null);
 
+    /// <seealso cref="Measles__Mumps_and_Rubella__MMR__Vaccine_Administered_Value"/>
     [CqlDeclaration("Measles, Mumps and Rubella (MMR) Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031")]
 	public CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Administered() => 
 		__Measles__Mumps_and_Rubella__MMR__Vaccine_Administered.Value;
 
+    /// <seealso cref="Mumps"/>
 	private CqlValueSet Mumps_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032", null);
 
+    /// <seealso cref="Mumps_Value"/>
     [CqlDeclaration("Mumps")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032")]
 	public CqlValueSet Mumps() => 
 		__Mumps.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Pneumococcal_Conjugate_Vaccine"/>
 	private CqlValueSet Pneumococcal_Conjugate_Vaccine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221", null);
 
+    /// <seealso cref="Pneumococcal_Conjugate_Vaccine_Value"/>
     [CqlDeclaration("Pneumococcal Conjugate Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221")]
 	public CqlValueSet Pneumococcal_Conjugate_Vaccine() => 
 		__Pneumococcal_Conjugate_Vaccine.Value;
 
+    /// <seealso cref="Pneumococcal_Conjugate_Vaccine_Administered"/>
 	private CqlValueSet Pneumococcal_Conjugate_Vaccine_Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046", null);
 
+    /// <seealso cref="Pneumococcal_Conjugate_Vaccine_Administered_Value"/>
     [CqlDeclaration("Pneumococcal Conjugate Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046")]
 	public CqlValueSet Pneumococcal_Conjugate_Vaccine_Administered() => 
 		__Pneumococcal_Conjugate_Vaccine_Administered.Value;
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
 	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
 	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Rotavirus_Vaccine__2_dose_schedule__Administered"/>
 	private CqlValueSet Rotavirus_Vaccine__2_dose_schedule__Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048", null);
 
+    /// <seealso cref="Rotavirus_Vaccine__2_dose_schedule__Administered_Value"/>
     [CqlDeclaration("Rotavirus Vaccine (2 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048")]
 	public CqlValueSet Rotavirus_Vaccine__2_dose_schedule__Administered() => 
 		__Rotavirus_Vaccine__2_dose_schedule__Administered.Value;
 
+    /// <seealso cref="Rotavirus_Vaccine__3_dose_schedule_"/>
 	private CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223", null);
 
+    /// <seealso cref="Rotavirus_Vaccine__3_dose_schedule__Value"/>
     [CqlDeclaration("Rotavirus Vaccine (3 dose schedule)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223")]
 	public CqlValueSet Rotavirus_Vaccine__3_dose_schedule_() => 
 		__Rotavirus_Vaccine__3_dose_schedule_.Value;
 
+    /// <seealso cref="Rotavirus_Vaccine__3_dose_schedule__Administered"/>
 	private CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047", null);
 
+    /// <seealso cref="Rotavirus_Vaccine__3_dose_schedule__Administered_Value"/>
     [CqlDeclaration("Rotavirus Vaccine (3 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047")]
 	public CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Administered() => 
 		__Rotavirus_Vaccine__3_dose_schedule__Administered.Value;
 
+    /// <seealso cref="Rubella"/>
 	private CqlValueSet Rubella_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037", null);
 
+    /// <seealso cref="Rubella_Value"/>
     [CqlDeclaration("Rubella")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037")]
 	public CqlValueSet Rubella() => 
 		__Rubella.Value;
 
+    /// <seealso cref="Severe_Combined_Immunodeficiency"/>
 	private CqlValueSet Severe_Combined_Immunodeficiency_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007", null);
 
+    /// <seealso cref="Severe_Combined_Immunodeficiency_Value"/>
     [CqlDeclaration("Severe Combined Immunodeficiency")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007")]
 	public CqlValueSet Severe_Combined_Immunodeficiency() => 
 		__Severe_Combined_Immunodeficiency.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Varicella_Zoster"/>
 	private CqlValueSet Varicella_Zoster_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039", null);
 
+    /// <seealso cref="Varicella_Zoster_Value"/>
     [CqlDeclaration("Varicella Zoster")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039")]
 	public CqlValueSet Varicella_Zoster() => 
 		__Varicella_Zoster.Value;
 
+    /// <seealso cref="Varicella_Zoster_Vaccine__VZV_"/>
 	private CqlValueSet Varicella_Zoster_Vaccine__VZV__Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170", null);
 
+    /// <seealso cref="Varicella_Zoster_Vaccine__VZV__Value"/>
     [CqlDeclaration("Varicella Zoster Vaccine (VZV)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170")]
 	public CqlValueSet Varicella_Zoster_Vaccine__VZV_() => 
 		__Varicella_Zoster_Vaccine__VZV_.Value;
 
+    /// <seealso cref="Varicella_Zoster_Vaccine__VZV__Administered"/>
 	private CqlValueSet Varicella_Zoster_Vaccine__VZV__Administered_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040", null);
 
+    /// <seealso cref="Varicella_Zoster_Vaccine__VZV__Administered_Value"/>
     [CqlDeclaration("Varicella Zoster Vaccine (VZV) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040")]
 	public CqlValueSet Varicella_Zoster_Vaccine__VZV__Administered() => 
 		__Varicella_Zoster_Vaccine__VZV__Administered.Value;
 
+    /// <seealso cref="Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_"/>
 	private CqlCode Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder__Value() => 
 		new CqlCode("433621000124101", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder__Value"/>
     [CqlDeclaration("Anaphylaxis due to Haemophilus influenzae type b vaccine (disorder)")]
 	public CqlCode Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_() => 
 		__Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_.Value;
 
+    /// <seealso cref="Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_"/>
 	private CqlCode Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder__Value() => 
 		new CqlCode("428321000124101", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder__Value"/>
     [CqlDeclaration("Anaphylaxis due to Hepatitis B vaccine (disorder)")]
 	public CqlCode Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_() => 
 		__Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_.Value;
 
+    /// <seealso cref="Anaphylaxis_due_to_rotavirus_vaccine__disorder_"/>
 	private CqlCode Anaphylaxis_due_to_rotavirus_vaccine__disorder__Value() => 
 		new CqlCode("428331000124103", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Anaphylaxis_due_to_rotavirus_vaccine__disorder__Value"/>
     [CqlDeclaration("Anaphylaxis due to rotavirus vaccine (disorder)")]
 	public CqlCode Anaphylaxis_due_to_rotavirus_vaccine__disorder_() => 
 		__Anaphylaxis_due_to_rotavirus_vaccine__disorder_.Value;
 
+    /// <seealso cref="Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional"/>
 	private CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional_Value() => 
 		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional_Value"/>
     [CqlDeclaration("Office or other outpatient visit for the evaluation and management of an established patient that may not require the presence of a physician or other qualified health care professional")]
 	public CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional() => 
 		__Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional.Value;
 
+    /// <seealso cref="rotavirus__live__monovalent_vaccine"/>
 	private CqlCode rotavirus__live__monovalent_vaccine_Value() => 
 		new CqlCode("119", "http://hl7.org/fhir/sid/cvx", null, null);
 
+    /// <seealso cref="rotavirus__live__monovalent_vaccine_Value"/>
     [CqlDeclaration("rotavirus, live, monovalent vaccine")]
 	public CqlCode rotavirus__live__monovalent_vaccine() => 
 		__rotavirus__live__monovalent_vaccine.Value;
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_"/>
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder__Value() => 
 		new CqlCode("471311000124103", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder__Value"/>
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Hepatitis A virus antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_.Value;
 
+    /// <seealso cref="Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach"/>
 	private CqlCode Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach_Value() => 
 		new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", null, null);
 
+    /// <seealso cref="Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach_Value"/>
     [CqlDeclaration("Introduction of Serum, Toxoid and Vaccine into Muscle, Percutaneous Approach")]
 	public CqlCode Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach() => 
 		__Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach.Value;
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_"/>
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder__Value() => 
 		new CqlCode("471361000124100", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder__Value"/>
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Influenza virus antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_.Value;
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_"/>
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder__Value() => 
 		new CqlCode("471331000124109", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder__Value"/>
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Measles morbillivirus and Mumps orthorubulavirus and Rubella virus antigens (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_.Value;
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_"/>
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder__Value() => 
 		new CqlCode("471141000124102", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder__Value"/>
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Streptococcus pneumoniae antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_.Value;
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_"/>
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder__Value() => 
 		new CqlCode("471321000124106", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder__Value"/>
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing human poliovirus antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_.Value;
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_"/>
 	private CqlCode Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder__Value() => 
 		new CqlCode("471341000124104", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder__Value"/>
     [CqlDeclaration("Anaphylaxis caused by vaccine containing Human alphaherpesvirus 3 antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("433621000124101", "http://snomed.info/sct", null, null),
 			new CqlCode("428321000124101", "http://snomed.info/sct", null, null),
@@ -774,13 +893,15 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null),
 		};
@@ -788,13 +909,15 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="CVX"/>
 	private CqlCode[] CVX_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("119", "http://hl7.org/fhir/sid/cvx", null, null),
 		};
@@ -802,13 +925,15 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="CVX_Value"/>
     [CqlDeclaration("CVX")]
 	public CqlCode[] CVX() => 
 		__CVX.Value;
 
+    /// <seealso cref="ICD10"/>
 	private CqlCode[] ICD10_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", null, null),
 		};
@@ -816,400 +941,440 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="ICD10_Value"/>
     [CqlDeclaration("ICD10")]
 	public CqlCode[] ICD10() => 
 		__ICD10.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("ChildhoodImmunizationStatusFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("ChildhoodImmunizationStatusFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Home_Healthcare_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		IEnumerable<Encounter> l_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
 		bool? m_(Encounter E)
 		{
-			var y_ = E?.Type;
+			List<CodeableConcept> y_ = E?.Type;
 			CqlConcept z_(CodeableConcept @this)
 			{
-				var ae_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept ae_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return ae_;
 			};
-			var aa_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)y_, z_);
+			IEnumerable<CqlConcept> aa_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)y_, z_);
 			bool? ab_(CqlConcept T)
 			{
-				var af_ = this.Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional();
-				var ag_ = context.Operators.ConvertCodeToConcept(af_);
-				var ah_ = context.Operators.Equivalent(T, ag_);
+				CqlCode af_ = this.Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional();
+				CqlConcept ag_ = context.Operators.ConvertCodeToConcept(af_);
+				bool? ah_ = context.Operators.Equivalent(T, ag_);
 
 				return ah_;
 			};
-			var ac_ = context.Operators.Where<CqlConcept>(aa_, ab_);
-			var ad_ = context.Operators.Exists<CqlConcept>(ac_);
+			IEnumerable<CqlConcept> ac_ = context.Operators.Where<CqlConcept>(aa_, ab_);
+			bool? ad_ = context.Operators.Exists<CqlConcept>(ac_);
 
 			return ad_;
 		};
-		var n_ = context.Operators.Where<Encounter>(l_, m_);
-		var o_ = this.Online_Assessments();
-		var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
-		var q_ = context.Operators.Union<Encounter>(n_, p_);
-		var r_ = context.Operators.Union<Encounter>(k_, q_);
-		var s_ = this.Telephone_Visits();
-		var t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
-		var u_ = context.Operators.Union<Encounter>(r_, t_);
-		var v_ = Status_1_6_000.Finished_Encounter(u_);
+		IEnumerable<Encounter> n_ = context.Operators.Where<Encounter>(l_, m_);
+		CqlValueSet o_ = this.Online_Assessments();
+		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(n_, p_);
+		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(k_, q_);
+		CqlValueSet s_ = this.Telephone_Visits();
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
+		IEnumerable<Encounter> u_ = context.Operators.Union<Encounter>(r_, t_);
+		IEnumerable<Encounter> v_ = Status_1_6_000.Finished_Encounter(u_);
 		bool? w_(Encounter ValidEncounters)
 		{
-			var ai_ = this.Measurement_Period();
-			var aj_ = ValidEncounters?.Period;
-			var ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
-			var al_ = QICoreCommon_2_0_000.ToInterval((ak_ as object));
-			var am_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ai_, al_, "day");
+			CqlInterval<CqlDateTime> ai_ = this.Measurement_Period();
+			Period aj_ = ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval((ak_ as object));
+			bool? am_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ai_, al_, "day");
 
 			return am_;
 		};
-		var x_ = context.Operators.Where<Encounter>(v_, w_);
+		IEnumerable<Encounter> x_ = context.Operators.Where<Encounter>(v_, w_);
 
 		return x_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Equal(f_, 2);
-		var h_ = this.Qualifying_Encounters();
-		var i_ = context.Operators.Exists<Encounter>(h_);
-		var j_ = context.Operators.And(g_, i_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.Equal(h_, 2);
+		IEnumerable<Encounter> j_ = this.Qualifying_Encounters();
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
+		bool? l_ = context.Operators.And(i_, k_);
 
-		return j_;
+		return l_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Date_of_Second_Birthday"/>
 	private CqlDate Date_of_Second_Birthday_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
-		var c_ = context.Operators.Quantity(2m, "years");
-		var d_ = context.Operators.Add(b_, c_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+		CqlQuantity e_ = context.Operators.Quantity(2m, "years");
+		CqlDate f_ = context.Operators.Add(d_, e_);
 
-		return d_;
+		return f_;
 	}
 
+    /// <seealso cref="Date_of_Second_Birthday_Value"/>
     [CqlDeclaration("Date of Second Birthday")]
 	public CqlDate Date_of_Second_Birthday() => 
 		__Date_of_Second_Birthday.Value;
 
+    /// <seealso cref="First_Two_Years"/>
 	private CqlInterval<CqlDate> First_Two_Years_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
-		var c_ = context.Operators.ConvertDateToDateTime(b_);
-		var d_ = context.Operators.DateFrom(c_);
-		var e_ = this.Date_of_Second_Birthday();
-		var f_ = context.Operators.Interval(d_, e_, true, true);
-
-		return f_;
-	}
-
-    [CqlDeclaration("First Two Years")]
-	public CqlInterval<CqlDate> First_Two_Years() => 
-		__First_Two_Years.Value;
-
-	private bool? Has_Severe_Combined_Immunodeficiency_Value()
-	{
-		var a_ = this.Severe_Combined_Immunodeficiency();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
-		bool? d_(Condition SevereImmuneDisorder)
-		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(SevereImmuneDisorder);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
-
-			return k_;
-		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
-		var f_ = context.Operators.Exists<Condition>(e_);
-
-		return f_;
-	}
-
-    [CqlDeclaration("Has Severe Combined Immunodeficiency")]
-	public bool? Has_Severe_Combined_Immunodeficiency() => 
-		__Has_Severe_Combined_Immunodeficiency.Value;
-
-	private bool? Has_Immunodeficiency_Value()
-	{
-		var a_ = this.Disorders_of_the_Immune_System();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
-		bool? d_(Condition ImmuneDisorder)
-		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(ImmuneDisorder);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
-
-			return k_;
-		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
-		var f_ = context.Operators.Exists<Condition>(e_);
-
-		return f_;
-	}
-
-    [CqlDeclaration("Has Immunodeficiency")]
-	public bool? Has_Immunodeficiency() => 
-		__Has_Immunodeficiency.Value;
-
-	private bool? Has_HIV_Value()
-	{
-		var a_ = this.HIV();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
-		bool? d_(Condition HIV)
-		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HIV);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
-
-			return k_;
-		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
-		var f_ = context.Operators.Exists<Condition>(e_);
-
-		return f_;
-	}
-
-    [CqlDeclaration("Has HIV")]
-	public bool? Has_HIV() => 
-		__Has_HIV.Value;
-
-	private bool? Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia_Value()
-	{
-		var a_ = this.Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
-		bool? d_(Condition LymphaticMalignantNeoplasm)
-		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(LymphaticMalignantNeoplasm);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
-
-			return k_;
-		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
-		var f_ = context.Operators.Exists<Condition>(e_);
-
-		return f_;
-	}
-
-    [CqlDeclaration("Has Lymphoreticular Cancer, Multiple Myeloma or Leukemia")]
-	public bool? Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia() => 
-		__Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia.Value;
-
-	private bool? Has_Intussusception_Value()
-	{
-		var a_ = this.Intussusception();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
-		bool? d_(Condition IntussusceptionDisorder)
-		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(IntussusceptionDisorder);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
-
-			return k_;
-		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
-		var f_ = context.Operators.Exists<Condition>(e_);
-
-		return f_;
-	}
-
-    [CqlDeclaration("Has Intussusception")]
-	public bool? Has_Intussusception() => 
-		__Has_Intussusception.Value;
-
-	private bool? Denominator_Exclusions_Value()
-	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = this.Has_Severe_Combined_Immunodeficiency();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_Immunodeficiency();
-		var e_ = context.Operators.Or(c_, d_);
-		var f_ = this.Has_HIV();
-		var g_ = context.Operators.Or(e_, f_);
-		var h_ = this.Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia();
-		var i_ = context.Operators.Or(g_, h_);
-		var j_ = this.Has_Intussusception();
-		var k_ = context.Operators.Or(i_, j_);
-
-		return k_;
-	}
-
-    [CqlDeclaration("Denominator Exclusions")]
-	public bool? Denominator_Exclusions() => 
-		__Denominator_Exclusions.Value;
-
-	private CqlInterval<CqlDate> Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old_Value()
-	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
-		var c_ = context.Operators.ConvertDateToDateTime(b_);
-		var d_ = context.Operators.DateFrom(c_);
-		var e_ = context.Operators.Quantity(42m, "days");
-		var f_ = context.Operators.Add(d_, e_);
-		var g_ = this.Date_of_Second_Birthday();
-		var h_ = context.Operators.Interval(f_, g_, true, true);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+		CqlDateTime e_ = context.Operators.ConvertDateToDateTime(d_);
+		CqlDate f_ = context.Operators.DateFrom(e_);
+		CqlDate g_ = this.Date_of_Second_Birthday();
+		CqlInterval<CqlDate> h_ = context.Operators.Interval(f_, g_, true, true);
 
 		return h_;
 	}
 
+    /// <seealso cref="First_Two_Years_Value"/>
+    [CqlDeclaration("First Two Years")]
+	public CqlInterval<CqlDate> First_Two_Years() => 
+		__First_Two_Years.Value;
+
+    /// <seealso cref="Has_Severe_Combined_Immunodeficiency"/>
+	private bool? Has_Severe_Combined_Immunodeficiency_Value()
+	{
+		CqlValueSet a_ = this.Severe_Combined_Immunodeficiency();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition SevereImmuneDisorder)
+		{
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(SevereImmuneDisorder);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
+		bool? f_ = context.Operators.Exists<Condition>(e_);
+
+		return f_;
+	}
+
+    /// <seealso cref="Has_Severe_Combined_Immunodeficiency_Value"/>
+    [CqlDeclaration("Has Severe Combined Immunodeficiency")]
+	public bool? Has_Severe_Combined_Immunodeficiency() => 
+		__Has_Severe_Combined_Immunodeficiency.Value;
+
+    /// <seealso cref="Has_Immunodeficiency"/>
+	private bool? Has_Immunodeficiency_Value()
+	{
+		CqlValueSet a_ = this.Disorders_of_the_Immune_System();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition ImmuneDisorder)
+		{
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(ImmuneDisorder);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
+		bool? f_ = context.Operators.Exists<Condition>(e_);
+
+		return f_;
+	}
+
+    /// <seealso cref="Has_Immunodeficiency_Value"/>
+    [CqlDeclaration("Has Immunodeficiency")]
+	public bool? Has_Immunodeficiency() => 
+		__Has_Immunodeficiency.Value;
+
+    /// <seealso cref="Has_HIV"/>
+	private bool? Has_HIV_Value()
+	{
+		CqlValueSet a_ = this.HIV();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition HIV)
+		{
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HIV);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
+		bool? f_ = context.Operators.Exists<Condition>(e_);
+
+		return f_;
+	}
+
+    /// <seealso cref="Has_HIV_Value"/>
+    [CqlDeclaration("Has HIV")]
+	public bool? Has_HIV() => 
+		__Has_HIV.Value;
+
+    /// <seealso cref="Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia"/>
+	private bool? Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia_Value()
+	{
+		CqlValueSet a_ = this.Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition LymphaticMalignantNeoplasm)
+		{
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(LymphaticMalignantNeoplasm);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
+		bool? f_ = context.Operators.Exists<Condition>(e_);
+
+		return f_;
+	}
+
+    /// <seealso cref="Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia_Value"/>
+    [CqlDeclaration("Has Lymphoreticular Cancer, Multiple Myeloma or Leukemia")]
+	public bool? Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia() => 
+		__Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia.Value;
+
+    /// <seealso cref="Has_Intussusception"/>
+	private bool? Has_Intussusception_Value()
+	{
+		CqlValueSet a_ = this.Intussusception();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition IntussusceptionDisorder)
+		{
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(IntussusceptionDisorder);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+
+			return k_;
+		};
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
+		bool? f_ = context.Operators.Exists<Condition>(e_);
+
+		return f_;
+	}
+
+    /// <seealso cref="Has_Intussusception_Value"/>
+    [CqlDeclaration("Has Intussusception")]
+	public bool? Has_Intussusception() => 
+		__Has_Intussusception.Value;
+
+    /// <seealso cref="Denominator_Exclusions"/>
+	private bool? Denominator_Exclusions_Value()
+	{
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? b_ = this.Has_Severe_Combined_Immunodeficiency();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = this.Has_Immunodeficiency();
+		bool? e_ = context.Operators.Or(c_, d_);
+		bool? f_ = this.Has_HIV();
+		bool? g_ = context.Operators.Or(e_, f_);
+		bool? h_ = this.Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia();
+		bool? i_ = context.Operators.Or(g_, h_);
+		bool? j_ = this.Has_Intussusception();
+		bool? k_ = context.Operators.Or(i_, j_);
+
+		return k_;
+	}
+
+    /// <seealso cref="Denominator_Exclusions_Value"/>
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions.Value;
+
+    /// <seealso cref="Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old"/>
+	private CqlInterval<CqlDate> Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old_Value()
+	{
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+		CqlDateTime e_ = context.Operators.ConvertDateToDateTime(d_);
+		CqlDate f_ = context.Operators.DateFrom(e_);
+		CqlQuantity g_ = context.Operators.Quantity(42m, "days");
+		CqlDate h_ = context.Operators.Add(f_, g_);
+		CqlDate i_ = this.Date_of_Second_Birthday();
+		CqlInterval<CqlDate> j_ = context.Operators.Interval(h_, i_, true, true);
+
+		return j_;
+	}
+
+    /// <seealso cref="Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old_Value"/>
     [CqlDeclaration("Vaccine Administration Interval - 42 Days up to 2 Years Old")]
 	public CqlInterval<CqlDate> Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old() => 
 		__Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old.Value;
 
+    /// <seealso cref="DTaP_Immunizations_or_Procedures"/>
 	private IEnumerable<CqlDate> DTaP_Immunizations_or_Procedures_Value()
 	{
-		var a_ = this.DTaP_Vaccine();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.DTaP_Vaccine();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization DTaPVaccination)
 		{
-			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var q_ = DTaPVaccination?.Occurrence;
-			var r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
-			var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
-			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			CqlInterval<CqlDate> p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType q_ = DTaPVaccination?.Occurrence;
+			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
 
 			return u_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlDate f_(Immunization DTaPVaccination)
 		{
-			var v_ = DTaPVaccination?.Occurrence;
-			var w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
-			var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
-			var y_ = CQMCommon_2_0_000.ToDateInterval(x_);
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.ConvertDateToDateTime(z_);
-			var ab_ = context.Operators.DateFrom(aa_);
+			DataType v_ = DTaPVaccination?.Occurrence;
+			CqlDateTime w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+			CqlInterval<CqlDate> y_ = CQMCommon_2_0_000.ToDateInterval(x_);
+			CqlDate z_ = context.Operators.Start(y_);
+			CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+			CqlDate ab_ = context.Operators.DateFrom(aa_);
 
 			return ab_;
 		};
-		var g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
-		var h_ = this.DTaP_Vaccine_Administered();
-		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
-		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
+		CqlValueSet h_ = this.DTaP_Vaccine_Administered();
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure DTaPProcedure)
 		{
-			var ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var ad_ = DTaPProcedure?.Performed;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = QICoreCommon_2_0_000.ToInterval(ae_);
-			var ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			var ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			CqlInterval<CqlDate> ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType ad_ = DTaPProcedure?.Performed;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
+			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
 
 			return ah_;
 		};
-		var l_ = context.Operators.Where<Procedure>(j_, k_);
+		IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
 		CqlDate m_(Procedure DTaPProcedure)
 		{
-			var ai_ = DTaPProcedure?.Performed;
-			var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
-			var al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.ConvertDateToDateTime(am_);
-			var ao_ = context.Operators.DateFrom(an_);
+			DataType ai_ = DTaPProcedure?.Performed;
+			object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			CqlInterval<CqlDate> al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
+			CqlDate am_ = context.Operators.Start(al_);
+			CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+			CqlDate ao_ = context.Operators.DateFrom(an_);
 
 			return ao_;
 		};
-		var n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
-		var o_ = context.Operators.Union<CqlDate>(g_, n_);
+		IEnumerable<CqlDate> n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
+		IEnumerable<CqlDate> o_ = context.Operators.Union<CqlDate>(g_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="DTaP_Immunizations_or_Procedures_Value"/>
     [CqlDeclaration("DTaP Immunizations or Procedures")]
 	public IEnumerable<CqlDate> DTaP_Immunizations_or_Procedures() => 
 		__DTaP_Immunizations_or_Procedures.Value;
 
+    /// <seealso cref="Four_DTaP_Vaccinations"/>
 	private IEnumerable<CqlDate> Four_DTaP_Vaccinations_Value()
 	{
-		var a_ = this.DTaP_Immunizations_or_Procedures();
-		var e_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate, CqlDate>(a_, a_, a_, a_);
+		IEnumerable<CqlDate> a_ = this.DTaP_Immunizations_or_Procedures();
+		IEnumerable<ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate>> e_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate, CqlDate>(a_, a_, a_, a_);
 		Tuple_EMDhFLcFhWVERAVVNfLAZYXJi f_(ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_EMDhFLcFhWVERAVVNfLAZYXJi
+			Tuple_EMDhFLcFhWVERAVVNfLAZYXJi l_ = new Tuple_EMDhFLcFhWVERAVVNfLAZYXJi
 			{
 				DTaPVaccination1 = _valueTuple.Item1,
 				DTaPVaccination2 = _valueTuple.Item2,
@@ -1219,134 +1384,140 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 			return l_;
 		};
-		var g_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate>, Tuple_EMDhFLcFhWVERAVVNfLAZYXJi>(e_, f_);
+		IEnumerable<Tuple_EMDhFLcFhWVERAVVNfLAZYXJi> g_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate>, Tuple_EMDhFLcFhWVERAVVNfLAZYXJi>(e_, f_);
 		bool? h_(Tuple_EMDhFLcFhWVERAVVNfLAZYXJi tuple_emdhflcfhwveravvnflazyxji)
 		{
-			var m_ = context.Operators.Quantity(1m, "day");
-			var n_ = context.Operators.Add(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination1, m_);
-			var o_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination2, n_, "day");
-			var q_ = context.Operators.Add(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination2, m_);
-			var r_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination3, q_, "day");
-			var s_ = context.Operators.And(o_, r_);
-			var u_ = context.Operators.Add(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination3, m_);
-			var v_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination4, u_, "day");
-			var w_ = context.Operators.And(s_, v_);
+			CqlQuantity m_ = context.Operators.Quantity(1m, "day");
+			CqlDate n_ = context.Operators.Add(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination1, m_);
+			bool? o_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination2, n_, "day");
+			CqlDate q_ = context.Operators.Add(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination2, m_);
+			bool? r_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination3, q_, "day");
+			bool? s_ = context.Operators.And(o_, r_);
+			CqlDate u_ = context.Operators.Add(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination3, m_);
+			bool? v_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination4, u_, "day");
+			bool? w_ = context.Operators.And(s_, v_);
 
 			return w_;
 		};
-		var i_ = context.Operators.Where<Tuple_EMDhFLcFhWVERAVVNfLAZYXJi>(g_, h_);
+		IEnumerable<Tuple_EMDhFLcFhWVERAVVNfLAZYXJi> i_ = context.Operators.Where<Tuple_EMDhFLcFhWVERAVVNfLAZYXJi>(g_, h_);
 		CqlDate j_(Tuple_EMDhFLcFhWVERAVVNfLAZYXJi tuple_emdhflcfhwveravvnflazyxji) => 
 			tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination1;
-		var k_ = context.Operators.Select<Tuple_EMDhFLcFhWVERAVVNfLAZYXJi, CqlDate>(i_, j_);
+		IEnumerable<CqlDate> k_ = context.Operators.Select<Tuple_EMDhFLcFhWVERAVVNfLAZYXJi, CqlDate>(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Four_DTaP_Vaccinations_Value"/>
     [CqlDeclaration("Four DTaP Vaccinations")]
 	public IEnumerable<CqlDate> Four_DTaP_Vaccinations() => 
 		__Four_DTaP_Vaccinations.Value;
 
+    /// <seealso cref="DTaP_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> DTaP_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Anaphylactic_Reaction_to_DTaP_Vaccine();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine();
-		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
-		var e_ = context.Operators.Union<Condition>(b_, d_);
-		var f_ = Status_1_6_000.Active_Condition(e_);
+		CqlValueSet a_ = this.Anaphylactic_Reaction_to_DTaP_Vaccine();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet c_ = this.Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine();
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
+		IEnumerable<Condition> f_ = Status_1_6_000.Active_Condition(e_);
 		bool? g_(Condition DTaPConditions)
 		{
-			var i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(DTaPConditions);
-			var j_ = context.Operators.Start(i_);
-			var k_ = context.Operators.DateFrom(j_);
-			var l_ = this.First_Two_Years();
-			var m_ = context.Operators.In<CqlDate>(k_, l_, "day");
+			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(DTaPConditions);
+			CqlDateTime j_ = context.Operators.Start(i_);
+			CqlDate k_ = context.Operators.DateFrom(j_);
+			CqlInterval<CqlDate> l_ = this.First_Two_Years();
+			bool? m_ = context.Operators.In<CqlDate>(k_, l_, "day");
 
 			return m_;
 		};
-		var h_ = context.Operators.Where<Condition>(f_, g_);
+		IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="DTaP_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("DTaP Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> DTaP_Numerator_Inclusion_Conditions() => 
 		__DTaP_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="Polio_Immunizations_or_Procedures"/>
 	private IEnumerable<CqlDate> Polio_Immunizations_or_Procedures_Value()
 	{
-		var a_ = this.Inactivated_Polio_Vaccine__IPV_();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Inactivated_Polio_Vaccine__IPV_();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization PolioVaccination)
 		{
-			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var q_ = PolioVaccination?.Occurrence;
-			var r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
-			var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
-			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			CqlInterval<CqlDate> p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType q_ = PolioVaccination?.Occurrence;
+			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
 
 			return u_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlDate f_(Immunization PolioVaccination)
 		{
-			var v_ = PolioVaccination?.Occurrence;
-			var w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
-			var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
-			var y_ = CQMCommon_2_0_000.ToDateInterval(x_);
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.ConvertDateToDateTime(z_);
-			var ab_ = context.Operators.DateFrom(aa_);
+			DataType v_ = PolioVaccination?.Occurrence;
+			CqlDateTime w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+			CqlInterval<CqlDate> y_ = CQMCommon_2_0_000.ToDateInterval(x_);
+			CqlDate z_ = context.Operators.Start(y_);
+			CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+			CqlDate ab_ = context.Operators.DateFrom(aa_);
 
 			return ab_;
 		};
-		var g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
-		var h_ = this.Inactivated_Polio_Vaccine__IPV__Administered();
-		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
-		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
+		CqlValueSet h_ = this.Inactivated_Polio_Vaccine__IPV__Administered();
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure PolioProcedure)
 		{
-			var ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var ad_ = PolioProcedure?.Performed;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = QICoreCommon_2_0_000.ToInterval(ae_);
-			var ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			var ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			CqlInterval<CqlDate> ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType ad_ = PolioProcedure?.Performed;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
+			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
 
 			return ah_;
 		};
-		var l_ = context.Operators.Where<Procedure>(j_, k_);
+		IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
 		CqlDate m_(Procedure PolioProcedure)
 		{
-			var ai_ = PolioProcedure?.Performed;
-			var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
-			var al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.ConvertDateToDateTime(am_);
-			var ao_ = context.Operators.DateFrom(an_);
+			DataType ai_ = PolioProcedure?.Performed;
+			object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			CqlInterval<CqlDate> al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
+			CqlDate am_ = context.Operators.Start(al_);
+			CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+			CqlDate ao_ = context.Operators.DateFrom(an_);
 
 			return ao_;
 		};
-		var n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
-		var o_ = context.Operators.Union<CqlDate>(g_, n_);
+		IEnumerable<CqlDate> n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
+		IEnumerable<CqlDate> o_ = context.Operators.Union<CqlDate>(g_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Polio_Immunizations_or_Procedures_Value"/>
     [CqlDeclaration("Polio Immunizations or Procedures")]
 	public IEnumerable<CqlDate> Polio_Immunizations_or_Procedures() => 
 		__Polio_Immunizations_or_Procedures.Value;
 
+    /// <seealso cref="Three_Polio_Vaccinations"/>
 	private IEnumerable<CqlDate> Three_Polio_Vaccinations_Value()
 	{
-		var a_ = this.Polio_Immunizations_or_Procedures();
-		var d_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate>(a_, a_, a_);
+		IEnumerable<CqlDate> a_ = this.Polio_Immunizations_or_Procedures();
+		IEnumerable<ValueTuple<CqlDate, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate>(a_, a_, a_);
 		Tuple_CNGHaZROXaJTHPICcbIaJbRXV e_(ValueTuple<CqlDate, CqlDate, CqlDate> _valueTuple)
 		{
-			var k_ = new Tuple_CNGHaZROXaJTHPICcbIaJbRXV
+			Tuple_CNGHaZROXaJTHPICcbIaJbRXV k_ = new Tuple_CNGHaZROXaJTHPICcbIaJbRXV
 			{
 				PolioVaccination1 = _valueTuple.Item1,
 				PolioVaccination2 = _valueTuple.Item2,
@@ -1355,538 +1526,572 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate>, Tuple_CNGHaZROXaJTHPICcbIaJbRXV>(d_, e_);
+		IEnumerable<Tuple_CNGHaZROXaJTHPICcbIaJbRXV> f_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate>, Tuple_CNGHaZROXaJTHPICcbIaJbRXV>(d_, e_);
 		bool? g_(Tuple_CNGHaZROXaJTHPICcbIaJbRXV tuple_cnghazroxajthpiccbiajbrxv)
 		{
-			var l_ = context.Operators.Quantity(1m, "day");
-			var m_ = context.Operators.Add(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination1, l_);
-			var n_ = context.Operators.SameOrAfter(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination2, m_, "day");
-			var p_ = context.Operators.Add(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination2, l_);
-			var q_ = context.Operators.SameOrAfter(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination3, p_, "day");
-			var r_ = context.Operators.And(n_, q_);
+			CqlQuantity l_ = context.Operators.Quantity(1m, "day");
+			CqlDate m_ = context.Operators.Add(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination1, l_);
+			bool? n_ = context.Operators.SameOrAfter(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination2, m_, "day");
+			CqlDate p_ = context.Operators.Add(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination2, l_);
+			bool? q_ = context.Operators.SameOrAfter(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination3, p_, "day");
+			bool? r_ = context.Operators.And(n_, q_);
 
 			return r_;
 		};
-		var h_ = context.Operators.Where<Tuple_CNGHaZROXaJTHPICcbIaJbRXV>(f_, g_);
+		IEnumerable<Tuple_CNGHaZROXaJTHPICcbIaJbRXV> h_ = context.Operators.Where<Tuple_CNGHaZROXaJTHPICcbIaJbRXV>(f_, g_);
 		CqlDate i_(Tuple_CNGHaZROXaJTHPICcbIaJbRXV tuple_cnghazroxajthpiccbiajbrxv) => 
 			tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination1;
-		var j_ = context.Operators.Select<Tuple_CNGHaZROXaJTHPICcbIaJbRXV, CqlDate>(h_, i_);
+		IEnumerable<CqlDate> j_ = context.Operators.Select<Tuple_CNGHaZROXaJTHPICcbIaJbRXV, CqlDate>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Three_Polio_Vaccinations_Value"/>
     [CqlDeclaration("Three Polio Vaccinations")]
 	public IEnumerable<CqlDate> Three_Polio_Vaccinations() => 
 		__Three_Polio_Vaccinations.Value;
 
+    /// <seealso cref="Polio_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> Polio_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
-		var d_ = Status_1_6_000.Active_Condition(c_);
+		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition PolioConditions)
 		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(PolioConditions);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(PolioConditions);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
 
 			return k_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Polio_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("Polio Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> Polio_Numerator_Inclusion_Conditions() => 
 		__Polio_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="Date_of_First_Birthday"/>
 	private CqlDate Date_of_First_Birthday_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
-		var c_ = context.Operators.ConvertDateToDateTime(b_);
-		var d_ = context.Operators.DateFrom(c_);
-		var e_ = context.Operators.Quantity(1m, "year");
-		var f_ = context.Operators.Add(d_, e_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+		CqlDateTime e_ = context.Operators.ConvertDateToDateTime(d_);
+		CqlDate f_ = context.Operators.DateFrom(e_);
+		CqlQuantity g_ = context.Operators.Quantity(1m, "year");
+		CqlDate h_ = context.Operators.Add(f_, g_);
 
-		return f_;
+		return h_;
 	}
 
+    /// <seealso cref="Date_of_First_Birthday_Value"/>
     [CqlDeclaration("Date of First Birthday")]
 	public CqlDate Date_of_First_Birthday() => 
 		__Date_of_First_Birthday.Value;
 
+    /// <seealso cref="Date_of_First_Birthday_to_Date_of_Second_Birthday"/>
 	private CqlInterval<CqlDate> Date_of_First_Birthday_to_Date_of_Second_Birthday_Value()
 	{
-		var a_ = this.Date_of_First_Birthday();
-		var b_ = this.Date_of_Second_Birthday();
-		var c_ = context.Operators.Interval(a_, b_, true, true);
+		CqlDate a_ = this.Date_of_First_Birthday();
+		CqlDate b_ = this.Date_of_Second_Birthday();
+		CqlInterval<CqlDate> c_ = context.Operators.Interval(a_, b_, true, true);
 
 		return c_;
 	}
 
+    /// <seealso cref="Date_of_First_Birthday_to_Date_of_Second_Birthday_Value"/>
     [CqlDeclaration("Date of First Birthday to Date of Second Birthday")]
 	public CqlInterval<CqlDate> Date_of_First_Birthday_to_Date_of_Second_Birthday() => 
 		__Date_of_First_Birthday_to_Date_of_Second_Birthday.Value;
 
+    /// <seealso cref="One_MMR_Vaccination"/>
 	private IEnumerable<object> One_MMR_Vaccination_Value()
 	{
-		var a_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization MMRVaccination)
 		{
-			var l_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
-			var m_ = MMRVaccination?.Occurrence;
-			var n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = CQMCommon_2_0_000.ToDateInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, null);
+			CqlInterval<CqlDate> l_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			DataType m_ = MMRVaccination?.Occurrence;
+			CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlInterval<CqlDate> p_ = CQMCommon_2_0_000.ToDateInterval(o_);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, null);
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
-		var f_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine_Administered();
-		var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
-		var h_ = Status_1_6_000.Completed_Procedure(g_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
+		CqlValueSet f_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine_Administered();
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		IEnumerable<Procedure> h_ = Status_1_6_000.Completed_Procedure(g_);
 		bool? i_(Procedure MMRProcedure)
 		{
-			var r_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
-			var s_ = MMRProcedure?.Performed;
-			var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-			var u_ = QICoreCommon_2_0_000.ToInterval(t_);
-			var v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			var w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
+			CqlInterval<CqlDate> r_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			DataType s_ = MMRProcedure?.Performed;
+			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
+			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
 
 			return w_;
 		};
-		var j_ = context.Operators.Where<Procedure>(h_, i_);
-		var k_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
+		IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>(h_, i_);
+		IEnumerable<object> k_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
 
 		return k_;
 	}
 
+    /// <seealso cref="One_MMR_Vaccination_Value"/>
     [CqlDeclaration("One MMR Vaccination")]
 	public IEnumerable<object> One_MMR_Vaccination() => 
 		__One_MMR_Vaccination.Value;
 
+    /// <seealso cref="MMR_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> MMR_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
-		var d_ = Status_1_6_000.Active_Condition(c_);
+		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition MMRConditions)
 		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MMRConditions);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MMRConditions);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
 
 			return k_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="MMR_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("MMR Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> MMR_Numerator_Inclusion_Conditions() => 
 		__MMR_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="Measles_Indicators"/>
 	private IEnumerable<Condition> Measles_Indicators_Value()
 	{
-		var a_ = this.Measles();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
+		CqlValueSet a_ = this.Measles();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition MeaslesDiagnosis)
 		{
-			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MeaslesDiagnosis);
-			var g_ = context.Operators.Start(f_);
-			var h_ = context.Operators.DateFrom(g_);
-			var i_ = this.First_Two_Years();
-			var j_ = context.Operators.In<CqlDate>(h_, i_, "day");
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MeaslesDiagnosis);
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlDate h_ = context.Operators.DateFrom(g_);
+			CqlInterval<CqlDate> i_ = this.First_Two_Years();
+			bool? j_ = context.Operators.In<CqlDate>(h_, i_, "day");
 
 			return j_;
 		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Measles_Indicators_Value"/>
     [CqlDeclaration("Measles Indicators")]
 	public IEnumerable<Condition> Measles_Indicators() => 
 		__Measles_Indicators.Value;
 
+    /// <seealso cref="Mumps_Indicators"/>
 	private IEnumerable<Condition> Mumps_Indicators_Value()
 	{
-		var a_ = this.Mumps();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
+		CqlValueSet a_ = this.Mumps();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition MumpsDiagnosis)
 		{
-			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MumpsDiagnosis);
-			var g_ = context.Operators.Start(f_);
-			var h_ = context.Operators.DateFrom(g_);
-			var i_ = this.First_Two_Years();
-			var j_ = context.Operators.In<CqlDate>(h_, i_, "day");
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(MumpsDiagnosis);
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlDate h_ = context.Operators.DateFrom(g_);
+			CqlInterval<CqlDate> i_ = this.First_Two_Years();
+			bool? j_ = context.Operators.In<CqlDate>(h_, i_, "day");
 
 			return j_;
 		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Mumps_Indicators_Value"/>
     [CqlDeclaration("Mumps Indicators")]
 	public IEnumerable<Condition> Mumps_Indicators() => 
 		__Mumps_Indicators.Value;
 
+    /// <seealso cref="Rubella_Indicators"/>
 	private IEnumerable<Condition> Rubella_Indicators_Value()
 	{
-		var a_ = this.Rubella();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
+		CqlValueSet a_ = this.Rubella();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition RubellaDiagnosis)
 		{
-			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(RubellaDiagnosis);
-			var g_ = context.Operators.Start(f_);
-			var h_ = context.Operators.DateFrom(g_);
-			var i_ = this.First_Two_Years();
-			var j_ = context.Operators.In<CqlDate>(h_, i_, "day");
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(RubellaDiagnosis);
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlDate h_ = context.Operators.DateFrom(g_);
+			CqlInterval<CqlDate> i_ = this.First_Two_Years();
+			bool? j_ = context.Operators.In<CqlDate>(h_, i_, "day");
 
 			return j_;
 		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Rubella_Indicators_Value"/>
     [CqlDeclaration("Rubella Indicators")]
 	public IEnumerable<Condition> Rubella_Indicators() => 
 		__Rubella_Indicators.Value;
 
+    /// <seealso cref="Hib_3_Dose_Immunizations_or_Procedures"/>
 	private IEnumerable<CqlDate> Hib_3_Dose_Immunizations_or_Procedures_Value()
 	{
-		var a_ = this.Hib_Vaccine__3_dose_schedule_();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Hib_Vaccine__3_dose_schedule_();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization ThreeDoseHibVaccine)
 		{
-			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var q_ = ThreeDoseHibVaccine?.Occurrence;
-			var r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
-			var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
-			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			CqlInterval<CqlDate> p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType q_ = ThreeDoseHibVaccine?.Occurrence;
+			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
 
 			return u_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlDate f_(Immunization ThreeDoseHibVaccine)
 		{
-			var v_ = ThreeDoseHibVaccine?.Occurrence;
-			var w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
-			var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
-			var y_ = CQMCommon_2_0_000.ToDateInterval(x_);
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.ConvertDateToDateTime(z_);
-			var ab_ = context.Operators.DateFrom(aa_);
+			DataType v_ = ThreeDoseHibVaccine?.Occurrence;
+			CqlDateTime w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+			CqlInterval<CqlDate> y_ = CQMCommon_2_0_000.ToDateInterval(x_);
+			CqlDate z_ = context.Operators.Start(y_);
+			CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+			CqlDate ab_ = context.Operators.DateFrom(aa_);
 
 			return ab_;
 		};
-		var g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
-		var h_ = this.Hib_Vaccine__3_dose_schedule__Administered();
-		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
-		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
+		CqlValueSet h_ = this.Hib_Vaccine__3_dose_schedule__Administered();
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure ThreeDoseHibProcedure)
 		{
-			var ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var ad_ = ThreeDoseHibProcedure?.Performed;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = QICoreCommon_2_0_000.ToInterval(ae_);
-			var ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			var ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			CqlInterval<CqlDate> ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType ad_ = ThreeDoseHibProcedure?.Performed;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
+			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
 
 			return ah_;
 		};
-		var l_ = context.Operators.Where<Procedure>(j_, k_);
+		IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
 		CqlDate m_(Procedure ThreeDoseHibProcedure)
 		{
-			var ai_ = ThreeDoseHibProcedure?.Performed;
-			var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
-			var al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.ConvertDateToDateTime(am_);
-			var ao_ = context.Operators.DateFrom(an_);
+			DataType ai_ = ThreeDoseHibProcedure?.Performed;
+			object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			CqlInterval<CqlDate> al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
+			CqlDate am_ = context.Operators.Start(al_);
+			CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+			CqlDate ao_ = context.Operators.DateFrom(an_);
 
 			return ao_;
 		};
-		var n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
-		var o_ = context.Operators.Union<CqlDate>(g_, n_);
+		IEnumerable<CqlDate> n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
+		IEnumerable<CqlDate> o_ = context.Operators.Union<CqlDate>(g_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Hib_3_Dose_Immunizations_or_Procedures_Value"/>
     [CqlDeclaration("Hib 3 Dose Immunizations or Procedures")]
 	public IEnumerable<CqlDate> Hib_3_Dose_Immunizations_or_Procedures() => 
 		__Hib_3_Dose_Immunizations_or_Procedures.Value;
 
+    /// <seealso cref="Hib_4_Dose_Immunizations_or_Procedures"/>
 	private IEnumerable<CqlDate> Hib_4_Dose_Immunizations_or_Procedures_Value()
 	{
-		var a_ = this.Hib_Vaccine__4_dose_schedule_();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Hib_Vaccine__4_dose_schedule_();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization HibVaccine)
 		{
-			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var q_ = HibVaccine?.Occurrence;
-			var r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
-			var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
-			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			CqlInterval<CqlDate> p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType q_ = HibVaccine?.Occurrence;
+			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
 
 			return u_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlDate f_(Immunization HibVaccine)
 		{
-			var v_ = HibVaccine?.Occurrence;
-			var w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
-			var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
-			var y_ = CQMCommon_2_0_000.ToDateInterval(x_);
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.ConvertDateToDateTime(z_);
-			var ab_ = context.Operators.DateFrom(aa_);
+			DataType v_ = HibVaccine?.Occurrence;
+			CqlDateTime w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+			CqlInterval<CqlDate> y_ = CQMCommon_2_0_000.ToDateInterval(x_);
+			CqlDate z_ = context.Operators.Start(y_);
+			CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+			CqlDate ab_ = context.Operators.DateFrom(aa_);
 
 			return ab_;
 		};
-		var g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
-		var h_ = this.Hib_Vaccine__4_dose_schedule__Administered();
-		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
-		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
+		CqlValueSet h_ = this.Hib_Vaccine__4_dose_schedule__Administered();
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure HibProcedure)
 		{
-			var ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var ad_ = HibProcedure?.Performed;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = QICoreCommon_2_0_000.ToInterval(ae_);
-			var ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			var ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			CqlInterval<CqlDate> ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType ad_ = HibProcedure?.Performed;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
+			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
 
 			return ah_;
 		};
-		var l_ = context.Operators.Where<Procedure>(j_, k_);
+		IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
 		CqlDate m_(Procedure HibProcedure)
 		{
-			var ai_ = HibProcedure?.Performed;
-			var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
-			var al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.ConvertDateToDateTime(am_);
-			var ao_ = context.Operators.DateFrom(an_);
+			DataType ai_ = HibProcedure?.Performed;
+			object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			CqlInterval<CqlDate> al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
+			CqlDate am_ = context.Operators.Start(al_);
+			CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+			CqlDate ao_ = context.Operators.DateFrom(an_);
 
 			return ao_;
 		};
-		var n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
-		var o_ = context.Operators.Union<CqlDate>(g_, n_);
+		IEnumerable<CqlDate> n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
+		IEnumerable<CqlDate> o_ = context.Operators.Union<CqlDate>(g_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Hib_4_Dose_Immunizations_or_Procedures_Value"/>
     [CqlDeclaration("Hib 4 Dose Immunizations or Procedures")]
 	public IEnumerable<CqlDate> Hib_4_Dose_Immunizations_or_Procedures() => 
 		__Hib_4_Dose_Immunizations_or_Procedures.Value;
 
+    /// <seealso cref="Hib_3_or_4_Dose_Immunizations"/>
 	private IEnumerable<CqlDate> Hib_3_or_4_Dose_Immunizations_Value()
 	{
-		var a_ = this.Hib_3_Dose_Immunizations_or_Procedures();
-		var b_ = this.Hib_4_Dose_Immunizations_or_Procedures();
-		var c_ = context.Operators.Union<CqlDate>(a_, b_);
+		IEnumerable<CqlDate> a_ = this.Hib_3_Dose_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> b_ = this.Hib_4_Dose_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> c_ = context.Operators.Union<CqlDate>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Hib_3_or_4_Dose_Immunizations_Value"/>
     [CqlDeclaration("Hib 3 or 4 Dose Immunizations")]
 	public IEnumerable<CqlDate> Hib_3_or_4_Dose_Immunizations() => 
 		__Hib_3_or_4_Dose_Immunizations.Value;
 
+    /// <seealso cref="All_Hib_Vaccinations"/>
 	private IEnumerable<CqlDate> All_Hib_Vaccinations_Value()
 	{
-		var a_ = this.Hib_3_or_4_Dose_Immunizations();
+		IEnumerable<CqlDate> a_ = this.Hib_3_or_4_Dose_Immunizations();
 		IEnumerable<CqlDate> c_(CqlDate AllHibDoses1)
 		{
-			var f_ = this.Hib_3_or_4_Dose_Immunizations();
+			IEnumerable<CqlDate> f_ = this.Hib_3_or_4_Dose_Immunizations();
 			bool? g_(CqlDate AllHibDoses2)
 			{
-				var k_ = context.Operators.Quantity(1m, "day");
-				var l_ = context.Operators.Subtract(AllHibDoses2, k_);
-				var m_ = context.Operators.Interval(l_, AllHibDoses2, false, false);
-				var n_ = context.Operators.In<CqlDate>(AllHibDoses1, m_, null);
+				CqlQuantity k_ = context.Operators.Quantity(1m, "day");
+				CqlDate l_ = context.Operators.Subtract(AllHibDoses2, k_);
+				CqlInterval<CqlDate> m_ = context.Operators.Interval(l_, AllHibDoses2, false, false);
+				bool? n_ = context.Operators.In<CqlDate>(AllHibDoses1, m_, null);
 
 				return n_;
 			};
-			var h_ = context.Operators.Where<CqlDate>(f_, g_);
+			IEnumerable<CqlDate> h_ = context.Operators.Where<CqlDate>(f_, g_);
 			CqlDate i_(CqlDate AllHibDoses2) => 
 				AllHibDoses1;
-			var j_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
+			IEnumerable<CqlDate> j_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
 
 			return j_;
 		};
-		var d_ = context.Operators.SelectMany<CqlDate, CqlDate>(a_, c_);
-		var e_ = context.Operators.Except<CqlDate>(a_, d_);
+		IEnumerable<CqlDate> d_ = context.Operators.SelectMany<CqlDate, CqlDate>(a_, c_);
+		IEnumerable<CqlDate> e_ = context.Operators.Except<CqlDate>(a_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="All_Hib_Vaccinations_Value"/>
     [CqlDeclaration("All Hib Vaccinations")]
 	public IEnumerable<CqlDate> All_Hib_Vaccinations() => 
 		__All_Hib_Vaccinations.Value;
 
+    /// <seealso cref="Has_Appropriate_Number_of_Hib_Immunizations"/>
 	private bool? Has_Appropriate_Number_of_Hib_Immunizations_Value()
 	{
-		var a_ = this.All_Hib_Vaccinations();
+		IEnumerable<CqlDate> a_ = this.All_Hib_Vaccinations();
 		bool? b_(CqlDate HibImmunization)
 		{
-			var e_ = this.Hib_4_Dose_Immunizations_or_Procedures();
-			var f_ = context.Operators.Count<CqlDate>(e_);
-			var g_ = context.Operators.Greater(f_, 0);
-			var h_ = this.All_Hib_Vaccinations();
+			IEnumerable<CqlDate> e_ = this.Hib_4_Dose_Immunizations_or_Procedures();
+			int? f_ = context.Operators.Count<CqlDate>(e_);
+			bool? g_ = context.Operators.Greater(f_, 0);
+			IEnumerable<CqlDate> h_ = this.All_Hib_Vaccinations();
 			CqlDate i_(CqlDate HibVaccinations) => 
 				HibVaccinations;
-			var j_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
-			var k_ = context.Operators.Distinct<CqlDate>(j_);
-			var l_ = context.Operators.Count<CqlDate>(k_);
-			var m_ = context.Operators.GreaterOrEqual(l_, 4);
-			var n_ = context.Operators.And(g_, m_);
-			var p_ = context.Operators.Count<CqlDate>(e_);
-			var q_ = context.Operators.Greater(p_, 0);
-			var r_ = context.Operators.IsFalse(q_);
-			var u_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
-			var v_ = context.Operators.Distinct<CqlDate>(u_);
-			var w_ = context.Operators.Count<CqlDate>(v_);
-			var x_ = context.Operators.GreaterOrEqual(w_, 3);
-			var y_ = context.Operators.And(r_, x_);
-			var z_ = context.Operators.Or(n_, y_);
+			IEnumerable<CqlDate> j_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
+			IEnumerable<CqlDate> k_ = context.Operators.Distinct<CqlDate>(j_);
+			int? l_ = context.Operators.Count<CqlDate>(k_);
+			bool? m_ = context.Operators.GreaterOrEqual(l_, 4);
+			bool? n_ = context.Operators.And(g_, m_);
+			int? p_ = context.Operators.Count<CqlDate>(e_);
+			bool? q_ = context.Operators.Greater(p_, 0);
+			bool? r_ = context.Operators.IsFalse(q_);
+			IEnumerable<CqlDate> u_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
+			IEnumerable<CqlDate> v_ = context.Operators.Distinct<CqlDate>(u_);
+			int? w_ = context.Operators.Count<CqlDate>(v_);
+			bool? x_ = context.Operators.GreaterOrEqual(w_, 3);
+			bool? y_ = context.Operators.And(r_, x_);
+			bool? z_ = context.Operators.Or(n_, y_);
 
 			return z_;
 		};
-		var c_ = context.Operators.Where<CqlDate>(a_, b_);
-		var d_ = context.Operators.Exists<CqlDate>(c_);
+		IEnumerable<CqlDate> c_ = context.Operators.Where<CqlDate>(a_, b_);
+		bool? d_ = context.Operators.Exists<CqlDate>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Has_Appropriate_Number_of_Hib_Immunizations_Value"/>
     [CqlDeclaration("Has Appropriate Number of Hib Immunizations")]
 	public bool? Has_Appropriate_Number_of_Hib_Immunizations() => 
 		__Has_Appropriate_Number_of_Hib_Immunizations.Value;
 
+    /// <seealso cref="Hib_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> Hib_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
-		var d_ = Status_1_6_000.Active_Condition(c_);
+		CqlCode a_ = this.Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition HibReaction)
 		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HibReaction);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HibReaction);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
 
 			return k_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Hib_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("Hib Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> Hib_Numerator_Inclusion_Conditions() => 
 		__Hib_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="Hepatitis_B_Immunizations_or_Procedures"/>
 	private IEnumerable<CqlDate> Hepatitis_B_Immunizations_or_Procedures_Value()
 	{
-		var a_ = this.Hepatitis_B_Vaccine();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Hepatitis_B_Vaccine();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization HepatitisBVaccination)
 		{
-			var p_ = this.First_Two_Years();
-			var q_ = HepatitisBVaccination?.Occurrence;
-			var r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
-			var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
-			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			CqlInterval<CqlDate> p_ = this.First_Two_Years();
+			DataType q_ = HepatitisBVaccination?.Occurrence;
+			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
 
 			return u_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlDate f_(Immunization HepatitisBVaccination)
 		{
-			var v_ = HepatitisBVaccination?.Occurrence;
-			var w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
-			var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
-			var y_ = CQMCommon_2_0_000.ToDateInterval(x_);
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.ConvertDateToDateTime(z_);
-			var ab_ = context.Operators.DateFrom(aa_);
+			DataType v_ = HepatitisBVaccination?.Occurrence;
+			CqlDateTime w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+			CqlInterval<CqlDate> y_ = CQMCommon_2_0_000.ToDateInterval(x_);
+			CqlDate z_ = context.Operators.Start(y_);
+			CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+			CqlDate ab_ = context.Operators.DateFrom(aa_);
 
 			return ab_;
 		};
-		var g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
-		var h_ = this.Hepatitis_B_Vaccine_Administered();
-		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
-		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
+		CqlValueSet h_ = this.Hepatitis_B_Vaccine_Administered();
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure HepatitisBProcedure)
 		{
-			var ac_ = this.First_Two_Years();
-			var ad_ = HepatitisBProcedure?.Performed;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = QICoreCommon_2_0_000.ToInterval(ae_);
-			var ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			var ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			CqlInterval<CqlDate> ac_ = this.First_Two_Years();
+			DataType ad_ = HepatitisBProcedure?.Performed;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
+			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
 
 			return ah_;
 		};
-		var l_ = context.Operators.Where<Procedure>(j_, k_);
+		IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
 		CqlDate m_(Procedure HepatitisBProcedure)
 		{
-			var ai_ = HepatitisBProcedure?.Performed;
-			var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
-			var al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.ConvertDateToDateTime(am_);
-			var ao_ = context.Operators.DateFrom(an_);
+			DataType ai_ = HepatitisBProcedure?.Performed;
+			object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			CqlInterval<CqlDate> al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
+			CqlDate am_ = context.Operators.Start(al_);
+			CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+			CqlDate ao_ = context.Operators.DateFrom(an_);
 
 			return ao_;
 		};
-		var n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
-		var o_ = context.Operators.Union<CqlDate>(g_, n_);
+		IEnumerable<CqlDate> n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
+		IEnumerable<CqlDate> o_ = context.Operators.Union<CqlDate>(g_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Hepatitis_B_Immunizations_or_Procedures_Value"/>
     [CqlDeclaration("Hepatitis B Immunizations or Procedures")]
 	public IEnumerable<CqlDate> Hepatitis_B_Immunizations_or_Procedures() => 
 		__Hepatitis_B_Immunizations_or_Procedures.Value;
 
+    /// <seealso cref="Three_Hepatitis_B_Vaccinations"/>
 	private IEnumerable<CqlDate> Three_Hepatitis_B_Vaccinations_Value()
 	{
-		var a_ = this.Hepatitis_B_Immunizations_or_Procedures();
-		var d_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate>(a_, a_, a_);
+		IEnumerable<CqlDate> a_ = this.Hepatitis_B_Immunizations_or_Procedures();
+		IEnumerable<ValueTuple<CqlDate, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate>(a_, a_, a_);
 		Tuple_EZTgahAUWGgSdGaDCgQNNIPGW e_(ValueTuple<CqlDate, CqlDate, CqlDate> _valueTuple)
 		{
-			var k_ = new Tuple_EZTgahAUWGgSdGaDCgQNNIPGW
+			Tuple_EZTgahAUWGgSdGaDCgQNNIPGW k_ = new Tuple_EZTgahAUWGgSdGaDCgQNNIPGW
 			{
 				HepatitisBVaccination1 = _valueTuple.Item1,
 				HepatitisBVaccination2 = _valueTuple.Item2,
@@ -1895,88 +2100,92 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate>, Tuple_EZTgahAUWGgSdGaDCgQNNIPGW>(d_, e_);
+		IEnumerable<Tuple_EZTgahAUWGgSdGaDCgQNNIPGW> f_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate>, Tuple_EZTgahAUWGgSdGaDCgQNNIPGW>(d_, e_);
 		bool? g_(Tuple_EZTgahAUWGgSdGaDCgQNNIPGW tuple_eztgahauwggsdgadcgqnnipgw)
 		{
-			var l_ = context.Operators.Quantity(1m, "day");
-			var m_ = context.Operators.Add(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination1, l_);
-			var n_ = context.Operators.SameOrAfter(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination2, m_, "day");
-			var p_ = context.Operators.Add(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination2, l_);
-			var q_ = context.Operators.SameOrAfter(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination3, p_, "day");
-			var r_ = context.Operators.And(n_, q_);
+			CqlQuantity l_ = context.Operators.Quantity(1m, "day");
+			CqlDate m_ = context.Operators.Add(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination1, l_);
+			bool? n_ = context.Operators.SameOrAfter(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination2, m_, "day");
+			CqlDate p_ = context.Operators.Add(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination2, l_);
+			bool? q_ = context.Operators.SameOrAfter(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination3, p_, "day");
+			bool? r_ = context.Operators.And(n_, q_);
 
 			return r_;
 		};
-		var h_ = context.Operators.Where<Tuple_EZTgahAUWGgSdGaDCgQNNIPGW>(f_, g_);
+		IEnumerable<Tuple_EZTgahAUWGgSdGaDCgQNNIPGW> h_ = context.Operators.Where<Tuple_EZTgahAUWGgSdGaDCgQNNIPGW>(f_, g_);
 		CqlDate i_(Tuple_EZTgahAUWGgSdGaDCgQNNIPGW tuple_eztgahauwggsdgadcgqnnipgw) => 
 			tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination1;
-		var j_ = context.Operators.Select<Tuple_EZTgahAUWGgSdGaDCgQNNIPGW, CqlDate>(h_, i_);
+		IEnumerable<CqlDate> j_ = context.Operators.Select<Tuple_EZTgahAUWGgSdGaDCgQNNIPGW, CqlDate>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Three_Hepatitis_B_Vaccinations_Value"/>
     [CqlDeclaration("Three Hepatitis B Vaccinations")]
 	public IEnumerable<CqlDate> Three_Hepatitis_B_Vaccinations() => 
 		__Three_Hepatitis_B_Vaccinations.Value;
 
+    /// <seealso cref="NewBorn_Vaccine_Requirement"/>
 	private IEnumerable<CqlDate> NewBorn_Vaccine_Requirement_Value()
 	{
-		var a_ = this.Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Procedure>(b_, null);
-		var d_ = Status_1_6_000.Completed_Procedure(c_);
+		CqlCode a_ = this.Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, null);
+		IEnumerable<Procedure> d_ = Status_1_6_000.Completed_Procedure(c_);
 		bool? e_(Procedure NewBornVaccine)
 		{
-			var i_ = this.Patient();
-			var j_ = i_?.BirthDateElement;
-			var k_ = j_?.Value;
-			var l_ = context.Operators.ConvertStringToDate(k_);
-			var m_ = context.Operators.ConvertDateToDateTime(l_);
-			var n_ = context.Operators.DateFrom(m_);
-			var p_ = i_?.BirthDateElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.ConvertStringToDate(q_);
-			var s_ = context.Operators.ConvertDateToDateTime(r_);
-			var t_ = context.Operators.DateFrom(s_);
-			var u_ = context.Operators.Quantity(7m, "days");
-			var v_ = context.Operators.Add(t_, u_);
-			var w_ = context.Operators.Interval(n_, v_, true, true);
-			var x_ = NewBornVaccine?.Performed;
-			var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-			var z_ = QICoreCommon_2_0_000.ToInterval(y_);
-			var aa_ = CQMCommon_2_0_000.ToDateInterval(z_);
-			var ab_ = context.Operators.IntervalIncludesInterval<CqlDate>(w_, aa_, "day");
+			Patient i_ = this.Patient();
+			Date j_ = i_?.BirthDateElement;
+			string k_ = j_?.Value;
+			CqlDate l_ = context.Operators.ConvertStringToDate(k_);
+			CqlDateTime m_ = context.Operators.ConvertDateToDateTime(l_);
+			CqlDate n_ = context.Operators.DateFrom(m_);
+			Date p_ = i_?.BirthDateElement;
+			string q_ = p_?.Value;
+			CqlDate r_ = context.Operators.ConvertStringToDate(q_);
+			CqlDateTime s_ = context.Operators.ConvertDateToDateTime(r_);
+			CqlDate t_ = context.Operators.DateFrom(s_);
+			CqlQuantity u_ = context.Operators.Quantity(7m, "days");
+			CqlDate v_ = context.Operators.Add(t_, u_);
+			CqlInterval<CqlDate> w_ = context.Operators.Interval(n_, v_, true, true);
+			DataType x_ = NewBornVaccine?.Performed;
+			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.ToInterval(y_);
+			CqlInterval<CqlDate> aa_ = CQMCommon_2_0_000.ToDateInterval(z_);
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDate>(w_, aa_, "day");
 
 			return ab_;
 		};
-		var f_ = context.Operators.Where<Procedure>(d_, e_);
+		IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);
 		CqlDate g_(Procedure NewBornVaccine)
 		{
-			var ac_ = NewBornVaccine?.Performed;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
-			var af_ = context.Operators.Start(ae_);
-			var ag_ = context.Operators.DateFrom(af_);
+			DataType ac_ = NewBornVaccine?.Performed;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
+			CqlDateTime af_ = context.Operators.Start(ae_);
+			CqlDate ag_ = context.Operators.DateFrom(af_);
 
 			return ag_;
 		};
-		var h_ = context.Operators.Select<Procedure, CqlDate>(f_, g_);
+		IEnumerable<CqlDate> h_ = context.Operators.Select<Procedure, CqlDate>(f_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="NewBorn_Vaccine_Requirement_Value"/>
     [CqlDeclaration("NewBorn Vaccine Requirement")]
 	public IEnumerable<CqlDate> NewBorn_Vaccine_Requirement() => 
 		__NewBorn_Vaccine_Requirement.Value;
 
+    /// <seealso cref="Meets_HepB_Vaccination_Requirement"/>
 	private IEnumerable<CqlDate> Meets_HepB_Vaccination_Requirement_Value()
 	{
-		var a_ = this.Hepatitis_B_Immunizations_or_Procedures();
-		var c_ = this.NewBorn_Vaccine_Requirement();
-		var d_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate>(a_, a_, c_);
+		IEnumerable<CqlDate> a_ = this.Hepatitis_B_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> c_ = this.NewBorn_Vaccine_Requirement();
+		IEnumerable<ValueTuple<CqlDate, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate>(a_, a_, c_);
 		Tuple_HDfaMbZGBWDPFETGQNFbceEeg e_(ValueTuple<CqlDate, CqlDate, CqlDate> _valueTuple)
 		{
-			var k_ = new Tuple_HDfaMbZGBWDPFETGQNFbceEeg
+			Tuple_HDfaMbZGBWDPFETGQNFbceEeg k_ = new Tuple_HDfaMbZGBWDPFETGQNFbceEeg
 			{
 				HepatitisBVaccination1 = _valueTuple.Item1,
 				HepatitisBVaccination2 = _valueTuple.Item2,
@@ -1985,204 +2194,214 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate>, Tuple_HDfaMbZGBWDPFETGQNFbceEeg>(d_, e_);
+		IEnumerable<Tuple_HDfaMbZGBWDPFETGQNFbceEeg> f_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate>, Tuple_HDfaMbZGBWDPFETGQNFbceEeg>(d_, e_);
 		bool? g_(Tuple_HDfaMbZGBWDPFETGQNFbceEeg tuple_hdfambzgbwdpfetgqnfbceeeg)
 		{
-			var l_ = context.Operators.Quantity(1m, "day");
-			var m_ = context.Operators.Add(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination1, l_);
-			var n_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination2, m_, "day");
-			var p_ = context.Operators.Add(tuple_hdfambzgbwdpfetgqnfbceeeg.NewBornVaccine3, l_);
-			var q_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination1, p_, "day");
-			var r_ = context.Operators.And(n_, q_);
-			var t_ = context.Operators.Add(tuple_hdfambzgbwdpfetgqnfbceeeg.NewBornVaccine3, l_);
-			var u_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination2, t_, "day");
-			var v_ = context.Operators.And(r_, u_);
+			CqlQuantity l_ = context.Operators.Quantity(1m, "day");
+			CqlDate m_ = context.Operators.Add(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination1, l_);
+			bool? n_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination2, m_, "day");
+			CqlDate p_ = context.Operators.Add(tuple_hdfambzgbwdpfetgqnfbceeeg.NewBornVaccine3, l_);
+			bool? q_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination1, p_, "day");
+			bool? r_ = context.Operators.And(n_, q_);
+			CqlDate t_ = context.Operators.Add(tuple_hdfambzgbwdpfetgqnfbceeeg.NewBornVaccine3, l_);
+			bool? u_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination2, t_, "day");
+			bool? v_ = context.Operators.And(r_, u_);
 
 			return v_;
 		};
-		var h_ = context.Operators.Where<Tuple_HDfaMbZGBWDPFETGQNFbceEeg>(f_, g_);
+		IEnumerable<Tuple_HDfaMbZGBWDPFETGQNFbceEeg> h_ = context.Operators.Where<Tuple_HDfaMbZGBWDPFETGQNFbceEeg>(f_, g_);
 		CqlDate i_(Tuple_HDfaMbZGBWDPFETGQNFbceEeg tuple_hdfambzgbwdpfetgqnfbceeeg) => 
 			tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination1;
-		var j_ = context.Operators.Select<Tuple_HDfaMbZGBWDPFETGQNFbceEeg, CqlDate>(h_, i_);
+		IEnumerable<CqlDate> j_ = context.Operators.Select<Tuple_HDfaMbZGBWDPFETGQNFbceEeg, CqlDate>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Meets_HepB_Vaccination_Requirement_Value"/>
     [CqlDeclaration("Meets HepB Vaccination Requirement")]
 	public IEnumerable<CqlDate> Meets_HepB_Vaccination_Requirement() => 
 		__Meets_HepB_Vaccination_Requirement.Value;
 
+    /// <seealso cref="Hepatitis_B_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> Hepatitis_B_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
-		var d_ = this.Hepatitis_B();
-		var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
-		var f_ = context.Operators.Union<Condition>(c_, e_);
-		var g_ = Status_1_6_000.Active_Condition(f_);
+		CqlCode a_ = this.Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		CqlValueSet d_ = this.Hepatitis_B();
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(c_, e_);
+		IEnumerable<Condition> g_ = Status_1_6_000.Active_Condition(f_);
 		bool? h_(Condition HepBConditions)
 		{
-			var j_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HepBConditions);
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = this.First_Two_Years();
-			var n_ = context.Operators.In<CqlDate>(l_, m_, "day");
+			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HepBConditions);
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			CqlInterval<CqlDate> m_ = this.First_Two_Years();
+			bool? n_ = context.Operators.In<CqlDate>(l_, m_, "day");
 
 			return n_;
 		};
-		var i_ = context.Operators.Where<Condition>(g_, h_);
+		IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Hepatitis_B_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("Hepatitis B Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> Hepatitis_B_Numerator_Inclusion_Conditions() => 
 		__Hepatitis_B_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="One_Chicken_Pox_Vaccination"/>
 	private IEnumerable<object> One_Chicken_Pox_Vaccination_Value()
 	{
-		var a_ = this.Varicella_Zoster_Vaccine__VZV_();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Varicella_Zoster_Vaccine__VZV_();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization ChickenPoxVaccination)
 		{
-			var l_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
-			var m_ = ChickenPoxVaccination?.Occurrence;
-			var n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = CQMCommon_2_0_000.ToDateInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, null);
+			CqlInterval<CqlDate> l_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			DataType m_ = ChickenPoxVaccination?.Occurrence;
+			CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlInterval<CqlDate> p_ = CQMCommon_2_0_000.ToDateInterval(o_);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, null);
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
-		var f_ = this.Varicella_Zoster_Vaccine__VZV__Administered();
-		var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
-		var h_ = Status_1_6_000.Completed_Procedure(g_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
+		CqlValueSet f_ = this.Varicella_Zoster_Vaccine__VZV__Administered();
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		IEnumerable<Procedure> h_ = Status_1_6_000.Completed_Procedure(g_);
 		bool? i_(Procedure ChickenPoxProcedure)
 		{
-			var r_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
-			var s_ = ChickenPoxProcedure?.Performed;
-			var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-			var u_ = QICoreCommon_2_0_000.ToInterval(t_);
-			var v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			var w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
+			CqlInterval<CqlDate> r_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			DataType s_ = ChickenPoxProcedure?.Performed;
+			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
+			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
 
 			return w_;
 		};
-		var j_ = context.Operators.Where<Procedure>(h_, i_);
-		var k_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
+		IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>(h_, i_);
+		IEnumerable<object> k_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
 
 		return k_;
 	}
 
+    /// <seealso cref="One_Chicken_Pox_Vaccination_Value"/>
     [CqlDeclaration("One Chicken Pox Vaccination")]
 	public IEnumerable<object> One_Chicken_Pox_Vaccination() => 
 		__One_Chicken_Pox_Vaccination.Value;
 
+    /// <seealso cref="Varicella_Zoster_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> Varicella_Zoster_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Varicella_Zoster();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_();
-		var d_ = context.Operators.ToList<CqlCode>(c_);
-		var e_ = context.Operators.RetrieveByCodes<Condition>(d_, null);
-		var f_ = context.Operators.Union<Condition>(b_, e_);
-		var g_ = Status_1_6_000.Active_Condition(f_);
+		CqlValueSet a_ = this.Varicella_Zoster();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlCode c_ = this.Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_();
+		IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, null);
+		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(b_, e_);
+		IEnumerable<Condition> g_ = Status_1_6_000.Active_Condition(f_);
 		bool? h_(Condition VaricellaZoster)
 		{
-			var j_ = QICoreCommon_2_0_000.ToPrevalenceInterval(VaricellaZoster);
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = this.First_Two_Years();
-			var n_ = context.Operators.In<CqlDate>(l_, m_, "day");
+			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToPrevalenceInterval(VaricellaZoster);
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			CqlInterval<CqlDate> m_ = this.First_Two_Years();
+			bool? n_ = context.Operators.In<CqlDate>(l_, m_, "day");
 
 			return n_;
 		};
-		var i_ = context.Operators.Where<Condition>(g_, h_);
+		IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Varicella_Zoster_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("Varicella Zoster Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> Varicella_Zoster_Numerator_Inclusion_Conditions() => 
 		__Varicella_Zoster_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="Pneumococcal_Conjugate_Immunizations_or_Procedures"/>
 	private IEnumerable<CqlDate> Pneumococcal_Conjugate_Immunizations_or_Procedures_Value()
 	{
-		var a_ = this.Pneumococcal_Conjugate_Vaccine();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Pneumococcal_Conjugate_Vaccine();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization PneumococcalVaccination)
 		{
-			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var q_ = PneumococcalVaccination?.Occurrence;
-			var r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
-			var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
-			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			CqlInterval<CqlDate> p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType q_ = PneumococcalVaccination?.Occurrence;
+			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
 
 			return u_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlDate f_(Immunization PneumococcalVaccination)
 		{
-			var v_ = PneumococcalVaccination?.Occurrence;
-			var w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
-			var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
-			var y_ = CQMCommon_2_0_000.ToDateInterval(x_);
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.ConvertDateToDateTime(z_);
-			var ab_ = context.Operators.DateFrom(aa_);
+			DataType v_ = PneumococcalVaccination?.Occurrence;
+			CqlDateTime w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+			CqlInterval<CqlDate> y_ = CQMCommon_2_0_000.ToDateInterval(x_);
+			CqlDate z_ = context.Operators.Start(y_);
+			CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+			CqlDate ab_ = context.Operators.DateFrom(aa_);
 
 			return ab_;
 		};
-		var g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
-		var h_ = this.Pneumococcal_Conjugate_Vaccine_Administered();
-		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
-		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
+		CqlValueSet h_ = this.Pneumococcal_Conjugate_Vaccine_Administered();
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure PneumococcalProcedure)
 		{
-			var ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var ad_ = PneumococcalProcedure?.Performed;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = QICoreCommon_2_0_000.ToInterval(ae_);
-			var ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			var ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			CqlInterval<CqlDate> ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType ad_ = PneumococcalProcedure?.Performed;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
+			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
 
 			return ah_;
 		};
-		var l_ = context.Operators.Where<Procedure>(j_, k_);
+		IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
 		CqlDate m_(Procedure PneumococcalProcedure)
 		{
-			var ai_ = PneumococcalProcedure?.Performed;
-			var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
-			var al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.ConvertDateToDateTime(am_);
-			var ao_ = context.Operators.DateFrom(an_);
+			DataType ai_ = PneumococcalProcedure?.Performed;
+			object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			CqlInterval<CqlDate> al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
+			CqlDate am_ = context.Operators.Start(al_);
+			CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+			CqlDate ao_ = context.Operators.DateFrom(an_);
 
 			return ao_;
 		};
-		var n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
-		var o_ = context.Operators.Union<CqlDate>(g_, n_);
+		IEnumerable<CqlDate> n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
+		IEnumerable<CqlDate> o_ = context.Operators.Union<CqlDate>(g_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Pneumococcal_Conjugate_Immunizations_or_Procedures_Value"/>
     [CqlDeclaration("Pneumococcal Conjugate Immunizations or Procedures")]
 	public IEnumerable<CqlDate> Pneumococcal_Conjugate_Immunizations_or_Procedures() => 
 		__Pneumococcal_Conjugate_Immunizations_or_Procedures.Value;
 
+    /// <seealso cref="Four_Pneumococcal_Conjugate_Vaccinations"/>
 	private IEnumerable<CqlDate> Four_Pneumococcal_Conjugate_Vaccinations_Value()
 	{
-		var a_ = this.Pneumococcal_Conjugate_Immunizations_or_Procedures();
-		var e_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate, CqlDate>(a_, a_, a_, a_);
+		IEnumerable<CqlDate> a_ = this.Pneumococcal_Conjugate_Immunizations_or_Procedures();
+		IEnumerable<ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate>> e_ = context.Operators.CrossJoin<CqlDate, CqlDate, CqlDate, CqlDate>(a_, a_, a_, a_);
 		Tuple_DdPDeOJhPYESfHGCOcBNOiPPP f_(ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_DdPDeOJhPYESfHGCOcBNOiPPP
+			Tuple_DdPDeOJhPYESfHGCOcBNOiPPP l_ = new Tuple_DdPDeOJhPYESfHGCOcBNOiPPP
 			{
 				PneumococcalVaccination1 = _valueTuple.Item1,
 				PneumococcalVaccination2 = _valueTuple.Item2,
@@ -2192,468 +2411,494 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 			return l_;
 		};
-		var g_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate>, Tuple_DdPDeOJhPYESfHGCOcBNOiPPP>(e_, f_);
+		IEnumerable<Tuple_DdPDeOJhPYESfHGCOcBNOiPPP> g_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate, CqlDate, CqlDate>, Tuple_DdPDeOJhPYESfHGCOcBNOiPPP>(e_, f_);
 		bool? h_(Tuple_DdPDeOJhPYESfHGCOcBNOiPPP tuple_ddpdeojhpyesfhgcocbnoippp)
 		{
-			var m_ = context.Operators.Quantity(1m, "day");
-			var n_ = context.Operators.Add(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination1, m_);
-			var o_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination2, n_, "day");
-			var q_ = context.Operators.Add(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination2, m_);
-			var r_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination3, q_, "day");
-			var s_ = context.Operators.And(o_, r_);
-			var u_ = context.Operators.Add(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination3, m_);
-			var v_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination4, u_, "day");
-			var w_ = context.Operators.And(s_, v_);
+			CqlQuantity m_ = context.Operators.Quantity(1m, "day");
+			CqlDate n_ = context.Operators.Add(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination1, m_);
+			bool? o_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination2, n_, "day");
+			CqlDate q_ = context.Operators.Add(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination2, m_);
+			bool? r_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination3, q_, "day");
+			bool? s_ = context.Operators.And(o_, r_);
+			CqlDate u_ = context.Operators.Add(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination3, m_);
+			bool? v_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination4, u_, "day");
+			bool? w_ = context.Operators.And(s_, v_);
 
 			return w_;
 		};
-		var i_ = context.Operators.Where<Tuple_DdPDeOJhPYESfHGCOcBNOiPPP>(g_, h_);
+		IEnumerable<Tuple_DdPDeOJhPYESfHGCOcBNOiPPP> i_ = context.Operators.Where<Tuple_DdPDeOJhPYESfHGCOcBNOiPPP>(g_, h_);
 		CqlDate j_(Tuple_DdPDeOJhPYESfHGCOcBNOiPPP tuple_ddpdeojhpyesfhgcocbnoippp) => 
 			tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination1;
-		var k_ = context.Operators.Select<Tuple_DdPDeOJhPYESfHGCOcBNOiPPP, CqlDate>(i_, j_);
+		IEnumerable<CqlDate> k_ = context.Operators.Select<Tuple_DdPDeOJhPYESfHGCOcBNOiPPP, CqlDate>(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Four_Pneumococcal_Conjugate_Vaccinations_Value"/>
     [CqlDeclaration("Four Pneumococcal Conjugate Vaccinations")]
 	public IEnumerable<CqlDate> Four_Pneumococcal_Conjugate_Vaccinations() => 
 		__Four_Pneumococcal_Conjugate_Vaccinations.Value;
 
+    /// <seealso cref="Pneumococcal_Conjugate_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> Pneumococcal_Conjugate_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
-		var d_ = Status_1_6_000.Active_Condition(c_);
+		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition PneumococcalReaction)
 		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(PneumococcalReaction);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(PneumococcalReaction);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
 
 			return k_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Pneumococcal_Conjugate_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("Pneumococcal Conjugate Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> Pneumococcal_Conjugate_Numerator_Inclusion_Conditions() => 
 		__Pneumococcal_Conjugate_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="One_Hepatitis_A_Vaccinations"/>
 	private IEnumerable<object> One_Hepatitis_A_Vaccinations_Value()
 	{
-		var a_ = this.Hepatitis_A_Vaccine();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Hepatitis_A_Vaccine();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization HepatitisAVaccination)
 		{
-			var l_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
-			var m_ = HepatitisAVaccination?.Occurrence;
-			var n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = CQMCommon_2_0_000.ToDateInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, null);
+			CqlInterval<CqlDate> l_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			DataType m_ = HepatitisAVaccination?.Occurrence;
+			CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlInterval<CqlDate> p_ = CQMCommon_2_0_000.ToDateInterval(o_);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, null);
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
-		var f_ = this.Hepatitis_A_Vaccine_Administered();
-		var g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
-		var h_ = Status_1_6_000.Completed_Procedure(g_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
+		CqlValueSet f_ = this.Hepatitis_A_Vaccine_Administered();
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		IEnumerable<Procedure> h_ = Status_1_6_000.Completed_Procedure(g_);
 		bool? i_(Procedure HepatitisAProcedure)
 		{
-			var r_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
-			var s_ = HepatitisAProcedure?.Performed;
-			var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-			var u_ = QICoreCommon_2_0_000.ToInterval(t_);
-			var v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			var w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
+			CqlInterval<CqlDate> r_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday();
+			DataType s_ = HepatitisAProcedure?.Performed;
+			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
+			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
 
 			return w_;
 		};
-		var j_ = context.Operators.Where<Procedure>(h_, i_);
-		var k_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
+		IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>(h_, i_);
+		IEnumerable<object> k_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
 
 		return k_;
 	}
 
+    /// <seealso cref="One_Hepatitis_A_Vaccinations_Value"/>
     [CqlDeclaration("One Hepatitis A Vaccinations")]
 	public IEnumerable<object> One_Hepatitis_A_Vaccinations() => 
 		__One_Hepatitis_A_Vaccinations.Value;
 
+    /// <seealso cref="Hepatitis_A_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> Hepatitis_A_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Hepatitis_A();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_();
-		var d_ = context.Operators.ToList<CqlCode>(c_);
-		var e_ = context.Operators.RetrieveByCodes<Condition>(d_, null);
-		var f_ = context.Operators.Union<Condition>(b_, e_);
-		var g_ = Status_1_6_000.Active_Condition(f_);
+		CqlValueSet a_ = this.Hepatitis_A();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlCode c_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_();
+		IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, null);
+		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(b_, e_);
+		IEnumerable<Condition> g_ = Status_1_6_000.Active_Condition(f_);
 		bool? h_(Condition HepatitisADiagnosis)
 		{
-			var j_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HepatitisADiagnosis);
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = this.First_Two_Years();
-			var n_ = context.Operators.In<CqlDate>(l_, m_, "day");
+			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HepatitisADiagnosis);
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			CqlInterval<CqlDate> m_ = this.First_Two_Years();
+			bool? n_ = context.Operators.In<CqlDate>(l_, m_, "day");
 
 			return n_;
 		};
-		var i_ = context.Operators.Where<Condition>(g_, h_);
+		IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Hepatitis_A_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("Hepatitis A Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> Hepatitis_A_Numerator_Inclusion_Conditions() => 
 		__Hepatitis_A_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="Rotavirus_2_Dose_Immunizations_or_Procedures"/>
 	private IEnumerable<CqlDate> Rotavirus_2_Dose_Immunizations_or_Procedures_Value()
 	{
-		var a_ = this.rotavirus__live__monovalent_vaccine();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Immunization>(b_, null);
-		var d_ = Status_1_6_000.Completed_Immunization(c_);
+		CqlCode a_ = this.rotavirus__live__monovalent_vaccine();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Immunization> c_ = context.Operators.RetrieveByCodes<Immunization>(b_, null);
+		IEnumerable<Immunization> d_ = Status_1_6_000.Completed_Immunization(c_);
 		bool? e_(Immunization TwoDoseRotavirusVaccine)
 		{
-			var q_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var r_ = TwoDoseRotavirusVaccine?.Occurrence;
-			var s_ = context.Operators.LateBoundProperty<CqlDateTime>(r_, "value");
-			var t_ = QICoreCommon_2_0_000.ToInterval((s_ as object));
-			var u_ = CQMCommon_2_0_000.ToDateInterval(t_);
-			var v_ = context.Operators.IntervalIncludesInterval<CqlDate>(q_, u_, "day");
+			CqlInterval<CqlDate> q_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType r_ = TwoDoseRotavirusVaccine?.Occurrence;
+			CqlDateTime s_ = context.Operators.LateBoundProperty<CqlDateTime>(r_, "value");
+			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.ToInterval((s_ as object));
+			CqlInterval<CqlDate> u_ = CQMCommon_2_0_000.ToDateInterval(t_);
+			bool? v_ = context.Operators.IntervalIncludesInterval<CqlDate>(q_, u_, "day");
 
 			return v_;
 		};
-		var f_ = context.Operators.Where<Immunization>(d_, e_);
+		IEnumerable<Immunization> f_ = context.Operators.Where<Immunization>(d_, e_);
 		CqlDate g_(Immunization TwoDoseRotavirusVaccine)
 		{
-			var w_ = TwoDoseRotavirusVaccine?.Occurrence;
-			var x_ = context.Operators.LateBoundProperty<CqlDateTime>(w_, "value");
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = CQMCommon_2_0_000.ToDateInterval(y_);
-			var aa_ = context.Operators.Start(z_);
-			var ab_ = context.Operators.ConvertDateToDateTime(aa_);
-			var ac_ = context.Operators.DateFrom(ab_);
+			DataType w_ = TwoDoseRotavirusVaccine?.Occurrence;
+			CqlDateTime x_ = context.Operators.LateBoundProperty<CqlDateTime>(w_, "value");
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlInterval<CqlDate> z_ = CQMCommon_2_0_000.ToDateInterval(y_);
+			CqlDate aa_ = context.Operators.Start(z_);
+			CqlDateTime ab_ = context.Operators.ConvertDateToDateTime(aa_);
+			CqlDate ac_ = context.Operators.DateFrom(ab_);
 
 			return ac_;
 		};
-		var h_ = context.Operators.Select<Immunization, CqlDate>(f_, g_);
-		var i_ = this.Rotavirus_Vaccine__2_dose_schedule__Administered();
-		var j_ = context.Operators.RetrieveByValueSet<Procedure>(i_, null);
-		var k_ = Status_1_6_000.Completed_Procedure(j_);
+		IEnumerable<CqlDate> h_ = context.Operators.Select<Immunization, CqlDate>(f_, g_);
+		CqlValueSet i_ = this.Rotavirus_Vaccine__2_dose_schedule__Administered();
+		IEnumerable<Procedure> j_ = context.Operators.RetrieveByValueSet<Procedure>(i_, null);
+		IEnumerable<Procedure> k_ = Status_1_6_000.Completed_Procedure(j_);
 		bool? l_(Procedure TwoDoseRotavirusProcedure)
 		{
-			var ad_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var ae_ = TwoDoseRotavirusProcedure?.Performed;
-			var af_ = FHIRHelpers_4_3_000.ToValue(ae_);
-			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
-			var ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
-			var ai_ = context.Operators.IntervalIncludesInterval<CqlDate>(ad_, ah_, "day");
+			CqlInterval<CqlDate> ad_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType ae_ = TwoDoseRotavirusProcedure?.Performed;
+			object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
+			CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			CqlInterval<CqlDate> ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
+			bool? ai_ = context.Operators.IntervalIncludesInterval<CqlDate>(ad_, ah_, "day");
 
 			return ai_;
 		};
-		var m_ = context.Operators.Where<Procedure>(k_, l_);
+		IEnumerable<Procedure> m_ = context.Operators.Where<Procedure>(k_, l_);
 		CqlDate n_(Procedure TwoDoseRotavirusProcedure)
 		{
-			var aj_ = TwoDoseRotavirusProcedure?.Performed;
-			var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-			var al_ = QICoreCommon_2_0_000.ToInterval(ak_);
-			var am_ = CQMCommon_2_0_000.ToDateInterval(al_);
-			var an_ = context.Operators.Start(am_);
-			var ao_ = context.Operators.ConvertDateToDateTime(an_);
-			var ap_ = context.Operators.DateFrom(ao_);
+			DataType aj_ = TwoDoseRotavirusProcedure?.Performed;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval(ak_);
+			CqlInterval<CqlDate> am_ = CQMCommon_2_0_000.ToDateInterval(al_);
+			CqlDate an_ = context.Operators.Start(am_);
+			CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
+			CqlDate ap_ = context.Operators.DateFrom(ao_);
 
 			return ap_;
 		};
-		var o_ = context.Operators.Select<Procedure, CqlDate>(m_, n_);
-		var p_ = context.Operators.Union<CqlDate>(h_, o_);
+		IEnumerable<CqlDate> o_ = context.Operators.Select<Procedure, CqlDate>(m_, n_);
+		IEnumerable<CqlDate> p_ = context.Operators.Union<CqlDate>(h_, o_);
 
 		return p_;
 	}
 
+    /// <seealso cref="Rotavirus_2_Dose_Immunizations_or_Procedures_Value"/>
     [CqlDeclaration("Rotavirus 2 Dose Immunizations or Procedures")]
 	public IEnumerable<CqlDate> Rotavirus_2_Dose_Immunizations_or_Procedures() => 
 		__Rotavirus_2_Dose_Immunizations_or_Procedures.Value;
 
+    /// <seealso cref="Rotavirus_3_Dose_Immunizations_or_Procedures"/>
 	private IEnumerable<CqlDate> Rotavirus_3_Dose_Immunizations_or_Procedures_Value()
 	{
-		var a_ = this.Rotavirus_Vaccine__3_dose_schedule_();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Rotavirus_Vaccine__3_dose_schedule_();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization ThreeDoseRotavirusVaccine)
 		{
-			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var q_ = ThreeDoseRotavirusVaccine?.Occurrence;
-			var r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
-			var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
-			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			CqlInterval<CqlDate> p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType q_ = ThreeDoseRotavirusVaccine?.Occurrence;
+			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
 
 			return u_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlDate f_(Immunization ThreeDoseRotavirusVaccine)
 		{
-			var v_ = ThreeDoseRotavirusVaccine?.Occurrence;
-			var w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
-			var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
-			var y_ = CQMCommon_2_0_000.ToDateInterval(x_);
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.ConvertDateToDateTime(z_);
-			var ab_ = context.Operators.DateFrom(aa_);
+			DataType v_ = ThreeDoseRotavirusVaccine?.Occurrence;
+			CqlDateTime w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+			CqlInterval<CqlDate> y_ = CQMCommon_2_0_000.ToDateInterval(x_);
+			CqlDate z_ = context.Operators.Start(y_);
+			CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+			CqlDate ab_ = context.Operators.DateFrom(aa_);
 
 			return ab_;
 		};
-		var g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
-		var h_ = this.Rotavirus_Vaccine__3_dose_schedule__Administered();
-		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
-		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
+		CqlValueSet h_ = this.Rotavirus_Vaccine__3_dose_schedule__Administered();
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure ThreeDoseRotavirusAdministered)
 		{
-			var ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var ad_ = ThreeDoseRotavirusAdministered?.Performed;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = QICoreCommon_2_0_000.ToInterval(ae_);
-			var ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			var ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			CqlInterval<CqlDate> ac_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType ad_ = ThreeDoseRotavirusAdministered?.Performed;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
+			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
 
 			return ah_;
 		};
-		var l_ = context.Operators.Where<Procedure>(j_, k_);
+		IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
 		CqlDate m_(Procedure ThreeDoseRotavirusAdministered)
 		{
-			var ai_ = ThreeDoseRotavirusAdministered?.Performed;
-			var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
-			var al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.ConvertDateToDateTime(am_);
-			var ao_ = context.Operators.DateFrom(an_);
+			DataType ai_ = ThreeDoseRotavirusAdministered?.Performed;
+			object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval(aj_);
+			CqlInterval<CqlDate> al_ = CQMCommon_2_0_000.ToDateInterval(ak_);
+			CqlDate am_ = context.Operators.Start(al_);
+			CqlDateTime an_ = context.Operators.ConvertDateToDateTime(am_);
+			CqlDate ao_ = context.Operators.DateFrom(an_);
 
 			return ao_;
 		};
-		var n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
-		var o_ = context.Operators.Union<CqlDate>(g_, n_);
+		IEnumerable<CqlDate> n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
+		IEnumerable<CqlDate> o_ = context.Operators.Union<CqlDate>(g_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Rotavirus_3_Dose_Immunizations_or_Procedures_Value"/>
     [CqlDeclaration("Rotavirus 3 Dose Immunizations or Procedures")]
 	public IEnumerable<CqlDate> Rotavirus_3_Dose_Immunizations_or_Procedures() => 
 		__Rotavirus_3_Dose_Immunizations_or_Procedures.Value;
 
+    /// <seealso cref="Rotavirus_2_or_3_Dose_Immunizations"/>
 	private IEnumerable<CqlDate> Rotavirus_2_or_3_Dose_Immunizations_Value()
 	{
-		var a_ = this.Rotavirus_2_Dose_Immunizations_or_Procedures();
-		var b_ = this.Rotavirus_3_Dose_Immunizations_or_Procedures();
-		var c_ = context.Operators.Union<CqlDate>(a_, b_);
+		IEnumerable<CqlDate> a_ = this.Rotavirus_2_Dose_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> b_ = this.Rotavirus_3_Dose_Immunizations_or_Procedures();
+		IEnumerable<CqlDate> c_ = context.Operators.Union<CqlDate>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Rotavirus_2_or_3_Dose_Immunizations_Value"/>
     [CqlDeclaration("Rotavirus 2 or 3 Dose Immunizations")]
 	public IEnumerable<CqlDate> Rotavirus_2_or_3_Dose_Immunizations() => 
 		__Rotavirus_2_or_3_Dose_Immunizations.Value;
 
+    /// <seealso cref="All_Rotavirus_Vaccinations"/>
 	private IEnumerable<CqlDate> All_Rotavirus_Vaccinations_Value()
 	{
-		var a_ = this.Rotavirus_2_or_3_Dose_Immunizations();
+		IEnumerable<CqlDate> a_ = this.Rotavirus_2_or_3_Dose_Immunizations();
 		IEnumerable<CqlDate> c_(CqlDate AllRotavirusDoses1)
 		{
-			var f_ = this.Rotavirus_2_or_3_Dose_Immunizations();
+			IEnumerable<CqlDate> f_ = this.Rotavirus_2_or_3_Dose_Immunizations();
 			bool? g_(CqlDate AllRotavirusDoses2)
 			{
-				var k_ = context.Operators.Quantity(1m, "day");
-				var l_ = context.Operators.Subtract(AllRotavirusDoses2, k_);
-				var m_ = context.Operators.Interval(l_, AllRotavirusDoses2, false, false);
-				var n_ = context.Operators.In<CqlDate>(AllRotavirusDoses1, m_, null);
+				CqlQuantity k_ = context.Operators.Quantity(1m, "day");
+				CqlDate l_ = context.Operators.Subtract(AllRotavirusDoses2, k_);
+				CqlInterval<CqlDate> m_ = context.Operators.Interval(l_, AllRotavirusDoses2, false, false);
+				bool? n_ = context.Operators.In<CqlDate>(AllRotavirusDoses1, m_, null);
 
 				return n_;
 			};
-			var h_ = context.Operators.Where<CqlDate>(f_, g_);
+			IEnumerable<CqlDate> h_ = context.Operators.Where<CqlDate>(f_, g_);
 			CqlDate i_(CqlDate AllRotavirusDoses2) => 
 				AllRotavirusDoses1;
-			var j_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
+			IEnumerable<CqlDate> j_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
 
 			return j_;
 		};
-		var d_ = context.Operators.SelectMany<CqlDate, CqlDate>(a_, c_);
-		var e_ = context.Operators.Except<CqlDate>(a_, d_);
+		IEnumerable<CqlDate> d_ = context.Operators.SelectMany<CqlDate, CqlDate>(a_, c_);
+		IEnumerable<CqlDate> e_ = context.Operators.Except<CqlDate>(a_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="All_Rotavirus_Vaccinations_Value"/>
     [CqlDeclaration("All Rotavirus Vaccinations")]
 	public IEnumerable<CqlDate> All_Rotavirus_Vaccinations() => 
 		__All_Rotavirus_Vaccinations.Value;
 
+    /// <seealso cref="Has_Appropriate_Number_of_Rotavirus_Immunizations"/>
 	private bool? Has_Appropriate_Number_of_Rotavirus_Immunizations_Value()
 	{
-		var a_ = this.All_Rotavirus_Vaccinations();
+		IEnumerable<CqlDate> a_ = this.All_Rotavirus_Vaccinations();
 		bool? b_(CqlDate RotavirusImmunization)
 		{
-			var e_ = this.Rotavirus_3_Dose_Immunizations_or_Procedures();
-			var f_ = context.Operators.Count<CqlDate>(e_);
-			var g_ = context.Operators.Greater(f_, 0);
-			var h_ = this.All_Rotavirus_Vaccinations();
+			IEnumerable<CqlDate> e_ = this.Rotavirus_3_Dose_Immunizations_or_Procedures();
+			int? f_ = context.Operators.Count<CqlDate>(e_);
+			bool? g_ = context.Operators.Greater(f_, 0);
+			IEnumerable<CqlDate> h_ = this.All_Rotavirus_Vaccinations();
 			CqlDate i_(CqlDate RotavirusVaccinations) => 
 				RotavirusVaccinations;
-			var j_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
-			var k_ = context.Operators.Distinct<CqlDate>(j_);
-			var l_ = context.Operators.Count<CqlDate>(k_);
-			var m_ = context.Operators.GreaterOrEqual(l_, 3);
-			var n_ = context.Operators.And(g_, m_);
-			var p_ = context.Operators.Count<CqlDate>(e_);
-			var q_ = context.Operators.Greater(p_, 0);
-			var r_ = context.Operators.IsFalse(q_);
-			var u_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
-			var v_ = context.Operators.Distinct<CqlDate>(u_);
-			var w_ = context.Operators.Count<CqlDate>(v_);
-			var x_ = context.Operators.GreaterOrEqual(w_, 2);
-			var y_ = context.Operators.And(r_, x_);
-			var z_ = context.Operators.Or(n_, y_);
+			IEnumerable<CqlDate> j_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
+			IEnumerable<CqlDate> k_ = context.Operators.Distinct<CqlDate>(j_);
+			int? l_ = context.Operators.Count<CqlDate>(k_);
+			bool? m_ = context.Operators.GreaterOrEqual(l_, 3);
+			bool? n_ = context.Operators.And(g_, m_);
+			int? p_ = context.Operators.Count<CqlDate>(e_);
+			bool? q_ = context.Operators.Greater(p_, 0);
+			bool? r_ = context.Operators.IsFalse(q_);
+			IEnumerable<CqlDate> u_ = context.Operators.Select<CqlDate, CqlDate>(h_, i_);
+			IEnumerable<CqlDate> v_ = context.Operators.Distinct<CqlDate>(u_);
+			int? w_ = context.Operators.Count<CqlDate>(v_);
+			bool? x_ = context.Operators.GreaterOrEqual(w_, 2);
+			bool? y_ = context.Operators.And(r_, x_);
+			bool? z_ = context.Operators.Or(n_, y_);
 
 			return z_;
 		};
-		var c_ = context.Operators.Where<CqlDate>(a_, b_);
-		var d_ = context.Operators.Exists<CqlDate>(c_);
+		IEnumerable<CqlDate> c_ = context.Operators.Where<CqlDate>(a_, b_);
+		bool? d_ = context.Operators.Exists<CqlDate>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Has_Appropriate_Number_of_Rotavirus_Immunizations_Value"/>
     [CqlDeclaration("Has Appropriate Number of Rotavirus Immunizations")]
 	public bool? Has_Appropriate_Number_of_Rotavirus_Immunizations() => 
 		__Has_Appropriate_Number_of_Rotavirus_Immunizations.Value;
 
+    /// <seealso cref="Rotavirus_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> Rotavirus_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Anaphylaxis_due_to_rotavirus_vaccine__disorder_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
-		var d_ = Status_1_6_000.Active_Condition(c_);
+		CqlCode a_ = this.Anaphylaxis_due_to_rotavirus_vaccine__disorder_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition RotavirusConditions)
 		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(RotavirusConditions);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(RotavirusConditions);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
 
 			return k_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Rotavirus_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("Rotavirus Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> Rotavirus_Numerator_Inclusion_Conditions() => 
 		__Rotavirus_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old"/>
 	private CqlInterval<CqlDate> Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.ConvertStringToDate(a_?.BirthDateElement?.Value);
-		var c_ = context.Operators.ConvertDateToDateTime(b_);
-		var d_ = context.Operators.DateFrom(c_);
-		var e_ = context.Operators.Quantity(180m, "days");
-		var f_ = context.Operators.Add(d_, e_);
-		var g_ = this.Date_of_Second_Birthday();
-		var h_ = context.Operators.Interval(f_, g_, true, true);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+		CqlDateTime e_ = context.Operators.ConvertDateToDateTime(d_);
+		CqlDate f_ = context.Operators.DateFrom(e_);
+		CqlQuantity g_ = context.Operators.Quantity(180m, "days");
+		CqlDate h_ = context.Operators.Add(f_, g_);
+		CqlDate i_ = this.Date_of_Second_Birthday();
+		CqlInterval<CqlDate> j_ = context.Operators.Interval(h_, i_, true, true);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old_Value"/>
     [CqlDeclaration("Vaccine Administration Interval - 180 Days up to 2 Years Old")]
 	public CqlInterval<CqlDate> Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old() => 
 		__Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old.Value;
 
+    /// <seealso cref="Influenza_Immunizations_or_Procedures"/>
 	private IEnumerable<CqlDate> Influenza_Immunizations_or_Procedures_Value()
 	{
-		var a_ = this.Child_Influenza_Immunization_Administered();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Child_Influenza_Immunization_Administered();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization InfluenzaVaccine)
 		{
-			var p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
-			var q_ = InfluenzaVaccine?.Occurrence;
-			var r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
-			var s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
-			var t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			var u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			CqlInterval<CqlDate> p_ = this.Vaccine_Administration_Interval___42_Days_up_to_2_Years_Old();
+			DataType q_ = InfluenzaVaccine?.Occurrence;
+			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
+			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
 
 			return u_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlDate f_(Immunization InfluenzaVaccine)
 		{
-			var v_ = InfluenzaVaccine?.Occurrence;
-			var w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
-			var x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
-			var y_ = CQMCommon_2_0_000.ToDateInterval(x_);
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.ConvertDateToDateTime(z_);
-			var ab_ = context.Operators.DateFrom(aa_);
+			DataType v_ = InfluenzaVaccine?.Occurrence;
+			CqlDateTime w_ = context.Operators.LateBoundProperty<CqlDateTime>(v_, "value");
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval((w_ as object));
+			CqlInterval<CqlDate> y_ = CQMCommon_2_0_000.ToDateInterval(x_);
+			CqlDate z_ = context.Operators.Start(y_);
+			CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+			CqlDate ab_ = context.Operators.DateFrom(aa_);
 
 			return ab_;
 		};
-		var g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
-		var h_ = this.Child_Influenza_Vaccine_Administered();
-		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
-		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
+		CqlValueSet h_ = this.Child_Influenza_Vaccine_Administered();
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure InfluenzaAdministration)
 		{
-			var ac_ = this.Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old();
-			var ad_ = ac_?.low;
-			var ae_ = context.Operators.ConvertDateToDateTime(ad_);
-			var ag_ = ac_?.high;
-			var ah_ = context.Operators.ConvertDateToDateTime(ag_);
-			var aj_ = ac_?.lowClosed;
-			var al_ = ac_?.highClosed;
-			var am_ = context.Operators.Interval(ae_, ah_, aj_, al_);
-			var an_ = InfluenzaAdministration?.Performed;
-			var ao_ = FHIRHelpers_4_3_000.ToValue(an_);
-			var ap_ = QICoreCommon_2_0_000.ToInterval(ao_);
-			var aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(am_, ap_, "day");
+			CqlInterval<CqlDate> ac_ = this.Vaccine_Administration_Interval___180_Days_up_to_2_Years_Old();
+			CqlDate ad_ = ac_?.low;
+			CqlDateTime ae_ = context.Operators.ConvertDateToDateTime(ad_);
+			CqlDate ag_ = ac_?.high;
+			CqlDateTime ah_ = context.Operators.ConvertDateToDateTime(ag_);
+			bool? aj_ = ac_?.lowClosed;
+			bool? al_ = ac_?.highClosed;
+			CqlInterval<CqlDateTime> am_ = context.Operators.Interval(ae_, ah_, aj_, al_);
+			DataType an_ = InfluenzaAdministration?.Performed;
+			object ao_ = FHIRHelpers_4_3_000.ToValue(an_);
+			CqlInterval<CqlDateTime> ap_ = QICoreCommon_2_0_000.ToInterval(ao_);
+			bool? aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(am_, ap_, "day");
 
 			return aq_;
 		};
-		var l_ = context.Operators.Where<Procedure>(j_, k_);
+		IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
 		CqlDate m_(Procedure InfluenzaAdministration)
 		{
-			var ar_ = InfluenzaAdministration?.Performed;
-			var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
-			var at_ = QICoreCommon_2_0_000.ToInterval(as_);
-			var au_ = CQMCommon_2_0_000.ToDateInterval(at_);
-			var av_ = context.Operators.Start(au_);
-			var aw_ = context.Operators.ConvertDateToDateTime(av_);
-			var ax_ = context.Operators.DateFrom(aw_);
+			DataType ar_ = InfluenzaAdministration?.Performed;
+			object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+			CqlInterval<CqlDateTime> at_ = QICoreCommon_2_0_000.ToInterval(as_);
+			CqlInterval<CqlDate> au_ = CQMCommon_2_0_000.ToDateInterval(at_);
+			CqlDate av_ = context.Operators.Start(au_);
+			CqlDateTime aw_ = context.Operators.ConvertDateToDateTime(av_);
+			CqlDate ax_ = context.Operators.DateFrom(aw_);
 
 			return ax_;
 		};
-		var n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
-		var o_ = context.Operators.Union<CqlDate>(g_, n_);
+		IEnumerable<CqlDate> n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
+		IEnumerable<CqlDate> o_ = context.Operators.Union<CqlDate>(g_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Influenza_Immunizations_or_Procedures_Value"/>
     [CqlDeclaration("Influenza Immunizations or Procedures")]
 	public IEnumerable<CqlDate> Influenza_Immunizations_or_Procedures() => 
 		__Influenza_Immunizations_or_Procedures.Value;
 
+    /// <seealso cref="Two_Influenza_Vaccinations"/>
 	private IEnumerable<CqlDate> Two_Influenza_Vaccinations_Value()
 	{
-		var a_ = this.Influenza_Immunizations_or_Procedures();
-		var c_ = context.Operators.CrossJoin<CqlDate, CqlDate>(a_, a_);
+		IEnumerable<CqlDate> a_ = this.Influenza_Immunizations_or_Procedures();
+		IEnumerable<ValueTuple<CqlDate, CqlDate>> c_ = context.Operators.CrossJoin<CqlDate, CqlDate>(a_, a_);
 		Tuple_BZhFLeRDagbPQMNheVJcUNfNQ d_(ValueTuple<CqlDate, CqlDate> _valueTuple)
 		{
-			var j_ = new Tuple_BZhFLeRDagbPQMNheVJcUNfNQ
+			Tuple_BZhFLeRDagbPQMNheVJcUNfNQ j_ = new Tuple_BZhFLeRDagbPQMNheVJcUNfNQ
 			{
 				FluVaccination1 = _valueTuple.Item1,
 				FluVaccination2 = _valueTuple.Item2,
@@ -2661,257 +2906,274 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 			return j_;
 		};
-		var e_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate>, Tuple_BZhFLeRDagbPQMNheVJcUNfNQ>(c_, d_);
+		IEnumerable<Tuple_BZhFLeRDagbPQMNheVJcUNfNQ> e_ = context.Operators.Select<ValueTuple<CqlDate, CqlDate>, Tuple_BZhFLeRDagbPQMNheVJcUNfNQ>(c_, d_);
 		bool? f_(Tuple_BZhFLeRDagbPQMNheVJcUNfNQ tuple_bzhflerdagbpqmnhevjcunfnq)
 		{
-			var k_ = context.Operators.Quantity(1m, "day");
-			var l_ = context.Operators.Add(tuple_bzhflerdagbpqmnhevjcunfnq.FluVaccination1, k_);
-			var m_ = context.Operators.SameOrAfter(tuple_bzhflerdagbpqmnhevjcunfnq.FluVaccination2, l_, "day");
+			CqlQuantity k_ = context.Operators.Quantity(1m, "day");
+			CqlDate l_ = context.Operators.Add(tuple_bzhflerdagbpqmnhevjcunfnq.FluVaccination1, k_);
+			bool? m_ = context.Operators.SameOrAfter(tuple_bzhflerdagbpqmnhevjcunfnq.FluVaccination2, l_, "day");
 
 			return m_;
 		};
-		var g_ = context.Operators.Where<Tuple_BZhFLeRDagbPQMNheVJcUNfNQ>(e_, f_);
+		IEnumerable<Tuple_BZhFLeRDagbPQMNheVJcUNfNQ> g_ = context.Operators.Where<Tuple_BZhFLeRDagbPQMNheVJcUNfNQ>(e_, f_);
 		CqlDate h_(Tuple_BZhFLeRDagbPQMNheVJcUNfNQ tuple_bzhflerdagbpqmnhevjcunfnq) => 
 			tuple_bzhflerdagbpqmnhevjcunfnq.FluVaccination1;
-		var i_ = context.Operators.Select<Tuple_BZhFLeRDagbPQMNheVJcUNfNQ, CqlDate>(g_, h_);
+		IEnumerable<CqlDate> i_ = context.Operators.Select<Tuple_BZhFLeRDagbPQMNheVJcUNfNQ, CqlDate>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Two_Influenza_Vaccinations_Value"/>
     [CqlDeclaration("Two Influenza Vaccinations")]
 	public IEnumerable<CqlDate> Two_Influenza_Vaccinations() => 
 		__Two_Influenza_Vaccinations.Value;
 
+    /// <seealso cref="LAIV_Vaccinations"/>
 	private IEnumerable<CqlDate> LAIV_Vaccinations_Value()
 	{
-		var a_ = this.Influenza_Virus_LAIV_Immunization();
-		var b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
-		var c_ = Status_1_6_000.Completed_Immunization(b_);
+		CqlValueSet a_ = this.Influenza_Virus_LAIV_Immunization();
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization LAIVVaccine)
 		{
-			var p_ = this.Date_of_Second_Birthday();
-			var r_ = context.Operators.Interval(p_, p_, true, true);
-			var s_ = LAIVVaccine?.Occurrence;
-			var t_ = context.Operators.LateBoundProperty<CqlDateTime>(s_, "value");
-			var u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
-			var v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			var w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, "day");
+			CqlDate p_ = this.Date_of_Second_Birthday();
+			CqlInterval<CqlDate> r_ = context.Operators.Interval(p_, p_, true, true);
+			DataType s_ = LAIVVaccine?.Occurrence;
+			CqlDateTime t_ = context.Operators.LateBoundProperty<CqlDateTime>(s_, "value");
+			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
+			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, "day");
 
 			return w_;
 		};
-		var e_ = context.Operators.Where<Immunization>(c_, d_);
+		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlDate f_(Immunization LAIVVaccine)
 		{
-			var x_ = LAIVVaccine?.Occurrence;
-			var y_ = context.Operators.LateBoundProperty<CqlDateTime>(x_, "value");
-			var z_ = QICoreCommon_2_0_000.ToInterval((y_ as object));
-			var aa_ = CQMCommon_2_0_000.ToDateInterval(z_);
-			var ab_ = context.Operators.Start(aa_);
-			var ac_ = context.Operators.ConvertDateToDateTime(ab_);
-			var ad_ = context.Operators.DateFrom(ac_);
+			DataType x_ = LAIVVaccine?.Occurrence;
+			CqlDateTime y_ = context.Operators.LateBoundProperty<CqlDateTime>(x_, "value");
+			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.ToInterval((y_ as object));
+			CqlInterval<CqlDate> aa_ = CQMCommon_2_0_000.ToDateInterval(z_);
+			CqlDate ab_ = context.Operators.Start(aa_);
+			CqlDateTime ac_ = context.Operators.ConvertDateToDateTime(ab_);
+			CqlDate ad_ = context.Operators.DateFrom(ac_);
 
 			return ad_;
 		};
-		var g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
-		var h_ = this.Influenza_Virus_LAIV_Procedure();
-		var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
-		var j_ = Status_1_6_000.Completed_Procedure(i_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
+		CqlValueSet h_ = this.Influenza_Virus_LAIV_Procedure();
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure InfluenzaAdministration)
 		{
-			var ae_ = this.Date_of_Second_Birthday();
-			var ag_ = context.Operators.Interval(ae_, ae_, true, true);
-			var ah_ = InfluenzaAdministration?.Performed;
-			var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-			var aj_ = QICoreCommon_2_0_000.ToInterval(ai_);
-			var ak_ = CQMCommon_2_0_000.ToDateInterval(aj_);
-			var al_ = context.Operators.IntervalIncludesInterval<CqlDate>(ag_, ak_, "day");
+			CqlDate ae_ = this.Date_of_Second_Birthday();
+			CqlInterval<CqlDate> ag_ = context.Operators.Interval(ae_, ae_, true, true);
+			DataType ah_ = InfluenzaAdministration?.Performed;
+			object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.ToInterval(ai_);
+			CqlInterval<CqlDate> ak_ = CQMCommon_2_0_000.ToDateInterval(aj_);
+			bool? al_ = context.Operators.IntervalIncludesInterval<CqlDate>(ag_, ak_, "day");
 
 			return al_;
 		};
-		var l_ = context.Operators.Where<Procedure>(j_, k_);
+		IEnumerable<Procedure> l_ = context.Operators.Where<Procedure>(j_, k_);
 		CqlDate m_(Procedure InfluenzaAdministration)
 		{
-			var am_ = InfluenzaAdministration?.Performed;
-			var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-			var ao_ = QICoreCommon_2_0_000.ToInterval(an_);
-			var ap_ = CQMCommon_2_0_000.ToDateInterval(ao_);
-			var aq_ = context.Operators.Start(ap_);
-			var ar_ = context.Operators.ConvertDateToDateTime(aq_);
-			var as_ = context.Operators.DateFrom(ar_);
+			DataType am_ = InfluenzaAdministration?.Performed;
+			object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+			CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_0_000.ToInterval(an_);
+			CqlInterval<CqlDate> ap_ = CQMCommon_2_0_000.ToDateInterval(ao_);
+			CqlDate aq_ = context.Operators.Start(ap_);
+			CqlDateTime ar_ = context.Operators.ConvertDateToDateTime(aq_);
+			CqlDate as_ = context.Operators.DateFrom(ar_);
 
 			return as_;
 		};
-		var n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
-		var o_ = context.Operators.Union<CqlDate>(g_, n_);
+		IEnumerable<CqlDate> n_ = context.Operators.Select<Procedure, CqlDate>(l_, m_);
+		IEnumerable<CqlDate> o_ = context.Operators.Union<CqlDate>(g_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="LAIV_Vaccinations_Value"/>
     [CqlDeclaration("LAIV Vaccinations")]
 	public IEnumerable<CqlDate> LAIV_Vaccinations() => 
 		__LAIV_Vaccinations.Value;
 
+    /// <seealso cref="Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination"/>
 	private bool? Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination_Value()
 	{
-		var a_ = this.LAIV_Vaccinations();
-		var b_ = context.Operators.Exists<CqlDate>(a_);
-		var c_ = this.Influenza_Immunizations_or_Procedures();
-		var d_ = context.Operators.Exists<CqlDate>(c_);
-		var e_ = context.Operators.And(b_, d_);
+		IEnumerable<CqlDate> a_ = this.LAIV_Vaccinations();
+		bool? b_ = context.Operators.Exists<CqlDate>(a_);
+		IEnumerable<CqlDate> c_ = this.Influenza_Immunizations_or_Procedures();
+		bool? d_ = context.Operators.Exists<CqlDate>(c_);
+		bool? e_ = context.Operators.And(b_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination_Value"/>
     [CqlDeclaration("Two Influenza Vaccinations Including One LAIV Vaccination")]
 	public bool? Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination() => 
 		__Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination.Value;
 
+    /// <seealso cref="Influenza_Numerator_Inclusion_Conditions"/>
 	private IEnumerable<Condition> Influenza_Numerator_Inclusion_Conditions_Value()
 	{
-		var a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
-		var d_ = Status_1_6_000.Active_Condition(c_);
+		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition InfluenzaConditions)
 		{
-			var g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(InfluenzaConditions);
-			var h_ = context.Operators.Start(g_);
-			var i_ = context.Operators.DateFrom(h_);
-			var j_ = this.First_Two_Years();
-			var k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.ToPrevalenceInterval(InfluenzaConditions);
+			CqlDateTime h_ = context.Operators.Start(g_);
+			CqlDate i_ = context.Operators.DateFrom(h_);
+			CqlInterval<CqlDate> j_ = this.First_Two_Years();
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
 
 			return k_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Influenza_Numerator_Inclusion_Conditions_Value"/>
     [CqlDeclaration("Influenza Numerator Inclusion Conditions")]
 	public IEnumerable<Condition> Influenza_Numerator_Inclusion_Conditions() => 
 		__Influenza_Numerator_Inclusion_Conditions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Four_DTaP_Vaccinations();
-		var b_ = context.Operators.Exists<CqlDate>(a_);
-		var c_ = this.DTaP_Numerator_Inclusion_Conditions();
-		var d_ = context.Operators.Exists<Condition>(c_);
-		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Three_Polio_Vaccinations();
-		var g_ = context.Operators.Exists<CqlDate>(f_);
-		var h_ = this.Polio_Numerator_Inclusion_Conditions();
-		var i_ = context.Operators.Exists<Condition>(h_);
-		var j_ = context.Operators.Or(g_, i_);
-		var k_ = context.Operators.And(e_, j_);
-		var l_ = this.One_MMR_Vaccination();
-		var m_ = context.Operators.Exists<object>(l_);
-		var n_ = this.MMR_Numerator_Inclusion_Conditions();
-		var o_ = context.Operators.Exists<Condition>(n_);
-		var p_ = context.Operators.Or(m_, o_);
-		var q_ = this.Measles_Indicators();
-		var r_ = context.Operators.Exists<Condition>(q_);
-		var s_ = this.Mumps_Indicators();
-		var t_ = context.Operators.Exists<Condition>(s_);
-		var u_ = context.Operators.And(r_, t_);
-		var v_ = this.Rubella_Indicators();
-		var w_ = context.Operators.Exists<Condition>(v_);
-		var x_ = context.Operators.And(u_, w_);
-		var y_ = context.Operators.Or(p_, x_);
-		var z_ = context.Operators.And(k_, y_);
-		var aa_ = this.Has_Appropriate_Number_of_Hib_Immunizations();
-		var ab_ = this.Hib_Numerator_Inclusion_Conditions();
-		var ac_ = context.Operators.Exists<Condition>(ab_);
-		var ad_ = context.Operators.Or(aa_, ac_);
-		var ae_ = context.Operators.And(z_, ad_);
-		var af_ = this.Three_Hepatitis_B_Vaccinations();
-		var ag_ = context.Operators.Exists<CqlDate>(af_);
-		var ah_ = this.Meets_HepB_Vaccination_Requirement();
-		var ai_ = context.Operators.Exists<CqlDate>(ah_);
-		var aj_ = this.Hepatitis_B_Numerator_Inclusion_Conditions();
-		var ak_ = context.Operators.Exists<Condition>(aj_);
-		var al_ = context.Operators.Or(ai_, ak_);
-		var am_ = context.Operators.Or(ag_, al_);
-		var an_ = context.Operators.And(ae_, am_);
-		var ao_ = this.One_Chicken_Pox_Vaccination();
-		var ap_ = context.Operators.Exists<object>(ao_);
-		var aq_ = this.Varicella_Zoster_Numerator_Inclusion_Conditions();
-		var ar_ = context.Operators.Exists<Condition>(aq_);
-		var as_ = context.Operators.Or(ap_, ar_);
-		var at_ = context.Operators.And(an_, as_);
-		var au_ = this.Four_Pneumococcal_Conjugate_Vaccinations();
-		var av_ = context.Operators.Exists<CqlDate>(au_);
-		var aw_ = this.Pneumococcal_Conjugate_Numerator_Inclusion_Conditions();
-		var ax_ = context.Operators.Exists<Condition>(aw_);
-		var ay_ = context.Operators.Or(av_, ax_);
-		var az_ = context.Operators.And(at_, ay_);
-		var ba_ = this.One_Hepatitis_A_Vaccinations();
-		var bb_ = context.Operators.Exists<object>(ba_);
-		var bc_ = this.Hepatitis_A_Numerator_Inclusion_Conditions();
-		var bd_ = context.Operators.Exists<Condition>(bc_);
-		var be_ = context.Operators.Or(bb_, bd_);
-		var bf_ = context.Operators.And(az_, be_);
-		var bg_ = this.Has_Appropriate_Number_of_Rotavirus_Immunizations();
-		var bh_ = this.Rotavirus_Numerator_Inclusion_Conditions();
-		var bi_ = context.Operators.Exists<Condition>(bh_);
-		var bj_ = context.Operators.Or(bg_, bi_);
-		var bk_ = context.Operators.And(bf_, bj_);
-		var bl_ = this.Two_Influenza_Vaccinations();
-		var bm_ = context.Operators.Exists<CqlDate>(bl_);
-		var bn_ = this.Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination();
-		var bo_ = context.Operators.Or(bm_, bn_);
-		var bp_ = this.Influenza_Numerator_Inclusion_Conditions();
-		var bq_ = context.Operators.Exists<Condition>(bp_);
-		var br_ = context.Operators.Or(bo_, bq_);
-		var bs_ = context.Operators.And(bk_, br_);
+		IEnumerable<CqlDate> a_ = this.Four_DTaP_Vaccinations();
+		bool? b_ = context.Operators.Exists<CqlDate>(a_);
+		IEnumerable<Condition> c_ = this.DTaP_Numerator_Inclusion_Conditions();
+		bool? d_ = context.Operators.Exists<Condition>(c_);
+		bool? e_ = context.Operators.Or(b_, d_);
+		IEnumerable<CqlDate> f_ = this.Three_Polio_Vaccinations();
+		bool? g_ = context.Operators.Exists<CqlDate>(f_);
+		IEnumerable<Condition> h_ = this.Polio_Numerator_Inclusion_Conditions();
+		bool? i_ = context.Operators.Exists<Condition>(h_);
+		bool? j_ = context.Operators.Or(g_, i_);
+		bool? k_ = context.Operators.And(e_, j_);
+		IEnumerable<object> l_ = this.One_MMR_Vaccination();
+		bool? m_ = context.Operators.Exists<object>(l_);
+		IEnumerable<Condition> n_ = this.MMR_Numerator_Inclusion_Conditions();
+		bool? o_ = context.Operators.Exists<Condition>(n_);
+		bool? p_ = context.Operators.Or(m_, o_);
+		IEnumerable<Condition> q_ = this.Measles_Indicators();
+		bool? r_ = context.Operators.Exists<Condition>(q_);
+		IEnumerable<Condition> s_ = this.Mumps_Indicators();
+		bool? t_ = context.Operators.Exists<Condition>(s_);
+		bool? u_ = context.Operators.And(r_, t_);
+		IEnumerable<Condition> v_ = this.Rubella_Indicators();
+		bool? w_ = context.Operators.Exists<Condition>(v_);
+		bool? x_ = context.Operators.And(u_, w_);
+		bool? y_ = context.Operators.Or(p_, x_);
+		bool? z_ = context.Operators.And(k_, y_);
+		bool? aa_ = this.Has_Appropriate_Number_of_Hib_Immunizations();
+		IEnumerable<Condition> ab_ = this.Hib_Numerator_Inclusion_Conditions();
+		bool? ac_ = context.Operators.Exists<Condition>(ab_);
+		bool? ad_ = context.Operators.Or(aa_, ac_);
+		bool? ae_ = context.Operators.And(z_, ad_);
+		IEnumerable<CqlDate> af_ = this.Three_Hepatitis_B_Vaccinations();
+		bool? ag_ = context.Operators.Exists<CqlDate>(af_);
+		IEnumerable<CqlDate> ah_ = this.Meets_HepB_Vaccination_Requirement();
+		bool? ai_ = context.Operators.Exists<CqlDate>(ah_);
+		IEnumerable<Condition> aj_ = this.Hepatitis_B_Numerator_Inclusion_Conditions();
+		bool? ak_ = context.Operators.Exists<Condition>(aj_);
+		bool? al_ = context.Operators.Or(ai_, ak_);
+		bool? am_ = context.Operators.Or(ag_, al_);
+		bool? an_ = context.Operators.And(ae_, am_);
+		IEnumerable<object> ao_ = this.One_Chicken_Pox_Vaccination();
+		bool? ap_ = context.Operators.Exists<object>(ao_);
+		IEnumerable<Condition> aq_ = this.Varicella_Zoster_Numerator_Inclusion_Conditions();
+		bool? ar_ = context.Operators.Exists<Condition>(aq_);
+		bool? as_ = context.Operators.Or(ap_, ar_);
+		bool? at_ = context.Operators.And(an_, as_);
+		IEnumerable<CqlDate> au_ = this.Four_Pneumococcal_Conjugate_Vaccinations();
+		bool? av_ = context.Operators.Exists<CqlDate>(au_);
+		IEnumerable<Condition> aw_ = this.Pneumococcal_Conjugate_Numerator_Inclusion_Conditions();
+		bool? ax_ = context.Operators.Exists<Condition>(aw_);
+		bool? ay_ = context.Operators.Or(av_, ax_);
+		bool? az_ = context.Operators.And(at_, ay_);
+		IEnumerable<object> ba_ = this.One_Hepatitis_A_Vaccinations();
+		bool? bb_ = context.Operators.Exists<object>(ba_);
+		IEnumerable<Condition> bc_ = this.Hepatitis_A_Numerator_Inclusion_Conditions();
+		bool? bd_ = context.Operators.Exists<Condition>(bc_);
+		bool? be_ = context.Operators.Or(bb_, bd_);
+		bool? bf_ = context.Operators.And(az_, be_);
+		bool? bg_ = this.Has_Appropriate_Number_of_Rotavirus_Immunizations();
+		IEnumerable<Condition> bh_ = this.Rotavirus_Numerator_Inclusion_Conditions();
+		bool? bi_ = context.Operators.Exists<Condition>(bh_);
+		bool? bj_ = context.Operators.Or(bg_, bi_);
+		bool? bk_ = context.Operators.And(bf_, bj_);
+		IEnumerable<CqlDate> bl_ = this.Two_Influenza_Vaccinations();
+		bool? bm_ = context.Operators.Exists<CqlDate>(bl_);
+		bool? bn_ = this.Two_Influenza_Vaccinations_Including_One_LAIV_Vaccination();
+		bool? bo_ = context.Operators.Or(bm_, bn_);
+		IEnumerable<Condition> bp_ = this.Influenza_Numerator_Inclusion_Conditions();
+		bool? bq_ = context.Operators.Exists<Condition>(bp_);
+		bool? br_ = context.Operators.Or(bo_, bq_);
+		bool? bs_ = context.Operators.And(bk_, br_);
 
 		return bs_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
@@ -90,85 +90,106 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 
     #endregion
 
+    /// <seealso cref="Clinical_Oral_Evaluation"/>
 	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", null);
 
+    /// <seealso cref="Clinical_Oral_Evaluation_Value"/>
     [CqlDeclaration("Clinical Oral Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
 	public CqlValueSet Clinical_Oral_Evaluation() => 
 		__Clinical_Oral_Evaluation.Value;
 
+    /// <seealso cref="Dental_Caries"/>
 	private CqlValueSet Dental_Caries_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004", null);
 
+    /// <seealso cref="Dental_Caries_Value"/>
     [CqlDeclaration("Dental Caries")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004")]
 	public CqlValueSet Dental_Caries() => 
 		__Dental_Caries.Value;
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
 	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
 	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Hospice_care_ambulatory"/>
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
 
+    /// <seealso cref="Hospice_care_ambulatory_Value"/>
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
 	public CqlValueSet Hospice_care_ambulatory() => 
 		__Hospice_care_ambulatory.Value;
 
+    /// <seealso cref="Discharge_to_healthcare_facility_for_hospice_care__procedure_"/>
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
 		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Discharge_to_healthcare_facility_for_hospice_care__procedure__Value"/>
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
+    /// <seealso cref="Discharge_to_home_for_hospice_care__procedure_"/>
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
 		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Discharge_to_home_for_hospice_care__procedure__Value"/>
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
+    /// <seealso cref="Hospice_care__Minimum_Data_Set_"/>
 	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
 		new CqlCode("45755-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Hospice_care__Minimum_Data_Set__Value"/>
     [CqlDeclaration("Hospice care [Minimum Data Set]")]
 	public CqlCode Hospice_care__Minimum_Data_Set_() => 
 		__Hospice_care__Minimum_Data_Set_.Value;
 
+    /// <seealso cref="Yes__qualifier_value_"/>
 	private CqlCode Yes__qualifier_value__Value() => 
 		new CqlCode("373066001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Yes__qualifier_value__Value"/>
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
 		__Yes__qualifier_value_.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("45755-6", "http://loinc.org", null, null),
 		};
@@ -176,13 +197,15 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
 			new CqlCode("428361000124107", "http://snomed.info/sct", null, null),
@@ -192,164 +215,189 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Clinical_Oral_Evaluation();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = Status_1_6_000.isEncounterPerformed(b_);
+		CqlValueSet a_ = this.Clinical_Oral_Evaluation();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter ValidEncounter)
 		{
-			var f_ = this.Measurement_Period();
-			var g_ = ValidEncounter?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			Period g_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
 
 			return i_;
 		};
-		var e_ = context.Operators.Where<Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(1, 20, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var i_ = this.Qualifying_Encounters();
-		var j_ = context.Operators.Exists<Encounter>(i_);
-		var k_ = context.Operators.And(h_, j_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
+		bool? l_ = context.Operators.Exists<Encounter>(k_);
+		bool? m_ = context.Operators.And(j_, l_);
 
-		return k_;
+		return m_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Dental_Caries();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Dental_Caries();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition DentalCaries)
 		{
-			var f_ = QICoreCommon_2_0_000.prevalenceInterval(DentalCaries);
-			var g_ = this.Measurement_Period();
-			var h_ = context.Operators.Overlaps(f_, g_, null);
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval(DentalCaries);
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			bool? h_ = context.Operators.Overlaps(f_, g_, null);
 
 			return h_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
@@ -146,198 +146,247 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Chlamydia_Screening"/>
 	private CqlValueSet Chlamydia_Screening_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052", null);
 
+    /// <seealso cref="Chlamydia_Screening_Value"/>
     [CqlDeclaration("Chlamydia Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052")]
 	public CqlValueSet Chlamydia_Screening() => 
 		__Chlamydia_Screening.Value;
 
+    /// <seealso cref="Complications_of_Pregnancy__Childbirth_and_the_Puerperium"/>
 	private CqlValueSet Complications_of_Pregnancy__Childbirth_and_the_Puerperium_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012", null);
 
+    /// <seealso cref="Complications_of_Pregnancy__Childbirth_and_the_Puerperium_Value"/>
     [CqlDeclaration("Complications of Pregnancy, Childbirth and the Puerperium")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012")]
 	public CqlValueSet Complications_of_Pregnancy__Childbirth_and_the_Puerperium() => 
 		__Complications_of_Pregnancy__Childbirth_and_the_Puerperium.Value;
 
+    /// <seealso cref="Contraceptive_Medications"/>
 	private CqlValueSet Contraceptive_Medications_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080", null);
 
+    /// <seealso cref="Contraceptive_Medications_Value"/>
     [CqlDeclaration("Contraceptive Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080")]
 	public CqlValueSet Contraceptive_Medications() => 
 		__Contraceptive_Medications.Value;
 
+    /// <seealso cref="Diagnoses_Used_to_Indicate_Sexual_Activity"/>
 	private CqlValueSet Diagnoses_Used_to_Indicate_Sexual_Activity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018", null);
 
+    /// <seealso cref="Diagnoses_Used_to_Indicate_Sexual_Activity_Value"/>
     [CqlDeclaration("Diagnoses Used to Indicate Sexual Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018")]
 	public CqlValueSet Diagnoses_Used_to_Indicate_Sexual_Activity() => 
 		__Diagnoses_Used_to_Indicate_Sexual_Activity.Value;
 
+    /// <seealso cref="Diagnostic_Studies_During_Pregnancy"/>
 	private CqlValueSet Diagnostic_Studies_During_Pregnancy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008", null);
 
+    /// <seealso cref="Diagnostic_Studies_During_Pregnancy_Value"/>
     [CqlDeclaration("Diagnostic Studies During Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008")]
 	public CqlValueSet Diagnostic_Studies_During_Pregnancy() => 
 		__Diagnostic_Studies_During_Pregnancy.Value;
 
+    /// <seealso cref="HIV"/>
 	private CqlValueSet HIV_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
 
+    /// <seealso cref="HIV_Value"/>
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
 	public CqlValueSet HIV() => 
 		__HIV.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Isotretinoin"/>
 	private CqlValueSet Isotretinoin_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143", null);
 
+    /// <seealso cref="Isotretinoin_Value"/>
     [CqlDeclaration("Isotretinoin")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143")]
 	public CqlValueSet Isotretinoin() => 
 		__Isotretinoin.Value;
 
+    /// <seealso cref="Lab_Tests_During_Pregnancy"/>
 	private CqlValueSet Lab_Tests_During_Pregnancy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007", null);
 
+    /// <seealso cref="Lab_Tests_During_Pregnancy_Value"/>
     [CqlDeclaration("Lab Tests During Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007")]
 	public CqlValueSet Lab_Tests_During_Pregnancy() => 
 		__Lab_Tests_During_Pregnancy.Value;
 
+    /// <seealso cref="Lab_Tests_for_Sexually_Transmitted_Infections"/>
 	private CqlValueSet Lab_Tests_for_Sexually_Transmitted_Infections_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051", null);
 
+    /// <seealso cref="Lab_Tests_for_Sexually_Transmitted_Infections_Value"/>
     [CqlDeclaration("Lab Tests for Sexually Transmitted Infections")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051")]
 	public CqlValueSet Lab_Tests_for_Sexually_Transmitted_Infections() => 
 		__Lab_Tests_for_Sexually_Transmitted_Infections.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Pap_Test"/>
 	private CqlValueSet Pap_Test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", null);
 
+    /// <seealso cref="Pap_Test_Value"/>
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
 	public CqlValueSet Pap_Test() => 
 		__Pap_Test.Value;
 
+    /// <seealso cref="Pregnancy_Test"/>
 	private CqlValueSet Pregnancy_Test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011", null);
 
+    /// <seealso cref="Pregnancy_Test_Value"/>
     [CqlDeclaration("Pregnancy Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011")]
 	public CqlValueSet Pregnancy_Test() => 
 		__Pregnancy_Test.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
 	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
 	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Procedures_Used_to_Indicate_Sexual_Activity"/>
 	private CqlValueSet Procedures_Used_to_Indicate_Sexual_Activity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017", null);
 
+    /// <seealso cref="Procedures_Used_to_Indicate_Sexual_Activity_Value"/>
     [CqlDeclaration("Procedures Used to Indicate Sexual Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017")]
 	public CqlValueSet Procedures_Used_to_Indicate_Sexual_Activity() => 
 		__Procedures_Used_to_Indicate_Sexual_Activity.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="XRay_Study"/>
 	private CqlValueSet XRay_Study_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034", null);
 
+    /// <seealso cref="XRay_Study_Value"/>
     [CqlDeclaration("XRay Study")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034")]
 	public CqlValueSet XRay_Study() => 
 		__XRay_Study.Value;
 
+    /// <seealso cref="Female"/>
 	private CqlCode Female_Value() => 
 		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null);
 
+    /// <seealso cref="Female_Value"/>
     [CqlDeclaration("Female")]
 	public CqlCode Female() => 
 		__Female.Value;
 
+    /// <seealso cref="Have_you_ever_had_vaginal_intercourse__PhenX_"/>
 	private CqlCode Have_you_ever_had_vaginal_intercourse__PhenX__Value() => 
 		new CqlCode("64728-9", "http://loinc.org", null, null);
 
+    /// <seealso cref="Have_you_ever_had_vaginal_intercourse__PhenX__Value"/>
     [CqlDeclaration("Have you ever had vaginal intercourse [PhenX]")]
 	public CqlCode Have_you_ever_had_vaginal_intercourse__PhenX_() => 
 		__Have_you_ever_had_vaginal_intercourse__PhenX_.Value;
 
+    /// <seealso cref="Yes__qualifier_value_"/>
 	private CqlCode Yes__qualifier_value__Value() => 
 		new CqlCode("373066001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Yes__qualifier_value__Value"/>
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
 		__Yes__qualifier_value_.Value;
 
+    /// <seealso cref="AdministrativeGender"/>
 	private CqlCode[] AdministrativeGender_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null),
 		};
@@ -345,13 +394,15 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="AdministrativeGender_Value"/>
     [CqlDeclaration("AdministrativeGender")]
 	public CqlCode[] AdministrativeGender() => 
 		__AdministrativeGender.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("64728-9", "http://loinc.org", null, null),
 		};
@@ -359,13 +410,15 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("373066001", "http://snomed.info/sct", null, null),
 		};
@@ -373,147 +426,163 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("ChlamydiaScreeninginWomenFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("ChlamydiaScreeninginWomenFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Home_Healthcare_Services();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Telephone_Visits();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Online_Assessments();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
-		var x_ = Status_1_6_000.Finished_Encounter(w_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Telephone_Visits();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Online_Assessments();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
+		IEnumerable<Encounter> x_ = Status_1_6_000.Finished_Encounter(w_);
 		bool? y_(Encounter ValidEncounters)
 		{
-			var aa_ = this.Measurement_Period();
-			var ab_ = ValidEncounters?.Period;
-			var ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-			var ad_ = QICoreCommon_2_0_000.ToInterval((ac_ as object));
-			var ae_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aa_, ad_, "day");
+			CqlInterval<CqlDateTime> aa_ = this.Measurement_Period();
+			Period ab_ = ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+			CqlInterval<CqlDateTime> ad_ = QICoreCommon_2_0_000.ToInterval((ac_ as object));
+			bool? ae_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aa_, ad_, "day");
 
 			return ae_;
 		};
-		var z_ = context.Operators.Where<Encounter>(x_, y_);
+		IEnumerable<Encounter> z_ = context.Operators.Where<Encounter>(x_, y_);
 
 		return z_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Has_Assessments_Identifying_Sexual_Activity"/>
 	private bool? Has_Assessments_Identifying_Sexual_Activity_Value()
 	{
-		var a_ = this.Have_you_ever_had_vaginal_intercourse__PhenX_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode a_ = this.Have_you_ever_had_vaginal_intercourse__PhenX_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation SexualActivityAssessment)
 		{
-			var h_ = SexualActivityAssessment?.Value;
-			var i_ = FHIRHelpers_4_3_000.ToValue(h_);
-			var j_ = this.Yes__qualifier_value_();
-			var k_ = context.Operators.ConvertCodeToConcept(j_);
-			var l_ = context.Operators.Equivalent((i_ as CqlConcept), k_);
-			var m_ = SexualActivityAssessment?.Effective;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval(n_);
+			DataType h_ = SexualActivityAssessment?.Value;
+			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
+			CqlCode j_ = this.Yes__qualifier_value_();
+			CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+			bool? l_ = context.Operators.Equivalent((i_ as CqlConcept), k_);
+			DataType m_ = SexualActivityAssessment?.Effective;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval(n_);
 			CqlInterval<CqlDateTime> p_()
 			{
 				bool s_()
 				{
-					var t_ = this.Measurement_Period();
-					var u_ = context.Operators.End(t_);
+					CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
+					CqlDateTime u_ = context.Operators.End(t_);
 
 					return (u_ is null);
 				};
@@ -523,463 +592,491 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 				}
 				else
 				{
-					var v_ = this.Measurement_Period();
-					var w_ = context.Operators.End(v_);
-					var y_ = context.Operators.End(v_);
-					var z_ = context.Operators.Interval(w_, y_, true, true);
+					CqlInterval<CqlDateTime> v_ = this.Measurement_Period();
+					CqlDateTime w_ = context.Operators.End(v_);
+					CqlDateTime y_ = context.Operators.End(v_);
+					CqlInterval<CqlDateTime> z_ = context.Operators.Interval(w_, y_, true, true);
 
 					return z_;
 				}
 			};
-			var q_ = context.Operators.SameOrBefore(o_, p_(), null);
-			var r_ = context.Operators.And(l_, q_);
+			bool? q_ = context.Operators.SameOrBefore(o_, p_(), null);
+			bool? r_ = context.Operators.And(l_, q_);
 
 			return r_;
 		};
-		var f_ = context.Operators.Where<Observation>(d_, e_);
-		var g_ = context.Operators.Exists<Observation>(f_);
+		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
+		bool? g_ = context.Operators.Exists<Observation>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Has_Assessments_Identifying_Sexual_Activity_Value"/>
     [CqlDeclaration("Has Assessments Identifying Sexual Activity")]
 	public bool? Has_Assessments_Identifying_Sexual_Activity() => 
 		__Has_Assessments_Identifying_Sexual_Activity.Value;
 
+    /// <seealso cref="Has_Diagnoses_Identifying_Sexual_Activity"/>
 	private bool? Has_Diagnoses_Identifying_Sexual_Activity_Value()
 	{
-		var a_ = this.Diagnoses_Used_to_Indicate_Sexual_Activity();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.HIV();
-		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
-		var e_ = context.Operators.Union<Condition>(b_, d_);
-		var f_ = this.Complications_of_Pregnancy__Childbirth_and_the_Puerperium();
-		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
-		var h_ = context.Operators.Union<Condition>(e_, g_);
+		CqlValueSet a_ = this.Diagnoses_Used_to_Indicate_Sexual_Activity();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet c_ = this.HIV();
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
+		CqlValueSet f_ = this.Complications_of_Pregnancy__Childbirth_and_the_Puerperium();
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		bool? i_(Condition SexualActivityDiagnosis)
 		{
-			var l_ = QICoreCommon_2_0_000.ToPrevalenceInterval(SexualActivityDiagnosis);
-			var m_ = this.Measurement_Period();
-			var n_ = context.Operators.Overlaps(l_, m_, null);
+			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.ToPrevalenceInterval(SexualActivityDiagnosis);
+			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
+			bool? n_ = context.Operators.Overlaps(l_, m_, null);
 
 			return n_;
 		};
-		var j_ = context.Operators.Where<Condition>(h_, i_);
-		var k_ = context.Operators.Exists<Condition>(j_);
+		IEnumerable<Condition> j_ = context.Operators.Where<Condition>(h_, i_);
+		bool? k_ = context.Operators.Exists<Condition>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Diagnoses_Identifying_Sexual_Activity_Value"/>
     [CqlDeclaration("Has Diagnoses Identifying Sexual Activity")]
 	public bool? Has_Diagnoses_Identifying_Sexual_Activity() => 
 		__Has_Diagnoses_Identifying_Sexual_Activity.Value;
 
+    /// <seealso cref="Has_Active_Contraceptive_Medications"/>
 	private bool? Has_Active_Contraceptive_Medications_Value()
 	{
-		var a_ = this.Contraceptive_Medications();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = Status_1_6_000.Active_Medication(e_);
+		CqlValueSet a_ = this.Contraceptive_Medications();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_Medication(e_);
 		bool? g_(MedicationRequest ActiveContraceptives)
 		{
-			var j_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ActiveContraceptives);
-			var k_ = j_?.low;
-			var l_ = context.Operators.ConvertDateToDateTime(k_);
-			var n_ = j_?.high;
-			var o_ = context.Operators.ConvertDateToDateTime(n_);
-			var q_ = j_?.lowClosed;
-			var s_ = j_?.highClosed;
-			var t_ = context.Operators.Interval(l_, o_, q_, s_);
-			var u_ = this.Measurement_Period();
-			var v_ = context.Operators.Overlaps(t_, u_, null);
+			CqlInterval<CqlDate> j_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ActiveContraceptives);
+			CqlDate k_ = j_?.low;
+			CqlDateTime l_ = context.Operators.ConvertDateToDateTime(k_);
+			CqlDate n_ = j_?.high;
+			CqlDateTime o_ = context.Operators.ConvertDateToDateTime(n_);
+			bool? q_ = j_?.lowClosed;
+			bool? s_ = j_?.highClosed;
+			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(l_, o_, q_, s_);
+			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
+			bool? v_ = context.Operators.Overlaps(t_, u_, null);
 
 			return v_;
 		};
-		var h_ = context.Operators.Where<MedicationRequest>(f_, g_);
-		var i_ = context.Operators.Exists<MedicationRequest>(h_);
+		IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+		bool? i_ = context.Operators.Exists<MedicationRequest>(h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Has_Active_Contraceptive_Medications_Value"/>
     [CqlDeclaration("Has Active Contraceptive Medications")]
 	public bool? Has_Active_Contraceptive_Medications() => 
 		__Has_Active_Contraceptive_Medications.Value;
 
+    /// <seealso cref="Has_Ordered_Contraceptive_Medications"/>
 	private bool? Has_Ordered_Contraceptive_Medications_Value()
 	{
-		var a_ = this.Contraceptive_Medications();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
+		CqlValueSet a_ = this.Contraceptive_Medications();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
 		bool? g_(MedicationRequest OrderedContraceptives)
 		{
-			var j_ = this.Measurement_Period();
-			var k_ = OrderedContraceptives?.AuthoredOnElement;
-			var l_ = context.Operators.Convert<CqlDateTime>(k_);
-			var m_ = QICoreCommon_2_0_000.ToInterval((l_ as object));
-			var n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, "day");
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			FhirDateTime k_ = OrderedContraceptives?.AuthoredOnElement;
+			CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+			CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.ToInterval((l_ as object));
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, "day");
 
 			return n_;
 		};
-		var h_ = context.Operators.Where<MedicationRequest>(f_, g_);
-		var i_ = context.Operators.Exists<MedicationRequest>(h_);
+		IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+		bool? i_ = context.Operators.Exists<MedicationRequest>(h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Has_Ordered_Contraceptive_Medications_Value"/>
     [CqlDeclaration("Has Ordered Contraceptive Medications")]
 	public bool? Has_Ordered_Contraceptive_Medications() => 
 		__Has_Ordered_Contraceptive_Medications.Value;
 
+    /// <seealso cref="Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy"/>
 	private bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy_Value()
 	{
-		var a_ = this.Pap_Test();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var c_ = this.Lab_Tests_During_Pregnancy();
-		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
-		var e_ = context.Operators.Union<ServiceRequest>(b_, d_);
-		var f_ = this.Lab_Tests_for_Sexually_Transmitted_Infections();
-		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
-		var h_ = context.Operators.Union<ServiceRequest>(e_, g_);
-		var i_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(h_);
+		CqlValueSet a_ = this.Pap_Test();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		CqlValueSet c_ = this.Lab_Tests_During_Pregnancy();
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
+		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
+		CqlValueSet f_ = this.Lab_Tests_for_Sexually_Transmitted_Infections();
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> h_ = context.Operators.Union<ServiceRequest>(e_, g_);
+		IEnumerable<ServiceRequest> i_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(h_);
 		bool? j_(ServiceRequest LabOrders)
 		{
-			var m_ = this.Measurement_Period();
-			var n_ = LabOrders?.AuthoredOnElement;
-			var o_ = context.Operators.Convert<CqlDateTime>(n_);
-			var p_ = QICoreCommon_2_0_000.ToInterval((o_ as object));
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
+			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
+			FhirDateTime n_ = LabOrders?.AuthoredOnElement;
+			CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.ToInterval((o_ as object));
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
 
 			return q_;
 		};
-		var k_ = context.Operators.Where<ServiceRequest>(i_, j_);
-		var l_ = context.Operators.Exists<ServiceRequest>(k_);
+		IEnumerable<ServiceRequest> k_ = context.Operators.Where<ServiceRequest>(i_, j_);
+		bool? l_ = context.Operators.Exists<ServiceRequest>(k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy_Value"/>
     [CqlDeclaration("Has Laboratory Tests Identifying Sexual Activity But Not Pregnancy")]
 	public bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy() => 
 		__Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy.Value;
 
+    /// <seealso cref="Has_Laboratory_Tests_Identifying_Sexual_Activity"/>
 	private bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_Value()
 	{
-		var a_ = this.Pregnancy_Test();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
+		CqlValueSet a_ = this.Pregnancy_Test();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		bool? d_(ServiceRequest PregnancyTest)
 		{
-			var i_ = this.Measurement_Period();
-			var j_ = PregnancyTest?.AuthoredOnElement;
-			var k_ = context.Operators.Convert<CqlDateTime>(j_);
-			var l_ = QICoreCommon_2_0_000.ToInterval((k_ as object));
-			var m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, l_, "day");
+			CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
+			FhirDateTime j_ = PregnancyTest?.AuthoredOnElement;
+			CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
+			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.ToInterval((k_ as object));
+			bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, l_, "day");
 
 			return m_;
 		};
-		var e_ = context.Operators.Where<ServiceRequest>(c_, d_);
-		var f_ = context.Operators.Exists<ServiceRequest>(e_);
-		var g_ = this.Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy();
-		var h_ = context.Operators.Or(f_, g_);
+		IEnumerable<ServiceRequest> e_ = context.Operators.Where<ServiceRequest>(c_, d_);
+		bool? f_ = context.Operators.Exists<ServiceRequest>(e_);
+		bool? g_ = this.Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy();
+		bool? h_ = context.Operators.Or(f_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Has_Laboratory_Tests_Identifying_Sexual_Activity_Value"/>
     [CqlDeclaration("Has Laboratory Tests Identifying Sexual Activity")]
 	public bool? Has_Laboratory_Tests_Identifying_Sexual_Activity() => 
 		__Has_Laboratory_Tests_Identifying_Sexual_Activity.Value;
 
+    /// <seealso cref="Has_Diagnostic_Studies_Identifying_Sexual_Activity"/>
 	private bool? Has_Diagnostic_Studies_Identifying_Sexual_Activity_Value()
 	{
-		var a_ = this.Diagnostic_Studies_During_Pregnancy();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
+		CqlValueSet a_ = this.Diagnostic_Studies_During_Pregnancy();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		bool? d_(ServiceRequest SexualActivityDiagnostics)
 		{
-			var g_ = this.Measurement_Period();
-			var h_ = SexualActivityDiagnostics?.AuthoredOnElement;
-			var i_ = context.Operators.Convert<CqlDateTime>(h_);
-			var j_ = QICoreCommon_2_0_000.ToInterval((i_ as object));
-			var k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			FhirDateTime h_ = SexualActivityDiagnostics?.AuthoredOnElement;
+			CqlDateTime i_ = context.Operators.Convert<CqlDateTime>(h_);
+			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval((i_ as object));
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
 
 			return k_;
 		};
-		var e_ = context.Operators.Where<ServiceRequest>(c_, d_);
-		var f_ = context.Operators.Exists<ServiceRequest>(e_);
+		IEnumerable<ServiceRequest> e_ = context.Operators.Where<ServiceRequest>(c_, d_);
+		bool? f_ = context.Operators.Exists<ServiceRequest>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Has_Diagnostic_Studies_Identifying_Sexual_Activity_Value"/>
     [CqlDeclaration("Has Diagnostic Studies Identifying Sexual Activity")]
 	public bool? Has_Diagnostic_Studies_Identifying_Sexual_Activity() => 
 		__Has_Diagnostic_Studies_Identifying_Sexual_Activity.Value;
 
+    /// <seealso cref="Has_Procedures_Identifying_Sexual_Activity"/>
 	private bool? Has_Procedures_Identifying_Sexual_Activity_Value()
 	{
-		var a_ = this.Procedures_Used_to_Indicate_Sexual_Activity();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		CqlValueSet a_ = this.Procedures_Used_to_Indicate_Sexual_Activity();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure ProceduresForSexualActivity)
 		{
-			var g_ = this.Measurement_Period();
-			var h_ = ProceduresForSexualActivity?.Performed;
-			var i_ = FHIRHelpers_4_3_000.ToValue(h_);
-			var j_ = QICoreCommon_2_0_000.ToInterval(i_);
-			var k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			DataType h_ = ProceduresForSexualActivity?.Performed;
+			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
+			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval(i_);
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
 
 			return k_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
-		var f_ = context.Operators.Exists<Procedure>(e_);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
+		bool? f_ = context.Operators.Exists<Procedure>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Has_Procedures_Identifying_Sexual_Activity_Value"/>
     [CqlDeclaration("Has Procedures Identifying Sexual Activity")]
 	public bool? Has_Procedures_Identifying_Sexual_Activity() => 
 		__Has_Procedures_Identifying_Sexual_Activity.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(16, 24, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var j_ = context.Operators.Convert<string>(a_?.GenderElement?.Value);
-		var k_ = context.Operators.Equal(j_, "female");
-		var l_ = context.Operators.And(h_, k_);
-		var m_ = this.Qualifying_Encounters();
-		var n_ = context.Operators.Exists<Encounter>(m_);
-		var o_ = context.Operators.And(l_, n_);
-		var p_ = this.Has_Assessments_Identifying_Sexual_Activity();
-		var q_ = this.Has_Diagnoses_Identifying_Sexual_Activity();
-		var r_ = context.Operators.Or(p_, q_);
-		var s_ = this.Has_Active_Contraceptive_Medications();
-		var t_ = context.Operators.Or(r_, s_);
-		var u_ = this.Has_Ordered_Contraceptive_Medications();
-		var v_ = context.Operators.Or(t_, u_);
-		var w_ = this.Has_Laboratory_Tests_Identifying_Sexual_Activity();
-		var x_ = context.Operators.Or(v_, w_);
-		var y_ = this.Has_Diagnostic_Studies_Identifying_Sexual_Activity();
-		var z_ = context.Operators.Or(x_, y_);
-		var aa_ = this.Has_Procedures_Identifying_Sexual_Activity();
-		var ab_ = context.Operators.Or(z_, aa_);
-		var ac_ = context.Operators.And(o_, ab_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(16, 24, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		Code<AdministrativeGender> l_ = a_?.GenderElement;
+		AdministrativeGender? m_ = l_?.Value;
+		string n_ = context.Operators.Convert<string>(m_);
+		bool? o_ = context.Operators.Equal(n_, "female");
+		bool? p_ = context.Operators.And(j_, o_);
+		IEnumerable<Encounter> q_ = this.Qualifying_Encounters();
+		bool? r_ = context.Operators.Exists<Encounter>(q_);
+		bool? s_ = context.Operators.And(p_, r_);
+		bool? t_ = this.Has_Assessments_Identifying_Sexual_Activity();
+		bool? u_ = this.Has_Diagnoses_Identifying_Sexual_Activity();
+		bool? v_ = context.Operators.Or(t_, u_);
+		bool? w_ = this.Has_Active_Contraceptive_Medications();
+		bool? x_ = context.Operators.Or(v_, w_);
+		bool? y_ = this.Has_Ordered_Contraceptive_Medications();
+		bool? z_ = context.Operators.Or(x_, y_);
+		bool? aa_ = this.Has_Laboratory_Tests_Identifying_Sexual_Activity();
+		bool? ab_ = context.Operators.Or(z_, aa_);
+		bool? ac_ = this.Has_Diagnostic_Studies_Identifying_Sexual_Activity();
+		bool? ad_ = context.Operators.Or(ab_, ac_);
+		bool? ae_ = this.Has_Procedures_Identifying_Sexual_Activity();
+		bool? af_ = context.Operators.Or(ad_, ae_);
+		bool? ag_ = context.Operators.And(s_, af_);
 
-		return ac_;
+		return ag_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Has_Pregnancy_Test_Exclusion"/>
 	private bool? Has_Pregnancy_Test_Exclusion_Value()
 	{
-		var a_ = this.Pregnancy_Test();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
+		CqlValueSet a_ = this.Pregnancy_Test();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		IEnumerable<ServiceRequest> d_(ServiceRequest PregnancyTest)
 		{
-			var m_ = this.XRay_Study();
-			var n_ = context.Operators.RetrieveByValueSet<ServiceRequest>(m_, null);
-			var o_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(n_);
+			CqlValueSet m_ = this.XRay_Study();
+			IEnumerable<ServiceRequest> n_ = context.Operators.RetrieveByValueSet<ServiceRequest>(m_, null);
+			IEnumerable<ServiceRequest> o_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(n_);
 			bool? p_(ServiceRequest XrayOrder)
 			{
-				var t_ = XrayOrder?.AuthoredOnElement;
-				var u_ = context.Operators.Convert<CqlDateTime>(t_);
-				var v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
-				var w_ = context.Operators.Start(v_);
-				var x_ = PregnancyTest?.AuthoredOnElement;
-				var y_ = context.Operators.Convert<CqlDateTime>(x_);
-				var z_ = QICoreCommon_2_0_000.ToInterval((y_ as object));
-				var aa_ = context.Operators.End(z_);
-				var ac_ = context.Operators.Convert<CqlDateTime>(x_);
-				var ad_ = QICoreCommon_2_0_000.ToInterval((ac_ as object));
-				var ae_ = context.Operators.End(ad_);
-				var af_ = context.Operators.Quantity(6m, "days");
-				var ag_ = context.Operators.Add(ae_, af_);
-				var ah_ = context.Operators.Interval(aa_, ag_, true, true);
-				var ai_ = context.Operators.In<CqlDateTime>(w_, ah_, "day");
-				var ak_ = context.Operators.Convert<CqlDateTime>(x_);
-				var al_ = QICoreCommon_2_0_000.ToInterval((ak_ as object));
-				var am_ = context.Operators.End(al_);
-				var an_ = context.Operators.Not((bool?)(am_ is null));
-				var ao_ = context.Operators.And(ai_, an_);
-				var ap_ = this.Measurement_Period();
-				var ar_ = context.Operators.Convert<CqlDateTime>(x_);
-				var as_ = QICoreCommon_2_0_000.ToInterval((ar_ as object));
-				var at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, null);
-				var au_ = context.Operators.And(ao_, at_);
+				FhirDateTime t_ = XrayOrder?.AuthoredOnElement;
+				CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
+				CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.ToInterval((u_ as object));
+				CqlDateTime w_ = context.Operators.Start(v_);
+				FhirDateTime x_ = PregnancyTest?.AuthoredOnElement;
+				CqlDateTime y_ = context.Operators.Convert<CqlDateTime>(x_);
+				CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.ToInterval((y_ as object));
+				CqlDateTime aa_ = context.Operators.End(z_);
+				CqlDateTime ac_ = context.Operators.Convert<CqlDateTime>(x_);
+				CqlInterval<CqlDateTime> ad_ = QICoreCommon_2_0_000.ToInterval((ac_ as object));
+				CqlDateTime ae_ = context.Operators.End(ad_);
+				CqlQuantity af_ = context.Operators.Quantity(6m, "days");
+				CqlDateTime ag_ = context.Operators.Add(ae_, af_);
+				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(aa_, ag_, true, true);
+				bool? ai_ = context.Operators.In<CqlDateTime>(w_, ah_, "day");
+				CqlDateTime ak_ = context.Operators.Convert<CqlDateTime>(x_);
+				CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval((ak_ as object));
+				CqlDateTime am_ = context.Operators.End(al_);
+				bool? an_ = context.Operators.Not((bool?)(am_ is null));
+				bool? ao_ = context.Operators.And(ai_, an_);
+				CqlInterval<CqlDateTime> ap_ = this.Measurement_Period();
+				CqlDateTime ar_ = context.Operators.Convert<CqlDateTime>(x_);
+				CqlInterval<CqlDateTime> as_ = QICoreCommon_2_0_000.ToInterval((ar_ as object));
+				bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, null);
+				bool? au_ = context.Operators.And(ao_, at_);
 
 				return au_;
 			};
-			var q_ = context.Operators.Where<ServiceRequest>(o_, p_);
+			IEnumerable<ServiceRequest> q_ = context.Operators.Where<ServiceRequest>(o_, p_);
 			ServiceRequest r_(ServiceRequest XrayOrder) => 
 				PregnancyTest;
-			var s_ = context.Operators.Select<ServiceRequest, ServiceRequest>(q_, r_);
+			IEnumerable<ServiceRequest> s_ = context.Operators.Select<ServiceRequest, ServiceRequest>(q_, r_);
 
 			return s_;
 		};
-		var e_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(c_, d_);
-		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var h_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(g_);
+		IEnumerable<ServiceRequest> e_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(c_, d_);
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> h_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(g_);
 		IEnumerable<ServiceRequest> i_(ServiceRequest PregnancyTestOrder)
 		{
-			var av_ = this.Isotretinoin();
-			var aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
-			var ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
-			var az_ = context.Operators.Union<MedicationRequest>(aw_, ay_);
-			var ba_ = Status_1_6_000.Active_or_Completed_Medication_Request(az_);
+			CqlValueSet av_ = this.Isotretinoin();
+			IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
+			IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
+			IEnumerable<MedicationRequest> az_ = context.Operators.Union<MedicationRequest>(aw_, ay_);
+			IEnumerable<MedicationRequest> ba_ = Status_1_6_000.Active_or_Completed_Medication_Request(az_);
 			bool? bb_(MedicationRequest AccutaneOrder)
 			{
-				var bf_ = AccutaneOrder?.AuthoredOnElement;
-				var bg_ = context.Operators.Convert<CqlDateTime>(bf_);
-				var bh_ = QICoreCommon_2_0_000.ToInterval((bg_ as object));
-				var bi_ = context.Operators.Start(bh_);
-				var bj_ = PregnancyTestOrder?.AuthoredOnElement;
-				var bk_ = context.Operators.Convert<CqlDateTime>(bj_);
-				var bl_ = QICoreCommon_2_0_000.ToInterval((bk_ as object));
-				var bm_ = context.Operators.End(bl_);
-				var bo_ = context.Operators.Convert<CqlDateTime>(bj_);
-				var bp_ = QICoreCommon_2_0_000.ToInterval((bo_ as object));
-				var bq_ = context.Operators.End(bp_);
-				var br_ = context.Operators.Quantity(6m, "days");
-				var bs_ = context.Operators.Add(bq_, br_);
-				var bt_ = context.Operators.Interval(bm_, bs_, true, true);
-				var bu_ = context.Operators.In<CqlDateTime>(bi_, bt_, "day");
-				var bw_ = context.Operators.Convert<CqlDateTime>(bj_);
-				var bx_ = QICoreCommon_2_0_000.ToInterval((bw_ as object));
-				var by_ = context.Operators.End(bx_);
-				var bz_ = context.Operators.Not((bool?)(by_ is null));
-				var ca_ = context.Operators.And(bu_, bz_);
-				var cb_ = this.Measurement_Period();
-				var cd_ = context.Operators.Convert<CqlDateTime>(bj_);
-				var ce_ = QICoreCommon_2_0_000.ToInterval((cd_ as object));
-				var cf_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cb_, ce_, null);
-				var cg_ = context.Operators.And(ca_, cf_);
+				FhirDateTime bf_ = AccutaneOrder?.AuthoredOnElement;
+				CqlDateTime bg_ = context.Operators.Convert<CqlDateTime>(bf_);
+				CqlInterval<CqlDateTime> bh_ = QICoreCommon_2_0_000.ToInterval((bg_ as object));
+				CqlDateTime bi_ = context.Operators.Start(bh_);
+				FhirDateTime bj_ = PregnancyTestOrder?.AuthoredOnElement;
+				CqlDateTime bk_ = context.Operators.Convert<CqlDateTime>(bj_);
+				CqlInterval<CqlDateTime> bl_ = QICoreCommon_2_0_000.ToInterval((bk_ as object));
+				CqlDateTime bm_ = context.Operators.End(bl_);
+				CqlDateTime bo_ = context.Operators.Convert<CqlDateTime>(bj_);
+				CqlInterval<CqlDateTime> bp_ = QICoreCommon_2_0_000.ToInterval((bo_ as object));
+				CqlDateTime bq_ = context.Operators.End(bp_);
+				CqlQuantity br_ = context.Operators.Quantity(6m, "days");
+				CqlDateTime bs_ = context.Operators.Add(bq_, br_);
+				CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(bm_, bs_, true, true);
+				bool? bu_ = context.Operators.In<CqlDateTime>(bi_, bt_, "day");
+				CqlDateTime bw_ = context.Operators.Convert<CqlDateTime>(bj_);
+				CqlInterval<CqlDateTime> bx_ = QICoreCommon_2_0_000.ToInterval((bw_ as object));
+				CqlDateTime by_ = context.Operators.End(bx_);
+				bool? bz_ = context.Operators.Not((bool?)(by_ is null));
+				bool? ca_ = context.Operators.And(bu_, bz_);
+				CqlInterval<CqlDateTime> cb_ = this.Measurement_Period();
+				CqlDateTime cd_ = context.Operators.Convert<CqlDateTime>(bj_);
+				CqlInterval<CqlDateTime> ce_ = QICoreCommon_2_0_000.ToInterval((cd_ as object));
+				bool? cf_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cb_, ce_, null);
+				bool? cg_ = context.Operators.And(ca_, cf_);
 
 				return cg_;
 			};
-			var bc_ = context.Operators.Where<MedicationRequest>(ba_, bb_);
+			IEnumerable<MedicationRequest> bc_ = context.Operators.Where<MedicationRequest>(ba_, bb_);
 			ServiceRequest bd_(MedicationRequest AccutaneOrder) => 
 				PregnancyTestOrder;
-			var be_ = context.Operators.Select<MedicationRequest, ServiceRequest>(bc_, bd_);
+			IEnumerable<ServiceRequest> be_ = context.Operators.Select<MedicationRequest, ServiceRequest>(bc_, bd_);
 
 			return be_;
 		};
-		var j_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(h_, i_);
-		var k_ = context.Operators.Union<ServiceRequest>(e_, j_);
-		var l_ = context.Operators.Exists<ServiceRequest>(k_);
+		IEnumerable<ServiceRequest> j_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(h_, i_);
+		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
+		bool? l_ = context.Operators.Exists<ServiceRequest>(k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Has_Pregnancy_Test_Exclusion_Value"/>
     [CqlDeclaration("Has Pregnancy Test Exclusion")]
 	public bool? Has_Pregnancy_Test_Exclusion() => 
 		__Has_Pregnancy_Test_Exclusion.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = this.Has_Pregnancy_Test_Exclusion();
-		var c_ = this.Has_Assessments_Identifying_Sexual_Activity();
-		var d_ = context.Operators.Not(c_);
-		var e_ = context.Operators.And(b_, d_);
-		var f_ = this.Has_Diagnoses_Identifying_Sexual_Activity();
-		var g_ = context.Operators.Not(f_);
-		var h_ = context.Operators.And(e_, g_);
-		var i_ = this.Has_Active_Contraceptive_Medications();
-		var j_ = context.Operators.Not(i_);
-		var k_ = context.Operators.And(h_, j_);
-		var l_ = this.Has_Ordered_Contraceptive_Medications();
-		var m_ = context.Operators.Not(l_);
-		var n_ = context.Operators.And(k_, m_);
-		var o_ = this.Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy();
-		var p_ = context.Operators.Not(o_);
-		var q_ = context.Operators.And(n_, p_);
-		var r_ = this.Has_Diagnostic_Studies_Identifying_Sexual_Activity();
-		var s_ = context.Operators.Not(r_);
-		var t_ = context.Operators.And(q_, s_);
-		var u_ = this.Has_Procedures_Identifying_Sexual_Activity();
-		var v_ = context.Operators.Not(u_);
-		var w_ = context.Operators.And(t_, v_);
-		var x_ = context.Operators.Or(a_, w_);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? b_ = this.Has_Pregnancy_Test_Exclusion();
+		bool? c_ = this.Has_Assessments_Identifying_Sexual_Activity();
+		bool? d_ = context.Operators.Not(c_);
+		bool? e_ = context.Operators.And(b_, d_);
+		bool? f_ = this.Has_Diagnoses_Identifying_Sexual_Activity();
+		bool? g_ = context.Operators.Not(f_);
+		bool? h_ = context.Operators.And(e_, g_);
+		bool? i_ = this.Has_Active_Contraceptive_Medications();
+		bool? j_ = context.Operators.Not(i_);
+		bool? k_ = context.Operators.And(h_, j_);
+		bool? l_ = this.Has_Ordered_Contraceptive_Medications();
+		bool? m_ = context.Operators.Not(l_);
+		bool? n_ = context.Operators.And(k_, m_);
+		bool? o_ = this.Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy();
+		bool? p_ = context.Operators.Not(o_);
+		bool? q_ = context.Operators.And(n_, p_);
+		bool? r_ = this.Has_Diagnostic_Studies_Identifying_Sexual_Activity();
+		bool? s_ = context.Operators.Not(r_);
+		bool? t_ = context.Operators.And(q_, s_);
+		bool? u_ = this.Has_Procedures_Identifying_Sexual_Activity();
+		bool? v_ = context.Operators.Not(u_);
+		bool? w_ = context.Operators.And(t_, v_);
+		bool? x_ = context.Operators.Or(a_, w_);
 
 		return x_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Chlamydia_Screening();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.Final_Lab_Observation(b_);
+		CqlValueSet a_ = this.Chlamydia_Screening();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation ChlamydiaTest)
 		{
 			object g_()
 			{
 				bool o_()
 				{
-					var r_ = ChlamydiaTest?.Effective;
-					var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-					var t_ = s_ is CqlDateTime;
+					DataType r_ = ChlamydiaTest?.Effective;
+					object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+					bool t_ = s_ is CqlDateTime;
 
 					return t_;
 				};
 				bool p_()
 				{
-					var u_ = ChlamydiaTest?.Effective;
-					var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-					var w_ = v_ is CqlInterval<CqlDateTime>;
+					DataType u_ = ChlamydiaTest?.Effective;
+					object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+					bool w_ = v_ is CqlInterval<CqlDateTime>;
 
 					return w_;
 				};
 				bool q_()
 				{
-					var x_ = ChlamydiaTest?.Effective;
-					var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-					var z_ = y_ is CqlDateTime;
+					DataType x_ = ChlamydiaTest?.Effective;
+					object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+					bool z_ = y_ is CqlDateTime;
 
 					return z_;
 				};
 				if (o_())
 				{
-					var aa_ = ChlamydiaTest?.Effective;
-					var ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
+					DataType aa_ = ChlamydiaTest?.Effective;
+					object ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
 
 					return ((ab_ as CqlDateTime) as object);
 				}
 				else if (p_())
 				{
-					var ac_ = ChlamydiaTest?.Effective;
-					var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+					DataType ac_ = ChlamydiaTest?.Effective;
+					object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
 
 					return ((ad_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (q_())
 				{
-					var ae_ = ChlamydiaTest?.Effective;
-					var af_ = FHIRHelpers_4_3_000.ToValue(ae_);
+					DataType ae_ = ChlamydiaTest?.Effective;
+					object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
 
 					return ((af_ as CqlDateTime) as object);
 				}
@@ -988,58 +1085,67 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 					return null;
 				}
 			};
-			var h_ = QICoreCommon_2_0_000.Latest(g_());
-			var i_ = this.Measurement_Period();
-			var j_ = context.Operators.In<CqlDateTime>(h_, i_, "day");
-			var k_ = ChlamydiaTest?.Value;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = context.Operators.Not((bool?)(l_ is null));
-			var n_ = context.Operators.And(j_, m_);
+			CqlDateTime h_ = QICoreCommon_2_0_000.Latest(g_());
+			CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
+			bool? j_ = context.Operators.In<CqlDateTime>(h_, i_, "day");
+			DataType k_ = ChlamydiaTest?.Value;
+			object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+			bool? m_ = context.Operators.Not((bool?)(l_ is null));
+			bool? n_ = context.Operators.And(j_, m_);
 
 			return n_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
-		var f_ = context.Operators.Exists<Observation>(e_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
+		bool? f_ = context.Operators.Exists<Observation>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Stratification_1"/>
 	private bool? Stratification_1_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(16, 20, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(16, 20, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Stratification_1_Value"/>
     [CqlDeclaration("Stratification 1")]
 	public bool? Stratification_1() => 
 		__Stratification_1.Value;
 
+    /// <seealso cref="Stratification_2"/>
 	private bool? Stratification_2_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(21, 24, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(21, 24, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Stratification_2_Value"/>
     [CqlDeclaration("Stratification 2")]
 	public bool? Stratification_2() => 
 		__Stratification_2.Value;

--- a/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
@@ -104,291 +104,330 @@ public class ColonCancerScreeningFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Colonoscopy"/>
 	private CqlValueSet Colonoscopy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", null);
 
+    /// <seealso cref="Colonoscopy_Value"/>
     [CqlDeclaration("Colonoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
 	public CqlValueSet Colonoscopy() => 
 		__Colonoscopy.Value;
 
+    /// <seealso cref="CT_Colonography"/>
 	private CqlValueSet CT_Colonography_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", null);
 
+    /// <seealso cref="CT_Colonography_Value"/>
     [CqlDeclaration("CT Colonography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
 	public CqlValueSet CT_Colonography() => 
 		__CT_Colonography.Value;
 
+    /// <seealso cref="Fecal_Occult_Blood_Test__FOBT_"/>
 	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", null);
 
+    /// <seealso cref="Fecal_Occult_Blood_Test__FOBT__Value"/>
     [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
 	public CqlValueSet Fecal_Occult_Blood_Test__FOBT_() => 
 		__Fecal_Occult_Blood_Test__FOBT_.Value;
 
+    /// <seealso cref="sDNA_FIT_Test"/>
 	private CqlValueSet sDNA_FIT_Test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", null);
 
+    /// <seealso cref="sDNA_FIT_Test_Value"/>
     [CqlDeclaration("sDNA FIT Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
 	public CqlValueSet sDNA_FIT_Test() => 
 		__sDNA_FIT_Test.Value;
 
+    /// <seealso cref="Flexible_Sigmoidoscopy"/>
 	private CqlValueSet Flexible_Sigmoidoscopy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", null);
 
+    /// <seealso cref="Flexible_Sigmoidoscopy_Value"/>
     [CqlDeclaration("Flexible Sigmoidoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
 	public CqlValueSet Flexible_Sigmoidoscopy() => 
 		__Flexible_Sigmoidoscopy.Value;
 
+    /// <seealso cref="Malignant_Neoplasm_of_Colon"/>
 	private CqlValueSet Malignant_Neoplasm_of_Colon_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", null);
 
+    /// <seealso cref="Malignant_Neoplasm_of_Colon_Value"/>
     [CqlDeclaration("Malignant Neoplasm of Colon")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
 	public CqlValueSet Malignant_Neoplasm_of_Colon() => 
 		__Malignant_Neoplasm_of_Colon.Value;
 
+    /// <seealso cref="Total_Colectomy"/>
 	private CqlValueSet Total_Colectomy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", null);
 
+    /// <seealso cref="Total_Colectomy_Value"/>
     [CqlDeclaration("Total Colectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
 	public CqlValueSet Total_Colectomy() => 
 		__Total_Colectomy.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("ColonCancerScreeningFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("ColonCancerScreeningFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(46, 75, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var i_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
-		var j_ = context.Operators.Exists<Encounter>(i_);
-		var k_ = context.Operators.And(h_, j_);
-
-		return k_;
-	}
-
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population() => 
-		__Initial_Population.Value;
-
-	private bool? Denominator_Value()
-	{
-		var a_ = this.Initial_Population();
-
-		return a_;
-	}
-
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator() => 
-		__Denominator.Value;
-
-	private IEnumerable<Condition> Malignant_Neoplasm_Value()
-	{
-		var a_ = this.Malignant_Neoplasm_of_Colon();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
-		bool? d_(Condition ColorectalCancer)
-		{
-			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(ColorectalCancer);
-			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.End(h_);
-			var j_ = context.Operators.SameOrBefore(g_, i_, "day");
-
-			return j_;
-		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
-
-		return e_;
-	}
-
-    [CqlDeclaration("Malignant Neoplasm")]
-	public IEnumerable<Condition> Malignant_Neoplasm() => 
-		__Malignant_Neoplasm.Value;
-
-	private IEnumerable<Procedure> Total_Colectomy_Performed_Value()
-	{
-		var a_ = this.Total_Colectomy();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.Completed_Procedure(b_);
-		bool? d_(Procedure Colectomy)
-		{
-			var f_ = Colectomy?.Performed;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.End(j_);
-			var l_ = context.Operators.SameOrBefore(i_, k_, "day");
-
-			return l_;
-		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
-
-		return e_;
-	}
-
-    [CqlDeclaration("Total Colectomy Performed")]
-	public IEnumerable<Procedure> Total_Colectomy_Performed() => 
-		__Total_Colectomy_Performed.Value;
-
-	private bool? Denominator_Exclusion_Value()
-	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = this.Malignant_Neoplasm();
-		var c_ = context.Operators.Exists<Condition>(b_);
-		var d_ = context.Operators.Or(a_, c_);
-		var e_ = this.Total_Colectomy_Performed();
-		var f_ = context.Operators.Exists<Procedure>(e_);
-		var g_ = context.Operators.Or(d_, f_);
-		var h_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty();
-		var i_ = context.Operators.Or(g_, h_);
-		var j_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home();
-		var k_ = context.Operators.Or(i_, j_);
-		var l_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
-		var m_ = context.Operators.Or(k_, l_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(46, 75, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
+		bool? l_ = context.Operators.Exists<Encounter>(k_);
+		bool? m_ = context.Operators.And(j_, l_);
 
 		return m_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population.Value;
+
+    /// <seealso cref="Denominator"/>
+	private bool? Denominator_Value()
+	{
+		bool? a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    /// <seealso cref="Denominator_Value"/>
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator.Value;
+
+    /// <seealso cref="Malignant_Neoplasm"/>
+	private IEnumerable<Condition> Malignant_Neoplasm_Value()
+	{
+		CqlValueSet a_ = this.Malignant_Neoplasm_of_Colon();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
+		bool? d_(Condition ColorectalCancer)
+		{
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(ColorectalCancer);
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.End(h_);
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, "day");
+
+			return j_;
+		};
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
+
+		return e_;
+	}
+
+    /// <seealso cref="Malignant_Neoplasm_Value"/>
+    [CqlDeclaration("Malignant Neoplasm")]
+	public IEnumerable<Condition> Malignant_Neoplasm() => 
+		__Malignant_Neoplasm.Value;
+
+    /// <seealso cref="Total_Colectomy_Performed"/>
+	private IEnumerable<Procedure> Total_Colectomy_Performed_Value()
+	{
+		CqlValueSet a_ = this.Total_Colectomy();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
+		bool? d_(Procedure Colectomy)
+		{
+			DataType f_ = Colectomy?.Performed;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
+			CqlDateTime i_ = context.Operators.End(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.End(j_);
+			bool? l_ = context.Operators.SameOrBefore(i_, k_, "day");
+
+			return l_;
+		};
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
+
+		return e_;
+	}
+
+    /// <seealso cref="Total_Colectomy_Performed_Value"/>
+    [CqlDeclaration("Total Colectomy Performed")]
+	public IEnumerable<Procedure> Total_Colectomy_Performed() => 
+		__Total_Colectomy_Performed.Value;
+
+    /// <seealso cref="Denominator_Exclusion"/>
+	private bool? Denominator_Exclusion_Value()
+	{
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		IEnumerable<Condition> b_ = this.Malignant_Neoplasm();
+		bool? c_ = context.Operators.Exists<Condition>(b_);
+		bool? d_ = context.Operators.Or(a_, c_);
+		IEnumerable<Procedure> e_ = this.Total_Colectomy_Performed();
+		bool? f_ = context.Operators.Exists<Procedure>(e_);
+		bool? g_ = context.Operators.Or(d_, f_);
+		bool? h_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty();
+		bool? i_ = context.Operators.Or(g_, h_);
+		bool? j_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home();
+		bool? k_ = context.Operators.Or(i_, j_);
+		bool? l_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		bool? m_ = context.Operators.Or(k_, l_);
+
+		return m_;
+	}
+
+    /// <seealso cref="Denominator_Exclusion_Value"/>
     [CqlDeclaration("Denominator Exclusion")]
 	public bool? Denominator_Exclusion() => 
 		__Denominator_Exclusion.Value;
 
+    /// <seealso cref="Fecal_Occult_Blood_Test_Performed"/>
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value()
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.Final_Lab_Observation(b_);
+		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation FecalOccultResult)
 		{
-			var f_ = FecalOccultResult?.Value;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = context.Operators.Not((bool?)(g_ is null));
+			DataType f_ = FecalOccultResult?.Value;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			bool? h_ = context.Operators.Not((bool?)(g_ is null));
 			object i_()
 			{
 				bool n_()
 				{
-					var q_ = FecalOccultResult?.Effective;
-					var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-					var s_ = r_ is CqlDateTime;
+					DataType q_ = FecalOccultResult?.Effective;
+					object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+					bool s_ = r_ is CqlDateTime;
 
 					return s_;
 				};
 				bool o_()
 				{
-					var t_ = FecalOccultResult?.Effective;
-					var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-					var v_ = u_ is CqlInterval<CqlDateTime>;
+					DataType t_ = FecalOccultResult?.Effective;
+					object u_ = FHIRHelpers_4_3_000.ToValue(t_);
+					bool v_ = u_ is CqlInterval<CqlDateTime>;
 
 					return v_;
 				};
 				bool p_()
 				{
-					var w_ = FecalOccultResult?.Effective;
-					var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-					var y_ = x_ is CqlDateTime;
+					DataType w_ = FecalOccultResult?.Effective;
+					object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+					bool y_ = x_ is CqlDateTime;
 
 					return y_;
 				};
 				if (n_())
 				{
-					var z_ = FecalOccultResult?.Effective;
-					var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+					DataType z_ = FecalOccultResult?.Effective;
+					object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
 
 					return ((aa_ as CqlDateTime) as object);
 				}
 				else if (o_())
 				{
-					var ab_ = FecalOccultResult?.Effective;
-					var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+					DataType ab_ = FecalOccultResult?.Effective;
+					object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 
 					return ((ac_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (p_())
 				{
-					var ad_ = FecalOccultResult?.Effective;
-					var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+					DataType ad_ = FecalOccultResult?.Effective;
+					object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 
 					return ((ae_ as CqlDateTime) as object);
 				}
@@ -397,76 +436,78 @@ public class ColonCancerScreeningFHIR_0_1_000
 					return null;
 				}
 			};
-			var j_ = QICoreCommon_2_0_000.Latest(i_());
-			var k_ = this.Measurement_Period();
-			var l_ = context.Operators.In<CqlDateTime>(j_, k_, "day");
-			var m_ = context.Operators.And(h_, l_);
+			CqlDateTime j_ = QICoreCommon_2_0_000.Latest(i_());
+			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, "day");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Fecal_Occult_Blood_Test_Performed_Value"/>
     [CqlDeclaration("Fecal Occult Blood Test Performed")]
 	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed() => 
 		__Fecal_Occult_Blood_Test_Performed.Value;
 
+    /// <seealso cref="Stool_DNA_with_FIT_Test_Performed"/>
 	private IEnumerable<Observation> Stool_DNA_with_FIT_Test_Performed_Value()
 	{
-		var a_ = this.sDNA_FIT_Test();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.Final_Lab_Observation(b_);
+		CqlValueSet a_ = this.sDNA_FIT_Test();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation sDNATest)
 		{
-			var f_ = sDNATest?.Value;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = context.Operators.Not((bool?)(g_ is null));
+			DataType f_ = sDNATest?.Value;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			bool? h_ = context.Operators.Not((bool?)(g_ is null));
 			object i_()
 			{
 				bool t_()
 				{
-					var w_ = sDNATest?.Effective;
-					var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-					var y_ = x_ is CqlDateTime;
+					DataType w_ = sDNATest?.Effective;
+					object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+					bool y_ = x_ is CqlDateTime;
 
 					return y_;
 				};
 				bool u_()
 				{
-					var z_ = sDNATest?.Effective;
-					var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
-					var ab_ = aa_ is CqlInterval<CqlDateTime>;
+					DataType z_ = sDNATest?.Effective;
+					object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+					bool ab_ = aa_ is CqlInterval<CqlDateTime>;
 
 					return ab_;
 				};
 				bool v_()
 				{
-					var ac_ = sDNATest?.Effective;
-					var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-					var ae_ = ad_ is CqlDateTime;
+					DataType ac_ = sDNATest?.Effective;
+					object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+					bool ae_ = ad_ is CqlDateTime;
 
 					return ae_;
 				};
 				if (t_())
 				{
-					var af_ = sDNATest?.Effective;
-					var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+					DataType af_ = sDNATest?.Effective;
+					object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
 
 					return ((ag_ as CqlDateTime) as object);
 				}
 				else if (u_())
 				{
-					var ah_ = sDNATest?.Effective;
-					var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+					DataType ah_ = sDNATest?.Effective;
+					object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
 
 					return ((ai_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (v_())
 				{
-					var aj_ = sDNATest?.Effective;
-					var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+					DataType aj_ = sDNATest?.Effective;
+					object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
 
 					return ((ak_ as CqlDateTime) as object);
 				}
@@ -475,173 +516,190 @@ public class ColonCancerScreeningFHIR_0_1_000
 					return null;
 				}
 			};
-			var j_ = QICoreCommon_2_0_000.Latest(i_());
-			var k_ = this.Measurement_Period();
-			var l_ = context.Operators.Start(k_);
-			var m_ = context.Operators.Quantity(2m, "years");
-			var n_ = context.Operators.Subtract(l_, m_);
-			var p_ = context.Operators.End(k_);
-			var q_ = context.Operators.Interval(n_, p_, true, true);
-			var r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
-			var s_ = context.Operators.And(h_, r_);
+			CqlDateTime j_ = QICoreCommon_2_0_000.Latest(i_());
+			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
+			CqlDateTime l_ = context.Operators.Start(k_);
+			CqlQuantity m_ = context.Operators.Quantity(2m, "years");
+			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
+			CqlDateTime p_ = context.Operators.End(k_);
+			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
+			bool? s_ = context.Operators.And(h_, r_);
 
 			return s_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Stool_DNA_with_FIT_Test_Performed_Value"/>
     [CqlDeclaration("Stool DNA with FIT Test Performed")]
 	public IEnumerable<Observation> Stool_DNA_with_FIT_Test_Performed() => 
 		__Stool_DNA_with_FIT_Test_Performed.Value;
 
+    /// <seealso cref="Flexible_Sigmoidoscopy_Performed"/>
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value()
 	{
-		var a_ = this.Flexible_Sigmoidoscopy();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure FlexibleSigmoidoscopy)
 		{
-			var f_ = FlexibleSigmoidoscopy?.Performed;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.Quantity(4m, "years");
-			var m_ = context.Operators.Subtract(k_, l_);
-			var o_ = context.Operators.End(j_);
-			var p_ = context.Operators.Interval(m_, o_, true, true);
-			var q_ = context.Operators.In<CqlDateTime>(i_, p_, "day");
+			DataType f_ = FlexibleSigmoidoscopy?.Performed;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
+			CqlDateTime i_ = context.Operators.End(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlQuantity l_ = context.Operators.Quantity(4m, "years");
+			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
+			CqlDateTime o_ = context.Operators.End(j_);
+			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, "day");
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Flexible_Sigmoidoscopy_Performed_Value"/>
     [CqlDeclaration("Flexible Sigmoidoscopy Performed")]
 	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed() => 
 		__Flexible_Sigmoidoscopy_Performed.Value;
 
+    /// <seealso cref="CT_Colonography_Performed"/>
 	private IEnumerable<Observation> CT_Colonography_Performed_Value()
 	{
-		var a_ = this.CT_Colonography();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.Final_Observation(b_);
+		CqlValueSet a_ = this.CT_Colonography();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.Final_Observation(b_);
 		bool? d_(Observation Colonography)
 		{
-			var f_ = Colonography?.Effective;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.Quantity(4m, "years");
-			var m_ = context.Operators.Subtract(k_, l_);
-			var o_ = context.Operators.End(j_);
-			var p_ = context.Operators.Interval(m_, o_, true, true);
-			var q_ = context.Operators.In<CqlDateTime>(i_, p_, "day");
+			DataType f_ = Colonography?.Effective;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
+			CqlDateTime i_ = context.Operators.End(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlQuantity l_ = context.Operators.Quantity(4m, "years");
+			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
+			CqlDateTime o_ = context.Operators.End(j_);
+			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, "day");
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="CT_Colonography_Performed_Value"/>
     [CqlDeclaration("CT Colonography Performed")]
 	public IEnumerable<Observation> CT_Colonography_Performed() => 
 		__CT_Colonography_Performed.Value;
 
+    /// <seealso cref="Colonoscopy_Performed"/>
 	private IEnumerable<Procedure> Colonoscopy_Performed_Value()
 	{
-		var a_ = this.Colonoscopy();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		CqlValueSet a_ = this.Colonoscopy();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure Colonoscopy)
 		{
-			var f_ = Colonoscopy?.Performed;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.Quantity(9m, "years");
-			var m_ = context.Operators.Subtract(k_, l_);
-			var o_ = context.Operators.End(j_);
-			var p_ = context.Operators.Interval(m_, o_, true, true);
-			var q_ = context.Operators.In<CqlDateTime>(i_, p_, "day");
+			DataType f_ = Colonoscopy?.Performed;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
+			CqlDateTime i_ = context.Operators.End(h_);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlQuantity l_ = context.Operators.Quantity(9m, "years");
+			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
+			CqlDateTime o_ = context.Operators.End(j_);
+			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, "day");
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Colonoscopy_Performed_Value"/>
     [CqlDeclaration("Colonoscopy Performed")]
 	public IEnumerable<Procedure> Colonoscopy_Performed() => 
 		__Colonoscopy_Performed.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Fecal_Occult_Blood_Test_Performed();
-		var b_ = context.Operators.Exists<Observation>(a_);
-		var c_ = this.Stool_DNA_with_FIT_Test_Performed();
-		var d_ = context.Operators.Exists<Observation>(c_);
-		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Flexible_Sigmoidoscopy_Performed();
-		var g_ = context.Operators.Exists<Procedure>(f_);
-		var h_ = context.Operators.Or(e_, g_);
-		var i_ = this.CT_Colonography_Performed();
-		var j_ = context.Operators.Exists<Observation>(i_);
-		var k_ = context.Operators.Or(h_, j_);
-		var l_ = this.Colonoscopy_Performed();
-		var m_ = context.Operators.Exists<Procedure>(l_);
-		var n_ = context.Operators.Or(k_, m_);
+		IEnumerable<Observation> a_ = this.Fecal_Occult_Blood_Test_Performed();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> c_ = this.Stool_DNA_with_FIT_Test_Performed();
+		bool? d_ = context.Operators.Exists<Observation>(c_);
+		bool? e_ = context.Operators.Or(b_, d_);
+		IEnumerable<Procedure> f_ = this.Flexible_Sigmoidoscopy_Performed();
+		bool? g_ = context.Operators.Exists<Procedure>(f_);
+		bool? h_ = context.Operators.Or(e_, g_);
+		IEnumerable<Observation> i_ = this.CT_Colonography_Performed();
+		bool? j_ = context.Operators.Exists<Observation>(i_);
+		bool? k_ = context.Operators.Or(h_, j_);
+		IEnumerable<Procedure> l_ = this.Colonoscopy_Performed();
+		bool? m_ = context.Operators.Exists<Procedure>(l_);
+		bool? n_ = context.Operators.Or(k_, m_);
 
 		return n_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Stratification_1"/>
 	private bool? Stratification_1_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(46, 49, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(46, 49, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Stratification_1_Value"/>
     [CqlDeclaration("Stratification 1")]
 	public bool? Stratification_1() => 
 		__Stratification_1.Value;
 
+    /// <seealso cref="Stratification_2"/>
 	private bool? Stratification_2_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(50, 75, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(50, 75, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Stratification_2_Value"/>
     [CqlDeclaration("Stratification 2")]
 	public bool? Stratification_2() => 
 		__Stratification_2.Value;

--- a/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
@@ -142,345 +142,442 @@ public class CumulativeMedicationDuration_4_0_000
 
     #endregion
 
+    /// <seealso cref="HS"/>
 	private CqlCode HS_Value() => 
 		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="HS_Value"/>
     [CqlDeclaration("HS")]
 	public CqlCode HS() => 
 		__HS.Value;
 
+    /// <seealso cref="WAKE"/>
 	private CqlCode WAKE_Value() => 
 		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="WAKE_Value"/>
     [CqlDeclaration("WAKE")]
 	public CqlCode WAKE() => 
 		__WAKE.Value;
 
+    /// <seealso cref="C"/>
 	private CqlCode C_Value() => 
 		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="C_Value"/>
     [CqlDeclaration("C")]
 	public CqlCode C() => 
 		__C.Value;
 
+    /// <seealso cref="CM"/>
 	private CqlCode CM_Value() => 
 		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="CM_Value"/>
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
+    /// <seealso cref="CD"/>
 	private CqlCode CD_Value() => 
 		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="CD_Value"/>
     [CqlDeclaration("CD")]
 	public CqlCode CD() => 
 		__CD.Value;
 
+    /// <seealso cref="CV"/>
 	private CqlCode CV_Value() => 
 		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="CV_Value"/>
     [CqlDeclaration("CV")]
 	public CqlCode CV() => 
 		__CV.Value;
 
+    /// <seealso cref="AC"/>
 	private CqlCode AC_Value() => 
 		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="AC_Value"/>
     [CqlDeclaration("AC")]
 	public CqlCode AC() => 
 		__AC.Value;
 
+    /// <seealso cref="ACM"/>
 	private CqlCode ACM_Value() => 
 		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="ACM_Value"/>
     [CqlDeclaration("ACM")]
 	public CqlCode ACM() => 
 		__ACM.Value;
 
+    /// <seealso cref="ACD"/>
 	private CqlCode ACD_Value() => 
 		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="ACD_Value"/>
     [CqlDeclaration("ACD")]
 	public CqlCode ACD() => 
 		__ACD.Value;
 
+    /// <seealso cref="ACV"/>
 	private CqlCode ACV_Value() => 
 		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="ACV_Value"/>
     [CqlDeclaration("ACV")]
 	public CqlCode ACV() => 
 		__ACV.Value;
 
+    /// <seealso cref="PC"/>
 	private CqlCode PC_Value() => 
 		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="PC_Value"/>
     [CqlDeclaration("PC")]
 	public CqlCode PC() => 
 		__PC.Value;
 
+    /// <seealso cref="PCM"/>
 	private CqlCode PCM_Value() => 
 		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="PCM_Value"/>
     [CqlDeclaration("PCM")]
 	public CqlCode PCM() => 
 		__PCM.Value;
 
+    /// <seealso cref="PCD"/>
 	private CqlCode PCD_Value() => 
 		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="PCD_Value"/>
     [CqlDeclaration("PCD")]
 	public CqlCode PCD() => 
 		__PCD.Value;
 
+    /// <seealso cref="PCV"/>
 	private CqlCode PCV_Value() => 
 		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
+    /// <seealso cref="PCV_Value"/>
     [CqlDeclaration("PCV")]
 	public CqlCode PCV() => 
 		__PCV.Value;
 
+    /// <seealso cref="MORN"/>
 	private CqlCode MORN_Value() => 
 		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="MORN_Value"/>
     [CqlDeclaration("MORN")]
 	public CqlCode MORN() => 
 		__MORN.Value;
 
+    /// <seealso cref="MORN_early"/>
 	private CqlCode MORN_early_Value() => 
 		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="MORN_early_Value"/>
     [CqlDeclaration("MORN.early")]
 	public CqlCode MORN_early() => 
 		__MORN_early.Value;
 
+    /// <seealso cref="MORN_late"/>
 	private CqlCode MORN_late_Value() => 
 		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="MORN_late_Value"/>
     [CqlDeclaration("MORN.late")]
 	public CqlCode MORN_late() => 
 		__MORN_late.Value;
 
+    /// <seealso cref="NOON"/>
 	private CqlCode NOON_Value() => 
 		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="NOON_Value"/>
     [CqlDeclaration("NOON")]
 	public CqlCode NOON() => 
 		__NOON.Value;
 
+    /// <seealso cref="AFT"/>
 	private CqlCode AFT_Value() => 
 		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="AFT_Value"/>
     [CqlDeclaration("AFT")]
 	public CqlCode AFT() => 
 		__AFT.Value;
 
+    /// <seealso cref="AFT_early"/>
 	private CqlCode AFT_early_Value() => 
 		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="AFT_early_Value"/>
     [CqlDeclaration("AFT.early")]
 	public CqlCode AFT_early() => 
 		__AFT_early.Value;
 
+    /// <seealso cref="AFT_late"/>
 	private CqlCode AFT_late_Value() => 
 		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="AFT_late_Value"/>
     [CqlDeclaration("AFT.late")]
 	public CqlCode AFT_late() => 
 		__AFT_late.Value;
 
+    /// <seealso cref="EVE"/>
 	private CqlCode EVE_Value() => 
 		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="EVE_Value"/>
     [CqlDeclaration("EVE")]
 	public CqlCode EVE() => 
 		__EVE.Value;
 
+    /// <seealso cref="EVE_early"/>
 	private CqlCode EVE_early_Value() => 
 		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="EVE_early_Value"/>
     [CqlDeclaration("EVE.early")]
 	public CqlCode EVE_early() => 
 		__EVE_early.Value;
 
+    /// <seealso cref="EVE_late"/>
 	private CqlCode EVE_late_Value() => 
 		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="EVE_late_Value"/>
     [CqlDeclaration("EVE.late")]
 	public CqlCode EVE_late() => 
 		__EVE_late.Value;
 
+    /// <seealso cref="NIGHT"/>
 	private CqlCode NIGHT_Value() => 
 		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="NIGHT_Value"/>
     [CqlDeclaration("NIGHT")]
 	public CqlCode NIGHT() => 
 		__NIGHT.Value;
 
+    /// <seealso cref="PHS"/>
 	private CqlCode PHS_Value() => 
 		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", null, null);
 
+    /// <seealso cref="PHS_Value"/>
     [CqlDeclaration("PHS")]
 	public CqlCode PHS() => 
 		__PHS.Value;
 
+    /// <seealso cref="Every_eight_hours__qualifier_value_"/>
 	private CqlCode Every_eight_hours__qualifier_value__Value() => 
 		new CqlCode("307469008", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_eight_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every eight hours (qualifier value)")]
 	public CqlCode Every_eight_hours__qualifier_value_() => 
 		__Every_eight_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_eight_to_twelve_hours__qualifier_value_"/>
 	private CqlCode Every_eight_to_twelve_hours__qualifier_value__Value() => 
 		new CqlCode("396140003", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_eight_to_twelve_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every eight to twelve hours (qualifier value)")]
 	public CqlCode Every_eight_to_twelve_hours__qualifier_value_() => 
 		__Every_eight_to_twelve_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_forty_eight_hours__qualifier_value_"/>
 	private CqlCode Every_forty_eight_hours__qualifier_value__Value() => 
 		new CqlCode("396131002", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_forty_eight_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every forty eight hours (qualifier value)")]
 	public CqlCode Every_forty_eight_hours__qualifier_value_() => 
 		__Every_forty_eight_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_forty_hours__qualifier_value_"/>
 	private CqlCode Every_forty_hours__qualifier_value__Value() => 
 		new CqlCode("396130001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_forty_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every forty hours (qualifier value)")]
 	public CqlCode Every_forty_hours__qualifier_value_() => 
 		__Every_forty_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_four_hours__qualifier_value_"/>
 	private CqlCode Every_four_hours__qualifier_value__Value() => 
 		new CqlCode("225756002", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_four_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every four hours (qualifier value)")]
 	public CqlCode Every_four_hours__qualifier_value_() => 
 		__Every_four_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_seventy_two_hours__qualifier_value_"/>
 	private CqlCode Every_seventy_two_hours__qualifier_value__Value() => 
 		new CqlCode("396143001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_seventy_two_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every seventy two hours (qualifier value)")]
 	public CqlCode Every_seventy_two_hours__qualifier_value_() => 
 		__Every_seventy_two_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_six_hours__qualifier_value_"/>
 	private CqlCode Every_six_hours__qualifier_value__Value() => 
 		new CqlCode("307468000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_six_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every six hours (qualifier value)")]
 	public CqlCode Every_six_hours__qualifier_value_() => 
 		__Every_six_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_six_to_eight_hours__qualifier_value_"/>
 	private CqlCode Every_six_to_eight_hours__qualifier_value__Value() => 
 		new CqlCode("396139000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_six_to_eight_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every six to eight hours (qualifier value)")]
 	public CqlCode Every_six_to_eight_hours__qualifier_value_() => 
 		__Every_six_to_eight_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_thirty_six_hours__qualifier_value_"/>
 	private CqlCode Every_thirty_six_hours__qualifier_value__Value() => 
 		new CqlCode("396126004", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_thirty_six_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every thirty six hours (qualifier value)")]
 	public CqlCode Every_thirty_six_hours__qualifier_value_() => 
 		__Every_thirty_six_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_three_to_four_hours__qualifier_value_"/>
 	private CqlCode Every_three_to_four_hours__qualifier_value__Value() => 
 		new CqlCode("225754004", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_three_to_four_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every three to four hours (qualifier value)")]
 	public CqlCode Every_three_to_four_hours__qualifier_value_() => 
 		__Every_three_to_four_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_three_to_six_hours__qualifier_value_"/>
 	private CqlCode Every_three_to_six_hours__qualifier_value__Value() => 
 		new CqlCode("396127008", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_three_to_six_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every three to six hours (qualifier value)")]
 	public CqlCode Every_three_to_six_hours__qualifier_value_() => 
 		__Every_three_to_six_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_twelve_hours__qualifier_value_"/>
 	private CqlCode Every_twelve_hours__qualifier_value__Value() => 
 		new CqlCode("307470009", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_twelve_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every twelve hours (qualifier value)")]
 	public CqlCode Every_twelve_hours__qualifier_value_() => 
 		__Every_twelve_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_twenty_four_hours__qualifier_value_"/>
 	private CqlCode Every_twenty_four_hours__qualifier_value__Value() => 
 		new CqlCode("396125000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_twenty_four_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every twenty four hours (qualifier value)")]
 	public CqlCode Every_twenty_four_hours__qualifier_value_() => 
 		__Every_twenty_four_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Every_two_to_four_hours__qualifier_value_"/>
 	private CqlCode Every_two_to_four_hours__qualifier_value__Value() => 
 		new CqlCode("225752000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Every_two_to_four_hours__qualifier_value__Value"/>
     [CqlDeclaration("Every two to four hours (qualifier value)")]
 	public CqlCode Every_two_to_four_hours__qualifier_value_() => 
 		__Every_two_to_four_hours__qualifier_value_.Value;
 
+    /// <seealso cref="Four_times_daily__qualifier_value_"/>
 	private CqlCode Four_times_daily__qualifier_value__Value() => 
 		new CqlCode("307439001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Four_times_daily__qualifier_value__Value"/>
     [CqlDeclaration("Four times daily (qualifier value)")]
 	public CqlCode Four_times_daily__qualifier_value_() => 
 		__Four_times_daily__qualifier_value_.Value;
 
+    /// <seealso cref="Once_daily__qualifier_value_"/>
 	private CqlCode Once_daily__qualifier_value__Value() => 
 		new CqlCode("229797004", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Once_daily__qualifier_value__Value"/>
     [CqlDeclaration("Once daily (qualifier value)")]
 	public CqlCode Once_daily__qualifier_value_() => 
 		__Once_daily__qualifier_value_.Value;
 
+    /// <seealso cref="One_to_four_times_a_day__qualifier_value_"/>
 	private CqlCode One_to_four_times_a_day__qualifier_value__Value() => 
 		new CqlCode("396109005", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="One_to_four_times_a_day__qualifier_value__Value"/>
     [CqlDeclaration("One to four times a day (qualifier value)")]
 	public CqlCode One_to_four_times_a_day__qualifier_value_() => 
 		__One_to_four_times_a_day__qualifier_value_.Value;
 
+    /// <seealso cref="One_to_three_times_a_day__qualifier_value_"/>
 	private CqlCode One_to_three_times_a_day__qualifier_value__Value() => 
 		new CqlCode("396108002", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="One_to_three_times_a_day__qualifier_value__Value"/>
     [CqlDeclaration("One to three times a day (qualifier value)")]
 	public CqlCode One_to_three_times_a_day__qualifier_value_() => 
 		__One_to_three_times_a_day__qualifier_value_.Value;
 
+    /// <seealso cref="One_to_two_times_a_day__qualifier_value_"/>
 	private CqlCode One_to_two_times_a_day__qualifier_value__Value() => 
 		new CqlCode("396107007", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="One_to_two_times_a_day__qualifier_value__Value"/>
     [CqlDeclaration("One to two times a day (qualifier value)")]
 	public CqlCode One_to_two_times_a_day__qualifier_value_() => 
 		__One_to_two_times_a_day__qualifier_value_.Value;
 
+    /// <seealso cref="Three_times_daily__qualifier_value_"/>
 	private CqlCode Three_times_daily__qualifier_value__Value() => 
 		new CqlCode("229798009", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Three_times_daily__qualifier_value__Value"/>
     [CqlDeclaration("Three times daily (qualifier value)")]
 	public CqlCode Three_times_daily__qualifier_value_() => 
 		__Three_times_daily__qualifier_value_.Value;
 
+    /// <seealso cref="Twice_a_day__qualifier_value_"/>
 	private CqlCode Twice_a_day__qualifier_value__Value() => 
 		new CqlCode("229799001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Twice_a_day__qualifier_value__Value"/>
     [CqlDeclaration("Twice a day (qualifier value)")]
 	public CqlCode Twice_a_day__qualifier_value_() => 
 		__Twice_a_day__qualifier_value_.Value;
 
+    /// <seealso cref="Two_to_four_times_a_day__qualifier_value_"/>
 	private CqlCode Two_to_four_times_a_day__qualifier_value__Value() => 
 		new CqlCode("396111001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Two_to_four_times_a_day__qualifier_value__Value"/>
     [CqlDeclaration("Two to four times a day (qualifier value)")]
 	public CqlCode Two_to_four_times_a_day__qualifier_value_() => 
 		__Two_to_four_times_a_day__qualifier_value_.Value;
 
+    /// <seealso cref="V3TimingEvent"/>
 	private CqlCode[] V3TimingEvent_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
 			new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
@@ -501,13 +598,15 @@ public class CumulativeMedicationDuration_4_0_000
 		return a_;
 	}
 
+    /// <seealso cref="V3TimingEvent_Value"/>
     [CqlDeclaration("V3TimingEvent")]
 	public CqlCode[] V3TimingEvent() => 
 		__V3TimingEvent.Value;
 
+    /// <seealso cref="EventTiming"/>
 	private CqlCode[] EventTiming_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("MORN", "http://hl7.org/fhir/event-timing", null, null),
 			new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", null, null),
@@ -526,29 +625,34 @@ public class CumulativeMedicationDuration_4_0_000
 		return a_;
 	}
 
+    /// <seealso cref="EventTiming_Value"/>
     [CqlDeclaration("EventTiming")]
 	public CqlCode[] EventTiming() => 
 		__EventTiming.Value;
 
+    /// <seealso cref="ErrorLevel"/>
 	private string ErrorLevel_Value()
 	{
-		var a_ = context.ResolveParameter("CumulativeMedicationDuration-4.0.000", "ErrorLevel", "Warning");
+		object a_ = context.ResolveParameter("CumulativeMedicationDuration-4.0.000", "ErrorLevel", "Warning");
 
 		return (string)a_;
 	}
 
+    /// <seealso cref="ErrorLevel_Value"/>
     [CqlDeclaration("ErrorLevel")]
 	public string ErrorLevel() => 
 		__ErrorLevel.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
@@ -560,395 +664,396 @@ public class CumulativeMedicationDuration_4_0_000
 		{
 			bool b_()
 			{
-				var w_ = period?.unit;
-				var x_ = context.Operators.Equal(w_, "h");
+				string w_ = period?.unit;
+				bool? x_ = context.Operators.Equal(w_, "h");
 
 				return (x_ ?? false);
 			};
 			bool c_()
 			{
-				var y_ = period?.unit;
-				var z_ = context.Operators.Equal(y_, "min");
+				string y_ = period?.unit;
+				bool? z_ = context.Operators.Equal(y_, "min");
 
 				return (z_ ?? false);
 			};
 			bool d_()
 			{
-				var aa_ = period?.unit;
-				var ab_ = context.Operators.Equal(aa_, "s");
+				string aa_ = period?.unit;
+				bool? ab_ = context.Operators.Equal(aa_, "s");
 
 				return (ab_ ?? false);
 			};
 			bool e_()
 			{
-				var ac_ = period?.unit;
-				var ad_ = context.Operators.Equal(ac_, "d");
+				string ac_ = period?.unit;
+				bool? ad_ = context.Operators.Equal(ac_, "d");
 
 				return (ad_ ?? false);
 			};
 			bool f_()
 			{
-				var ae_ = period?.unit;
-				var af_ = context.Operators.Equal(ae_, "wk");
+				string ae_ = period?.unit;
+				bool? af_ = context.Operators.Equal(ae_, "wk");
 
 				return (af_ ?? false);
 			};
 			bool g_()
 			{
-				var ag_ = period?.unit;
-				var ah_ = context.Operators.Equal(ag_, "mo");
+				string ag_ = period?.unit;
+				bool? ah_ = context.Operators.Equal(ag_, "mo");
 
 				return (ah_ ?? false);
 			};
 			bool h_()
 			{
-				var ai_ = period?.unit;
-				var aj_ = context.Operators.Equal(ai_, "a");
+				string ai_ = period?.unit;
+				bool? aj_ = context.Operators.Equal(ai_, "a");
 
 				return (aj_ ?? false);
 			};
 			bool i_()
 			{
-				var ak_ = period?.unit;
-				var al_ = context.Operators.Equal(ak_, "hour");
+				string ak_ = period?.unit;
+				bool? al_ = context.Operators.Equal(ak_, "hour");
 
 				return (al_ ?? false);
 			};
 			bool j_()
 			{
-				var am_ = period?.unit;
-				var an_ = context.Operators.Equal(am_, "minute");
+				string am_ = period?.unit;
+				bool? an_ = context.Operators.Equal(am_, "minute");
 
 				return (an_ ?? false);
 			};
 			bool k_()
 			{
-				var ao_ = period?.unit;
-				var ap_ = context.Operators.Equal(ao_, "second");
+				string ao_ = period?.unit;
+				bool? ap_ = context.Operators.Equal(ao_, "second");
 
 				return (ap_ ?? false);
 			};
 			bool l_()
 			{
-				var aq_ = period?.unit;
-				var ar_ = context.Operators.Equal(aq_, "day");
+				string aq_ = period?.unit;
+				bool? ar_ = context.Operators.Equal(aq_, "day");
 
 				return (ar_ ?? false);
 			};
 			bool m_()
 			{
-				var as_ = period?.unit;
-				var at_ = context.Operators.Equal(as_, "week");
+				string as_ = period?.unit;
+				bool? at_ = context.Operators.Equal(as_, "week");
 
 				return (at_ ?? false);
 			};
 			bool n_()
 			{
-				var au_ = period?.unit;
-				var av_ = context.Operators.Equal(au_, "month");
+				string au_ = period?.unit;
+				bool? av_ = context.Operators.Equal(au_, "month");
 
 				return (av_ ?? false);
 			};
 			bool o_()
 			{
-				var aw_ = period?.unit;
-				var ax_ = context.Operators.Equal(aw_, "year");
+				string aw_ = period?.unit;
+				bool? ax_ = context.Operators.Equal(aw_, "year");
 
 				return (ax_ ?? false);
 			};
 			bool p_()
 			{
-				var ay_ = period?.unit;
-				var az_ = context.Operators.Equal(ay_, "hours");
+				string ay_ = period?.unit;
+				bool? az_ = context.Operators.Equal(ay_, "hours");
 
 				return (az_ ?? false);
 			};
 			bool q_()
 			{
-				var ba_ = period?.unit;
-				var bb_ = context.Operators.Equal(ba_, "minutes");
+				string ba_ = period?.unit;
+				bool? bb_ = context.Operators.Equal(ba_, "minutes");
 
 				return (bb_ ?? false);
 			};
 			bool r_()
 			{
-				var bc_ = period?.unit;
-				var bd_ = context.Operators.Equal(bc_, "seconds");
+				string bc_ = period?.unit;
+				bool? bd_ = context.Operators.Equal(bc_, "seconds");
 
 				return (bd_ ?? false);
 			};
 			bool s_()
 			{
-				var be_ = period?.unit;
-				var bf_ = context.Operators.Equal(be_, "days");
+				string be_ = period?.unit;
+				bool? bf_ = context.Operators.Equal(be_, "days");
 
 				return (bf_ ?? false);
 			};
 			bool t_()
 			{
-				var bg_ = period?.unit;
-				var bh_ = context.Operators.Equal(bg_, "weeks");
+				string bg_ = period?.unit;
+				bool? bh_ = context.Operators.Equal(bg_, "weeks");
 
 				return (bh_ ?? false);
 			};
 			bool u_()
 			{
-				var bi_ = period?.unit;
-				var bj_ = context.Operators.Equal(bi_, "months");
+				string bi_ = period?.unit;
+				bool? bj_ = context.Operators.Equal(bi_, "months");
 
 				return (bj_ ?? false);
 			};
 			bool v_()
 			{
-				var bk_ = period?.unit;
-				var bl_ = context.Operators.Equal(bk_, "years");
+				string bk_ = period?.unit;
+				bool? bl_ = context.Operators.Equal(bk_, "years");
 
 				return (bl_ ?? false);
 			};
 			if (b_())
 			{
-				var bm_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var bn_ = period?.value;
-				var bo_ = context.Operators.Divide(24.0m, bn_);
-				var bp_ = context.Operators.Multiply(bm_, bo_);
+				decimal? bm_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? bn_ = period?.value;
+				decimal? bo_ = context.Operators.Divide(24.0m, bn_);
+				decimal? bp_ = context.Operators.Multiply(bm_, bo_);
 
 				return bp_;
 			}
 			else if (c_())
 			{
-				var bq_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var br_ = period?.value;
-				var bs_ = context.Operators.Divide(24.0m, br_);
-				var bt_ = context.Operators.Multiply(bq_, bs_);
-				var bu_ = context.Operators.ConvertIntegerToDecimal(60);
-				var bv_ = context.Operators.Multiply(bt_, bu_);
+				decimal? bq_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? br_ = period?.value;
+				decimal? bs_ = context.Operators.Divide(24.0m, br_);
+				decimal? bt_ = context.Operators.Multiply(bq_, bs_);
+				decimal? bu_ = context.Operators.ConvertIntegerToDecimal(60);
+				decimal? bv_ = context.Operators.Multiply(bt_, bu_);
 
 				return bv_;
 			}
 			else if (d_())
 			{
-				var bw_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var bx_ = period?.value;
-				var by_ = context.Operators.Divide(24.0m, bx_);
-				var bz_ = context.Operators.Multiply(bw_, by_);
-				var ca_ = context.Operators.ConvertIntegerToDecimal(60);
-				var cb_ = context.Operators.Multiply(bz_, ca_);
-				var cd_ = context.Operators.Multiply(cb_, ca_);
+				decimal? bw_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? bx_ = period?.value;
+				decimal? by_ = context.Operators.Divide(24.0m, bx_);
+				decimal? bz_ = context.Operators.Multiply(bw_, by_);
+				decimal? ca_ = context.Operators.ConvertIntegerToDecimal(60);
+				decimal? cb_ = context.Operators.Multiply(bz_, ca_);
+				decimal? cd_ = context.Operators.Multiply(cb_, ca_);
 
 				return cd_;
 			}
 			else if (e_())
 			{
-				var ce_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var cf_ = period?.value;
-				var cg_ = context.Operators.Divide(24.0m, cf_);
-				var ch_ = context.Operators.Multiply(ce_, cg_);
-				var ci_ = context.Operators.ConvertIntegerToDecimal(24);
-				var cj_ = context.Operators.Divide(ch_, ci_);
+				decimal? ce_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? cf_ = period?.value;
+				decimal? cg_ = context.Operators.Divide(24.0m, cf_);
+				decimal? ch_ = context.Operators.Multiply(ce_, cg_);
+				decimal? ci_ = context.Operators.ConvertIntegerToDecimal(24);
+				decimal? cj_ = context.Operators.Divide(ch_, ci_);
 
 				return cj_;
 			}
 			else if (f_())
 			{
-				var ck_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var cl_ = period?.value;
-				var cm_ = context.Operators.Divide(24.0m, cl_);
-				var cn_ = context.Operators.Multiply(ck_, cm_);
-				var co_ = context.Operators.Multiply(24, 7);
-				var cp_ = context.Operators.ConvertIntegerToDecimal(co_);
-				var cq_ = context.Operators.Divide(cn_, cp_);
+				decimal? ck_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? cl_ = period?.value;
+				decimal? cm_ = context.Operators.Divide(24.0m, cl_);
+				decimal? cn_ = context.Operators.Multiply(ck_, cm_);
+				int? co_ = context.Operators.Multiply(24, 7);
+				decimal? cp_ = context.Operators.ConvertIntegerToDecimal(co_);
+				decimal? cq_ = context.Operators.Divide(cn_, cp_);
 
 				return cq_;
 			}
 			else if (g_())
 			{
-				var cr_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var cs_ = period?.value;
-				var ct_ = context.Operators.Divide(24.0m, cs_);
-				var cu_ = context.Operators.Multiply(cr_, ct_);
-				var cv_ = context.Operators.Multiply(24, 30);
-				var cw_ = context.Operators.ConvertIntegerToDecimal(cv_);
-				var cx_ = context.Operators.Divide(cu_, cw_);
+				decimal? cr_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? cs_ = period?.value;
+				decimal? ct_ = context.Operators.Divide(24.0m, cs_);
+				decimal? cu_ = context.Operators.Multiply(cr_, ct_);
+				int? cv_ = context.Operators.Multiply(24, 30);
+				decimal? cw_ = context.Operators.ConvertIntegerToDecimal(cv_);
+				decimal? cx_ = context.Operators.Divide(cu_, cw_);
 
 				return cx_;
 			}
 			else if (h_())
 			{
-				var cy_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var cz_ = period?.value;
-				var da_ = context.Operators.Divide(24.0m, cz_);
-				var db_ = context.Operators.Multiply(cy_, da_);
-				var dc_ = context.Operators.Multiply(24, 365);
-				var dd_ = context.Operators.ConvertIntegerToDecimal(dc_);
-				var de_ = context.Operators.Divide(db_, dd_);
+				decimal? cy_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? cz_ = period?.value;
+				decimal? da_ = context.Operators.Divide(24.0m, cz_);
+				decimal? db_ = context.Operators.Multiply(cy_, da_);
+				int? dc_ = context.Operators.Multiply(24, 365);
+				decimal? dd_ = context.Operators.ConvertIntegerToDecimal(dc_);
+				decimal? de_ = context.Operators.Divide(db_, dd_);
 
 				return de_;
 			}
 			else if (i_())
 			{
-				var df_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var dg_ = period?.value;
-				var dh_ = context.Operators.Divide(24.0m, dg_);
-				var di_ = context.Operators.Multiply(df_, dh_);
+				decimal? df_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? dg_ = period?.value;
+				decimal? dh_ = context.Operators.Divide(24.0m, dg_);
+				decimal? di_ = context.Operators.Multiply(df_, dh_);
 
 				return di_;
 			}
 			else if (j_())
 			{
-				var dj_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var dk_ = period?.value;
-				var dl_ = context.Operators.Divide(24.0m, dk_);
-				var dm_ = context.Operators.Multiply(dj_, dl_);
-				var dn_ = context.Operators.ConvertIntegerToDecimal(60);
-				var do_ = context.Operators.Multiply(dm_, dn_);
+				decimal? dj_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? dk_ = period?.value;
+				decimal? dl_ = context.Operators.Divide(24.0m, dk_);
+				decimal? dm_ = context.Operators.Multiply(dj_, dl_);
+				decimal? dn_ = context.Operators.ConvertIntegerToDecimal(60);
+				decimal? do_ = context.Operators.Multiply(dm_, dn_);
 
 				return do_;
 			}
 			else if (k_())
 			{
-				var dp_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var dq_ = period?.value;
-				var dr_ = context.Operators.Divide(24.0m, dq_);
-				var ds_ = context.Operators.Multiply(dp_, dr_);
-				var dt_ = context.Operators.ConvertIntegerToDecimal(60);
-				var du_ = context.Operators.Multiply(ds_, dt_);
-				var dw_ = context.Operators.Multiply(du_, dt_);
+				decimal? dp_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? dq_ = period?.value;
+				decimal? dr_ = context.Operators.Divide(24.0m, dq_);
+				decimal? ds_ = context.Operators.Multiply(dp_, dr_);
+				decimal? dt_ = context.Operators.ConvertIntegerToDecimal(60);
+				decimal? du_ = context.Operators.Multiply(ds_, dt_);
+				decimal? dw_ = context.Operators.Multiply(du_, dt_);
 
 				return dw_;
 			}
 			else if (l_())
 			{
-				var dx_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var dy_ = period?.value;
-				var dz_ = context.Operators.Divide(24.0m, dy_);
-				var ea_ = context.Operators.Multiply(dx_, dz_);
-				var eb_ = context.Operators.ConvertIntegerToDecimal(24);
-				var ec_ = context.Operators.Divide(ea_, eb_);
+				decimal? dx_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? dy_ = period?.value;
+				decimal? dz_ = context.Operators.Divide(24.0m, dy_);
+				decimal? ea_ = context.Operators.Multiply(dx_, dz_);
+				decimal? eb_ = context.Operators.ConvertIntegerToDecimal(24);
+				decimal? ec_ = context.Operators.Divide(ea_, eb_);
 
 				return ec_;
 			}
 			else if (m_())
 			{
-				var ed_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var ee_ = period?.value;
-				var ef_ = context.Operators.Divide(24.0m, ee_);
-				var eg_ = context.Operators.Multiply(ed_, ef_);
-				var eh_ = context.Operators.Multiply(24, 7);
-				var ei_ = context.Operators.ConvertIntegerToDecimal(eh_);
-				var ej_ = context.Operators.Divide(eg_, ei_);
+				decimal? ed_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? ee_ = period?.value;
+				decimal? ef_ = context.Operators.Divide(24.0m, ee_);
+				decimal? eg_ = context.Operators.Multiply(ed_, ef_);
+				int? eh_ = context.Operators.Multiply(24, 7);
+				decimal? ei_ = context.Operators.ConvertIntegerToDecimal(eh_);
+				decimal? ej_ = context.Operators.Divide(eg_, ei_);
 
 				return ej_;
 			}
 			else if (n_())
 			{
-				var ek_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var el_ = period?.value;
-				var em_ = context.Operators.Divide(24.0m, el_);
-				var en_ = context.Operators.Multiply(ek_, em_);
-				var eo_ = context.Operators.Multiply(24, 30);
-				var ep_ = context.Operators.ConvertIntegerToDecimal(eo_);
-				var eq_ = context.Operators.Divide(en_, ep_);
+				decimal? ek_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? el_ = period?.value;
+				decimal? em_ = context.Operators.Divide(24.0m, el_);
+				decimal? en_ = context.Operators.Multiply(ek_, em_);
+				int? eo_ = context.Operators.Multiply(24, 30);
+				decimal? ep_ = context.Operators.ConvertIntegerToDecimal(eo_);
+				decimal? eq_ = context.Operators.Divide(en_, ep_);
 
 				return eq_;
 			}
 			else if (o_())
 			{
-				var er_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var es_ = period?.value;
-				var et_ = context.Operators.Divide(24.0m, es_);
-				var eu_ = context.Operators.Multiply(er_, et_);
-				var ev_ = context.Operators.Multiply(24, 365);
-				var ew_ = context.Operators.ConvertIntegerToDecimal(ev_);
-				var ex_ = context.Operators.Divide(eu_, ew_);
+				decimal? er_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? es_ = period?.value;
+				decimal? et_ = context.Operators.Divide(24.0m, es_);
+				decimal? eu_ = context.Operators.Multiply(er_, et_);
+				int? ev_ = context.Operators.Multiply(24, 365);
+				decimal? ew_ = context.Operators.ConvertIntegerToDecimal(ev_);
+				decimal? ex_ = context.Operators.Divide(eu_, ew_);
 
 				return ex_;
 			}
 			else if (p_())
 			{
-				var ey_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var ez_ = period?.value;
-				var fa_ = context.Operators.Divide(24.0m, ez_);
-				var fb_ = context.Operators.Multiply(ey_, fa_);
+				decimal? ey_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? ez_ = period?.value;
+				decimal? fa_ = context.Operators.Divide(24.0m, ez_);
+				decimal? fb_ = context.Operators.Multiply(ey_, fa_);
 
 				return fb_;
 			}
 			else if (q_())
 			{
-				var fc_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var fd_ = period?.value;
-				var fe_ = context.Operators.Divide(24.0m, fd_);
-				var ff_ = context.Operators.Multiply(fc_, fe_);
-				var fg_ = context.Operators.ConvertIntegerToDecimal(60);
-				var fh_ = context.Operators.Multiply(ff_, fg_);
+				decimal? fc_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? fd_ = period?.value;
+				decimal? fe_ = context.Operators.Divide(24.0m, fd_);
+				decimal? ff_ = context.Operators.Multiply(fc_, fe_);
+				decimal? fg_ = context.Operators.ConvertIntegerToDecimal(60);
+				decimal? fh_ = context.Operators.Multiply(ff_, fg_);
 
 				return fh_;
 			}
 			else if (r_())
 			{
-				var fi_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var fj_ = period?.value;
-				var fk_ = context.Operators.Divide(24.0m, fj_);
-				var fl_ = context.Operators.Multiply(fi_, fk_);
-				var fm_ = context.Operators.ConvertIntegerToDecimal(60);
-				var fn_ = context.Operators.Multiply(fl_, fm_);
-				var fp_ = context.Operators.Multiply(fn_, fm_);
+				decimal? fi_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? fj_ = period?.value;
+				decimal? fk_ = context.Operators.Divide(24.0m, fj_);
+				decimal? fl_ = context.Operators.Multiply(fi_, fk_);
+				decimal? fm_ = context.Operators.ConvertIntegerToDecimal(60);
+				decimal? fn_ = context.Operators.Multiply(fl_, fm_);
+				decimal? fp_ = context.Operators.Multiply(fn_, fm_);
 
 				return fp_;
 			}
 			else if (s_())
 			{
-				var fq_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var fr_ = period?.value;
-				var fs_ = context.Operators.Divide(24.0m, fr_);
-				var ft_ = context.Operators.Multiply(fq_, fs_);
-				var fu_ = context.Operators.ConvertIntegerToDecimal(24);
-				var fv_ = context.Operators.Divide(ft_, fu_);
+				decimal? fq_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? fr_ = period?.value;
+				decimal? fs_ = context.Operators.Divide(24.0m, fr_);
+				decimal? ft_ = context.Operators.Multiply(fq_, fs_);
+				decimal? fu_ = context.Operators.ConvertIntegerToDecimal(24);
+				decimal? fv_ = context.Operators.Divide(ft_, fu_);
 
 				return fv_;
 			}
 			else if (t_())
 			{
-				var fw_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var fx_ = period?.value;
-				var fy_ = context.Operators.Divide(24.0m, fx_);
-				var fz_ = context.Operators.Multiply(fw_, fy_);
-				var ga_ = context.Operators.Multiply(24, 7);
-				var gb_ = context.Operators.ConvertIntegerToDecimal(ga_);
-				var gc_ = context.Operators.Divide(fz_, gb_);
+				decimal? fw_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? fx_ = period?.value;
+				decimal? fy_ = context.Operators.Divide(24.0m, fx_);
+				decimal? fz_ = context.Operators.Multiply(fw_, fy_);
+				int? ga_ = context.Operators.Multiply(24, 7);
+				decimal? gb_ = context.Operators.ConvertIntegerToDecimal(ga_);
+				decimal? gc_ = context.Operators.Divide(fz_, gb_);
 
 				return gc_;
 			}
 			else if (u_())
 			{
-				var gd_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var ge_ = period?.value;
-				var gf_ = context.Operators.Divide(24.0m, ge_);
-				var gg_ = context.Operators.Multiply(gd_, gf_);
-				var gh_ = context.Operators.Multiply(24, 30);
-				var gi_ = context.Operators.ConvertIntegerToDecimal(gh_);
-				var gj_ = context.Operators.Divide(gg_, gi_);
+				decimal? gd_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? ge_ = period?.value;
+				decimal? gf_ = context.Operators.Divide(24.0m, ge_);
+				decimal? gg_ = context.Operators.Multiply(gd_, gf_);
+				int? gh_ = context.Operators.Multiply(24, 30);
+				decimal? gi_ = context.Operators.ConvertIntegerToDecimal(gh_);
+				decimal? gj_ = context.Operators.Divide(gg_, gi_);
 
 				return gj_;
 			}
 			else if (v_())
 			{
-				var gk_ = context.Operators.ConvertIntegerToDecimal(frequency);
-				var gl_ = period?.value;
-				var gm_ = context.Operators.Divide(24.0m, gl_);
-				var gn_ = context.Operators.Multiply(gk_, gm_);
-				var go_ = context.Operators.Multiply(24, 365);
-				var gp_ = context.Operators.ConvertIntegerToDecimal(go_);
-				var gq_ = context.Operators.Divide(gn_, gp_);
+				decimal? gk_ = context.Operators.ConvertIntegerToDecimal(frequency);
+				decimal? gl_ = period?.value;
+				decimal? gm_ = context.Operators.Divide(24.0m, gl_);
+				decimal? gn_ = context.Operators.Multiply(gk_, gm_);
+				int? go_ = context.Operators.Multiply(24, 365);
+				decimal? gp_ = context.Operators.ConvertIntegerToDecimal(go_);
+				decimal? gq_ = context.Operators.Divide(gn_, gp_);
 
 				return gq_;
 			}
 			else
 			{
-				var gr_ = this.ErrorLevel();
-				var gs_ = context.Operators.Concatenate("Unknown unit ", (period?.unit ?? ""));
-				var gt_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownUnit", gr_, gs_);
+				string gr_ = this.ErrorLevel();
+				string gs_ = period?.unit;
+				string gt_ = context.Operators.Concatenate("Unknown unit ", (gs_ ?? ""));
+				object gu_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownUnit", gr_, gt_);
 
-				return (decimal?)gt_;
+				return (decimal?)gu_;
 			}
 		};
 
@@ -962,486 +1067,486 @@ public class CumulativeMedicationDuration_4_0_000
 		{
 			bool b_()
 			{
-				var aw_ = this.HS();
-				var ax_ = context.Operators.Equivalent(frequency, aw_);
+				CqlCode aw_ = this.HS();
+				bool? ax_ = context.Operators.Equivalent(frequency, aw_);
 
 				return (ax_ ?? false);
 			};
 			bool c_()
 			{
-				var ay_ = this.WAKE();
-				var az_ = context.Operators.Equivalent(frequency, ay_);
+				CqlCode ay_ = this.WAKE();
+				bool? az_ = context.Operators.Equivalent(frequency, ay_);
 
 				return (az_ ?? false);
 			};
 			bool d_()
 			{
-				var ba_ = this.C();
-				var bb_ = context.Operators.Equivalent(frequency, ba_);
+				CqlCode ba_ = this.C();
+				bool? bb_ = context.Operators.Equivalent(frequency, ba_);
 
 				return (bb_ ?? false);
 			};
 			bool e_()
 			{
-				var bc_ = this.CM();
-				var bd_ = context.Operators.Equivalent(frequency, bc_);
+				CqlCode bc_ = this.CM();
+				bool? bd_ = context.Operators.Equivalent(frequency, bc_);
 
 				return (bd_ ?? false);
 			};
 			bool f_()
 			{
-				var be_ = this.CD();
-				var bf_ = context.Operators.Equivalent(frequency, be_);
+				CqlCode be_ = this.CD();
+				bool? bf_ = context.Operators.Equivalent(frequency, be_);
 
 				return (bf_ ?? false);
 			};
 			bool g_()
 			{
-				var bg_ = this.CV();
-				var bh_ = context.Operators.Equivalent(frequency, bg_);
+				CqlCode bg_ = this.CV();
+				bool? bh_ = context.Operators.Equivalent(frequency, bg_);
 
 				return (bh_ ?? false);
 			};
 			bool h_()
 			{
-				var bi_ = this.AC();
-				var bj_ = context.Operators.Equivalent(frequency, bi_);
+				CqlCode bi_ = this.AC();
+				bool? bj_ = context.Operators.Equivalent(frequency, bi_);
 
 				return (bj_ ?? false);
 			};
 			bool i_()
 			{
-				var bk_ = this.ACM();
-				var bl_ = context.Operators.Equivalent(frequency, bk_);
+				CqlCode bk_ = this.ACM();
+				bool? bl_ = context.Operators.Equivalent(frequency, bk_);
 
 				return (bl_ ?? false);
 			};
 			bool j_()
 			{
-				var bm_ = this.ACD();
-				var bn_ = context.Operators.Equivalent(frequency, bm_);
+				CqlCode bm_ = this.ACD();
+				bool? bn_ = context.Operators.Equivalent(frequency, bm_);
 
 				return (bn_ ?? false);
 			};
 			bool k_()
 			{
-				var bo_ = this.ACV();
-				var bp_ = context.Operators.Equivalent(frequency, bo_);
+				CqlCode bo_ = this.ACV();
+				bool? bp_ = context.Operators.Equivalent(frequency, bo_);
 
 				return (bp_ ?? false);
 			};
 			bool l_()
 			{
-				var bq_ = this.PC();
-				var br_ = context.Operators.Equivalent(frequency, bq_);
+				CqlCode bq_ = this.PC();
+				bool? br_ = context.Operators.Equivalent(frequency, bq_);
 
 				return (br_ ?? false);
 			};
 			bool m_()
 			{
-				var bs_ = this.PCM();
-				var bt_ = context.Operators.Equivalent(frequency, bs_);
+				CqlCode bs_ = this.PCM();
+				bool? bt_ = context.Operators.Equivalent(frequency, bs_);
 
 				return (bt_ ?? false);
 			};
 			bool n_()
 			{
-				var bu_ = this.PCD();
-				var bv_ = context.Operators.Equivalent(frequency, bu_);
+				CqlCode bu_ = this.PCD();
+				bool? bv_ = context.Operators.Equivalent(frequency, bu_);
 
 				return (bv_ ?? false);
 			};
 			bool o_()
 			{
-				var bw_ = this.PCV();
-				var bx_ = context.Operators.Equivalent(frequency, bw_);
+				CqlCode bw_ = this.PCV();
+				bool? bx_ = context.Operators.Equivalent(frequency, bw_);
 
 				return (bx_ ?? false);
 			};
 			bool p_()
 			{
-				var by_ = this.MORN();
-				var bz_ = context.Operators.Equivalent(frequency, by_);
+				CqlCode by_ = this.MORN();
+				bool? bz_ = context.Operators.Equivalent(frequency, by_);
 
 				return (bz_ ?? false);
 			};
 			bool q_()
 			{
-				var ca_ = this.MORN_early();
-				var cb_ = context.Operators.Equivalent(frequency, ca_);
+				CqlCode ca_ = this.MORN_early();
+				bool? cb_ = context.Operators.Equivalent(frequency, ca_);
 
 				return (cb_ ?? false);
 			};
 			bool r_()
 			{
-				var cc_ = this.MORN_late();
-				var cd_ = context.Operators.Equivalent(frequency, cc_);
+				CqlCode cc_ = this.MORN_late();
+				bool? cd_ = context.Operators.Equivalent(frequency, cc_);
 
 				return (cd_ ?? false);
 			};
 			bool s_()
 			{
-				var ce_ = this.NOON();
-				var cf_ = context.Operators.Equivalent(frequency, ce_);
+				CqlCode ce_ = this.NOON();
+				bool? cf_ = context.Operators.Equivalent(frequency, ce_);
 
 				return (cf_ ?? false);
 			};
 			bool t_()
 			{
-				var cg_ = this.AFT();
-				var ch_ = context.Operators.Equivalent(frequency, cg_);
+				CqlCode cg_ = this.AFT();
+				bool? ch_ = context.Operators.Equivalent(frequency, cg_);
 
 				return (ch_ ?? false);
 			};
 			bool u_()
 			{
-				var ci_ = this.AFT_early();
-				var cj_ = context.Operators.Equivalent(frequency, ci_);
+				CqlCode ci_ = this.AFT_early();
+				bool? cj_ = context.Operators.Equivalent(frequency, ci_);
 
 				return (cj_ ?? false);
 			};
 			bool v_()
 			{
-				var ck_ = this.AFT_late();
-				var cl_ = context.Operators.Equivalent(frequency, ck_);
+				CqlCode ck_ = this.AFT_late();
+				bool? cl_ = context.Operators.Equivalent(frequency, ck_);
 
 				return (cl_ ?? false);
 			};
 			bool w_()
 			{
-				var cm_ = this.EVE();
-				var cn_ = context.Operators.Equivalent(frequency, cm_);
+				CqlCode cm_ = this.EVE();
+				bool? cn_ = context.Operators.Equivalent(frequency, cm_);
 
 				return (cn_ ?? false);
 			};
 			bool x_()
 			{
-				var co_ = this.EVE_early();
-				var cp_ = context.Operators.Equivalent(frequency, co_);
+				CqlCode co_ = this.EVE_early();
+				bool? cp_ = context.Operators.Equivalent(frequency, co_);
 
 				return (cp_ ?? false);
 			};
 			bool y_()
 			{
-				var cq_ = this.EVE_late();
-				var cr_ = context.Operators.Equivalent(frequency, cq_);
+				CqlCode cq_ = this.EVE_late();
+				bool? cr_ = context.Operators.Equivalent(frequency, cq_);
 
 				return (cr_ ?? false);
 			};
 			bool z_()
 			{
-				var cs_ = this.NIGHT();
-				var ct_ = context.Operators.Equivalent(frequency, cs_);
+				CqlCode cs_ = this.NIGHT();
+				bool? ct_ = context.Operators.Equivalent(frequency, cs_);
 
 				return (ct_ ?? false);
 			};
 			bool aa_()
 			{
-				var cu_ = this.PHS();
-				var cv_ = context.Operators.Equivalent(frequency, cu_);
+				CqlCode cu_ = this.PHS();
+				bool? cv_ = context.Operators.Equivalent(frequency, cu_);
 
 				return (cv_ ?? false);
 			};
 			bool ab_()
 			{
-				var cw_ = this.Once_daily__qualifier_value_();
-				var cx_ = context.Operators.Equivalent(frequency, cw_);
+				CqlCode cw_ = this.Once_daily__qualifier_value_();
+				bool? cx_ = context.Operators.Equivalent(frequency, cw_);
 
 				return (cx_ ?? false);
 			};
 			bool ac_()
 			{
-				var cy_ = this.Twice_a_day__qualifier_value_();
-				var cz_ = context.Operators.Equivalent(frequency, cy_);
+				CqlCode cy_ = this.Twice_a_day__qualifier_value_();
+				bool? cz_ = context.Operators.Equivalent(frequency, cy_);
 
 				return (cz_ ?? false);
 			};
 			bool ad_()
 			{
-				var da_ = this.Three_times_daily__qualifier_value_();
-				var db_ = context.Operators.Equivalent(frequency, da_);
+				CqlCode da_ = this.Three_times_daily__qualifier_value_();
+				bool? db_ = context.Operators.Equivalent(frequency, da_);
 
 				return (db_ ?? false);
 			};
 			bool ae_()
 			{
-				var dc_ = this.Four_times_daily__qualifier_value_();
-				var dd_ = context.Operators.Equivalent(frequency, dc_);
+				CqlCode dc_ = this.Four_times_daily__qualifier_value_();
+				bool? dd_ = context.Operators.Equivalent(frequency, dc_);
 
 				return (dd_ ?? false);
 			};
 			bool af_()
 			{
-				var de_ = this.Every_twenty_four_hours__qualifier_value_();
-				var df_ = context.Operators.Equivalent(frequency, de_);
+				CqlCode de_ = this.Every_twenty_four_hours__qualifier_value_();
+				bool? df_ = context.Operators.Equivalent(frequency, de_);
 
 				return (df_ ?? false);
 			};
 			bool ag_()
 			{
-				var dg_ = this.Every_twelve_hours__qualifier_value_();
-				var dh_ = context.Operators.Equivalent(frequency, dg_);
+				CqlCode dg_ = this.Every_twelve_hours__qualifier_value_();
+				bool? dh_ = context.Operators.Equivalent(frequency, dg_);
 
 				return (dh_ ?? false);
 			};
 			bool ah_()
 			{
-				var di_ = this.Every_thirty_six_hours__qualifier_value_();
-				var dj_ = context.Operators.Equivalent(frequency, di_);
+				CqlCode di_ = this.Every_thirty_six_hours__qualifier_value_();
+				bool? dj_ = context.Operators.Equivalent(frequency, di_);
 
 				return (dj_ ?? false);
 			};
 			bool ai_()
 			{
-				var dk_ = this.Every_eight_hours__qualifier_value_();
-				var dl_ = context.Operators.Equivalent(frequency, dk_);
+				CqlCode dk_ = this.Every_eight_hours__qualifier_value_();
+				bool? dl_ = context.Operators.Equivalent(frequency, dk_);
 
 				return (dl_ ?? false);
 			};
 			bool aj_()
 			{
-				var dm_ = this.Every_four_hours__qualifier_value_();
-				var dn_ = context.Operators.Equivalent(frequency, dm_);
+				CqlCode dm_ = this.Every_four_hours__qualifier_value_();
+				bool? dn_ = context.Operators.Equivalent(frequency, dm_);
 
 				return (dn_ ?? false);
 			};
 			bool ak_()
 			{
-				var do_ = this.Every_six_hours__qualifier_value_();
-				var dp_ = context.Operators.Equivalent(frequency, do_);
+				CqlCode do_ = this.Every_six_hours__qualifier_value_();
+				bool? dp_ = context.Operators.Equivalent(frequency, do_);
 
 				return (dp_ ?? false);
 			};
 			bool al_()
 			{
-				var dq_ = this.Every_seventy_two_hours__qualifier_value_();
-				var dr_ = context.Operators.Equivalent(frequency, dq_);
+				CqlCode dq_ = this.Every_seventy_two_hours__qualifier_value_();
+				bool? dr_ = context.Operators.Equivalent(frequency, dq_);
 
 				return (dr_ ?? false);
 			};
 			bool am_()
 			{
-				var ds_ = this.Every_forty_eight_hours__qualifier_value_();
-				var dt_ = context.Operators.Equivalent(frequency, ds_);
+				CqlCode ds_ = this.Every_forty_eight_hours__qualifier_value_();
+				bool? dt_ = context.Operators.Equivalent(frequency, ds_);
 
 				return (dt_ ?? false);
 			};
 			bool an_()
 			{
-				var du_ = this.Every_eight_to_twelve_hours__qualifier_value_();
-				var dv_ = context.Operators.Equivalent(frequency, du_);
+				CqlCode du_ = this.Every_eight_to_twelve_hours__qualifier_value_();
+				bool? dv_ = context.Operators.Equivalent(frequency, du_);
 
 				return (dv_ ?? false);
 			};
 			bool ao_()
 			{
-				var dw_ = this.Every_six_to_eight_hours__qualifier_value_();
-				var dx_ = context.Operators.Equivalent(frequency, dw_);
+				CqlCode dw_ = this.Every_six_to_eight_hours__qualifier_value_();
+				bool? dx_ = context.Operators.Equivalent(frequency, dw_);
 
 				return (dx_ ?? false);
 			};
 			bool ap_()
 			{
-				var dy_ = this.Every_three_to_four_hours__qualifier_value_();
-				var dz_ = context.Operators.Equivalent(frequency, dy_);
+				CqlCode dy_ = this.Every_three_to_four_hours__qualifier_value_();
+				bool? dz_ = context.Operators.Equivalent(frequency, dy_);
 
 				return (dz_ ?? false);
 			};
 			bool aq_()
 			{
-				var ea_ = this.Every_three_to_six_hours__qualifier_value_();
-				var eb_ = context.Operators.Equivalent(frequency, ea_);
+				CqlCode ea_ = this.Every_three_to_six_hours__qualifier_value_();
+				bool? eb_ = context.Operators.Equivalent(frequency, ea_);
 
 				return (eb_ ?? false);
 			};
 			bool ar_()
 			{
-				var ec_ = this.Every_two_to_four_hours__qualifier_value_();
-				var ed_ = context.Operators.Equivalent(frequency, ec_);
+				CqlCode ec_ = this.Every_two_to_four_hours__qualifier_value_();
+				bool? ed_ = context.Operators.Equivalent(frequency, ec_);
 
 				return (ed_ ?? false);
 			};
 			bool as_()
 			{
-				var ee_ = this.One_to_four_times_a_day__qualifier_value_();
-				var ef_ = context.Operators.Equivalent(frequency, ee_);
+				CqlCode ee_ = this.One_to_four_times_a_day__qualifier_value_();
+				bool? ef_ = context.Operators.Equivalent(frequency, ee_);
 
 				return (ef_ ?? false);
 			};
 			bool at_()
 			{
-				var eg_ = this.One_to_three_times_a_day__qualifier_value_();
-				var eh_ = context.Operators.Equivalent(frequency, eg_);
+				CqlCode eg_ = this.One_to_three_times_a_day__qualifier_value_();
+				bool? eh_ = context.Operators.Equivalent(frequency, eg_);
 
 				return (eh_ ?? false);
 			};
 			bool au_()
 			{
-				var ei_ = this.One_to_two_times_a_day__qualifier_value_();
-				var ej_ = context.Operators.Equivalent(frequency, ei_);
+				CqlCode ei_ = this.One_to_two_times_a_day__qualifier_value_();
+				bool? ej_ = context.Operators.Equivalent(frequency, ei_);
 
 				return (ej_ ?? false);
 			};
 			bool av_()
 			{
-				var ek_ = this.Two_to_four_times_a_day__qualifier_value_();
-				var el_ = context.Operators.Equivalent(frequency, ek_);
+				CqlCode ek_ = this.Two_to_four_times_a_day__qualifier_value_();
+				bool? el_ = context.Operators.Equivalent(frequency, ek_);
 
 				return (el_ ?? false);
 			};
 			if (b_())
 			{
-				var em_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? em_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return em_;
 			}
 			else if (c_())
 			{
-				var en_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? en_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return en_;
 			}
 			else if (d_())
 			{
-				var eo_ = context.Operators.ConvertIntegerToDecimal(3);
+				decimal? eo_ = context.Operators.ConvertIntegerToDecimal(3);
 
 				return eo_;
 			}
 			else if (e_())
 			{
-				var ep_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? ep_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return ep_;
 			}
 			else if (f_())
 			{
-				var eq_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? eq_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return eq_;
 			}
 			else if (g_())
 			{
-				var er_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? er_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return er_;
 			}
 			else if (h_())
 			{
-				var es_ = context.Operators.ConvertIntegerToDecimal(3);
+				decimal? es_ = context.Operators.ConvertIntegerToDecimal(3);
 
 				return es_;
 			}
 			else if (i_())
 			{
-				var et_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? et_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return et_;
 			}
 			else if (j_())
 			{
-				var eu_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? eu_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return eu_;
 			}
 			else if (k_())
 			{
-				var ev_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? ev_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return ev_;
 			}
 			else if (l_())
 			{
-				var ew_ = context.Operators.ConvertIntegerToDecimal(3);
+				decimal? ew_ = context.Operators.ConvertIntegerToDecimal(3);
 
 				return ew_;
 			}
 			else if (m_())
 			{
-				var ex_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? ex_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return ex_;
 			}
 			else if (n_())
 			{
-				var ey_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? ey_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return ey_;
 			}
 			else if (o_())
 			{
-				var ez_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? ez_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return ez_;
 			}
 			else if (p_())
 			{
-				var fa_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fa_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fa_;
 			}
 			else if (q_())
 			{
-				var fb_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fb_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fb_;
 			}
 			else if (r_())
 			{
-				var fc_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fc_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fc_;
 			}
 			else if (s_())
 			{
-				var fd_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fd_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fd_;
 			}
 			else if (t_())
 			{
-				var fe_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fe_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fe_;
 			}
 			else if (u_())
 			{
-				var ff_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? ff_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return ff_;
 			}
 			else if (v_())
 			{
-				var fg_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fg_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fg_;
 			}
 			else if (w_())
 			{
-				var fh_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fh_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fh_;
 			}
 			else if (x_())
 			{
-				var fi_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fi_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fi_;
 			}
 			else if (y_())
 			{
-				var fj_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fj_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fj_;
 			}
 			else if (z_())
 			{
-				var fk_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fk_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fk_;
 			}
 			else if (aa_())
 			{
-				var fl_ = context.Operators.ConvertIntegerToDecimal(1);
+				decimal? fl_ = context.Operators.ConvertIntegerToDecimal(1);
 
 				return fl_;
 			}
@@ -1531,11 +1636,12 @@ public class CumulativeMedicationDuration_4_0_000
 			}
 			else
 			{
-				var fm_ = this.ErrorLevel();
-				var fn_ = context.Operators.Concatenate("Unknown frequency code ", (frequency?.code ?? ""));
-				var fo_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownFrequencyCode", fm_, fn_);
+				string fm_ = this.ErrorLevel();
+				string fn_ = frequency?.code;
+				string fo_ = context.Operators.Concatenate("Unknown frequency code ", (fn_ ?? ""));
+				object fp_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownFrequencyCode", fm_, fo_);
 
-				return (decimal?)fo_;
+				return (decimal?)fp_;
 			}
 		};
 
@@ -1551,7 +1657,7 @@ public class CumulativeMedicationDuration_4_0_000
     [CqlDeclaration("MedicationRequestPeriod")]
 	public CqlInterval<CqlDate> MedicationRequestPeriod(MedicationRequest Request)
 	{
-		var a_ = new MedicationRequest[]
+		MedicationRequest[] a_ = new MedicationRequest[]
 		{
 			Request,
 		};
@@ -1561,237 +1667,237 @@ public class CumulativeMedicationDuration_4_0_000
 			{
 				bool f_()
 				{
-					var h_ = R?.DosageInstruction;
-					var i_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
-					var j_ = i_?.Timing;
-					var k_ = j_?.Repeat;
-					var l_ = k_?.Bounds;
-					var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-					var n_ = context.Operators.Start((m_ as CqlInterval<CqlDateTime>));
-					var o_ = context.Operators.DateFrom(n_);
-					var p_ = R?.AuthoredOnElement;
-					var q_ = context.Operators.Convert<CqlDateTime>(p_);
-					var r_ = context.Operators.DateFrom(q_);
-					var s_ = R?.DispenseRequest;
-					var t_ = s_?.ValidityPeriod;
-					var u_ = FHIRHelpers_4_3_000.ToInterval(t_);
-					var v_ = context.Operators.Start(u_);
-					var w_ = context.Operators.DateFrom(v_);
-					var x_ = context.Operators.Not((bool?)(((o_ ?? r_) ?? w_) is null));
-					var z_ = s_?.ExpectedSupplyDuration;
-					var aa_ = FHIRHelpers_4_3_000.ToQuantity((Quantity)z_);
-					var ab_ = context.Operators.ConvertQuantity(aa_, "d");
-					var ac_ = ab_?.value;
-					var ae_ = s_?.Quantity;
-					var af_ = FHIRHelpers_4_3_000.ToQuantity(ae_);
-					var ag_ = af_?.value;
-					var ai_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
-					var aj_ = ai_?.DoseAndRate;
-					var ak_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)aj_);
-					var al_ = ak_?.Dose;
-					var am_ = FHIRHelpers_4_3_000.ToValue(al_);
-					var an_ = context.Operators.End((am_ as CqlInterval<CqlQuantity>));
-					var ap_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
-					var aq_ = ap_?.DoseAndRate;
-					var ar_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)aq_);
-					var as_ = ar_?.Dose;
-					var at_ = FHIRHelpers_4_3_000.ToValue(as_);
-					var au_ = (an_ ?? (at_ as CqlQuantity))?.value;
-					var aw_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
-					var ax_ = aw_?.Timing;
-					var ay_ = ax_?.Repeat;
-					var az_ = ay_?.FrequencyMaxElement;
-					var ba_ = az_?.Value;
-					var bc_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
-					var bd_ = bc_?.Timing;
-					var be_ = bd_?.Repeat;
-					var bf_ = be_?.FrequencyElement;
-					var bg_ = bf_?.Value;
-					var bi_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
-					var bj_ = bi_?.Timing;
-					var bk_ = bj_?.Repeat;
-					var bl_ = bk_?.PeriodElement;
-					var bm_ = bl_?.Value;
-					var bo_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
-					var bp_ = bo_?.Timing;
-					var bq_ = bp_?.Repeat;
-					var br_ = bq_?.PeriodUnitElement;
-					var bs_ = br_?.Value;
-					var bt_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(bs_);
-					var bu_ = context.Operators.Convert<string>(bt_);
-					var bv_ = this.Quantity(bm_, bu_);
-					var bw_ = this.ToDaily((ba_ ?? bg_), bv_);
-					var by_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
-					var bz_ = by_?.Timing;
-					var ca_ = bz_?.Repeat;
-					var cb_ = ca_?.TimeOfDayElement;
-					var cc_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(cb_, "value");
-					var cd_ = context.Operators.Count<CqlTime>(cc_);
-					var ce_ = context.Operators.ConvertIntegerToDecimal(cd_);
-					var cf_ = context.Operators.Multiply(au_, ((bw_ ?? ce_) ?? 1.0m));
-					var cg_ = context.Operators.Divide(ag_, cf_);
-					var ci_ = s_?.NumberOfRepeatsAllowedElement;
-					var cj_ = ci_?.Value;
-					var ck_ = context.Operators.Add(1, (cj_ ?? 0));
-					var cl_ = context.Operators.ConvertIntegerToDecimal(ck_);
-					var cm_ = context.Operators.Multiply((ac_ ?? cg_), cl_);
-					var cn_ = context.Operators.Not((bool?)(cm_ is null));
-					var co_ = context.Operators.And(x_, cn_);
+					List<Dosage> h_ = R?.DosageInstruction;
+					Dosage i_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
+					Timing j_ = i_?.Timing;
+					Timing.RepeatComponent k_ = j_?.Repeat;
+					DataType l_ = k_?.Bounds;
+					object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+					CqlDateTime n_ = context.Operators.Start((m_ as CqlInterval<CqlDateTime>));
+					CqlDate o_ = context.Operators.DateFrom(n_);
+					FhirDateTime p_ = R?.AuthoredOnElement;
+					CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+					CqlDate r_ = context.Operators.DateFrom(q_);
+					MedicationRequest.DispenseRequestComponent s_ = R?.DispenseRequest;
+					Period t_ = s_?.ValidityPeriod;
+					CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(t_);
+					CqlDateTime v_ = context.Operators.Start(u_);
+					CqlDate w_ = context.Operators.DateFrom(v_);
+					bool? x_ = context.Operators.Not((bool?)(((o_ ?? r_) ?? w_) is null));
+					Duration z_ = s_?.ExpectedSupplyDuration;
+					CqlQuantity aa_ = FHIRHelpers_4_3_000.ToQuantity((Quantity)z_);
+					CqlQuantity ab_ = context.Operators.ConvertQuantity(aa_, "d");
+					decimal? ac_ = ab_?.value;
+					Quantity ae_ = s_?.Quantity;
+					CqlQuantity af_ = FHIRHelpers_4_3_000.ToQuantity(ae_);
+					decimal? ag_ = af_?.value;
+					Dosage ai_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
+					List<Dosage.DoseAndRateComponent> aj_ = ai_?.DoseAndRate;
+					Dosage.DoseAndRateComponent ak_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)aj_);
+					DataType al_ = ak_?.Dose;
+					object am_ = FHIRHelpers_4_3_000.ToValue(al_);
+					CqlQuantity an_ = context.Operators.End((am_ as CqlInterval<CqlQuantity>));
+					Dosage ap_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
+					List<Dosage.DoseAndRateComponent> aq_ = ap_?.DoseAndRate;
+					Dosage.DoseAndRateComponent ar_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)aq_);
+					DataType as_ = ar_?.Dose;
+					object at_ = FHIRHelpers_4_3_000.ToValue(as_);
+					decimal? au_ = (an_ ?? (at_ as CqlQuantity))?.value;
+					Dosage aw_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
+					Timing ax_ = aw_?.Timing;
+					Timing.RepeatComponent ay_ = ax_?.Repeat;
+					PositiveInt az_ = ay_?.FrequencyMaxElement;
+					int? ba_ = az_?.Value;
+					Dosage bc_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
+					Timing bd_ = bc_?.Timing;
+					Timing.RepeatComponent be_ = bd_?.Repeat;
+					PositiveInt bf_ = be_?.FrequencyElement;
+					int? bg_ = bf_?.Value;
+					Dosage bi_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
+					Timing bj_ = bi_?.Timing;
+					Timing.RepeatComponent bk_ = bj_?.Repeat;
+					FhirDecimal bl_ = bk_?.PeriodElement;
+					decimal? bm_ = bl_?.Value;
+					Dosage bo_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
+					Timing bp_ = bo_?.Timing;
+					Timing.RepeatComponent bq_ = bp_?.Repeat;
+					Code<Timing.UnitsOfTime> br_ = bq_?.PeriodUnitElement;
+					Timing.UnitsOfTime? bs_ = br_?.Value;
+					Code<Timing.UnitsOfTime> bt_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(bs_);
+					string bu_ = context.Operators.Convert<string>(bt_);
+					CqlQuantity bv_ = this.Quantity(bm_, bu_);
+					decimal? bw_ = this.ToDaily((ba_ ?? bg_), bv_);
+					Dosage by_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)h_);
+					Timing bz_ = by_?.Timing;
+					Timing.RepeatComponent ca_ = bz_?.Repeat;
+					List<Time> cb_ = ca_?.TimeOfDayElement;
+					IEnumerable<CqlTime> cc_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(cb_, "value");
+					int? cd_ = context.Operators.Count<CqlTime>(cc_);
+					decimal? ce_ = context.Operators.ConvertIntegerToDecimal(cd_);
+					decimal? cf_ = context.Operators.Multiply(au_, ((bw_ ?? ce_) ?? 1.0m));
+					decimal? cg_ = context.Operators.Divide(ag_, cf_);
+					UnsignedInt ci_ = s_?.NumberOfRepeatsAllowedElement;
+					int? cj_ = ci_?.Value;
+					int? ck_ = context.Operators.Add(1, (cj_ ?? 0));
+					decimal? cl_ = context.Operators.ConvertIntegerToDecimal(ck_);
+					decimal? cm_ = context.Operators.Multiply((ac_ ?? cg_), cl_);
+					bool? cn_ = context.Operators.Not((bool?)(cm_ is null));
+					bool? co_ = context.Operators.And(x_, cn_);
 
 					return (co_ ?? false);
 				};
 				bool g_()
 				{
-					var cp_ = R?.DosageInstruction;
-					var cq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
-					var cr_ = cq_?.Timing;
-					var cs_ = cr_?.Repeat;
-					var ct_ = cs_?.Bounds;
-					var cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
-					var cv_ = context.Operators.Start((cu_ as CqlInterval<CqlDateTime>));
-					var cw_ = context.Operators.DateFrom(cv_);
-					var cx_ = R?.AuthoredOnElement;
-					var cy_ = context.Operators.Convert<CqlDateTime>(cx_);
-					var cz_ = context.Operators.DateFrom(cy_);
-					var da_ = R?.DispenseRequest;
-					var db_ = da_?.ValidityPeriod;
-					var dc_ = FHIRHelpers_4_3_000.ToInterval(db_);
-					var dd_ = context.Operators.Start(dc_);
-					var de_ = context.Operators.DateFrom(dd_);
-					var df_ = context.Operators.Not((bool?)(((cw_ ?? cz_) ?? de_) is null));
-					var dh_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
-					var di_ = dh_?.Timing;
-					var dj_ = di_?.Repeat;
-					var dk_ = dj_?.Bounds;
-					var dl_ = FHIRHelpers_4_3_000.ToValue(dk_);
-					var dm_ = (dl_ as CqlInterval<CqlDateTime>)?.high;
-					var dn_ = context.Operators.Not((bool?)(dm_ is null));
-					var do_ = context.Operators.And(df_, dn_);
+					List<Dosage> cp_ = R?.DosageInstruction;
+					Dosage cq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
+					Timing cr_ = cq_?.Timing;
+					Timing.RepeatComponent cs_ = cr_?.Repeat;
+					DataType ct_ = cs_?.Bounds;
+					object cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
+					CqlDateTime cv_ = context.Operators.Start((cu_ as CqlInterval<CqlDateTime>));
+					CqlDate cw_ = context.Operators.DateFrom(cv_);
+					FhirDateTime cx_ = R?.AuthoredOnElement;
+					CqlDateTime cy_ = context.Operators.Convert<CqlDateTime>(cx_);
+					CqlDate cz_ = context.Operators.DateFrom(cy_);
+					MedicationRequest.DispenseRequestComponent da_ = R?.DispenseRequest;
+					Period db_ = da_?.ValidityPeriod;
+					CqlInterval<CqlDateTime> dc_ = FHIRHelpers_4_3_000.ToInterval(db_);
+					CqlDateTime dd_ = context.Operators.Start(dc_);
+					CqlDate de_ = context.Operators.DateFrom(dd_);
+					bool? df_ = context.Operators.Not((bool?)(((cw_ ?? cz_) ?? de_) is null));
+					Dosage dh_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
+					Timing di_ = dh_?.Timing;
+					Timing.RepeatComponent dj_ = di_?.Repeat;
+					DataType dk_ = dj_?.Bounds;
+					object dl_ = FHIRHelpers_4_3_000.ToValue(dk_);
+					CqlDateTime dm_ = (dl_ as CqlInterval<CqlDateTime>)?.high;
+					bool? dn_ = context.Operators.Not((bool?)(dm_ is null));
+					bool? do_ = context.Operators.And(df_, dn_);
 
 					return (do_ ?? false);
 				};
 				if (f_())
 				{
-					var dp_ = R?.DosageInstruction;
-					var dq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
-					var dr_ = dq_?.Timing;
-					var ds_ = dr_?.Repeat;
-					var dt_ = ds_?.Bounds;
-					var du_ = FHIRHelpers_4_3_000.ToValue(dt_);
-					var dv_ = context.Operators.Start((du_ as CqlInterval<CqlDateTime>));
-					var dw_ = context.Operators.DateFrom(dv_);
-					var dx_ = R?.AuthoredOnElement;
-					var dy_ = context.Operators.Convert<CqlDateTime>(dx_);
-					var dz_ = context.Operators.DateFrom(dy_);
-					var ea_ = R?.DispenseRequest;
-					var eb_ = ea_?.ValidityPeriod;
-					var ec_ = FHIRHelpers_4_3_000.ToInterval(eb_);
-					var ed_ = context.Operators.Start(ec_);
-					var ee_ = context.Operators.DateFrom(ed_);
-					var eg_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
-					var eh_ = eg_?.Timing;
-					var ei_ = eh_?.Repeat;
-					var ej_ = ei_?.Bounds;
-					var ek_ = FHIRHelpers_4_3_000.ToValue(ej_);
-					var el_ = context.Operators.Start((ek_ as CqlInterval<CqlDateTime>));
-					var em_ = context.Operators.DateFrom(el_);
-					var eo_ = context.Operators.Convert<CqlDateTime>(dx_);
-					var ep_ = context.Operators.DateFrom(eo_);
-					var er_ = ea_?.ValidityPeriod;
-					var es_ = FHIRHelpers_4_3_000.ToInterval(er_);
-					var et_ = context.Operators.Start(es_);
-					var eu_ = context.Operators.DateFrom(et_);
-					var ew_ = ea_?.ExpectedSupplyDuration;
-					var ex_ = FHIRHelpers_4_3_000.ToQuantity((Quantity)ew_);
-					var ey_ = context.Operators.ConvertQuantity(ex_, "d");
-					var ez_ = ey_?.value;
-					var fb_ = ea_?.Quantity;
-					var fc_ = FHIRHelpers_4_3_000.ToQuantity(fb_);
-					var fd_ = fc_?.value;
-					var ff_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
-					var fg_ = ff_?.DoseAndRate;
-					var fh_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)fg_);
-					var fi_ = fh_?.Dose;
-					var fj_ = FHIRHelpers_4_3_000.ToValue(fi_);
-					var fk_ = context.Operators.End((fj_ as CqlInterval<CqlQuantity>));
-					var fm_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
-					var fn_ = fm_?.DoseAndRate;
-					var fo_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)fn_);
-					var fp_ = fo_?.Dose;
-					var fq_ = FHIRHelpers_4_3_000.ToValue(fp_);
-					var fr_ = (fk_ ?? (fq_ as CqlQuantity))?.value;
-					var ft_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
-					var fu_ = ft_?.Timing;
-					var fv_ = fu_?.Repeat;
-					var fw_ = fv_?.FrequencyMaxElement;
-					var fx_ = fw_?.Value;
-					var fz_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
-					var ga_ = fz_?.Timing;
-					var gb_ = ga_?.Repeat;
-					var gc_ = gb_?.FrequencyElement;
-					var gd_ = gc_?.Value;
-					var gf_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
-					var gg_ = gf_?.Timing;
-					var gh_ = gg_?.Repeat;
-					var gi_ = gh_?.PeriodElement;
-					var gj_ = gi_?.Value;
-					var gl_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
-					var gm_ = gl_?.Timing;
-					var gn_ = gm_?.Repeat;
-					var go_ = gn_?.PeriodUnitElement;
-					var gp_ = go_?.Value;
-					var gq_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(gp_);
-					var gr_ = context.Operators.Convert<string>(gq_);
-					var gs_ = this.Quantity(gj_, gr_);
-					var gt_ = this.ToDaily((fx_ ?? gd_), gs_);
-					var gv_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
-					var gw_ = gv_?.Timing;
-					var gx_ = gw_?.Repeat;
-					var gy_ = gx_?.TimeOfDayElement;
-					var gz_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(gy_, "value");
-					var ha_ = context.Operators.Count<CqlTime>(gz_);
-					var hb_ = context.Operators.ConvertIntegerToDecimal(ha_);
-					var hc_ = context.Operators.Multiply(fr_, ((gt_ ?? hb_) ?? 1.0m));
-					var hd_ = context.Operators.Divide(fd_, hc_);
-					var hf_ = ea_?.NumberOfRepeatsAllowedElement;
-					var hg_ = hf_?.Value;
-					var hh_ = context.Operators.Add(1, (hg_ ?? 0));
-					var hi_ = context.Operators.ConvertIntegerToDecimal(hh_);
-					var hj_ = context.Operators.Multiply((ez_ ?? hd_), hi_);
-					var hk_ = context.Operators.ConvertIntegerToDecimal(1);
-					var hl_ = context.Operators.Subtract(hj_, hk_);
-					var hm_ = this.Quantity(hl_, "day");
-					var hn_ = context.Operators.Add(((em_ ?? ep_) ?? eu_), hm_);
-					var ho_ = context.Operators.Interval(((dw_ ?? dz_) ?? ee_), hn_, true, true);
+					List<Dosage> dp_ = R?.DosageInstruction;
+					Dosage dq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
+					Timing dr_ = dq_?.Timing;
+					Timing.RepeatComponent ds_ = dr_?.Repeat;
+					DataType dt_ = ds_?.Bounds;
+					object du_ = FHIRHelpers_4_3_000.ToValue(dt_);
+					CqlDateTime dv_ = context.Operators.Start((du_ as CqlInterval<CqlDateTime>));
+					CqlDate dw_ = context.Operators.DateFrom(dv_);
+					FhirDateTime dx_ = R?.AuthoredOnElement;
+					CqlDateTime dy_ = context.Operators.Convert<CqlDateTime>(dx_);
+					CqlDate dz_ = context.Operators.DateFrom(dy_);
+					MedicationRequest.DispenseRequestComponent ea_ = R?.DispenseRequest;
+					Period eb_ = ea_?.ValidityPeriod;
+					CqlInterval<CqlDateTime> ec_ = FHIRHelpers_4_3_000.ToInterval(eb_);
+					CqlDateTime ed_ = context.Operators.Start(ec_);
+					CqlDate ee_ = context.Operators.DateFrom(ed_);
+					Dosage eg_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
+					Timing eh_ = eg_?.Timing;
+					Timing.RepeatComponent ei_ = eh_?.Repeat;
+					DataType ej_ = ei_?.Bounds;
+					object ek_ = FHIRHelpers_4_3_000.ToValue(ej_);
+					CqlDateTime el_ = context.Operators.Start((ek_ as CqlInterval<CqlDateTime>));
+					CqlDate em_ = context.Operators.DateFrom(el_);
+					CqlDateTime eo_ = context.Operators.Convert<CqlDateTime>(dx_);
+					CqlDate ep_ = context.Operators.DateFrom(eo_);
+					Period er_ = ea_?.ValidityPeriod;
+					CqlInterval<CqlDateTime> es_ = FHIRHelpers_4_3_000.ToInterval(er_);
+					CqlDateTime et_ = context.Operators.Start(es_);
+					CqlDate eu_ = context.Operators.DateFrom(et_);
+					Duration ew_ = ea_?.ExpectedSupplyDuration;
+					CqlQuantity ex_ = FHIRHelpers_4_3_000.ToQuantity((Quantity)ew_);
+					CqlQuantity ey_ = context.Operators.ConvertQuantity(ex_, "d");
+					decimal? ez_ = ey_?.value;
+					Quantity fb_ = ea_?.Quantity;
+					CqlQuantity fc_ = FHIRHelpers_4_3_000.ToQuantity(fb_);
+					decimal? fd_ = fc_?.value;
+					Dosage ff_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
+					List<Dosage.DoseAndRateComponent> fg_ = ff_?.DoseAndRate;
+					Dosage.DoseAndRateComponent fh_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)fg_);
+					DataType fi_ = fh_?.Dose;
+					object fj_ = FHIRHelpers_4_3_000.ToValue(fi_);
+					CqlQuantity fk_ = context.Operators.End((fj_ as CqlInterval<CqlQuantity>));
+					Dosage fm_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
+					List<Dosage.DoseAndRateComponent> fn_ = fm_?.DoseAndRate;
+					Dosage.DoseAndRateComponent fo_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)fn_);
+					DataType fp_ = fo_?.Dose;
+					object fq_ = FHIRHelpers_4_3_000.ToValue(fp_);
+					decimal? fr_ = (fk_ ?? (fq_ as CqlQuantity))?.value;
+					Dosage ft_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
+					Timing fu_ = ft_?.Timing;
+					Timing.RepeatComponent fv_ = fu_?.Repeat;
+					PositiveInt fw_ = fv_?.FrequencyMaxElement;
+					int? fx_ = fw_?.Value;
+					Dosage fz_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
+					Timing ga_ = fz_?.Timing;
+					Timing.RepeatComponent gb_ = ga_?.Repeat;
+					PositiveInt gc_ = gb_?.FrequencyElement;
+					int? gd_ = gc_?.Value;
+					Dosage gf_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
+					Timing gg_ = gf_?.Timing;
+					Timing.RepeatComponent gh_ = gg_?.Repeat;
+					FhirDecimal gi_ = gh_?.PeriodElement;
+					decimal? gj_ = gi_?.Value;
+					Dosage gl_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
+					Timing gm_ = gl_?.Timing;
+					Timing.RepeatComponent gn_ = gm_?.Repeat;
+					Code<Timing.UnitsOfTime> go_ = gn_?.PeriodUnitElement;
+					Timing.UnitsOfTime? gp_ = go_?.Value;
+					Code<Timing.UnitsOfTime> gq_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(gp_);
+					string gr_ = context.Operators.Convert<string>(gq_);
+					CqlQuantity gs_ = this.Quantity(gj_, gr_);
+					decimal? gt_ = this.ToDaily((fx_ ?? gd_), gs_);
+					Dosage gv_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)dp_);
+					Timing gw_ = gv_?.Timing;
+					Timing.RepeatComponent gx_ = gw_?.Repeat;
+					List<Time> gy_ = gx_?.TimeOfDayElement;
+					IEnumerable<CqlTime> gz_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(gy_, "value");
+					int? ha_ = context.Operators.Count<CqlTime>(gz_);
+					decimal? hb_ = context.Operators.ConvertIntegerToDecimal(ha_);
+					decimal? hc_ = context.Operators.Multiply(fr_, ((gt_ ?? hb_) ?? 1.0m));
+					decimal? hd_ = context.Operators.Divide(fd_, hc_);
+					UnsignedInt hf_ = ea_?.NumberOfRepeatsAllowedElement;
+					int? hg_ = hf_?.Value;
+					int? hh_ = context.Operators.Add(1, (hg_ ?? 0));
+					decimal? hi_ = context.Operators.ConvertIntegerToDecimal(hh_);
+					decimal? hj_ = context.Operators.Multiply((ez_ ?? hd_), hi_);
+					decimal? hk_ = context.Operators.ConvertIntegerToDecimal(1);
+					decimal? hl_ = context.Operators.Subtract(hj_, hk_);
+					CqlQuantity hm_ = this.Quantity(hl_, "day");
+					CqlDate hn_ = context.Operators.Add(((em_ ?? ep_) ?? eu_), hm_);
+					CqlInterval<CqlDate> ho_ = context.Operators.Interval(((dw_ ?? dz_) ?? ee_), hn_, true, true);
 
 					return ho_;
 				}
 				else if (g_())
 				{
-					var hp_ = R?.DosageInstruction;
-					var hq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)hp_);
-					var hr_ = hq_?.Timing;
-					var hs_ = hr_?.Repeat;
-					var ht_ = hs_?.Bounds;
-					var hu_ = FHIRHelpers_4_3_000.ToValue(ht_);
-					var hv_ = context.Operators.Start((hu_ as CqlInterval<CqlDateTime>));
-					var hw_ = context.Operators.DateFrom(hv_);
-					var hx_ = R?.AuthoredOnElement;
-					var hy_ = context.Operators.Convert<CqlDateTime>(hx_);
-					var hz_ = context.Operators.DateFrom(hy_);
-					var ia_ = R?.DispenseRequest;
-					var ib_ = ia_?.ValidityPeriod;
-					var ic_ = FHIRHelpers_4_3_000.ToInterval(ib_);
-					var id_ = context.Operators.Start(ic_);
-					var ie_ = context.Operators.DateFrom(id_);
-					var ig_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)hp_);
-					var ih_ = ig_?.Timing;
-					var ii_ = ih_?.Repeat;
-					var ij_ = ii_?.Bounds;
-					var ik_ = FHIRHelpers_4_3_000.ToValue(ij_);
-					var il_ = context.Operators.End((ik_ as CqlInterval<CqlDateTime>));
-					var im_ = context.Operators.DateFrom(il_);
-					var in_ = context.Operators.Interval(((hw_ ?? hz_) ?? ie_), im_, true, true);
+					List<Dosage> hp_ = R?.DosageInstruction;
+					Dosage hq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)hp_);
+					Timing hr_ = hq_?.Timing;
+					Timing.RepeatComponent hs_ = hr_?.Repeat;
+					DataType ht_ = hs_?.Bounds;
+					object hu_ = FHIRHelpers_4_3_000.ToValue(ht_);
+					CqlDateTime hv_ = context.Operators.Start((hu_ as CqlInterval<CqlDateTime>));
+					CqlDate hw_ = context.Operators.DateFrom(hv_);
+					FhirDateTime hx_ = R?.AuthoredOnElement;
+					CqlDateTime hy_ = context.Operators.Convert<CqlDateTime>(hx_);
+					CqlDate hz_ = context.Operators.DateFrom(hy_);
+					MedicationRequest.DispenseRequestComponent ia_ = R?.DispenseRequest;
+					Period ib_ = ia_?.ValidityPeriod;
+					CqlInterval<CqlDateTime> ic_ = FHIRHelpers_4_3_000.ToInterval(ib_);
+					CqlDateTime id_ = context.Operators.Start(ic_);
+					CqlDate ie_ = context.Operators.DateFrom(id_);
+					Dosage ig_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)hp_);
+					Timing ih_ = ig_?.Timing;
+					Timing.RepeatComponent ii_ = ih_?.Repeat;
+					DataType ij_ = ii_?.Bounds;
+					object ik_ = FHIRHelpers_4_3_000.ToValue(ij_);
+					CqlDateTime il_ = context.Operators.End((ik_ as CqlInterval<CqlDateTime>));
+					CqlDate im_ = context.Operators.DateFrom(il_);
+					CqlInterval<CqlDate> in_ = context.Operators.Interval(((hw_ ?? hz_) ?? ie_), im_, true, true);
 
 					return in_;
 				}
@@ -1803,8 +1909,8 @@ public class CumulativeMedicationDuration_4_0_000
 
 			return e_();
 		};
-		var c_ = context.Operators.Select<MedicationRequest, CqlInterval<CqlDate>>((IEnumerable<MedicationRequest>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDate>>(c_);
+		IEnumerable<CqlInterval<CqlDate>> c_ = context.Operators.Select<MedicationRequest, CqlInterval<CqlDate>>((IEnumerable<MedicationRequest>)a_, b_);
+		CqlInterval<CqlDate> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDate>>(c_);
 
 		return d_;
 	}
@@ -1812,7 +1918,7 @@ public class CumulativeMedicationDuration_4_0_000
     [CqlDeclaration("MedicationDispensePeriod")]
 	public CqlInterval<CqlDate> MedicationDispensePeriod(MedicationDispense Dispense)
 	{
-		var a_ = new MedicationDispense[]
+		MedicationDispense[] a_ = new MedicationDispense[]
 		{
 			Dispense,
 		};
@@ -1822,141 +1928,141 @@ public class CumulativeMedicationDuration_4_0_000
 			{
 				bool f_()
 				{
-					var g_ = D?.WhenHandedOverElement;
-					var h_ = context.Operators.Convert<CqlDateTime>(g_);
-					var i_ = context.Operators.DateFrom(h_);
-					var j_ = D?.WhenPreparedElement;
-					var k_ = context.Operators.Convert<CqlDateTime>(j_);
-					var l_ = context.Operators.DateFrom(k_);
-					var m_ = context.Operators.Not((bool?)((i_ ?? l_) is null));
-					var n_ = D?.DaysSupply;
-					var o_ = FHIRHelpers_4_3_000.ToQuantity(n_);
-					var p_ = context.Operators.ConvertQuantity(o_, "d");
-					var q_ = p_?.value;
-					var r_ = D?.Quantity;
-					var s_ = FHIRHelpers_4_3_000.ToQuantity(r_);
-					var t_ = s_?.value;
-					var u_ = D?.DosageInstruction;
-					var v_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
-					var w_ = v_?.DoseAndRate;
-					var x_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)w_);
-					var y_ = x_?.Dose;
-					var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-					var aa_ = context.Operators.End((z_ as CqlInterval<CqlQuantity>));
-					var ac_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
-					var ad_ = ac_?.DoseAndRate;
-					var ae_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)ad_);
-					var af_ = ae_?.Dose;
-					var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
-					var ah_ = (aa_ ?? (ag_ as CqlQuantity))?.value;
-					var aj_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
-					var ak_ = aj_?.Timing;
-					var al_ = ak_?.Repeat;
-					var am_ = al_?.FrequencyMaxElement;
-					var an_ = am_?.Value;
-					var ap_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
-					var aq_ = ap_?.Timing;
-					var ar_ = aq_?.Repeat;
-					var as_ = ar_?.FrequencyElement;
-					var at_ = as_?.Value;
-					var av_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
-					var aw_ = av_?.Timing;
-					var ax_ = aw_?.Repeat;
-					var ay_ = ax_?.PeriodElement;
-					var az_ = ay_?.Value;
-					var bb_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
-					var bc_ = bb_?.Timing;
-					var bd_ = bc_?.Repeat;
-					var be_ = bd_?.PeriodUnitElement;
-					var bf_ = be_?.Value;
-					var bg_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(bf_);
-					var bh_ = context.Operators.Convert<string>(bg_);
-					var bi_ = this.Quantity(az_, bh_);
-					var bj_ = this.ToDaily((an_ ?? at_), bi_);
-					var bl_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
-					var bm_ = bl_?.Timing;
-					var bn_ = bm_?.Repeat;
-					var bo_ = bn_?.TimeOfDayElement;
-					var bp_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(bo_, "value");
-					var bq_ = context.Operators.Count<CqlTime>(bp_);
-					var br_ = context.Operators.ConvertIntegerToDecimal(bq_);
-					var bs_ = context.Operators.Multiply(ah_, ((bj_ ?? br_) ?? 1.0m));
-					var bt_ = context.Operators.Divide(t_, bs_);
-					var bu_ = context.Operators.Not((bool?)((q_ ?? bt_) is null));
-					var bv_ = context.Operators.And(m_, bu_);
+					FhirDateTime g_ = D?.WhenHandedOverElement;
+					CqlDateTime h_ = context.Operators.Convert<CqlDateTime>(g_);
+					CqlDate i_ = context.Operators.DateFrom(h_);
+					FhirDateTime j_ = D?.WhenPreparedElement;
+					CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
+					CqlDate l_ = context.Operators.DateFrom(k_);
+					bool? m_ = context.Operators.Not((bool?)((i_ ?? l_) is null));
+					Quantity n_ = D?.DaysSupply;
+					CqlQuantity o_ = FHIRHelpers_4_3_000.ToQuantity(n_);
+					CqlQuantity p_ = context.Operators.ConvertQuantity(o_, "d");
+					decimal? q_ = p_?.value;
+					Quantity r_ = D?.Quantity;
+					CqlQuantity s_ = FHIRHelpers_4_3_000.ToQuantity(r_);
+					decimal? t_ = s_?.value;
+					List<Dosage> u_ = D?.DosageInstruction;
+					Dosage v_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
+					List<Dosage.DoseAndRateComponent> w_ = v_?.DoseAndRate;
+					Dosage.DoseAndRateComponent x_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)w_);
+					DataType y_ = x_?.Dose;
+					object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+					CqlQuantity aa_ = context.Operators.End((z_ as CqlInterval<CqlQuantity>));
+					Dosage ac_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
+					List<Dosage.DoseAndRateComponent> ad_ = ac_?.DoseAndRate;
+					Dosage.DoseAndRateComponent ae_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)ad_);
+					DataType af_ = ae_?.Dose;
+					object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+					decimal? ah_ = (aa_ ?? (ag_ as CqlQuantity))?.value;
+					Dosage aj_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
+					Timing ak_ = aj_?.Timing;
+					Timing.RepeatComponent al_ = ak_?.Repeat;
+					PositiveInt am_ = al_?.FrequencyMaxElement;
+					int? an_ = am_?.Value;
+					Dosage ap_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
+					Timing aq_ = ap_?.Timing;
+					Timing.RepeatComponent ar_ = aq_?.Repeat;
+					PositiveInt as_ = ar_?.FrequencyElement;
+					int? at_ = as_?.Value;
+					Dosage av_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
+					Timing aw_ = av_?.Timing;
+					Timing.RepeatComponent ax_ = aw_?.Repeat;
+					FhirDecimal ay_ = ax_?.PeriodElement;
+					decimal? az_ = ay_?.Value;
+					Dosage bb_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
+					Timing bc_ = bb_?.Timing;
+					Timing.RepeatComponent bd_ = bc_?.Repeat;
+					Code<Timing.UnitsOfTime> be_ = bd_?.PeriodUnitElement;
+					Timing.UnitsOfTime? bf_ = be_?.Value;
+					Code<Timing.UnitsOfTime> bg_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(bf_);
+					string bh_ = context.Operators.Convert<string>(bg_);
+					CqlQuantity bi_ = this.Quantity(az_, bh_);
+					decimal? bj_ = this.ToDaily((an_ ?? at_), bi_);
+					Dosage bl_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)u_);
+					Timing bm_ = bl_?.Timing;
+					Timing.RepeatComponent bn_ = bm_?.Repeat;
+					List<Time> bo_ = bn_?.TimeOfDayElement;
+					IEnumerable<CqlTime> bp_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(bo_, "value");
+					int? bq_ = context.Operators.Count<CqlTime>(bp_);
+					decimal? br_ = context.Operators.ConvertIntegerToDecimal(bq_);
+					decimal? bs_ = context.Operators.Multiply(ah_, ((bj_ ?? br_) ?? 1.0m));
+					decimal? bt_ = context.Operators.Divide(t_, bs_);
+					bool? bu_ = context.Operators.Not((bool?)((q_ ?? bt_) is null));
+					bool? bv_ = context.Operators.And(m_, bu_);
 
 					return (bv_ ?? false);
 				};
 				if (f_())
 				{
-					var bw_ = D?.WhenHandedOverElement;
-					var bx_ = context.Operators.Convert<CqlDateTime>(bw_);
-					var by_ = context.Operators.DateFrom(bx_);
-					var bz_ = D?.WhenPreparedElement;
-					var ca_ = context.Operators.Convert<CqlDateTime>(bz_);
-					var cb_ = context.Operators.DateFrom(ca_);
-					var cd_ = context.Operators.Convert<CqlDateTime>(bw_);
-					var ce_ = context.Operators.DateFrom(cd_);
-					var cg_ = context.Operators.Convert<CqlDateTime>(bz_);
-					var ch_ = context.Operators.DateFrom(cg_);
-					var ci_ = D?.DaysSupply;
-					var cj_ = FHIRHelpers_4_3_000.ToQuantity(ci_);
-					var ck_ = context.Operators.ConvertQuantity(cj_, "d");
-					var cl_ = ck_?.value;
-					var cm_ = D?.Quantity;
-					var cn_ = FHIRHelpers_4_3_000.ToQuantity(cm_);
-					var co_ = cn_?.value;
-					var cp_ = D?.DosageInstruction;
-					var cq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
-					var cr_ = cq_?.DoseAndRate;
-					var cs_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)cr_);
-					var ct_ = cs_?.Dose;
-					var cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
-					var cv_ = context.Operators.End((cu_ as CqlInterval<CqlQuantity>));
-					var cx_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
-					var cy_ = cx_?.DoseAndRate;
-					var cz_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)cy_);
-					var da_ = cz_?.Dose;
-					var db_ = FHIRHelpers_4_3_000.ToValue(da_);
-					var dc_ = (cv_ ?? (db_ as CqlQuantity))?.value;
-					var de_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
-					var df_ = de_?.Timing;
-					var dg_ = df_?.Repeat;
-					var dh_ = dg_?.FrequencyMaxElement;
-					var di_ = dh_?.Value;
-					var dk_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
-					var dl_ = dk_?.Timing;
-					var dm_ = dl_?.Repeat;
-					var dn_ = dm_?.FrequencyElement;
-					var do_ = dn_?.Value;
-					var dq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
-					var dr_ = dq_?.Timing;
-					var ds_ = dr_?.Repeat;
-					var dt_ = ds_?.PeriodElement;
-					var du_ = dt_?.Value;
-					var dw_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
-					var dx_ = dw_?.Timing;
-					var dy_ = dx_?.Repeat;
-					var dz_ = dy_?.PeriodUnitElement;
-					var ea_ = dz_?.Value;
-					var eb_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(ea_);
-					var ec_ = context.Operators.Convert<string>(eb_);
-					var ed_ = this.Quantity(du_, ec_);
-					var ee_ = this.ToDaily((di_ ?? do_), ed_);
-					var eg_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
-					var eh_ = eg_?.Timing;
-					var ei_ = eh_?.Repeat;
-					var ej_ = ei_?.TimeOfDayElement;
-					var ek_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(ej_, "value");
-					var el_ = context.Operators.Count<CqlTime>(ek_);
-					var em_ = context.Operators.ConvertIntegerToDecimal(el_);
-					var en_ = context.Operators.Multiply(dc_, ((ee_ ?? em_) ?? 1.0m));
-					var eo_ = context.Operators.Divide(co_, en_);
-					var ep_ = context.Operators.ConvertIntegerToDecimal(1);
-					var eq_ = context.Operators.Subtract((cl_ ?? eo_), ep_);
-					var er_ = this.Quantity(eq_, "day");
-					var es_ = context.Operators.Add((ce_ ?? ch_), er_);
-					var et_ = context.Operators.Interval((by_ ?? cb_), es_, true, true);
+					FhirDateTime bw_ = D?.WhenHandedOverElement;
+					CqlDateTime bx_ = context.Operators.Convert<CqlDateTime>(bw_);
+					CqlDate by_ = context.Operators.DateFrom(bx_);
+					FhirDateTime bz_ = D?.WhenPreparedElement;
+					CqlDateTime ca_ = context.Operators.Convert<CqlDateTime>(bz_);
+					CqlDate cb_ = context.Operators.DateFrom(ca_);
+					CqlDateTime cd_ = context.Operators.Convert<CqlDateTime>(bw_);
+					CqlDate ce_ = context.Operators.DateFrom(cd_);
+					CqlDateTime cg_ = context.Operators.Convert<CqlDateTime>(bz_);
+					CqlDate ch_ = context.Operators.DateFrom(cg_);
+					Quantity ci_ = D?.DaysSupply;
+					CqlQuantity cj_ = FHIRHelpers_4_3_000.ToQuantity(ci_);
+					CqlQuantity ck_ = context.Operators.ConvertQuantity(cj_, "d");
+					decimal? cl_ = ck_?.value;
+					Quantity cm_ = D?.Quantity;
+					CqlQuantity cn_ = FHIRHelpers_4_3_000.ToQuantity(cm_);
+					decimal? co_ = cn_?.value;
+					List<Dosage> cp_ = D?.DosageInstruction;
+					Dosage cq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
+					List<Dosage.DoseAndRateComponent> cr_ = cq_?.DoseAndRate;
+					Dosage.DoseAndRateComponent cs_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)cr_);
+					DataType ct_ = cs_?.Dose;
+					object cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
+					CqlQuantity cv_ = context.Operators.End((cu_ as CqlInterval<CqlQuantity>));
+					Dosage cx_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
+					List<Dosage.DoseAndRateComponent> cy_ = cx_?.DoseAndRate;
+					Dosage.DoseAndRateComponent cz_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)cy_);
+					DataType da_ = cz_?.Dose;
+					object db_ = FHIRHelpers_4_3_000.ToValue(da_);
+					decimal? dc_ = (cv_ ?? (db_ as CqlQuantity))?.value;
+					Dosage de_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
+					Timing df_ = de_?.Timing;
+					Timing.RepeatComponent dg_ = df_?.Repeat;
+					PositiveInt dh_ = dg_?.FrequencyMaxElement;
+					int? di_ = dh_?.Value;
+					Dosage dk_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
+					Timing dl_ = dk_?.Timing;
+					Timing.RepeatComponent dm_ = dl_?.Repeat;
+					PositiveInt dn_ = dm_?.FrequencyElement;
+					int? do_ = dn_?.Value;
+					Dosage dq_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
+					Timing dr_ = dq_?.Timing;
+					Timing.RepeatComponent ds_ = dr_?.Repeat;
+					FhirDecimal dt_ = ds_?.PeriodElement;
+					decimal? du_ = dt_?.Value;
+					Dosage dw_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
+					Timing dx_ = dw_?.Timing;
+					Timing.RepeatComponent dy_ = dx_?.Repeat;
+					Code<Timing.UnitsOfTime> dz_ = dy_?.PeriodUnitElement;
+					Timing.UnitsOfTime? ea_ = dz_?.Value;
+					Code<Timing.UnitsOfTime> eb_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(ea_);
+					string ec_ = context.Operators.Convert<string>(eb_);
+					CqlQuantity ed_ = this.Quantity(du_, ec_);
+					decimal? ee_ = this.ToDaily((di_ ?? do_), ed_);
+					Dosage eg_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)cp_);
+					Timing eh_ = eg_?.Timing;
+					Timing.RepeatComponent ei_ = eh_?.Repeat;
+					List<Time> ej_ = ei_?.TimeOfDayElement;
+					IEnumerable<CqlTime> ek_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(ej_, "value");
+					int? el_ = context.Operators.Count<CqlTime>(ek_);
+					decimal? em_ = context.Operators.ConvertIntegerToDecimal(el_);
+					decimal? en_ = context.Operators.Multiply(dc_, ((ee_ ?? em_) ?? 1.0m));
+					decimal? eo_ = context.Operators.Divide(co_, en_);
+					decimal? ep_ = context.Operators.ConvertIntegerToDecimal(1);
+					decimal? eq_ = context.Operators.Subtract((cl_ ?? eo_), ep_);
+					CqlQuantity er_ = this.Quantity(eq_, "day");
+					CqlDate es_ = context.Operators.Add((ce_ ?? ch_), er_);
+					CqlInterval<CqlDate> et_ = context.Operators.Interval((by_ ?? cb_), es_, true, true);
 
 					return et_;
 				}
@@ -1968,8 +2074,8 @@ public class CumulativeMedicationDuration_4_0_000
 
 			return e_();
 		};
-		var c_ = context.Operators.Select<MedicationDispense, CqlInterval<CqlDate>>((IEnumerable<MedicationDispense>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDate>>(c_);
+		IEnumerable<CqlInterval<CqlDate>> c_ = context.Operators.Select<MedicationDispense, CqlInterval<CqlDate>>((IEnumerable<MedicationDispense>)a_, b_);
+		CqlInterval<CqlDate> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDate>>(c_);
 
 		return d_;
 	}
@@ -1977,7 +2083,7 @@ public class CumulativeMedicationDuration_4_0_000
     [CqlDeclaration("TherapeuticDuration")]
 	public CqlQuantity TherapeuticDuration(CqlConcept medication)
 	{
-		var a_ = context.Operators.Quantity(14m, "days");
+		CqlQuantity a_ = context.Operators.Quantity(14m, "days");
 
 		return a_;
 	}
@@ -1985,7 +2091,7 @@ public class CumulativeMedicationDuration_4_0_000
     [CqlDeclaration("MedicationAdministrationPeriod")]
 	public CqlInterval<CqlDate> MedicationAdministrationPeriod(MedicationAdministration Administration)
 	{
-		var a_ = new MedicationAdministration[]
+		MedicationAdministration[] a_ = new MedicationAdministration[]
 		{
 			Administration,
 		};
@@ -1995,35 +2101,35 @@ public class CumulativeMedicationDuration_4_0_000
 			{
 				bool f_()
 				{
-					var g_ = Administration?.Effective;
-					var h_ = FHIRHelpers_4_3_000.ToValue(g_);
-					var i_ = context.Operators.Start((h_ as CqlInterval<CqlDateTime>));
-					var j_ = context.Operators.DateFrom(i_);
-					var k_ = context.Operators.Not((bool?)(j_ is null));
-					var l_ = Administration?.Medication;
-					var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-					var n_ = this.TherapeuticDuration((m_ as CqlConcept));
-					var o_ = context.Operators.Not((bool?)(n_ is null));
-					var p_ = context.Operators.And(k_, o_);
+					DataType g_ = Administration?.Effective;
+					object h_ = FHIRHelpers_4_3_000.ToValue(g_);
+					CqlDateTime i_ = context.Operators.Start((h_ as CqlInterval<CqlDateTime>));
+					CqlDate j_ = context.Operators.DateFrom(i_);
+					bool? k_ = context.Operators.Not((bool?)(j_ is null));
+					DataType l_ = Administration?.Medication;
+					object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+					CqlQuantity n_ = this.TherapeuticDuration((m_ as CqlConcept));
+					bool? o_ = context.Operators.Not((bool?)(n_ is null));
+					bool? p_ = context.Operators.And(k_, o_);
 
 					return (p_ ?? false);
 				};
 				if (f_())
 				{
-					var q_ = Administration?.Effective;
-					var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-					var s_ = context.Operators.Start((r_ as CqlInterval<CqlDateTime>));
-					var t_ = context.Operators.DateFrom(s_);
-					var v_ = FHIRHelpers_4_3_000.ToValue(q_);
-					var w_ = context.Operators.Start((v_ as CqlInterval<CqlDateTime>));
-					var x_ = context.Operators.DateFrom(w_);
-					var y_ = Administration?.Medication;
-					var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-					var aa_ = this.TherapeuticDuration((z_ as CqlConcept));
-					var ab_ = context.Operators.Add(x_, aa_);
-					var ac_ = context.Operators.ConvertIntegerToQuantity(1);
-					var ad_ = context.Operators.Subtract(ab_, ac_);
-					var ae_ = context.Operators.Interval(t_, ad_, true, true);
+					DataType q_ = Administration?.Effective;
+					object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+					CqlDateTime s_ = context.Operators.Start((r_ as CqlInterval<CqlDateTime>));
+					CqlDate t_ = context.Operators.DateFrom(s_);
+					object v_ = FHIRHelpers_4_3_000.ToValue(q_);
+					CqlDateTime w_ = context.Operators.Start((v_ as CqlInterval<CqlDateTime>));
+					CqlDate x_ = context.Operators.DateFrom(w_);
+					DataType y_ = Administration?.Medication;
+					object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+					CqlQuantity aa_ = this.TherapeuticDuration((z_ as CqlConcept));
+					CqlDate ab_ = context.Operators.Add(x_, aa_);
+					CqlQuantity ac_ = context.Operators.ConvertIntegerToQuantity(1);
+					CqlDate ad_ = context.Operators.Subtract(ab_, ac_);
+					CqlInterval<CqlDate> ae_ = context.Operators.Interval(t_, ad_, true, true);
 
 					return ae_;
 				}
@@ -2035,8 +2141,8 @@ public class CumulativeMedicationDuration_4_0_000
 
 			return e_();
 		};
-		var c_ = context.Operators.Select<MedicationAdministration, CqlInterval<CqlDate>>((IEnumerable<MedicationAdministration>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDate>>(c_);
+		IEnumerable<CqlInterval<CqlDate>> c_ = context.Operators.Select<MedicationAdministration, CqlInterval<CqlDate>>((IEnumerable<MedicationAdministration>)a_, b_);
+		CqlInterval<CqlDate> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDate>>(c_);
 
 		return d_;
 	}
@@ -2048,18 +2154,18 @@ public class CumulativeMedicationDuration_4_0_000
 		{
 			if ((context.Operators.Not((bool?)(Intervals is null)) ?? false))
 			{
-				var b_ = context.Operators.Collapse(Intervals, "day");
+				IEnumerable<CqlInterval<CqlDate>> b_ = context.Operators.Collapse(Intervals, "day");
 				int? c_(CqlInterval<CqlDate> X)
 				{
-					var f_ = context.Operators.Start(X);
-					var g_ = context.Operators.End(X);
-					var h_ = context.Operators.DifferenceBetween(f_, g_, "day");
-					var i_ = context.Operators.Add(h_, 1);
+					CqlDate f_ = context.Operators.Start(X);
+					CqlDate g_ = context.Operators.End(X);
+					int? h_ = context.Operators.DifferenceBetween(f_, g_, "day");
+					int? i_ = context.Operators.Add(h_, 1);
 
 					return i_;
 				};
-				var d_ = context.Operators.Select<CqlInterval<CqlDate>, int?>(b_, c_);
-				var e_ = context.Operators.Sum(d_);
+				IEnumerable<int?> d_ = context.Operators.Select<CqlInterval<CqlDate>, int?>(b_, c_);
+				int? e_ = context.Operators.Sum(d_);
 
 				return e_;
 			}
@@ -2077,51 +2183,51 @@ public class CumulativeMedicationDuration_4_0_000
 	{
 		IEnumerable<CqlInterval<CqlDate>> a_(IEnumerable<CqlInterval<CqlDate>> R, CqlInterval<CqlDate> I)
 		{
-			var c_ = new CqlInterval<CqlDate>[]
+			CqlInterval<CqlDate>[] c_ = new CqlInterval<CqlDate>[]
 			{
 				I,
 			};
 			CqlInterval<CqlDate> d_(CqlInterval<CqlDate> X)
 			{
-				var i_ = context.Operators.Last<CqlInterval<CqlDate>>(R);
-				var j_ = context.Operators.End(i_);
-				var k_ = context.Operators.Quantity(1m, "day");
-				var l_ = context.Operators.Add(j_, k_);
-				var m_ = context.Operators.Start(X);
-				var n_ = new CqlDate[]
+				CqlInterval<CqlDate> i_ = context.Operators.Last<CqlInterval<CqlDate>>(R);
+				CqlDate j_ = context.Operators.End(i_);
+				CqlQuantity k_ = context.Operators.Quantity(1m, "day");
+				CqlDate l_ = context.Operators.Add(j_, k_);
+				CqlDate m_ = context.Operators.Start(X);
+				CqlDate[] n_ = new CqlDate[]
 				{
 					l_,
 					m_,
 				};
-				var o_ = context.Operators.Max<CqlDate>((n_ as IEnumerable<CqlDate>));
-				var q_ = context.Operators.End(i_);
-				var s_ = context.Operators.Add(q_, k_);
-				var u_ = new CqlDate[]
+				CqlDate o_ = context.Operators.Max<CqlDate>((n_ as IEnumerable<CqlDate>));
+				CqlDate q_ = context.Operators.End(i_);
+				CqlDate s_ = context.Operators.Add(q_, k_);
+				CqlDate[] u_ = new CqlDate[]
 				{
 					s_,
 					m_,
 				};
-				var v_ = context.Operators.Max<CqlDate>((u_ as IEnumerable<CqlDate>));
-				var x_ = context.Operators.End(X);
-				var y_ = context.Operators.DurationBetween(m_, x_, "day");
-				var z_ = context.Operators.ConvertIntegerToDecimal((y_ ?? 0));
-				var aa_ = this.Quantity(z_, "day");
-				var ab_ = context.Operators.Add(v_, aa_);
-				var ac_ = context.Operators.Interval(o_, ab_, true, true);
+				CqlDate v_ = context.Operators.Max<CqlDate>((u_ as IEnumerable<CqlDate>));
+				CqlDate x_ = context.Operators.End(X);
+				int? y_ = context.Operators.DurationBetween(m_, x_, "day");
+				decimal? z_ = context.Operators.ConvertIntegerToDecimal((y_ ?? 0));
+				CqlQuantity aa_ = this.Quantity(z_, "day");
+				CqlDate ab_ = context.Operators.Add(v_, aa_);
+				CqlInterval<CqlDate> ac_ = context.Operators.Interval(o_, ab_, true, true);
 
 				return ac_;
 			};
-			var e_ = context.Operators.Select<CqlInterval<CqlDate>, CqlInterval<CqlDate>>((IEnumerable<CqlInterval<CqlDate>>)c_, d_);
-			var f_ = context.Operators.SingletonFrom<CqlInterval<CqlDate>>(e_);
-			var g_ = new CqlInterval<CqlDate>[]
+			IEnumerable<CqlInterval<CqlDate>> e_ = context.Operators.Select<CqlInterval<CqlDate>, CqlInterval<CqlDate>>((IEnumerable<CqlInterval<CqlDate>>)c_, d_);
+			CqlInterval<CqlDate> f_ = context.Operators.SingletonFrom<CqlInterval<CqlDate>>(e_);
+			CqlInterval<CqlDate>[] g_ = new CqlInterval<CqlDate>[]
 			{
 				f_,
 			};
-			var h_ = context.Operators.Union<CqlInterval<CqlDate>>(R, (g_ as IEnumerable<CqlInterval<CqlDate>>));
+			IEnumerable<CqlInterval<CqlDate>> h_ = context.Operators.Union<CqlInterval<CqlDate>>(R, (g_ as IEnumerable<CqlInterval<CqlDate>>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Aggregate<CqlInterval<CqlDate>, IEnumerable<CqlInterval<CqlDate>>>(intervals, a_, null);
+		IEnumerable<CqlInterval<CqlDate>> b_ = context.Operators.Aggregate<CqlInterval<CqlDate>, IEnumerable<CqlInterval<CqlDate>>>(intervals, a_, null);
 
 		return b_;
 	}
@@ -2133,13 +2239,13 @@ public class CumulativeMedicationDuration_4_0_000
 		{
 			if (medication is MedicationRequest)
 			{
-				var b_ = this.MedicationRequestPeriod((medication as MedicationRequest));
+				CqlInterval<CqlDate> b_ = this.MedicationRequestPeriod((medication as MedicationRequest));
 
 				return b_;
 			}
 			else if (medication is MedicationDispense)
 			{
-				var c_ = this.MedicationDispensePeriod((medication as MedicationDispense));
+				CqlInterval<CqlDate> c_ = this.MedicationDispensePeriod((medication as MedicationDispense));
 
 				return c_;
 			}
@@ -2157,35 +2263,35 @@ public class CumulativeMedicationDuration_4_0_000
 	{
 		bool? a_(object M)
 		{
-			var l_ = M is MedicationRequest;
+			bool l_ = M is MedicationRequest;
 
 			return (l_ as bool?);
 		};
-		var b_ = context.Operators.Where<object>(Medications, a_);
+		IEnumerable<object> b_ = context.Operators.Where<object>(Medications, a_);
 		CqlInterval<CqlDate> c_(object M)
 		{
-			var m_ = this.MedicationRequestPeriod((M as MedicationRequest));
+			CqlInterval<CqlDate> m_ = this.MedicationRequestPeriod((M as MedicationRequest));
 
 			return m_;
 		};
-		var d_ = context.Operators.Select<object, CqlInterval<CqlDate>>(b_, c_);
+		IEnumerable<CqlInterval<CqlDate>> d_ = context.Operators.Select<object, CqlInterval<CqlDate>>(b_, c_);
 		bool? e_(object M)
 		{
-			var n_ = M is MedicationDispense;
+			bool n_ = M is MedicationDispense;
 
 			return (n_ as bool?);
 		};
-		var f_ = context.Operators.Where<object>(Medications, e_);
+		IEnumerable<object> f_ = context.Operators.Where<object>(Medications, e_);
 		CqlInterval<CqlDate> g_(object M)
 		{
-			var o_ = this.MedicationDispensePeriod((M as MedicationDispense));
+			CqlInterval<CqlDate> o_ = this.MedicationDispensePeriod((M as MedicationDispense));
 
 			return o_;
 		};
-		var h_ = context.Operators.Select<object, CqlInterval<CqlDate>>(f_, g_);
-		var i_ = this.RolloutIntervals(h_);
-		var j_ = context.Operators.Union<CqlInterval<CqlDate>>(d_, i_);
-		var k_ = this.CumulativeDuration(j_);
+		IEnumerable<CqlInterval<CqlDate>> h_ = context.Operators.Select<object, CqlInterval<CqlDate>>(f_, g_);
+		IEnumerable<CqlInterval<CqlDate>> i_ = this.RolloutIntervals(h_);
+		IEnumerable<CqlInterval<CqlDate>> j_ = context.Operators.Union<CqlInterval<CqlDate>>(d_, i_);
+		int? k_ = this.CumulativeDuration(j_);
 
 		return k_;
 	}

--- a/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
@@ -122,154 +122,193 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility"/>
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility_Value"/>
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
 	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
+    /// <seealso cref="Diabetic_Retinopathy"/>
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
 
+    /// <seealso cref="Diabetic_Retinopathy_Value"/>
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
 	public CqlValueSet Diabetic_Retinopathy() => 
 		__Diabetic_Retinopathy.Value;
 
+    /// <seealso cref="Level_of_Severity_of_Retinopathy_Findings"/>
 	private CqlValueSet Level_of_Severity_of_Retinopathy_Findings_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", null);
 
+    /// <seealso cref="Level_of_Severity_of_Retinopathy_Findings_Value"/>
     [CqlDeclaration("Level of Severity of Retinopathy Findings")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283")]
 	public CqlValueSet Level_of_Severity_of_Retinopathy_Findings() => 
 		__Level_of_Severity_of_Retinopathy_Findings.Value;
 
+    /// <seealso cref="Macular_Edema_Findings_Present"/>
 	private CqlValueSet Macular_Edema_Findings_Present_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", null);
 
+    /// <seealso cref="Macular_Edema_Findings_Present_Value"/>
     [CqlDeclaration("Macular Edema Findings Present")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320")]
 	public CqlValueSet Macular_Edema_Findings_Present() => 
 		__Macular_Edema_Findings_Present.Value;
 
+    /// <seealso cref="Macular_Exam"/>
 	private CqlValueSet Macular_Exam_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", null);
 
+    /// <seealso cref="Macular_Exam_Value"/>
     [CqlDeclaration("Macular Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251")]
 	public CqlValueSet Macular_Exam() => 
 		__Macular_Exam.Value;
 
+    /// <seealso cref="Medical_Reason"/>
 	private CqlValueSet Medical_Reason_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
 
+    /// <seealso cref="Medical_Reason_Value"/>
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
 	public CqlValueSet Medical_Reason() => 
 		__Medical_Reason.Value;
 
+    /// <seealso cref="Nursing_Facility_Visit"/>
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
+    /// <seealso cref="Nursing_Facility_Visit_Value"/>
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
 	public CqlValueSet Nursing_Facility_Visit() => 
 		__Nursing_Facility_Visit.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Ophthalmological_Services"/>
 	private CqlValueSet Ophthalmological_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
 
+    /// <seealso cref="Ophthalmological_Services_Value"/>
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
 	public CqlValueSet Ophthalmological_Services() => 
 		__Ophthalmological_Services.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Patient_Reason"/>
 	private CqlValueSet Patient_Reason_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
 
+    /// <seealso cref="Patient_Reason_Value"/>
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
 	public CqlValueSet Patient_Reason() => 
 		__Patient_Reason.Value;
 
+    /// <seealso cref="Macular_edema_absent__situation_"/>
 	private CqlValueSet Macular_edema_absent__situation__Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391", null);
 
+    /// <seealso cref="Macular_edema_absent__situation__Value"/>
     [CqlDeclaration("Macular edema absent (situation)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391")]
 	public CqlValueSet Macular_edema_absent__situation_() => 
 		__Macular_edema_absent__situation_.Value;
 
+    /// <seealso cref="Healthcare_professional__occupation_"/>
 	private CqlCode Healthcare_professional__occupation__Value() => 
 		new CqlCode("223366009", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Healthcare_professional__occupation__Value"/>
     [CqlDeclaration("Healthcare professional (occupation)")]
 	public CqlCode Healthcare_professional__occupation_() => 
 		__Healthcare_professional__occupation_.Value;
 
+    /// <seealso cref="Medical_practitioner__occupation_"/>
 	private CqlCode Medical_practitioner__occupation__Value() => 
 		new CqlCode("158965000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Medical_practitioner__occupation__Value"/>
     [CqlDeclaration("Medical practitioner (occupation)")]
 	public CqlCode Medical_practitioner__occupation_() => 
 		__Medical_practitioner__occupation_.Value;
 
+    /// <seealso cref="Ophthalmologist__occupation_"/>
 	private CqlCode Ophthalmologist__occupation__Value() => 
 		new CqlCode("422234006", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Ophthalmologist__occupation__Value"/>
     [CqlDeclaration("Ophthalmologist (occupation)")]
 	public CqlCode Ophthalmologist__occupation_() => 
 		__Ophthalmologist__occupation_.Value;
 
+    /// <seealso cref="Optometrist__occupation_"/>
 	private CqlCode Optometrist__occupation__Value() => 
 		new CqlCode("28229004", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Optometrist__occupation__Value"/>
     [CqlDeclaration("Optometrist (occupation)")]
 	public CqlCode Optometrist__occupation_() => 
 		__Optometrist__occupation_.Value;
 
+    /// <seealso cref="Physician__occupation_"/>
 	private CqlCode Physician__occupation__Value() => 
 		new CqlCode("309343006", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Physician__occupation__Value"/>
     [CqlDeclaration("Physician (occupation)")]
 	public CqlCode Physician__occupation_() => 
 		__Physician__occupation_.Value;
 
+    /// <seealso cref="@virtual"/>
 	private CqlCode @virtual_Value() => 
 		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="@virtual_Value"/>
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
+    /// <seealso cref="AMB"/>
 	private CqlCode AMB_Value() => 
 		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="AMB_Value"/>
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
 		__AMB.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("223366009", "http://snomed.info/sct", null, null),
 			new CqlCode("158965000", "http://snomed.info/sct", null, null),
@@ -281,13 +320,15 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
@@ -296,670 +337,713 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounter_During_Measurement_Period"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Ophthalmological_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Outpatient_Consultation();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Nursing_Facility_Visit();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = context.Operators.Union<Encounter>(k_, m_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Ophthalmological_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Nursing_Facility_Visit();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter QualifyingEncounter)
 		{
-			var q_ = this.Measurement_Period();
-			var r_ = QualifyingEncounter?.Period;
-			var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, null);
-			var u_ = QualifyingEncounter?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
-			var x_ = context.Operators.Equal(w_, "finished");
-			var y_ = context.Operators.And(t_, x_);
-			var z_ = QualifyingEncounter?.Class;
-			var aa_ = FHIRHelpers_4_3_000.ToCode(z_);
-			var ab_ = this.@virtual();
-			var ac_ = context.Operators.Equivalent(aa_, ab_);
-			var ad_ = context.Operators.Not(ac_);
-			var ae_ = context.Operators.And(y_, ad_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			Period r_ = QualifyingEncounter?.Period;
+			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, null);
+			Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
+			Encounter.EncounterStatus? v_ = u_?.Value;
+			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+			bool? x_ = context.Operators.Equal(w_, "finished");
+			bool? y_ = context.Operators.And(t_, x_);
+			Coding z_ = QualifyingEncounter?.Class;
+			CqlCode aa_ = FHIRHelpers_4_3_000.ToCode(z_);
+			CqlCode ab_ = this.@virtual();
+			bool? ac_ = context.Operators.Equivalent(aa_, ab_);
+			bool? ad_ = context.Operators.Not(ac_);
+			bool? ae_ = context.Operators.And(y_, ad_);
 
 			return ae_;
 		};
-		var p_ = context.Operators.Where<Encounter>(n_, o_);
+		IEnumerable<Encounter> p_ = context.Operators.Where<Encounter>(n_, o_);
 
 		return p_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_During_Measurement_Period_Value"/>
     [CqlDeclaration("Qualifying Encounter During Measurement Period")]
 	public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period() => 
 		__Qualifying_Encounter_During_Measurement_Period.Value;
 
+    /// <seealso cref="Diabetic_Retinopathy_Encounter"/>
 	private IEnumerable<Encounter> Diabetic_Retinopathy_Encounter_Value()
 	{
-		var a_ = this.Qualifying_Encounter_During_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_During_Measurement_Period();
 		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
 		{
-			var d_ = this.Diabetic_Retinopathy();
-			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			CqlValueSet d_ = this.Diabetic_Retinopathy();
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
 			bool? f_(Condition DiabeticRetinopathy)
 			{
-				var j_ = QICoreCommon_2_0_000.prevalenceInterval(DiabeticRetinopathy);
-				var k_ = ValidQualifyingEncounter?.Period;
-				var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var m_ = context.Operators.Overlaps(j_, l_, null);
-				var n_ = QICoreCommon_2_0_000.isActive(DiabeticRetinopathy);
-				var o_ = context.Operators.And(m_, n_);
-				var p_ = DiabeticRetinopathy?.VerificationStatus;
-				var q_ = FHIRHelpers_4_3_000.ToConcept(p_);
-				var r_ = QICoreCommon_2_0_000.unconfirmed();
-				var s_ = context.Operators.ConvertCodeToConcept(r_);
-				var t_ = context.Operators.Equivalent(q_, s_);
-				var v_ = FHIRHelpers_4_3_000.ToConcept(p_);
-				var w_ = QICoreCommon_2_0_000.refuted();
-				var x_ = context.Operators.ConvertCodeToConcept(w_);
-				var y_ = context.Operators.Equivalent(v_, x_);
-				var z_ = context.Operators.Or(t_, y_);
-				var ab_ = FHIRHelpers_4_3_000.ToConcept(p_);
-				var ac_ = QICoreCommon_2_0_000.entered_in_error();
-				var ad_ = context.Operators.ConvertCodeToConcept(ac_);
-				var ae_ = context.Operators.Equivalent(ab_, ad_);
-				var af_ = context.Operators.Or(z_, ae_);
-				var ag_ = context.Operators.Not(af_);
-				var ah_ = context.Operators.And(o_, ag_);
+				CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.prevalenceInterval(DiabeticRetinopathy);
+				Period k_ = ValidQualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				bool? m_ = context.Operators.Overlaps(j_, l_, null);
+				bool? n_ = QICoreCommon_2_0_000.isActive(DiabeticRetinopathy);
+				bool? o_ = context.Operators.And(m_, n_);
+				CodeableConcept p_ = DiabeticRetinopathy?.VerificationStatus;
+				CqlConcept q_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				CqlCode r_ = QICoreCommon_2_0_000.unconfirmed();
+				CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+				bool? t_ = context.Operators.Equivalent(q_, s_);
+				CqlConcept v_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				CqlCode w_ = QICoreCommon_2_0_000.refuted();
+				CqlConcept x_ = context.Operators.ConvertCodeToConcept(w_);
+				bool? y_ = context.Operators.Equivalent(v_, x_);
+				bool? z_ = context.Operators.Or(t_, y_);
+				CqlConcept ab_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				CqlCode ac_ = QICoreCommon_2_0_000.entered_in_error();
+				CqlConcept ad_ = context.Operators.ConvertCodeToConcept(ac_);
+				bool? ae_ = context.Operators.Equivalent(ab_, ad_);
+				bool? af_ = context.Operators.Or(z_, ae_);
+				bool? ag_ = context.Operators.Not(af_);
+				bool? ah_ = context.Operators.And(o_, ag_);
 
 				return ah_;
 			};
-			var g_ = context.Operators.Where<Condition>(e_, f_);
+			IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 			Encounter h_(Condition DiabeticRetinopathy) => 
 				ValidQualifyingEncounter;
-			var i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Diabetic_Retinopathy_Encounter_Value"/>
     [CqlDeclaration("Diabetic Retinopathy Encounter")]
 	public IEnumerable<Encounter> Diabetic_Retinopathy_Encounter() => 
 		__Diabetic_Retinopathy_Encounter.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 18);
-		var h_ = this.Diabetic_Retinopathy_Encounter();
-		var i_ = context.Operators.Exists<Encounter>(h_);
-		var j_ = context.Operators.And(g_, i_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+		IEnumerable<Encounter> j_ = this.Diabetic_Retinopathy_Encounter();
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
+		bool? l_ = context.Operators.And(i_, k_);
 
-		return j_;
+		return l_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Macular_Exam_Performed"/>
 	private IEnumerable<Observation> Macular_Exam_Performed_Value()
 	{
-		var a_ = this.Macular_Exam();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.Macular_Exam();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		IEnumerable<Observation> c_(Observation MacularExam)
 		{
-			var g_ = this.Diabetic_Retinopathy_Encounter();
+			IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter();
 			bool? h_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var l_ = EncounterDiabeticRetinopathy?.Period;
-				var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-				var n_ = MacularExam?.Effective;
-				var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-				var p_ = QICoreCommon_2_0_000.toInterval(o_);
-				var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
+				Period l_ = EncounterDiabeticRetinopathy?.Period;
+				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+				DataType n_ = MacularExam?.Effective;
+				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
 
 				return q_;
 			};
-			var i_ = context.Operators.Where<Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
 			Observation j_(Encounter EncounterDiabeticRetinopathy) => 
 				MacularExam;
-			var k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+			IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
 
 			return k_;
 		};
-		var d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
 		bool? e_(Observation MacularExam)
 		{
-			var r_ = MacularExam?.Value;
-			var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-			var t_ = context.Operators.Not((bool?)(s_ is null));
-			var u_ = MacularExam?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
-			var x_ = context.Operators.Convert<string>(w_);
-			var y_ = new string[]
+			DataType r_ = MacularExam?.Value;
+			object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+			bool? t_ = context.Operators.Not((bool?)(s_ is null));
+			Code<ObservationStatus> u_ = MacularExam?.StatusElement;
+			ObservationStatus? v_ = u_?.Value;
+			Code<ObservationStatus> w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
+			string x_ = context.Operators.Convert<string>(w_);
+			string[] y_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 				"preliminary",
 			};
-			var z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
-			var aa_ = context.Operators.And(t_, z_);
+			bool? z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
+			bool? aa_ = context.Operators.And(t_, z_);
 
 			return aa_;
 		};
-		var f_ = context.Operators.Where<Observation>(d_, e_);
+		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Macular_Exam_Performed_Value"/>
     [CqlDeclaration("Macular Exam Performed")]
 	public IEnumerable<Observation> Macular_Exam_Performed() => 
 		__Macular_Exam_Performed.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
-		var b_ = this.Macular_Exam_Performed();
-		var c_ = context.Operators.Exists<Observation>(b_);
-		var d_ = context.Operators.And(a_, c_);
+		bool? a_ = this.Initial_Population();
+		IEnumerable<Observation> b_ = this.Macular_Exam_Performed();
+		bool? c_ = context.Operators.Exists<Observation>(b_);
+		bool? d_ = context.Operators.And(a_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Level_of_Severity_of_Retinopathy_Findings_Communicated"/>
 	private IEnumerable<Communication> Level_of_Severity_of_Retinopathy_Findings_Communicated_Value()
 	{
-		var a_ = this.Level_of_Severity_of_Retinopathy_Findings();
-		var b_ = typeof(Communication).GetProperty("ReasonCode");
-		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		CqlValueSet a_ = this.Level_of_Severity_of_Retinopathy_Findings();
+		PropertyInfo b_ = typeof(Communication).GetProperty("ReasonCode");
+		IEnumerable<Communication> c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
 		IEnumerable<Communication> d_(Communication LevelOfSeverityCommunicated)
 		{
-			var h_ = this.Diabetic_Retinopathy_Encounter();
+			IEnumerable<Encounter> h_ = this.Diabetic_Retinopathy_Encounter();
 			bool? i_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var m_ = LevelOfSeverityCommunicated?.SentElement;
-				var n_ = context.Operators.Convert<CqlDateTime>(m_);
-				var o_ = EncounterDiabeticRetinopathy?.Period;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = context.Operators.Start(p_);
-				var r_ = context.Operators.After(n_, q_, null);
-				var t_ = context.Operators.Convert<CqlDateTime>(m_);
-				var u_ = this.Measurement_Period();
-				var v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
-				var w_ = context.Operators.And(r_, v_);
+				FhirDateTime m_ = LevelOfSeverityCommunicated?.SentElement;
+				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+				Period o_ = EncounterDiabeticRetinopathy?.Period;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				CqlDateTime q_ = context.Operators.Start(p_);
+				bool? r_ = context.Operators.After(n_, q_, null);
+				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
+				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
+				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
+				bool? w_ = context.Operators.And(r_, v_);
 
 				return w_;
 			};
-			var j_ = context.Operators.Where<Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
 			Communication k_(Encounter EncounterDiabeticRetinopathy) => 
 				LevelOfSeverityCommunicated;
-			var l_ = context.Operators.Select<Encounter, Communication>(j_, k_);
+			IEnumerable<Communication> l_ = context.Operators.Select<Encounter, Communication>(j_, k_);
 
 			return l_;
 		};
-		var e_ = context.Operators.SelectMany<Communication, Communication>(c_, d_);
+		IEnumerable<Communication> e_ = context.Operators.SelectMany<Communication, Communication>(c_, d_);
 		bool? f_(Communication LevelOfSeverityCommunicated)
 		{
-			var x_ = LevelOfSeverityCommunicated?.StatusElement;
-			var y_ = x_?.Value;
-			var z_ = context.Operators.Convert<Code<EventStatus>>(y_);
-			var aa_ = context.Operators.Equal(z_, "completed");
+			Code<EventStatus> x_ = LevelOfSeverityCommunicated?.StatusElement;
+			EventStatus? y_ = x_?.Value;
+			Code<EventStatus> z_ = context.Operators.Convert<Code<EventStatus>>(y_);
+			bool? aa_ = context.Operators.Equal(z_, "completed");
 
 			return aa_;
 		};
-		var g_ = context.Operators.Where<Communication>(e_, f_);
+		IEnumerable<Communication> g_ = context.Operators.Where<Communication>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Level_of_Severity_of_Retinopathy_Findings_Communicated_Value"/>
     [CqlDeclaration("Level of Severity of Retinopathy Findings Communicated")]
 	public IEnumerable<Communication> Level_of_Severity_of_Retinopathy_Findings_Communicated() => 
 		__Level_of_Severity_of_Retinopathy_Findings_Communicated.Value;
 
+    /// <seealso cref="Macular_Edema_Absence_Communicated"/>
 	private IEnumerable<Communication> Macular_Edema_Absence_Communicated_Value()
 	{
-		var a_ = this.Macular_edema_absent__situation_();
-		var b_ = typeof(Communication).GetProperty("ReasonCode");
-		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		CqlValueSet a_ = this.Macular_edema_absent__situation_();
+		PropertyInfo b_ = typeof(Communication).GetProperty("ReasonCode");
+		IEnumerable<Communication> c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
 		IEnumerable<Communication> d_(Communication MacularEdemaAbsentCommunicated)
 		{
-			var h_ = this.Diabetic_Retinopathy_Encounter();
+			IEnumerable<Encounter> h_ = this.Diabetic_Retinopathy_Encounter();
 			bool? i_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var m_ = MacularEdemaAbsentCommunicated?.SentElement;
-				var n_ = context.Operators.Convert<CqlDateTime>(m_);
-				var o_ = EncounterDiabeticRetinopathy?.Period;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = context.Operators.Start(p_);
-				var r_ = context.Operators.After(n_, q_, null);
-				var t_ = context.Operators.Convert<CqlDateTime>(m_);
-				var u_ = this.Measurement_Period();
-				var v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
-				var w_ = context.Operators.And(r_, v_);
+				FhirDateTime m_ = MacularEdemaAbsentCommunicated?.SentElement;
+				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+				Period o_ = EncounterDiabeticRetinopathy?.Period;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				CqlDateTime q_ = context.Operators.Start(p_);
+				bool? r_ = context.Operators.After(n_, q_, null);
+				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
+				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
+				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
+				bool? w_ = context.Operators.And(r_, v_);
 
 				return w_;
 			};
-			var j_ = context.Operators.Where<Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
 			Communication k_(Encounter EncounterDiabeticRetinopathy) => 
 				MacularEdemaAbsentCommunicated;
-			var l_ = context.Operators.Select<Encounter, Communication>(j_, k_);
+			IEnumerable<Communication> l_ = context.Operators.Select<Encounter, Communication>(j_, k_);
 
 			return l_;
 		};
-		var e_ = context.Operators.SelectMany<Communication, Communication>(c_, d_);
+		IEnumerable<Communication> e_ = context.Operators.SelectMany<Communication, Communication>(c_, d_);
 		bool? f_(Communication MacularEdemaAbsentCommunicated)
 		{
-			var x_ = MacularEdemaAbsentCommunicated?.StatusElement;
-			var y_ = x_?.Value;
-			var z_ = context.Operators.Convert<Code<EventStatus>>(y_);
-			var aa_ = context.Operators.Equal(z_, "completed");
+			Code<EventStatus> x_ = MacularEdemaAbsentCommunicated?.StatusElement;
+			EventStatus? y_ = x_?.Value;
+			Code<EventStatus> z_ = context.Operators.Convert<Code<EventStatus>>(y_);
+			bool? aa_ = context.Operators.Equal(z_, "completed");
 
 			return aa_;
 		};
-		var g_ = context.Operators.Where<Communication>(e_, f_);
+		IEnumerable<Communication> g_ = context.Operators.Where<Communication>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Macular_Edema_Absence_Communicated_Value"/>
     [CqlDeclaration("Macular Edema Absence Communicated")]
 	public IEnumerable<Communication> Macular_Edema_Absence_Communicated() => 
 		__Macular_Edema_Absence_Communicated.Value;
 
+    /// <seealso cref="Macular_Edema_Presence_Communicated"/>
 	private IEnumerable<Communication> Macular_Edema_Presence_Communicated_Value()
 	{
-		var a_ = this.Macular_Edema_Findings_Present();
-		var b_ = typeof(Communication).GetProperty("ReasonCode");
-		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		CqlValueSet a_ = this.Macular_Edema_Findings_Present();
+		PropertyInfo b_ = typeof(Communication).GetProperty("ReasonCode");
+		IEnumerable<Communication> c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
 		IEnumerable<Communication> d_(Communication MacularEdemaPresentCommunicated)
 		{
-			var h_ = this.Diabetic_Retinopathy_Encounter();
+			IEnumerable<Encounter> h_ = this.Diabetic_Retinopathy_Encounter();
 			bool? i_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var m_ = MacularEdemaPresentCommunicated?.SentElement;
-				var n_ = context.Operators.Convert<CqlDateTime>(m_);
-				var o_ = EncounterDiabeticRetinopathy?.Period;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = context.Operators.Start(p_);
-				var r_ = context.Operators.After(n_, q_, null);
-				var t_ = context.Operators.Convert<CqlDateTime>(m_);
-				var u_ = this.Measurement_Period();
-				var v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
-				var w_ = context.Operators.And(r_, v_);
+				FhirDateTime m_ = MacularEdemaPresentCommunicated?.SentElement;
+				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+				Period o_ = EncounterDiabeticRetinopathy?.Period;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				CqlDateTime q_ = context.Operators.Start(p_);
+				bool? r_ = context.Operators.After(n_, q_, null);
+				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
+				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
+				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
+				bool? w_ = context.Operators.And(r_, v_);
 
 				return w_;
 			};
-			var j_ = context.Operators.Where<Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
 			Communication k_(Encounter EncounterDiabeticRetinopathy) => 
 				MacularEdemaPresentCommunicated;
-			var l_ = context.Operators.Select<Encounter, Communication>(j_, k_);
+			IEnumerable<Communication> l_ = context.Operators.Select<Encounter, Communication>(j_, k_);
 
 			return l_;
 		};
-		var e_ = context.Operators.SelectMany<Communication, Communication>(c_, d_);
+		IEnumerable<Communication> e_ = context.Operators.SelectMany<Communication, Communication>(c_, d_);
 		bool? f_(Communication MacularEdemaPresentCommunicated)
 		{
-			var x_ = MacularEdemaPresentCommunicated?.StatusElement;
-			var y_ = x_?.Value;
-			var z_ = context.Operators.Convert<Code<EventStatus>>(y_);
-			var aa_ = context.Operators.Equal(z_, "completed");
+			Code<EventStatus> x_ = MacularEdemaPresentCommunicated?.StatusElement;
+			EventStatus? y_ = x_?.Value;
+			Code<EventStatus> z_ = context.Operators.Convert<Code<EventStatus>>(y_);
+			bool? aa_ = context.Operators.Equal(z_, "completed");
 
 			return aa_;
 		};
-		var g_ = context.Operators.Where<Communication>(e_, f_);
+		IEnumerable<Communication> g_ = context.Operators.Where<Communication>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Macular_Edema_Presence_Communicated_Value"/>
     [CqlDeclaration("Macular Edema Presence Communicated")]
 	public IEnumerable<Communication> Macular_Edema_Presence_Communicated() => 
 		__Macular_Edema_Presence_Communicated.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated();
-		var b_ = context.Operators.Exists<Communication>(a_);
-		var c_ = this.Macular_Edema_Absence_Communicated();
-		var d_ = context.Operators.Exists<Communication>(c_);
-		var e_ = this.Macular_Edema_Presence_Communicated();
-		var f_ = context.Operators.Exists<Communication>(e_);
-		var g_ = context.Operators.Or(d_, f_);
-		var h_ = context.Operators.And(b_, g_);
+		IEnumerable<Communication> a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated();
+		bool? b_ = context.Operators.Exists<Communication>(a_);
+		IEnumerable<Communication> c_ = this.Macular_Edema_Absence_Communicated();
+		bool? d_ = context.Operators.Exists<Communication>(c_);
+		IEnumerable<Communication> e_ = this.Macular_Edema_Presence_Communicated();
+		bool? f_ = context.Operators.Exists<Communication>(e_);
+		bool? g_ = context.Operators.Or(d_, f_);
+		bool? h_ = context.Operators.And(b_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy"/>
 	private IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy_Value()
 	{
-		var a_ = this.Level_of_Severity_of_Retinopathy_Findings();
-		var b_ = typeof(Communication).GetProperty("ReasonCode");
-		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
-		var f_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
-		var g_ = context.Operators.Union<Communication>(c_, f_);
+		CqlValueSet a_ = this.Level_of_Severity_of_Retinopathy_Findings();
+		PropertyInfo b_ = typeof(Communication).GetProperty("ReasonCode");
+		IEnumerable<Communication> c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		IEnumerable<Communication> f_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		IEnumerable<Communication> g_ = context.Operators.Union<Communication>(c_, f_);
 		IEnumerable<Communication> h_(Communication LevelOfSeverityNotCommunicated)
 		{
-			var l_ = this.Diabetic_Retinopathy_Encounter();
+			IEnumerable<Encounter> l_ = this.Diabetic_Retinopathy_Encounter();
 			bool? m_(Encounter EncounterDiabeticRetinopathy)
 			{
 				bool? q_(Extension @this)
 				{
-					var z_ = @this?.Url;
-					var aa_ = context.Operators.Convert<FhirUri>(z_);
-					var ab_ = FHIRHelpers_4_3_000.ToString(aa_);
-					var ac_ = context.Operators.Equal(ab_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+					string z_ = @this?.Url;
+					FhirUri aa_ = context.Operators.Convert<FhirUri>(z_);
+					string ab_ = FHIRHelpers_4_3_000.ToString(aa_);
+					bool? ac_ = context.Operators.Equal(ab_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
 
 					return ac_;
 				};
-				var r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((LevelOfSeverityNotCommunicated is DomainResource)
+				IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((LevelOfSeverityNotCommunicated is DomainResource)
 						? ((LevelOfSeverityNotCommunicated as DomainResource).Extension)
 						: null), q_);
 				DataType s_(Extension @this)
 				{
-					var ad_ = @this?.Value;
+					DataType ad_ = @this?.Value;
 
 					return ad_;
 				};
-				var t_ = context.Operators.Select<Extension, DataType>(r_, s_);
-				var u_ = context.Operators.SingletonFrom<DataType>(t_);
-				var v_ = context.Operators.Convert<CqlDateTime>(u_);
-				var w_ = EncounterDiabeticRetinopathy?.Period;
-				var x_ = FHIRHelpers_4_3_000.ToInterval(w_);
-				var y_ = context.Operators.In<CqlDateTime>(v_, x_, null);
+				IEnumerable<DataType> t_ = context.Operators.Select<Extension, DataType>(r_, s_);
+				DataType u_ = context.Operators.SingletonFrom<DataType>(t_);
+				CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+				Period w_ = EncounterDiabeticRetinopathy?.Period;
+				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(w_);
+				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, null);
 
 				return y_;
 			};
-			var n_ = context.Operators.Where<Encounter>(l_, m_);
+			IEnumerable<Encounter> n_ = context.Operators.Where<Encounter>(l_, m_);
 			Communication o_(Encounter EncounterDiabeticRetinopathy) => 
 				LevelOfSeverityNotCommunicated;
-			var p_ = context.Operators.Select<Encounter, Communication>(n_, o_);
+			IEnumerable<Communication> p_ = context.Operators.Select<Encounter, Communication>(n_, o_);
 
 			return p_;
 		};
-		var i_ = context.Operators.SelectMany<Communication, Communication>(g_, h_);
+		IEnumerable<Communication> i_ = context.Operators.SelectMany<Communication, Communication>(g_, h_);
 		bool? j_(Communication LevelOfSeverityNotCommunicated)
 		{
-			var ae_ = LevelOfSeverityNotCommunicated?.StatusReason;
-			var af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
-			var ag_ = this.Medical_Reason();
-			var ah_ = context.Operators.ConceptInValueSet(af_, ag_);
-			var aj_ = FHIRHelpers_4_3_000.ToConcept(ae_);
-			var ak_ = this.Patient_Reason();
-			var al_ = context.Operators.ConceptInValueSet(aj_, ak_);
-			var am_ = context.Operators.Or(ah_, al_);
+			CodeableConcept ae_ = LevelOfSeverityNotCommunicated?.StatusReason;
+			CqlConcept af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
+			CqlValueSet ag_ = this.Medical_Reason();
+			bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+			CqlConcept aj_ = FHIRHelpers_4_3_000.ToConcept(ae_);
+			CqlValueSet ak_ = this.Patient_Reason();
+			bool? al_ = context.Operators.ConceptInValueSet(aj_, ak_);
+			bool? am_ = context.Operators.Or(ah_, al_);
 
 			return am_;
 		};
-		var k_ = context.Operators.Where<Communication>(i_, j_);
+		IEnumerable<Communication> k_ = context.Operators.Where<Communication>(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy_Value"/>
     [CqlDeclaration("Medical or Patient Reason for Not Communicating Level of Severity of Retinopathy")]
 	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy() => 
 		__Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy.Value;
 
+    /// <seealso cref="Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema"/>
 	private IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema_Value()
 	{
-		var a_ = this.Macular_edema_absent__situation_();
-		var b_ = typeof(Communication).GetProperty("ReasonCode");
-		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
-		var f_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
-		var g_ = context.Operators.Union<Communication>(c_, f_);
+		CqlValueSet a_ = this.Macular_edema_absent__situation_();
+		PropertyInfo b_ = typeof(Communication).GetProperty("ReasonCode");
+		IEnumerable<Communication> c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		IEnumerable<Communication> f_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		IEnumerable<Communication> g_ = context.Operators.Union<Communication>(c_, f_);
 		IEnumerable<Communication> h_(Communication MacularEdemaAbsentNotCommunicated)
 		{
-			var l_ = this.Diabetic_Retinopathy_Encounter();
+			IEnumerable<Encounter> l_ = this.Diabetic_Retinopathy_Encounter();
 			bool? m_(Encounter EncounterDiabeticRetinopathy)
 			{
 				bool? q_(Extension @this)
 				{
-					var z_ = @this?.Url;
-					var aa_ = context.Operators.Convert<FhirUri>(z_);
-					var ab_ = FHIRHelpers_4_3_000.ToString(aa_);
-					var ac_ = context.Operators.Equal(ab_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+					string z_ = @this?.Url;
+					FhirUri aa_ = context.Operators.Convert<FhirUri>(z_);
+					string ab_ = FHIRHelpers_4_3_000.ToString(aa_);
+					bool? ac_ = context.Operators.Equal(ab_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
 
 					return ac_;
 				};
-				var r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MacularEdemaAbsentNotCommunicated is DomainResource)
+				IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MacularEdemaAbsentNotCommunicated is DomainResource)
 						? ((MacularEdemaAbsentNotCommunicated as DomainResource).Extension)
 						: null), q_);
 				DataType s_(Extension @this)
 				{
-					var ad_ = @this?.Value;
+					DataType ad_ = @this?.Value;
 
 					return ad_;
 				};
-				var t_ = context.Operators.Select<Extension, DataType>(r_, s_);
-				var u_ = context.Operators.SingletonFrom<DataType>(t_);
-				var v_ = context.Operators.Convert<CqlDateTime>(u_);
-				var w_ = EncounterDiabeticRetinopathy?.Period;
-				var x_ = FHIRHelpers_4_3_000.ToInterval(w_);
-				var y_ = context.Operators.In<CqlDateTime>(v_, x_, null);
+				IEnumerable<DataType> t_ = context.Operators.Select<Extension, DataType>(r_, s_);
+				DataType u_ = context.Operators.SingletonFrom<DataType>(t_);
+				CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+				Period w_ = EncounterDiabeticRetinopathy?.Period;
+				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(w_);
+				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, null);
 
 				return y_;
 			};
-			var n_ = context.Operators.Where<Encounter>(l_, m_);
+			IEnumerable<Encounter> n_ = context.Operators.Where<Encounter>(l_, m_);
 			Communication o_(Encounter EncounterDiabeticRetinopathy) => 
 				MacularEdemaAbsentNotCommunicated;
-			var p_ = context.Operators.Select<Encounter, Communication>(n_, o_);
+			IEnumerable<Communication> p_ = context.Operators.Select<Encounter, Communication>(n_, o_);
 
 			return p_;
 		};
-		var i_ = context.Operators.SelectMany<Communication, Communication>(g_, h_);
+		IEnumerable<Communication> i_ = context.Operators.SelectMany<Communication, Communication>(g_, h_);
 		bool? j_(Communication MacularEdemaAbsentNotCommunicated)
 		{
-			var ae_ = MacularEdemaAbsentNotCommunicated?.StatusReason;
-			var af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
-			var ag_ = this.Medical_Reason();
-			var ah_ = context.Operators.ConceptInValueSet(af_, ag_);
-			var aj_ = FHIRHelpers_4_3_000.ToConcept(ae_);
-			var ak_ = this.Patient_Reason();
-			var al_ = context.Operators.ConceptInValueSet(aj_, ak_);
-			var am_ = context.Operators.Or(ah_, al_);
+			CodeableConcept ae_ = MacularEdemaAbsentNotCommunicated?.StatusReason;
+			CqlConcept af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
+			CqlValueSet ag_ = this.Medical_Reason();
+			bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+			CqlConcept aj_ = FHIRHelpers_4_3_000.ToConcept(ae_);
+			CqlValueSet ak_ = this.Patient_Reason();
+			bool? al_ = context.Operators.ConceptInValueSet(aj_, ak_);
+			bool? am_ = context.Operators.Or(ah_, al_);
 
 			return am_;
 		};
-		var k_ = context.Operators.Where<Communication>(i_, j_);
+		IEnumerable<Communication> k_ = context.Operators.Where<Communication>(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema_Value"/>
     [CqlDeclaration("Medical or Patient Reason for Not Communicating Absence of Macular Edema")]
 	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema() => 
 		__Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema.Value;
 
+    /// <seealso cref="Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema"/>
 	private IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema_Value()
 	{
-		var a_ = this.Macular_Edema_Findings_Present();
-		var b_ = typeof(Communication).GetProperty("ReasonCode");
-		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
-		var f_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
-		var g_ = context.Operators.Union<Communication>(c_, f_);
+		CqlValueSet a_ = this.Macular_Edema_Findings_Present();
+		PropertyInfo b_ = typeof(Communication).GetProperty("ReasonCode");
+		IEnumerable<Communication> c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		IEnumerable<Communication> f_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
+		IEnumerable<Communication> g_ = context.Operators.Union<Communication>(c_, f_);
 		IEnumerable<Communication> h_(Communication MacularEdemaPresentNotCommunicated)
 		{
-			var l_ = this.Diabetic_Retinopathy_Encounter();
+			IEnumerable<Encounter> l_ = this.Diabetic_Retinopathy_Encounter();
 			bool? m_(Encounter EncounterDiabeticRetinopathy)
 			{
 				bool? q_(Extension @this)
 				{
-					var z_ = @this?.Url;
-					var aa_ = context.Operators.Convert<FhirUri>(z_);
-					var ab_ = FHIRHelpers_4_3_000.ToString(aa_);
-					var ac_ = context.Operators.Equal(ab_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+					string z_ = @this?.Url;
+					FhirUri aa_ = context.Operators.Convert<FhirUri>(z_);
+					string ab_ = FHIRHelpers_4_3_000.ToString(aa_);
+					bool? ac_ = context.Operators.Equal(ab_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
 
 					return ac_;
 				};
-				var r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MacularEdemaPresentNotCommunicated is DomainResource)
+				IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MacularEdemaPresentNotCommunicated is DomainResource)
 						? ((MacularEdemaPresentNotCommunicated as DomainResource).Extension)
 						: null), q_);
 				DataType s_(Extension @this)
 				{
-					var ad_ = @this?.Value;
+					DataType ad_ = @this?.Value;
 
 					return ad_;
 				};
-				var t_ = context.Operators.Select<Extension, DataType>(r_, s_);
-				var u_ = context.Operators.SingletonFrom<DataType>(t_);
-				var v_ = context.Operators.Convert<CqlDateTime>(u_);
-				var w_ = EncounterDiabeticRetinopathy?.Period;
-				var x_ = FHIRHelpers_4_3_000.ToInterval(w_);
-				var y_ = context.Operators.In<CqlDateTime>(v_, x_, null);
+				IEnumerable<DataType> t_ = context.Operators.Select<Extension, DataType>(r_, s_);
+				DataType u_ = context.Operators.SingletonFrom<DataType>(t_);
+				CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+				Period w_ = EncounterDiabeticRetinopathy?.Period;
+				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(w_);
+				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, null);
 
 				return y_;
 			};
-			var n_ = context.Operators.Where<Encounter>(l_, m_);
+			IEnumerable<Encounter> n_ = context.Operators.Where<Encounter>(l_, m_);
 			Communication o_(Encounter EncounterDiabeticRetinopathy) => 
 				MacularEdemaPresentNotCommunicated;
-			var p_ = context.Operators.Select<Encounter, Communication>(n_, o_);
+			IEnumerable<Communication> p_ = context.Operators.Select<Encounter, Communication>(n_, o_);
 
 			return p_;
 		};
-		var i_ = context.Operators.SelectMany<Communication, Communication>(g_, h_);
+		IEnumerable<Communication> i_ = context.Operators.SelectMany<Communication, Communication>(g_, h_);
 		bool? j_(Communication MacularEdemaPresentNotCommunicated)
 		{
-			var ae_ = MacularEdemaPresentNotCommunicated?.StatusReason;
-			var af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
-			var ag_ = this.Medical_Reason();
-			var ah_ = context.Operators.ConceptInValueSet(af_, ag_);
-			var aj_ = FHIRHelpers_4_3_000.ToConcept(ae_);
-			var ak_ = this.Patient_Reason();
-			var al_ = context.Operators.ConceptInValueSet(aj_, ak_);
-			var am_ = context.Operators.Or(ah_, al_);
+			CodeableConcept ae_ = MacularEdemaPresentNotCommunicated?.StatusReason;
+			CqlConcept af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
+			CqlValueSet ag_ = this.Medical_Reason();
+			bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+			CqlConcept aj_ = FHIRHelpers_4_3_000.ToConcept(ae_);
+			CqlValueSet ak_ = this.Patient_Reason();
+			bool? al_ = context.Operators.ConceptInValueSet(aj_, ak_);
+			bool? am_ = context.Operators.Or(ah_, al_);
 
 			return am_;
 		};
-		var k_ = context.Operators.Where<Communication>(i_, j_);
+		IEnumerable<Communication> k_ = context.Operators.Where<Communication>(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema_Value"/>
     [CqlDeclaration("Medical or Patient Reason for Not Communicating Presence of Macular Edema")]
 	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema() => 
 		__Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema.Value;
 
+    /// <seealso cref="Denominator_Exceptions"/>
 	private bool? Denominator_Exceptions_Value()
 	{
-		var a_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy();
-		var b_ = context.Operators.Exists<Communication>(a_);
-		var c_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema();
-		var d_ = context.Operators.Exists<Communication>(c_);
-		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema();
-		var g_ = context.Operators.Exists<Communication>(f_);
-		var h_ = context.Operators.Or(e_, g_);
+		IEnumerable<Communication> a_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy();
+		bool? b_ = context.Operators.Exists<Communication>(a_);
+		IEnumerable<Communication> c_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema();
+		bool? d_ = context.Operators.Exists<Communication>(c_);
+		bool? e_ = context.Operators.Or(b_, d_);
+		IEnumerable<Communication> f_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema();
+		bool? g_ = context.Operators.Exists<Communication>(f_);
+		bool? h_ = context.Operators.Or(e_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Denominator_Exceptions_Value"/>
     [CqlDeclaration("Denominator Exceptions")]
 	public bool? Denominator_Exceptions() => 
 		__Denominator_Exceptions.Value;
 
+    /// <seealso cref="Results_of_Dilated_Macular_or_Fundus_Exam_Communicated"/>
 	private bool? Results_of_Dilated_Macular_or_Fundus_Exam_Communicated_Value()
 	{
-		var a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated();
-		var b_ = context.Operators.Exists<Communication>(a_);
-		var c_ = this.Macular_Edema_Absence_Communicated();
-		var d_ = context.Operators.Exists<Communication>(c_);
-		var e_ = this.Macular_Edema_Presence_Communicated();
-		var f_ = context.Operators.Exists<Communication>(e_);
-		var g_ = context.Operators.Or(d_, f_);
-		var h_ = context.Operators.And(b_, g_);
+		IEnumerable<Communication> a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated();
+		bool? b_ = context.Operators.Exists<Communication>(a_);
+		IEnumerable<Communication> c_ = this.Macular_Edema_Absence_Communicated();
+		bool? d_ = context.Operators.Exists<Communication>(c_);
+		IEnumerable<Communication> e_ = this.Macular_Edema_Presence_Communicated();
+		bool? f_ = context.Operators.Exists<Communication>(e_);
+		bool? g_ = context.Operators.Or(d_, f_);
+		bool? h_ = context.Operators.And(b_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Results_of_Dilated_Macular_or_Fundus_Exam_Communicated_Value"/>
     [CqlDeclaration("Results of Dilated Macular or Fundus Exam Communicated")]
 	public bool? Results_of_Dilated_Macular_or_Fundus_Exam_Communicated() => 
 		__Results_of_Dilated_Macular_or_Fundus_Exam_Communicated.Value;

--- a/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
@@ -102,512 +102,574 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Behavioral_Neuropsych_Assessment"/>
 	private CqlValueSet Behavioral_Neuropsych_Assessment_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023", null);
 
+    /// <seealso cref="Behavioral_Neuropsych_Assessment_Value"/>
     [CqlDeclaration("Behavioral/Neuropsych Assessment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023")]
 	public CqlValueSet Behavioral_Neuropsych_Assessment() => 
 		__Behavioral_Neuropsych_Assessment.Value;
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility"/>
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility_Value"/>
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
 	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
+    /// <seealso cref="Cognitive_Assessment"/>
 	private CqlValueSet Cognitive_Assessment_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332", null);
 
+    /// <seealso cref="Cognitive_Assessment_Value"/>
     [CqlDeclaration("Cognitive Assessment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332")]
 	public CqlValueSet Cognitive_Assessment() => 
 		__Cognitive_Assessment.Value;
 
+    /// <seealso cref="Dementia_and_Mental_Degenerations"/>
 	private CqlValueSet Dementia_and_Mental_Degenerations_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005", null);
 
+    /// <seealso cref="Dementia_and_Mental_Degenerations_Value"/>
     [CqlDeclaration("Dementia & Mental Degenerations")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005")]
 	public CqlValueSet Dementia_and_Mental_Degenerations() => 
 		__Dementia_and_Mental_Degenerations.Value;
 
+    /// <seealso cref="Face_to_Face_Interaction"/>
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
 
+    /// <seealso cref="Face_to_Face_Interaction_Value"/>
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
 	public CqlValueSet Face_to_Face_Interaction() => 
 		__Face_to_Face_Interaction.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Nursing_Facility_Visit"/>
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
+    /// <seealso cref="Nursing_Facility_Visit_Value"/>
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
 	public CqlValueSet Nursing_Facility_Visit() => 
 		__Nursing_Facility_Visit.Value;
 
+    /// <seealso cref="Occupational_Therapy_Evaluation"/>
 	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", null);
 
+    /// <seealso cref="Occupational_Therapy_Evaluation_Value"/>
     [CqlDeclaration("Occupational Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
 	public CqlValueSet Occupational_Therapy_Evaluation() => 
 		__Occupational_Therapy_Evaluation.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Patient_Provider_Interaction"/>
 	private CqlValueSet Patient_Provider_Interaction_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", null);
 
+    /// <seealso cref="Patient_Provider_Interaction_Value"/>
     [CqlDeclaration("Patient Provider Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012")]
 	public CqlValueSet Patient_Provider_Interaction() => 
 		__Patient_Provider_Interaction.Value;
 
+    /// <seealso cref="Patient_Reason"/>
 	private CqlValueSet Patient_Reason_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
 
+    /// <seealso cref="Patient_Reason_Value"/>
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
 	public CqlValueSet Patient_Reason() => 
 		__Patient_Reason.Value;
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation"/>
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation_Value"/>
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
 	public CqlValueSet Psych_Visit_Diagnostic_Evaluation() => 
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
+    /// <seealso cref="Psych_Visit_Psychotherapy"/>
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
 
+    /// <seealso cref="Psych_Visit_Psychotherapy_Value"/>
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
 	public CqlValueSet Psych_Visit_Psychotherapy() => 
 		__Psych_Visit_Psychotherapy.Value;
 
+    /// <seealso cref="Standardized_Tools_Score_for_Assessment_of_Cognition"/>
 	private CqlValueSet Standardized_Tools_Score_for_Assessment_of_Cognition_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006", null);
 
+    /// <seealso cref="Standardized_Tools_Score_for_Assessment_of_Cognition_Value"/>
     [CqlDeclaration("Standardized Tools Score for Assessment of Cognition")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006")]
 	public CqlValueSet Standardized_Tools_Score_for_Assessment_of_Cognition() => 
 		__Standardized_Tools_Score_for_Assessment_of_Cognition.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("DementiaCognitiveAssessmentFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("DementiaCognitiveAssessmentFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Encounter_to_Assess_Cognition"/>
 	private IEnumerable<Encounter> Encounter_to_Assess_Cognition_Value()
 	{
-		var a_ = this.Psych_Visit_Diagnostic_Evaluation();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Nursing_Facility_Visit();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Home_Healthcare_Services();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Psych_Visit_Psychotherapy();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Behavioral_Neuropsych_Assessment();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Occupational_Therapy_Evaluation();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Office_Visit();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
-		var x_ = this.Outpatient_Consultation();
-		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
-		var z_ = context.Operators.Union<Encounter>(w_, y_);
+		CqlValueSet a_ = this.Psych_Visit_Diagnostic_Evaluation();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Nursing_Facility_Visit();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Psych_Visit_Psychotherapy();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Behavioral_Neuropsych_Assessment();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Occupational_Therapy_Evaluation();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Office_Visit();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
+		CqlValueSet x_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> z_ = context.Operators.Union<Encounter>(w_, y_);
 
 		return z_;
 	}
 
+    /// <seealso cref="Encounter_to_Assess_Cognition_Value"/>
     [CqlDeclaration("Encounter to Assess Cognition")]
 	public IEnumerable<Encounter> Encounter_to_Assess_Cognition() => 
 		__Encounter_to_Assess_Cognition.Value;
 
+    /// <seealso cref="Dementia_Encounter_During_Measurement_Period"/>
 	private IEnumerable<Encounter> Dementia_Encounter_During_Measurement_Period_Value()
 	{
-		var a_ = this.Encounter_to_Assess_Cognition();
+		IEnumerable<Encounter> a_ = this.Encounter_to_Assess_Cognition();
 		IEnumerable<Encounter> b_(Encounter EncounterAssessCognition)
 		{
-			var d_ = this.Dementia_and_Mental_Degenerations();
-			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			CqlValueSet d_ = this.Dementia_and_Mental_Degenerations();
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
 			bool? f_(Condition Dementia)
 			{
-				var j_ = this.Measurement_Period();
-				var k_ = EncounterAssessCognition?.Period;
-				var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, null);
-				var n_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
-				var p_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var q_ = context.Operators.Overlaps(n_, p_, "day");
-				var r_ = context.Operators.And(m_, q_);
-				var s_ = QICoreCommon_2_0_000.isActive(Dementia);
-				var t_ = context.Operators.And(r_, s_);
-				var u_ = Dementia?.VerificationStatus;
-				var v_ = FHIRHelpers_4_3_000.ToConcept(u_);
-				var w_ = QICoreCommon_2_0_000.unconfirmed();
-				var x_ = context.Operators.ConvertCodeToConcept(w_);
-				var y_ = context.Operators.Equivalent(v_, x_);
-				var aa_ = FHIRHelpers_4_3_000.ToConcept(u_);
-				var ab_ = QICoreCommon_2_0_000.refuted();
-				var ac_ = context.Operators.ConvertCodeToConcept(ab_);
-				var ad_ = context.Operators.Equivalent(aa_, ac_);
-				var ae_ = context.Operators.Or(y_, ad_);
-				var ag_ = FHIRHelpers_4_3_000.ToConcept(u_);
-				var ah_ = QICoreCommon_2_0_000.entered_in_error();
-				var ai_ = context.Operators.ConvertCodeToConcept(ah_);
-				var aj_ = context.Operators.Equivalent(ag_, ai_);
-				var ak_ = context.Operators.Or(ae_, aj_);
-				var al_ = context.Operators.Not(ak_);
-				var am_ = context.Operators.And(t_, al_);
+				CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+				Period k_ = EncounterAssessCognition?.Period;
+				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, null);
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				bool? q_ = context.Operators.Overlaps(n_, p_, "day");
+				bool? r_ = context.Operators.And(m_, q_);
+				bool? s_ = QICoreCommon_2_0_000.isActive(Dementia);
+				bool? t_ = context.Operators.And(r_, s_);
+				CodeableConcept u_ = Dementia?.VerificationStatus;
+				CqlConcept v_ = FHIRHelpers_4_3_000.ToConcept(u_);
+				CqlCode w_ = QICoreCommon_2_0_000.unconfirmed();
+				CqlConcept x_ = context.Operators.ConvertCodeToConcept(w_);
+				bool? y_ = context.Operators.Equivalent(v_, x_);
+				CqlConcept aa_ = FHIRHelpers_4_3_000.ToConcept(u_);
+				CqlCode ab_ = QICoreCommon_2_0_000.refuted();
+				CqlConcept ac_ = context.Operators.ConvertCodeToConcept(ab_);
+				bool? ad_ = context.Operators.Equivalent(aa_, ac_);
+				bool? ae_ = context.Operators.Or(y_, ad_);
+				CqlConcept ag_ = FHIRHelpers_4_3_000.ToConcept(u_);
+				CqlCode ah_ = QICoreCommon_2_0_000.entered_in_error();
+				CqlConcept ai_ = context.Operators.ConvertCodeToConcept(ah_);
+				bool? aj_ = context.Operators.Equivalent(ag_, ai_);
+				bool? ak_ = context.Operators.Or(ae_, aj_);
+				bool? al_ = context.Operators.Not(ak_);
+				bool? am_ = context.Operators.And(t_, al_);
 
 				return am_;
 			};
-			var g_ = context.Operators.Where<Condition>(e_, f_);
+			IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 			Encounter h_(Condition Dementia) => 
 				EncounterAssessCognition;
-			var i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Dementia_Encounter_During_Measurement_Period_Value"/>
     [CqlDeclaration("Dementia Encounter During Measurement Period")]
 	public IEnumerable<Encounter> Dementia_Encounter_During_Measurement_Period() => 
 		__Dementia_Encounter_During_Measurement_Period.Value;
 
+    /// <seealso cref="Qualifying_Encounter_During_Measurement_Period"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
 	{
-		var a_ = this.Encounter_to_Assess_Cognition();
-		var b_ = this.Patient_Provider_Interaction();
-		var c_ = context.Operators.RetrieveByValueSet<Encounter>(b_, null);
-		var d_ = context.Operators.Union<Encounter>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Encounter_to_Assess_Cognition();
+		CqlValueSet b_ = this.Patient_Provider_Interaction();
+		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(b_, null);
+		IEnumerable<Encounter> d_ = context.Operators.Union<Encounter>(a_, c_);
 		bool? e_(Encounter ValidEncounter)
 		{
-			var g_ = this.Measurement_Period();
-			var h_ = ValidEncounter?.Period;
-			var i_ = FHIRHelpers_4_3_000.ToInterval(h_);
-			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, null);
-			var k_ = ValidEncounter?.StatusElement;
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
-			var n_ = context.Operators.Equal(m_, "finished");
-			var o_ = context.Operators.And(j_, n_);
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			Period h_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, null);
+			Code<Encounter.EncounterStatus> k_ = ValidEncounter?.StatusElement;
+			Encounter.EncounterStatus? l_ = k_?.Value;
+			Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
+			bool? n_ = context.Operators.Equal(m_, "finished");
+			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;
 		};
-		var f_ = context.Operators.Where<Encounter>(d_, e_);
+		IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_During_Measurement_Period_Value"/>
     [CqlDeclaration("Qualifying Encounter During Measurement Period")]
 	public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period() => 
 		__Qualifying_Encounter_During_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Dementia_Encounter_During_Measurement_Period();
-		var b_ = context.Operators.Exists<Encounter>(a_);
-		var c_ = this.Qualifying_Encounter_During_Measurement_Period();
-		var d_ = context.Operators.Count<Encounter>(c_);
-		var e_ = context.Operators.GreaterOrEqual(d_, 2);
-		var f_ = context.Operators.And(b_, e_);
+		IEnumerable<Encounter> a_ = this.Dementia_Encounter_During_Measurement_Period();
+		bool? b_ = context.Operators.Exists<Encounter>(a_);
+		IEnumerable<Encounter> c_ = this.Qualifying_Encounter_During_Measurement_Period();
+		int? d_ = context.Operators.Count<Encounter>(c_);
+		bool? e_ = context.Operators.GreaterOrEqual(d_, 2);
+		bool? f_ = context.Operators.And(b_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods"/>
 	private IEnumerable<Observation> Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value()
 	{
-		var a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = this.Cognitive_Assessment();
-		var d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
-		var e_ = context.Operators.Union<Observation>(b_, d_);
+		CqlValueSet a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet c_ = this.Cognitive_Assessment();
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation CognitiveAssessment)
 		{
-			var j_ = this.Dementia_Encounter_During_Measurement_Period();
+			IEnumerable<Encounter> j_ = this.Dementia_Encounter_During_Measurement_Period();
 			bool? k_(Encounter EncounterDementia)
 			{
-				var o_ = CognitiveAssessment?.Effective;
-				var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-				var q_ = QICoreCommon_2_0_000.toInterval(p_);
-				var r_ = context.Operators.Start(q_);
-				var s_ = EncounterDementia?.Period;
-				var t_ = FHIRHelpers_4_3_000.ToInterval(s_);
-				var u_ = context.Operators.End(t_);
-				var v_ = context.Operators.Quantity(12m, "months");
-				var w_ = context.Operators.Subtract(u_, v_);
-				var y_ = FHIRHelpers_4_3_000.ToInterval(s_);
-				var z_ = context.Operators.End(y_);
-				var aa_ = context.Operators.Interval(w_, z_, true, true);
-				var ab_ = context.Operators.In<CqlDateTime>(r_, aa_, "day");
-				var ad_ = FHIRHelpers_4_3_000.ToInterval(s_);
-				var ae_ = context.Operators.End(ad_);
-				var af_ = context.Operators.Not((bool?)(ae_ is null));
-				var ag_ = context.Operators.And(ab_, af_);
+				DataType o_ = CognitiveAssessment?.Effective;
+				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+				CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
+				CqlDateTime r_ = context.Operators.Start(q_);
+				Period s_ = EncounterDementia?.Period;
+				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(s_);
+				CqlDateTime u_ = context.Operators.End(t_);
+				CqlQuantity v_ = context.Operators.Quantity(12m, "months");
+				CqlDateTime w_ = context.Operators.Subtract(u_, v_);
+				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(s_);
+				CqlDateTime z_ = context.Operators.End(y_);
+				CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(w_, z_, true, true);
+				bool? ab_ = context.Operators.In<CqlDateTime>(r_, aa_, "day");
+				CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(s_);
+				CqlDateTime ae_ = context.Operators.End(ad_);
+				bool? af_ = context.Operators.Not((bool?)(ae_ is null));
+				bool? ag_ = context.Operators.And(ab_, af_);
 
 				return ag_;
 			};
-			var l_ = context.Operators.Where<Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
 			Observation m_(Encounter EncounterDementia) => 
 				CognitiveAssessment;
-			var n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
+			IEnumerable<Observation> n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
 
 			return n_;
 		};
-		var g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
+		IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
 		bool? h_(Observation CognitiveAssessment)
 		{
-			var ah_ = CognitiveAssessment?.Value;
-			var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-			var aj_ = context.Operators.Not((bool?)(ai_ is null));
-			var ak_ = CognitiveAssessment?.StatusElement;
-			var al_ = ak_?.Value;
-			var am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
-			var an_ = context.Operators.Convert<string>(am_);
-			var ao_ = new string[]
+			DataType ah_ = CognitiveAssessment?.Value;
+			object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+			bool? aj_ = context.Operators.Not((bool?)(ai_ is null));
+			Code<ObservationStatus> ak_ = CognitiveAssessment?.StatusElement;
+			ObservationStatus? al_ = ak_?.Value;
+			Code<ObservationStatus> am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
+			string an_ = context.Operators.Convert<string>(am_);
+			string[] ao_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 				"preliminary",
 			};
-			var ap_ = context.Operators.In<string>(an_, (ao_ as IEnumerable<string>));
-			var aq_ = context.Operators.And(aj_, ap_);
+			bool? ap_ = context.Operators.In<string>(an_, (ao_ as IEnumerable<string>));
+			bool? aq_ = context.Operators.And(aj_, ap_);
 
 			return aq_;
 		};
-		var i_ = context.Operators.Where<Observation>(g_, h_);
+		IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value"/>
     [CqlDeclaration("Assessment of Cognition Using Standardized Tools or Alternate Methods")]
 	public IEnumerable<Observation> Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods() => 
 		__Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods();
-		var b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> a_ = this.Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods"/>
 	private IEnumerable<Observation> Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value()
 	{
-		var a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = this.Cognitive_Assessment();
-		var d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
-		var e_ = context.Operators.Union<Observation>(b_, d_);
+		CqlValueSet a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet c_ = this.Cognitive_Assessment();
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation NoCognitiveAssessment)
 		{
-			var j_ = this.Dementia_Encounter_During_Measurement_Period();
+			IEnumerable<Encounter> j_ = this.Dementia_Encounter_During_Measurement_Period();
 			bool? k_(Encounter EncounterDementia)
 			{
-				var o_ = NoCognitiveAssessment?.IssuedElement;
-				var p_ = o_?.Value;
-				var q_ = context.Operators.Convert<CqlDateTime>(p_);
-				var r_ = EncounterDementia?.Period;
-				var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
+				Instant o_ = NoCognitiveAssessment?.IssuedElement;
+				DateTimeOffset? p_ = o_?.Value;
+				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+				Period r_ = EncounterDementia?.Period;
+				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
 
 				return t_;
 			};
-			var l_ = context.Operators.Where<Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
 			Observation m_(Encounter EncounterDementia) => 
 				NoCognitiveAssessment;
-			var n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
+			IEnumerable<Observation> n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
 
 			return n_;
 		};
-		var g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
+		IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
 		bool? h_(Observation NoCognitiveAssessment)
 		{
 			bool? u_(Extension @this)
 			{
-				var ad_ = @this?.Url;
-				var ae_ = context.Operators.Convert<FhirUri>(ad_);
-				var af_ = FHIRHelpers_4_3_000.ToString(ae_);
-				var ag_ = context.Operators.Equal(af_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+				string ad_ = @this?.Url;
+				FhirUri ae_ = context.Operators.Convert<FhirUri>(ad_);
+				string af_ = FHIRHelpers_4_3_000.ToString(ae_);
+				bool? ag_ = context.Operators.Equal(af_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
 
 				return ag_;
 			};
-			var v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoCognitiveAssessment is DomainResource)
+			IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoCognitiveAssessment is DomainResource)
 					? ((NoCognitiveAssessment as DomainResource).Extension)
 					: null), u_);
 			DataType w_(Extension @this)
 			{
-				var ah_ = @this?.Value;
+				DataType ah_ = @this?.Value;
 
 				return ah_;
 			};
-			var x_ = context.Operators.Select<Extension, DataType>(v_, w_);
-			var y_ = context.Operators.SingletonFrom<DataType>(x_);
-			var z_ = context.Operators.Convert<CodeableConcept>(y_);
-			var aa_ = FHIRHelpers_4_3_000.ToConcept(z_);
-			var ab_ = this.Patient_Reason();
-			var ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+			IEnumerable<DataType> x_ = context.Operators.Select<Extension, DataType>(v_, w_);
+			DataType y_ = context.Operators.SingletonFrom<DataType>(x_);
+			CodeableConcept z_ = context.Operators.Convert<CodeableConcept>(y_);
+			CqlConcept aa_ = FHIRHelpers_4_3_000.ToConcept(z_);
+			CqlValueSet ab_ = this.Patient_Reason();
+			bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
 
 			return ac_;
 		};
-		var i_ = context.Operators.Where<Observation>(g_, h_);
+		IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value"/>
     [CqlDeclaration("Patient Reason for Not Performing Assessment of Cognition Using Standardized Tools or Alternate Methods")]
 	public IEnumerable<Observation> Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods() => 
 		__Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods.Value;
 
+    /// <seealso cref="Denominator_Exceptions"/>
 	private bool? Denominator_Exceptions_Value()
 	{
-		var a_ = this.Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods();
-		var b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> a_ = this.Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Denominator_Exceptions_Value"/>
     [CqlDeclaration("Denominator Exceptions")]
 	public bool? Denominator_Exceptions() => 
 		__Denominator_Exceptions.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;

--- a/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
@@ -106,381 +106,439 @@ public class DiabetesEyeExamFHIR_0_0_001
 
     #endregion
 
+    /// <seealso cref="Annual_Wellness_Visit"/>
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
+    /// <seealso cref="Annual_Wellness_Visit_Value"/>
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
 	public CqlValueSet Annual_Wellness_Visit() => 
 		__Annual_Wellness_Visit.Value;
 
+    /// <seealso cref="Diabetes"/>
 	private CqlValueSet Diabetes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
 
+    /// <seealso cref="Diabetes_Value"/>
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
 	public CqlValueSet Diabetes() => 
 		__Diabetes.Value;
 
+    /// <seealso cref="Diabetic_Retinopathy"/>
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
 
+    /// <seealso cref="Diabetic_Retinopathy_Value"/>
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
 	public CqlValueSet Diabetic_Retinopathy() => 
 		__Diabetic_Retinopathy.Value;
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
 	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
 	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Hospice_Care_Ambulatory"/>
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
 
+    /// <seealso cref="Hospice_Care_Ambulatory_Value"/>
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
 	public CqlValueSet Hospice_Care_Ambulatory() => 
 		__Hospice_Care_Ambulatory.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Ophthalmological_Services"/>
 	private CqlValueSet Ophthalmological_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
 
+    /// <seealso cref="Ophthalmological_Services_Value"/>
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
 	public CqlValueSet Ophthalmological_Services() => 
 		__Ophthalmological_Services.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Retinal_or_Dilated_Eye_Exam"/>
 	private CqlValueSet Retinal_or_Dilated_Eye_Exam_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088", null);
 
+    /// <seealso cref="Retinal_or_Dilated_Eye_Exam_Value"/>
     [CqlDeclaration("Retinal or Dilated Eye Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088")]
 	public CqlValueSet Retinal_or_Dilated_Eye_Exam() => 
 		__Retinal_or_Dilated_Eye_Exam.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("DiabetesEyeExamFHIR-0.0.001", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("DiabetesEyeExamFHIR-0.0.001", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Annual_Wellness_Visit();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Home_Healthcare_Services();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Ophthalmological_Services();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Telephone_Visits();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = context.Operators.Union<Encounter>(q_, s_);
-		var u_ = Status_1_6_000.isEncounterPerformed(t_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Ophthalmological_Services();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Telephone_Visits();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
+		IEnumerable<Encounter> u_ = Status_1_6_000.isEncounterPerformed(t_);
 		bool? v_(Encounter ValidEncounters)
 		{
-			var x_ = this.Measurement_Period();
-			var y_ = ValidEncounters?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, "day");
+			CqlInterval<CqlDateTime> x_ = this.Measurement_Period();
+			Period y_ = ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, "day");
 
 			return aa_;
 		};
-		var w_ = context.Operators.Where<Encounter>(u_, v_);
+		IEnumerable<Encounter> w_ = context.Operators.Where<Encounter>(u_, v_);
 
 		return w_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(18, 75, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var i_ = this.Qualifying_Encounters();
-		var j_ = context.Operators.Exists<Encounter>(i_);
-		var k_ = context.Operators.And(h_, j_);
-		var l_ = this.Diabetes();
-		var m_ = context.Operators.RetrieveByValueSet<Condition>(l_, null);
-		bool? n_(Condition Diabetes)
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
+		bool? l_ = context.Operators.Exists<Encounter>(k_);
+		bool? m_ = context.Operators.And(j_, l_);
+		CqlValueSet n_ = this.Diabetes();
+		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, null);
+		bool? p_(Condition Diabetes)
 		{
-			var r_ = QICoreCommon_2_0_000.prevalenceInterval(Diabetes);
-			var s_ = this.Measurement_Period();
-			var t_ = context.Operators.Overlaps(r_, s_, null);
+			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.prevalenceInterval(Diabetes);
+			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
+			bool? v_ = context.Operators.Overlaps(t_, u_, null);
 
-			return t_;
+			return v_;
 		};
-		var o_ = context.Operators.Where<Condition>(m_, n_);
-		var p_ = context.Operators.Exists<Condition>(o_);
-		var q_ = context.Operators.And(k_, p_);
+		IEnumerable<Condition> q_ = context.Operators.Where<Condition>(o_, p_);
+		bool? r_ = context.Operators.Exists<Condition>(q_);
+		bool? s_ = context.Operators.And(m_, r_);
 
-		return q_;
+		return s_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home();
-		var e_ = context.Operators.Or(c_, d_);
-		var f_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
-		var g_ = context.Operators.Or(e_, f_);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? b_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home();
+		bool? e_ = context.Operators.Or(c_, d_);
+		bool? f_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		bool? g_ = context.Operators.Or(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Diabetic_Retinopathy_Overlapping_Measurement_Period"/>
 	private bool? Diabetic_Retinopathy_Overlapping_Measurement_Period_Value()
 	{
-		var a_ = this.Diabetic_Retinopathy();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Diabetic_Retinopathy();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition Retinopathy)
 		{
-			var f_ = QICoreCommon_2_0_000.prevalenceInterval(Retinopathy);
-			var g_ = this.Measurement_Period();
-			var h_ = context.Operators.Overlaps(f_, g_, null);
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval(Retinopathy);
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			bool? h_ = context.Operators.Overlaps(f_, g_, null);
 
 			return h_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Diabetic_Retinopathy_Overlapping_Measurement_Period_Value"/>
     [CqlDeclaration("Diabetic Retinopathy Overlapping Measurement Period")]
 	public bool? Diabetic_Retinopathy_Overlapping_Measurement_Period() => 
 		__Diabetic_Retinopathy_Overlapping_Measurement_Period.Value;
 
+    /// <seealso cref="Retinal_Exam_in_Measurement_Period"/>
 	private IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_Value()
 	{
-		var a_ = this.Retinal_or_Dilated_Eye_Exam();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		CqlValueSet a_ = this.Retinal_or_Dilated_Eye_Exam();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation RetinalExam)
 		{
-			var f_ = this.Measurement_Period();
-			var g_ = RetinalExam?.Effective;
-			var h_ = FHIRHelpers_4_3_000.ToValue(g_);
-			var i_ = QICoreCommon_2_0_000.toInterval(h_);
-			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, "day");
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			DataType g_ = RetinalExam?.Effective;
+			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
+			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.toInterval(h_);
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, "day");
 
 			return j_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Retinal_Exam_in_Measurement_Period_Value"/>
     [CqlDeclaration("Retinal Exam in Measurement Period")]
 	public IEnumerable<Observation> Retinal_Exam_in_Measurement_Period() => 
 		__Retinal_Exam_in_Measurement_Period.Value;
 
+    /// <seealso cref="Retinal_Exam_in_Measurement_Period_or_Year_Prior"/>
 	private IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_or_Year_Prior_Value()
 	{
-		var a_ = this.Retinal_or_Dilated_Eye_Exam();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		CqlValueSet a_ = this.Retinal_or_Dilated_Eye_Exam();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation RetinalExam)
 		{
-			var f_ = this.Measurement_Period();
-			var g_ = context.Operators.Start(f_);
-			var h_ = context.Operators.Quantity(1m, "year");
-			var i_ = context.Operators.Subtract(g_, h_);
-			var k_ = context.Operators.End(f_);
-			var l_ = context.Operators.Interval(i_, k_, true, true);
-			var m_ = RetinalExam?.Effective;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var o_ = QICoreCommon_2_0_000.toInterval(n_);
-			var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlQuantity h_ = context.Operators.Quantity(1m, "year");
+			CqlDateTime i_ = context.Operators.Subtract(g_, h_);
+			CqlDateTime k_ = context.Operators.End(f_);
+			CqlInterval<CqlDateTime> l_ = context.Operators.Interval(i_, k_, true, true);
+			DataType m_ = RetinalExam?.Effective;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
 
 			return p_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Retinal_Exam_in_Measurement_Period_or_Year_Prior_Value"/>
     [CqlDeclaration("Retinal Exam in Measurement Period or Year Prior")]
 	public IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_or_Year_Prior() => 
 		__Retinal_Exam_in_Measurement_Period_or_Year_Prior.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Diabetic_Retinopathy_Overlapping_Measurement_Period();
-		var b_ = this.Retinal_Exam_in_Measurement_Period();
-		var c_ = context.Operators.Exists<Observation>(b_);
-		var d_ = context.Operators.And(a_, c_);
-		var f_ = context.Operators.Not(a_);
-		var g_ = this.Retinal_Exam_in_Measurement_Period_or_Year_Prior();
-		var h_ = context.Operators.Exists<Observation>(g_);
-		var i_ = context.Operators.And(f_, h_);
-		var j_ = context.Operators.Or(d_, i_);
+		bool? a_ = this.Diabetic_Retinopathy_Overlapping_Measurement_Period();
+		IEnumerable<Observation> b_ = this.Retinal_Exam_in_Measurement_Period();
+		bool? c_ = context.Operators.Exists<Observation>(b_);
+		bool? d_ = context.Operators.And(a_, c_);
+		bool? f_ = context.Operators.Not(a_);
+		IEnumerable<Observation> g_ = this.Retinal_Exam_in_Measurement_Period_or_Year_Prior();
+		bool? h_ = context.Operators.Exists<Observation>(g_);
+		bool? i_ = context.Operators.And(f_, h_);
+		bool? j_ = context.Operators.Or(d_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
@@ -86,205 +86,230 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Diabetes"/>
 	private CqlValueSet Diabetes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
 
+    /// <seealso cref="Diabetes_Value"/>
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
 	public CqlValueSet Diabetes() => 
 		__Diabetes.Value;
 
+    /// <seealso cref="HbA1c_Laboratory_Test"/>
 	private CqlValueSet HbA1c_Laboratory_Test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", null);
 
+    /// <seealso cref="HbA1c_Laboratory_Test_Value"/>
     [CqlDeclaration("HbA1c Laboratory Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013")]
 	public CqlValueSet HbA1c_Laboratory_Test() => 
 		__HbA1c_Laboratory_Test.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(18, 75, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var i_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
-		var j_ = context.Operators.Exists<Encounter>(i_);
-		var k_ = context.Operators.And(h_, j_);
-		var l_ = this.Diabetes();
-		var m_ = context.Operators.RetrieveByValueSet<Condition>(l_, null);
-		bool? n_(Condition Diabetes)
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
+		bool? l_ = context.Operators.Exists<Encounter>(k_);
+		bool? m_ = context.Operators.And(j_, l_);
+		CqlValueSet n_ = this.Diabetes();
+		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, null);
+		bool? p_(Condition Diabetes)
 		{
-			var r_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
-			var s_ = this.Measurement_Period();
-			var t_ = context.Operators.Overlaps(r_, s_, null);
+			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
+			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
+			bool? v_ = context.Operators.Overlaps(t_, u_, null);
 
-			return t_;
+			return v_;
 		};
-		var o_ = context.Operators.Where<Condition>(m_, n_);
-		var p_ = context.Operators.Exists<Condition>(o_);
-		var q_ = context.Operators.And(k_, p_);
+		IEnumerable<Condition> q_ = context.Operators.Where<Condition>(o_, p_);
+		bool? r_ = context.Operators.Exists<Condition>(q_);
+		bool? s_ = context.Operators.And(m_, r_);
 
-		return q_;
+		return s_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home();
-		var e_ = context.Operators.Or(c_, d_);
-		var f_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
-		var g_ = context.Operators.Or(e_, f_);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? b_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_with_Advanced_Illness_and_Frailty();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = AdvancedIllnessandFrailty_1_8_000.Is_Age_66_or_Older_Living_Long_Term_in_a_Nursing_Home();
+		bool? e_ = context.Operators.Or(c_, d_);
+		bool? f_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		bool? g_ = context.Operators.Or(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Most_Recent_HbA1c"/>
 	private Observation Most_Recent_HbA1c_Value()
 	{
-		var a_ = this.HbA1c_Laboratory_Test();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
+		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation RecentHbA1c)
 		{
 			object i_()
 			{
 				bool m_()
 				{
-					var p_ = RecentHbA1c?.Effective;
-					var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-					var r_ = q_ is CqlDateTime;
+					DataType p_ = RecentHbA1c?.Effective;
+					object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+					bool r_ = q_ is CqlDateTime;
 
 					return r_;
 				};
 				bool n_()
 				{
-					var s_ = RecentHbA1c?.Effective;
-					var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-					var u_ = t_ is CqlInterval<CqlDateTime>;
+					DataType s_ = RecentHbA1c?.Effective;
+					object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+					bool u_ = t_ is CqlInterval<CqlDateTime>;
 
 					return u_;
 				};
 				bool o_()
 				{
-					var v_ = RecentHbA1c?.Effective;
-					var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-					var x_ = w_ is CqlDateTime;
+					DataType v_ = RecentHbA1c?.Effective;
+					object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+					bool x_ = w_ is CqlDateTime;
 
 					return x_;
 				};
 				if (m_())
 				{
-					var y_ = RecentHbA1c?.Effective;
-					var z_ = FHIRHelpers_4_3_000.ToValue(y_);
+					DataType y_ = RecentHbA1c?.Effective;
+					object z_ = FHIRHelpers_4_3_000.ToValue(y_);
 
 					return ((z_ as CqlDateTime) as object);
 				}
 				else if (n_())
 				{
-					var aa_ = RecentHbA1c?.Effective;
-					var ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
+					DataType aa_ = RecentHbA1c?.Effective;
+					object ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
 
 					return ((ab_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (o_())
 				{
-					var ac_ = RecentHbA1c?.Effective;
-					var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+					DataType ac_ = RecentHbA1c?.Effective;
+					object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
 
 					return ((ad_ as CqlDateTime) as object);
 				}
@@ -293,111 +318,119 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 					return null;
 				}
 			};
-			var j_ = QICoreCommon_2_0_000.Latest(i_());
-			var k_ = this.Measurement_Period();
-			var l_ = context.Operators.In<CqlDateTime>(j_, k_, "day");
+			CqlDateTime j_ = QICoreCommon_2_0_000.Latest(i_());
+			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, "day");
 
 			return l_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			var ae_ = @this?.Effective;
-			var af_ = FHIRHelpers_4_3_000.ToValue(ae_);
-			var ag_ = QICoreCommon_2_0_000.ToInterval(af_);
-			var ah_ = context.Operators.Start(ag_);
+			DataType ae_ = @this?.Effective;
+			object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
+			CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.ToInterval(af_);
+			CqlDateTime ah_ = context.Operators.Start(ag_);
 
 			return ah_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Most_Recent_HbA1c_Value"/>
     [CqlDeclaration("Most Recent HbA1c")]
 	public Observation Most_Recent_HbA1c() => 
 		__Most_Recent_HbA1c.Value;
 
+    /// <seealso cref="Has_Most_Recent_HbA1c_Without_Result"/>
 	private bool? Has_Most_Recent_HbA1c_Without_Result_Value()
 	{
-		var a_ = this.Most_Recent_HbA1c();
-		var b_ = context.Operators.Not((bool?)(a_ is null));
-		var d_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
-		var e_ = context.Operators.And(b_, (bool?)(d_ is null));
+		Observation a_ = this.Most_Recent_HbA1c();
+		bool? b_ = context.Operators.Not((bool?)(a_ is null));
+		DataType d_ = a_?.Value;
+		object e_ = FHIRHelpers_4_3_000.ToValue(d_);
+		bool? f_ = context.Operators.And(b_, (bool?)(e_ is null));
 
-		return e_;
+		return f_;
 	}
 
+    /// <seealso cref="Has_Most_Recent_HbA1c_Without_Result_Value"/>
     [CqlDeclaration("Has Most Recent HbA1c Without Result")]
 	public bool? Has_Most_Recent_HbA1c_Without_Result() => 
 		__Has_Most_Recent_HbA1c_Without_Result.Value;
 
+    /// <seealso cref="Has_Most_Recent_Elevated_HbA1c"/>
 	private bool? Has_Most_Recent_Elevated_HbA1c_Value()
 	{
-		var a_ = this.Most_Recent_HbA1c();
-		var b_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
-		var c_ = context.Operators.Quantity(9m, "%");
-		var d_ = context.Operators.Greater((b_ as CqlQuantity), c_);
+		Observation a_ = this.Most_Recent_HbA1c();
+		DataType b_ = a_?.Value;
+		object c_ = FHIRHelpers_4_3_000.ToValue(b_);
+		CqlQuantity d_ = context.Operators.Quantity(9m, "%");
+		bool? e_ = context.Operators.Greater((c_ as CqlQuantity), d_);
 
-		return d_;
+		return e_;
 	}
 
+    /// <seealso cref="Has_Most_Recent_Elevated_HbA1c_Value"/>
     [CqlDeclaration("Has Most Recent Elevated HbA1c")]
 	public bool? Has_Most_Recent_Elevated_HbA1c() => 
 		__Has_Most_Recent_Elevated_HbA1c.Value;
 
+    /// <seealso cref="Has_No_Record_Of_HbA1c"/>
 	private bool? Has_No_Record_Of_HbA1c_Value()
 	{
-		var a_ = this.HbA1c_Laboratory_Test();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
+		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation NoHbA1c)
 		{
 			object h_()
 			{
 				bool l_()
 				{
-					var o_ = NoHbA1c?.Effective;
-					var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-					var q_ = p_ is CqlDateTime;
+					DataType o_ = NoHbA1c?.Effective;
+					object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+					bool q_ = p_ is CqlDateTime;
 
 					return q_;
 				};
 				bool m_()
 				{
-					var r_ = NoHbA1c?.Effective;
-					var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-					var t_ = s_ is CqlInterval<CqlDateTime>;
+					DataType r_ = NoHbA1c?.Effective;
+					object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+					bool t_ = s_ is CqlInterval<CqlDateTime>;
 
 					return t_;
 				};
 				bool n_()
 				{
-					var u_ = NoHbA1c?.Effective;
-					var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-					var w_ = v_ is CqlDateTime;
+					DataType u_ = NoHbA1c?.Effective;
+					object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+					bool w_ = v_ is CqlDateTime;
 
 					return w_;
 				};
 				if (l_())
 				{
-					var x_ = NoHbA1c?.Effective;
-					var y_ = FHIRHelpers_4_3_000.ToValue(x_);
+					DataType x_ = NoHbA1c?.Effective;
+					object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 
 					return ((y_ as CqlDateTime) as object);
 				}
 				else if (m_())
 				{
-					var z_ = NoHbA1c?.Effective;
-					var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+					DataType z_ = NoHbA1c?.Effective;
+					object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
 
 					return ((aa_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (n_())
 				{
-					var ab_ = NoHbA1c?.Effective;
-					var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+					DataType ab_ = NoHbA1c?.Effective;
+					object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 
 					return ((ac_ as CqlDateTime) as object);
 				}
@@ -406,34 +439,37 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 					return null;
 				}
 			};
-			var i_ = QICoreCommon_2_0_000.Latest(h_());
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.In<CqlDateTime>(i_, j_, "day");
+			CqlDateTime i_ = QICoreCommon_2_0_000.Latest(h_());
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			bool? k_ = context.Operators.In<CqlDateTime>(i_, j_, "day");
 
 			return k_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
-		var f_ = context.Operators.Exists<Observation>(e_);
-		var g_ = context.Operators.Not(f_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
+		bool? f_ = context.Operators.Exists<Observation>(e_);
+		bool? g_ = context.Operators.Not(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Has_No_Record_Of_HbA1c_Value"/>
     [CqlDeclaration("Has No Record Of HbA1c")]
 	public bool? Has_No_Record_Of_HbA1c() => 
 		__Has_No_Record_Of_HbA1c.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Has_Most_Recent_HbA1c_Without_Result();
-		var b_ = this.Has_Most_Recent_Elevated_HbA1c();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_No_Record_Of_HbA1c();
-		var e_ = context.Operators.Or(c_, d_);
+		bool? a_ = this.Has_Most_Recent_HbA1c_Without_Result();
+		bool? b_ = this.Has_Most_Recent_Elevated_HbA1c();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = this.Has_No_Record_Of_HbA1c();
+		bool? e_ = context.Operators.Or(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
@@ -86,194 +86,217 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 
     #endregion
 
+    /// <seealso cref="Antithrombotic_Therapy_for_Ischemic_Stroke"/>
 	private CqlValueSet Antithrombotic_Therapy_for_Ischemic_Stroke_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62", null);
 
+    /// <seealso cref="Antithrombotic_Therapy_for_Ischemic_Stroke_Value"/>
     [CqlDeclaration("Antithrombotic Therapy for Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62")]
 	public CqlValueSet Antithrombotic_Therapy_for_Ischemic_Stroke() => 
 		__Antithrombotic_Therapy_for_Ischemic_Stroke.Value;
 
+    /// <seealso cref="Medical_Reason_For_Not_Providing_Treatment"/>
 	private CqlValueSet Medical_Reason_For_Not_Providing_Treatment_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", null);
 
+    /// <seealso cref="Medical_Reason_For_Not_Providing_Treatment_Value"/>
     [CqlDeclaration("Medical Reason For Not Providing Treatment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
 	public CqlValueSet Medical_Reason_For_Not_Providing_Treatment() => 
 		__Medical_Reason_For_Not_Providing_Treatment.Value;
 
+    /// <seealso cref="Patient_Refusal"/>
 	private CqlValueSet Patient_Refusal_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", null);
 
+    /// <seealso cref="Patient_Refusal_Value"/>
     [CqlDeclaration("Patient Refusal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
 	public CqlValueSet Patient_Refusal() => 
 		__Patient_Refusal.Value;
 
+    /// <seealso cref="Pharmacological_Contraindications_For_Antithrombotic_Therapy"/>
 	private CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", null);
 
+    /// <seealso cref="Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value"/>
     [CqlDeclaration("Pharmacological Contraindications For Antithrombotic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52")]
 	public CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy() => 
 		__Pharmacological_Contraindications_For_Antithrombotic_Therapy.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("DischargedonAntithromboticTherapyFHIR-0.9.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("DischargedonAntithromboticTherapyFHIR-0.9.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = TJCOverall_8_11_000.Encounter_with_Principal_Diagnosis_and_Age();
+		IEnumerable<Encounter> a_ = TJCOverall_8_11_000.Encounter_with_Principal_Diagnosis_and_Age();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke"/>
 	private IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke_Value()
 	{
-		var a_ = this.Denominator();
+		IEnumerable<Encounter> a_ = this.Denominator();
 		IEnumerable<Encounter> b_(Encounter Encounter)
 		{
-			var d_ = TJCOverall_8_11_000.Intervention_Comfort_Measures();
+			IEnumerable<object> d_ = TJCOverall_8_11_000.Intervention_Comfort_Measures();
 			bool? e_(object ComfortMeasure)
 			{
-				var i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = QICoreCommon_2_0_000.toInterval(j_);
-				var l_ = context.Operators.Start(k_);
-				var m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
-				var n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
-				var o_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
-				var p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
+				object i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
+				CqlDateTime l_ = context.Operators.Start(k_);
+				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
+				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
 
 				return p_;
 			};
-			var f_ = context.Operators.Where<object>(d_, e_);
+			IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
 			Encounter g_(object ComfortMeasure) => 
 				Encounter;
-			var h_ = context.Operators.Select<object, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke_Value"/>
     [CqlDeclaration("Encounter with Comfort Measures during Hospitalization for Patients with Documented Ischemic Stroke")]
 	public IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke() => 
 		__Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private IEnumerable<Encounter> Denominator_Exclusions_Value()
 	{
-		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounters_with_Discharge_Disposition();
-		var b_ = this.Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounters_with_Discharge_Disposition();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Comfort_Measures_during_Hospitalization_for_Patients_with_Documented_Ischemic_Stroke();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public IEnumerable<Encounter> Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
-			var e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			var h_ = context.Operators.Union<MedicationRequest>(e_, g_);
+			CqlValueSet d_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			bool? i_(MedicationRequest DischargeAntithrombotic)
 			{
-				var m_ = DischargeAntithrombotic?.AuthoredOnElement;
-				var n_ = context.Operators.Convert<CqlDateTime>(m_);
-				var o_ = IschemicStrokeEncounter?.Period;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = context.Operators.In<CqlDateTime>(n_, p_, null);
+				FhirDateTime m_ = DischargeAntithrombotic?.AuthoredOnElement;
+				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+				Period o_ = IschemicStrokeEncounter?.Period;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, null);
 
 				return q_;
 			};
-			var j_ = context.Operators.Where<MedicationRequest>(h_, i_);
+			IEnumerable<MedicationRequest> j_ = context.Operators.Where<MedicationRequest>(h_, i_);
 			Encounter k_(MedicationRequest DischargeAntithrombotic) => 
 				IschemicStrokeEncounter;
-			var l_ = context.Operators.Select<MedicationRequest, Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Select<MedicationRequest, Encounter>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Antithrombotic_Therapy_at_Discharge"/>
 	private IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge_Value()
 	{
-		var a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest Antithrombotic)
 		{
-			var h_ = QICoreCommon_2_0_000.isCommunity(Antithrombotic);
-			var i_ = QICoreCommon_2_0_000.isDischarge(Antithrombotic);
-			var j_ = context.Operators.Or(h_, i_);
-			var k_ = Antithrombotic?.StatusElement;
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<string>(l_);
-			var n_ = new string[]
+			bool? h_ = QICoreCommon_2_0_000.isCommunity(Antithrombotic);
+			bool? i_ = QICoreCommon_2_0_000.isDischarge(Antithrombotic);
+			bool? j_ = context.Operators.Or(h_, i_);
+			Code<MedicationRequest.MedicationrequestStatus> k_ = Antithrombotic?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? l_ = k_?.Value;
+			string m_ = context.Operators.Convert<string>(l_);
+			string[] n_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var o_ = context.Operators.In<string>(m_, (n_ as IEnumerable<string>));
-			var p_ = context.Operators.And(j_, o_);
-			var q_ = Antithrombotic?.IntentElement;
-			var r_ = q_?.Value;
-			var s_ = context.Operators.Convert<string>(r_);
-			var t_ = new string[]
+			bool? o_ = context.Operators.In<string>(m_, (n_ as IEnumerable<string>));
+			bool? p_ = context.Operators.And(j_, o_);
+			Code<MedicationRequest.MedicationRequestIntent> q_ = Antithrombotic?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? r_ = q_?.Value;
+			string s_ = context.Operators.Convert<string>(r_);
+			string[] t_ = new string[]
 			{
 				"order",
 				"original-order",
@@ -281,61 +304,63 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				"filler-order",
 				"instance-order",
 			};
-			var u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
-			var v_ = context.Operators.And(p_, u_);
-			var w_ = Antithrombotic?.DoNotPerformElement;
-			var x_ = w_?.Value;
-			var y_ = context.Operators.IsTrue(x_);
-			var z_ = context.Operators.Not(y_);
-			var aa_ = context.Operators.And(v_, z_);
+			bool? u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
+			bool? v_ = context.Operators.And(p_, u_);
+			FhirBoolean w_ = Antithrombotic?.DoNotPerformElement;
+			bool? x_ = w_?.Value;
+			bool? y_ = context.Operators.IsTrue(x_);
+			bool? z_ = context.Operators.Not(y_);
+			bool? aa_ = context.Operators.And(v_, z_);
 
 			return aa_;
 		};
-		var g_ = context.Operators.Where<MedicationRequest>(e_, f_);
+		IEnumerable<MedicationRequest> g_ = context.Operators.Where<MedicationRequest>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Antithrombotic_Therapy_at_Discharge_Value"/>
     [CqlDeclaration("Antithrombotic Therapy at Discharge")]
 	public IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge() => 
 		__Antithrombotic_Therapy_at_Discharge.Value;
 
+    /// <seealso cref="Reason_for_Not_Giving_Antithrombotic_at_Discharge"/>
 	private IEnumerable<MedicationRequest> Reason_for_Not_Giving_Antithrombotic_at_Discharge_Value()
 	{
-		var a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest NoAntithromboticDischarge)
 		{
-			var h_ = NoAntithromboticDischarge?.ReasonCode;
+			List<CodeableConcept> h_ = NoAntithromboticDischarge?.ReasonCode;
 			CqlConcept i_(CodeableConcept @this)
 			{
-				var ac_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept ac_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return ac_;
 			};
-			var j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
-			var k_ = this.Medical_Reason_For_Not_Providing_Treatment();
-			var l_ = context.Operators.ConceptsInValueSet(j_, k_);
+			IEnumerable<CqlConcept> j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
+			CqlValueSet k_ = this.Medical_Reason_For_Not_Providing_Treatment();
+			bool? l_ = context.Operators.ConceptsInValueSet(j_, k_);
 			CqlConcept n_(CodeableConcept @this)
 			{
-				var ad_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept ad_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return ad_;
 			};
-			var o_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, n_);
-			var p_ = this.Patient_Refusal();
-			var q_ = context.Operators.ConceptsInValueSet(o_, p_);
-			var r_ = context.Operators.Or(l_, q_);
-			var s_ = QICoreCommon_2_0_000.isCommunity(NoAntithromboticDischarge);
-			var t_ = QICoreCommon_2_0_000.isDischarge(NoAntithromboticDischarge);
-			var u_ = context.Operators.Or(s_, t_);
-			var v_ = context.Operators.And(r_, u_);
-			var w_ = NoAntithromboticDischarge?.IntentElement;
-			var x_ = w_?.Value;
-			var y_ = context.Operators.Convert<string>(x_);
-			var z_ = new string[]
+			IEnumerable<CqlConcept> o_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, n_);
+			CqlValueSet p_ = this.Patient_Refusal();
+			bool? q_ = context.Operators.ConceptsInValueSet(o_, p_);
+			bool? r_ = context.Operators.Or(l_, q_);
+			bool? s_ = QICoreCommon_2_0_000.isCommunity(NoAntithromboticDischarge);
+			bool? t_ = QICoreCommon_2_0_000.isDischarge(NoAntithromboticDischarge);
+			bool? u_ = context.Operators.Or(s_, t_);
+			bool? v_ = context.Operators.And(r_, u_);
+			Code<MedicationRequest.MedicationRequestIntent> w_ = NoAntithromboticDischarge?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? x_ = w_?.Value;
+			string y_ = context.Operators.Convert<string>(x_);
+			string[] z_ = new string[]
 			{
 				"order",
 				"original-order",
@@ -343,77 +368,81 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				"filler-order",
 				"instance-order",
 			};
-			var aa_ = context.Operators.In<string>(y_, (z_ as IEnumerable<string>));
-			var ab_ = context.Operators.And(v_, aa_);
+			bool? aa_ = context.Operators.In<string>(y_, (z_ as IEnumerable<string>));
+			bool? ab_ = context.Operators.And(v_, aa_);
 
 			return ab_;
 		};
-		var g_ = context.Operators.Where<MedicationRequest>(e_, f_);
+		IEnumerable<MedicationRequest> g_ = context.Operators.Where<MedicationRequest>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Reason_for_Not_Giving_Antithrombotic_at_Discharge_Value"/>
     [CqlDeclaration("Reason for Not Giving Antithrombotic at Discharge")]
 	public IEnumerable<MedicationRequest> Reason_for_Not_Giving_Antithrombotic_at_Discharge() => 
 		__Reason_for_Not_Giving_Antithrombotic_at_Discharge.Value;
 
+    /// <seealso cref="Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge"/>
 	private IEnumerable<Encounter> Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge_Value()
 	{
-		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Reason_for_Not_Giving_Antithrombotic_at_Discharge();
+			IEnumerable<MedicationRequest> d_ = this.Reason_for_Not_Giving_Antithrombotic_at_Discharge();
 			bool? e_(MedicationRequest NoDischargeAntithrombotic)
 			{
-				var i_ = NoDischargeAntithrombotic?.AuthoredOnElement;
-				var j_ = context.Operators.Convert<CqlDateTime>(i_);
-				var k_ = IschemicStrokeEncounter?.Period;
-				var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
+				FhirDateTime i_ = NoDischargeAntithrombotic?.AuthoredOnElement;
+				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+				Period k_ = IschemicStrokeEncounter?.Period;
+				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
 
 				return m_;
 			};
-			var f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+			IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
 			Encounter g_(MedicationRequest NoDischargeAntithrombotic) => 
 				IschemicStrokeEncounter;
-			var h_ = context.Operators.Select<MedicationRequest, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<MedicationRequest, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge_Value"/>
     [CqlDeclaration("Encounter with Documented Reason for No Antithrombotic At Discharge")]
 	public IEnumerable<Encounter> Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge() => 
 		__Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge.Value;
 
+    /// <seealso cref="Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge"/>
 	private IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value()
 	{
-		var a_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet a_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest Pharmacological)
 		{
-			var h_ = QICoreCommon_2_0_000.isCommunity(Pharmacological);
-			var i_ = QICoreCommon_2_0_000.isDischarge(Pharmacological);
-			var j_ = context.Operators.Or(h_, i_);
-			var k_ = Pharmacological?.StatusElement;
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<string>(l_);
-			var n_ = new string[]
+			bool? h_ = QICoreCommon_2_0_000.isCommunity(Pharmacological);
+			bool? i_ = QICoreCommon_2_0_000.isDischarge(Pharmacological);
+			bool? j_ = context.Operators.Or(h_, i_);
+			Code<MedicationRequest.MedicationrequestStatus> k_ = Pharmacological?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? l_ = k_?.Value;
+			string m_ = context.Operators.Convert<string>(l_);
+			string[] n_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var o_ = context.Operators.In<string>(m_, (n_ as IEnumerable<string>));
-			var p_ = context.Operators.And(j_, o_);
-			var q_ = Pharmacological?.IntentElement;
-			var r_ = q_?.Value;
-			var s_ = context.Operators.Convert<string>(r_);
-			var t_ = new string[]
+			bool? o_ = context.Operators.In<string>(m_, (n_ as IEnumerable<string>));
+			bool? p_ = context.Operators.And(j_, o_);
+			Code<MedicationRequest.MedicationRequestIntent> q_ = Pharmacological?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? r_ = q_?.Value;
+			string s_ = context.Operators.Convert<string>(r_);
+			string[] t_ = new string[]
 			{
 				"order",
 				"original-order",
@@ -421,110 +450,123 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				"filler-order",
 				"instance-order",
 			};
-			var u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
-			var v_ = context.Operators.And(p_, u_);
-			var w_ = Pharmacological?.DoNotPerformElement;
-			var x_ = w_?.Value;
-			var y_ = context.Operators.IsTrue(x_);
-			var z_ = context.Operators.Not(y_);
-			var aa_ = context.Operators.And(v_, z_);
+			bool? u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
+			bool? v_ = context.Operators.And(p_, u_);
+			FhirBoolean w_ = Pharmacological?.DoNotPerformElement;
+			bool? x_ = w_?.Value;
+			bool? y_ = context.Operators.IsTrue(x_);
+			bool? z_ = context.Operators.Not(y_);
+			bool? aa_ = context.Operators.And(v_, z_);
 
 			return aa_;
 		};
-		var g_ = context.Operators.Where<MedicationRequest>(e_, f_);
+		IEnumerable<MedicationRequest> g_ = context.Operators.Where<MedicationRequest>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value"/>
     [CqlDeclaration("Pharmacological Contraindications for Antithrombotic Therapy at Discharge")]
 	public IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge() => 
 		__Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge.Value;
 
+    /// <seealso cref="Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge"/>
 	private IEnumerable<Encounter> Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value()
 	{
-		var a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = TJCOverall_8_11_000.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge();
+			IEnumerable<MedicationRequest> d_ = this.Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge();
 			bool? e_(MedicationRequest DischargePharmacological)
 			{
-				var i_ = DischargePharmacological?.AuthoredOnElement;
-				var j_ = context.Operators.Convert<CqlDateTime>(i_);
-				var k_ = IschemicStrokeEncounter?.Period;
-				var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
+				FhirDateTime i_ = DischargePharmacological?.AuthoredOnElement;
+				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+				Period k_ = IschemicStrokeEncounter?.Period;
+				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
 
 				return m_;
 			};
-			var f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+			IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
 			Encounter g_(MedicationRequest DischargePharmacological) => 
 				IschemicStrokeEncounter;
-			var h_ = context.Operators.Select<MedicationRequest, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<MedicationRequest, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value"/>
     [CqlDeclaration("Encounter with Pharmacological Contraindications for Antithrombotic Therapy at Discharge")]
 	public IEnumerable<Encounter> Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge() => 
 		__Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge.Value;
 
+    /// <seealso cref="Denominator_Exceptions"/>
 	private IEnumerable<Encounter> Denominator_Exceptions_Value()
 	{
-		var a_ = this.Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge();
-		var b_ = this.Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_Documented_Reason_for_No_Antithrombotic_At_Discharge();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Exceptions_Value"/>
     [CqlDeclaration("Denominator Exceptions")]
 	public IEnumerable<Encounter> Denominator_Exceptions() => 
 		__Denominator_Exceptions.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -42,21 +42,23 @@ public class FHIRHelpers_4_3_000
 			}
 			else if ((period?.StartElement is null))
 			{
-				var b_ = period?.StartElement;
-				var c_ = context.Operators.Convert<CqlDateTime>(b_);
-				var d_ = period?.EndElement;
-				var e_ = context.Operators.Convert<CqlDateTime>(d_);
-				var f_ = context.Operators.Interval(c_, e_, false, true);
+				FhirDateTime b_ = period?.StartElement;
+				CqlDateTime c_ = context.Operators.Convert<CqlDateTime>(b_);
+				FhirDateTime d_ = period?.EndElement;
+				CqlDateTime e_ = context.Operators.Convert<CqlDateTime>(d_);
+				CqlInterval<CqlDateTime> f_ = context.Operators.Interval(c_, e_, false, true);
 
 				return f_;
 			}
 			else
 			{
-				var g_ = context.Operators.Convert<CqlDateTime>(period?.StartElement);
-				var h_ = context.Operators.Convert<CqlDateTime>(period?.EndElement);
-				var i_ = context.Operators.Interval(g_, h_, true, true);
+				FhirDateTime g_ = period?.StartElement;
+				CqlDateTime h_ = context.Operators.Convert<CqlDateTime>(g_);
+				FhirDateTime i_ = period?.EndElement;
+				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+				CqlInterval<CqlDateTime> k_ = context.Operators.Interval(h_, j_, true, true);
 
-				return i_;
+				return k_;
 			}
 		};
 
@@ -80,72 +82,72 @@ public class FHIRHelpers_4_3_000
 				{
 					bool c_()
 					{
-						var g_ = quantity?.ComparatorElement;
-						var h_ = g_?.Value;
-						var i_ = context.Operators.Convert<string>(h_);
-						var j_ = context.Operators.Equal(i_, "<");
+						Code<Quantity.QuantityComparator> g_ = quantity?.ComparatorElement;
+						Quantity.QuantityComparator? h_ = g_?.Value;
+						string i_ = context.Operators.Convert<string>(h_);
+						bool? j_ = context.Operators.Equal(i_, "<");
 
 						return (j_ ?? false);
 					};
 					bool d_()
 					{
-						var k_ = quantity?.ComparatorElement;
-						var l_ = k_?.Value;
-						var m_ = context.Operators.Convert<string>(l_);
-						var n_ = context.Operators.Equal(m_, "<=");
+						Code<Quantity.QuantityComparator> k_ = quantity?.ComparatorElement;
+						Quantity.QuantityComparator? l_ = k_?.Value;
+						string m_ = context.Operators.Convert<string>(l_);
+						bool? n_ = context.Operators.Equal(m_, "<=");
 
 						return (n_ ?? false);
 					};
 					bool e_()
 					{
-						var o_ = quantity?.ComparatorElement;
-						var p_ = o_?.Value;
-						var q_ = context.Operators.Convert<string>(p_);
-						var r_ = context.Operators.Equal(q_, ">=");
+						Code<Quantity.QuantityComparator> o_ = quantity?.ComparatorElement;
+						Quantity.QuantityComparator? p_ = o_?.Value;
+						string q_ = context.Operators.Convert<string>(p_);
+						bool? r_ = context.Operators.Equal(q_, ">=");
 
 						return (r_ ?? false);
 					};
 					bool f_()
 					{
-						var s_ = quantity?.ComparatorElement;
-						var t_ = s_?.Value;
-						var u_ = context.Operators.Convert<string>(t_);
-						var v_ = context.Operators.Equal(u_, ">");
+						Code<Quantity.QuantityComparator> s_ = quantity?.ComparatorElement;
+						Quantity.QuantityComparator? t_ = s_?.Value;
+						string u_ = context.Operators.Convert<string>(t_);
+						bool? v_ = context.Operators.Equal(u_, ">");
 
 						return (v_ ?? false);
 					};
 					if (c_())
 					{
-						var w_ = this.ToQuantityIgnoringComparator(quantity);
-						var x_ = context.Operators.Interval(null, w_, true, false);
+						CqlQuantity w_ = this.ToQuantityIgnoringComparator(quantity);
+						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(null, w_, true, false);
 
 						return x_;
 					}
 					else if (d_())
 					{
-						var y_ = this.ToQuantityIgnoringComparator(quantity);
-						var z_ = context.Operators.Interval(null, y_, true, true);
+						CqlQuantity y_ = this.ToQuantityIgnoringComparator(quantity);
+						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(null, y_, true, true);
 
 						return z_;
 					}
 					else if (e_())
 					{
-						var aa_ = this.ToQuantityIgnoringComparator(quantity);
-						var ab_ = context.Operators.Interval(aa_, null, true, true);
+						CqlQuantity aa_ = this.ToQuantityIgnoringComparator(quantity);
+						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, null, true, true);
 
 						return ab_;
 					}
 					else if (f_())
 					{
-						var ac_ = this.ToQuantityIgnoringComparator(quantity);
-						var ad_ = context.Operators.Interval(ac_, null, false, true);
+						CqlQuantity ac_ = this.ToQuantityIgnoringComparator(quantity);
+						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, null, false, true);
 
 						return ad_;
 					}
 					else
 					{
-						var ae_ = this.ToQuantity(quantity);
-						var ag_ = context.Operators.Interval(ae_, ae_, true, true);
+						CqlQuantity ae_ = this.ToQuantity(quantity);
+						CqlInterval<CqlQuantity> ag_ = context.Operators.Interval(ae_, ae_, true, true);
 
 						return ag_;
 					}
@@ -170,11 +172,13 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				var b_ = this.ToQuantity(range?.Low);
-				var c_ = this.ToQuantity(range?.High);
-				var d_ = context.Operators.Interval(b_, c_, true, true);
+				Quantity b_ = range?.Low;
+				CqlQuantity c_ = this.ToQuantity(b_);
+				Quantity d_ = range?.High;
+				CqlQuantity e_ = this.ToQuantity(d_);
+				CqlInterval<CqlQuantity> f_ = context.Operators.Interval(c_, e_, true, true);
 
-				return d_;
+				return f_;
 			}
 		};
 
@@ -239,20 +243,20 @@ public class FHIRHelpers_4_3_000
 		{
 			bool b_()
 			{
-				var d_ = quantity?.ComparatorElement;
-				var e_ = context.Operators.Not((bool?)(d_ is null));
+				Code<Quantity.QuantityComparator> d_ = quantity?.ComparatorElement;
+				bool? e_ = context.Operators.Not((bool?)(d_ is null));
 
 				return (e_ ?? false);
 			};
 			bool c_()
 			{
-				var f_ = quantity?.SystemElement;
-				var h_ = f_?.Value;
-				var i_ = context.Operators.Equal(h_, "http://unitsofmeasure.org");
-				var j_ = context.Operators.Or((bool?)(f_ is null), i_);
-				var l_ = f_?.Value;
-				var m_ = context.Operators.Equal(l_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
-				var n_ = context.Operators.Or(j_, m_);
+				FhirUri f_ = quantity?.SystemElement;
+				string h_ = f_?.Value;
+				bool? i_ = context.Operators.Equal(h_, "http://unitsofmeasure.org");
+				bool? j_ = context.Operators.Or((bool?)(f_ is null), i_);
+				string l_ = f_?.Value;
+				bool? m_ = context.Operators.Equal(l_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
+				bool? n_ = context.Operators.Or(j_, m_);
 
 				return (n_ ?? false);
 			};
@@ -266,33 +270,39 @@ public class FHIRHelpers_4_3_000
 			}
 			else if (b_())
 			{
-				var o_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
+				object o_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
 
 				return (o_ as CqlQuantity);
 			}
 			else if (c_())
 			{
-				var p_ = quantity?.ValueElement;
-				var q_ = p_?.Value;
-				var r_ = quantity?.CodeElement;
-				var s_ = r_?.Value;
-				var t_ = quantity?.UnitElement;
-				var u_ = t_?.Value;
-				var v_ = this.ToCalendarUnit(((s_ ?? u_) ?? "1"));
+				FhirDecimal p_ = quantity?.ValueElement;
+				decimal? q_ = p_?.Value;
+				Code r_ = quantity?.CodeElement;
+				string s_ = r_?.Value;
+				FhirString t_ = quantity?.UnitElement;
+				string u_ = t_?.Value;
+				string v_ = this.ToCalendarUnit(((s_ ?? u_) ?? "1"));
 
 				return new CqlQuantity(q_, v_);
 			}
 			else
 			{
-				var w_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", (quantity?.UnitElement?.Value ?? ""));
-				var x_ = context.Operators.Concatenate((w_ ?? ""), " (");
-				var y_ = context.Operators.Concatenate((x_ ?? ""), (quantity?.SystemElement?.Value ?? ""));
-				var z_ = context.Operators.Concatenate((y_ ?? ""), "|");
-				var aa_ = context.Operators.Concatenate((z_ ?? ""), (quantity?.CodeElement?.Value ?? ""));
-				var ab_ = context.Operators.Concatenate((aa_ ?? ""), ")");
-				var ac_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ab_);
+				FhirString w_ = quantity?.UnitElement;
+				string x_ = w_?.Value;
+				string y_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", (x_ ?? ""));
+				string z_ = context.Operators.Concatenate((y_ ?? ""), " (");
+				FhirUri aa_ = quantity?.SystemElement;
+				string ab_ = aa_?.Value;
+				string ac_ = context.Operators.Concatenate((z_ ?? ""), (ab_ ?? ""));
+				string ad_ = context.Operators.Concatenate((ac_ ?? ""), "|");
+				Code ae_ = quantity?.CodeElement;
+				string af_ = ae_?.Value;
+				string ag_ = context.Operators.Concatenate((ad_ ?? ""), (af_ ?? ""));
+				string ah_ = context.Operators.Concatenate((ag_ ?? ""), ")");
+				object ai_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ah_);
 
-				return (ac_ as CqlQuantity);
+				return (ai_ as CqlQuantity);
 			}
 		};
 
@@ -309,13 +319,13 @@ public class FHIRHelpers_4_3_000
 		{
 			bool b_()
 			{
-				var c_ = quantity?.SystemElement;
-				var e_ = c_?.Value;
-				var f_ = context.Operators.Equal(e_, "http://unitsofmeasure.org");
-				var g_ = context.Operators.Or((bool?)(c_ is null), f_);
-				var i_ = c_?.Value;
-				var j_ = context.Operators.Equal(i_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
-				var k_ = context.Operators.Or(g_, j_);
+				FhirUri c_ = quantity?.SystemElement;
+				string e_ = c_?.Value;
+				bool? f_ = context.Operators.Equal(e_, "http://unitsofmeasure.org");
+				bool? g_ = context.Operators.Or((bool?)(c_ is null), f_);
+				string i_ = c_?.Value;
+				bool? j_ = context.Operators.Equal(i_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
+				bool? k_ = context.Operators.Or(g_, j_);
 
 				return (k_ ?? false);
 			};
@@ -329,27 +339,33 @@ public class FHIRHelpers_4_3_000
 			}
 			else if (b_())
 			{
-				var l_ = quantity?.ValueElement;
-				var m_ = l_?.Value;
-				var n_ = quantity?.CodeElement;
-				var o_ = n_?.Value;
-				var p_ = quantity?.UnitElement;
-				var q_ = p_?.Value;
-				var r_ = this.ToCalendarUnit(((o_ ?? q_) ?? "1"));
+				FhirDecimal l_ = quantity?.ValueElement;
+				decimal? m_ = l_?.Value;
+				Code n_ = quantity?.CodeElement;
+				string o_ = n_?.Value;
+				FhirString p_ = quantity?.UnitElement;
+				string q_ = p_?.Value;
+				string r_ = this.ToCalendarUnit(((o_ ?? q_) ?? "1"));
 
 				return new CqlQuantity(m_, r_);
 			}
 			else
 			{
-				var s_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", (quantity?.UnitElement?.Value ?? ""));
-				var t_ = context.Operators.Concatenate((s_ ?? ""), " (");
-				var u_ = context.Operators.Concatenate((t_ ?? ""), (quantity?.SystemElement?.Value ?? ""));
-				var v_ = context.Operators.Concatenate((u_ ?? ""), "|");
-				var w_ = context.Operators.Concatenate((v_ ?? ""), (quantity?.CodeElement?.Value ?? ""));
-				var x_ = context.Operators.Concatenate((w_ ?? ""), ")");
-				var y_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", x_);
+				FhirString s_ = quantity?.UnitElement;
+				string t_ = s_?.Value;
+				string u_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", (t_ ?? ""));
+				string v_ = context.Operators.Concatenate((u_ ?? ""), " (");
+				FhirUri w_ = quantity?.SystemElement;
+				string x_ = w_?.Value;
+				string y_ = context.Operators.Concatenate((v_ ?? ""), (x_ ?? ""));
+				string z_ = context.Operators.Concatenate((y_ ?? ""), "|");
+				Code aa_ = quantity?.CodeElement;
+				string ab_ = aa_?.Value;
+				string ac_ = context.Operators.Concatenate((z_ ?? ""), (ab_ ?? ""));
+				string ad_ = context.Operators.Concatenate((ac_ ?? ""), ")");
+				object ae_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ad_);
 
-				return (y_ as CqlQuantity);
+				return (ae_ as CqlQuantity);
 			}
 		};
 
@@ -368,10 +384,12 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				var b_ = this.ToQuantity(ratio?.Numerator);
-				var c_ = this.ToQuantity(ratio?.Denominator);
+				Quantity b_ = ratio?.Numerator;
+				CqlQuantity c_ = this.ToQuantity(b_);
+				Quantity d_ = ratio?.Denominator;
+				CqlQuantity e_ = this.ToQuantity(d_);
 
-				return new CqlRatio(b_, c_);
+				return new CqlRatio(c_, e_);
 			}
 		};
 
@@ -390,7 +408,16 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				return new CqlCode(coding?.CodeElement?.Value, coding?.SystemElement?.Value, coding?.VersionElement?.Value, coding?.DisplayElement?.Value);
+				Code b_ = coding?.CodeElement;
+				string c_ = b_?.Value;
+				FhirUri d_ = coding?.SystemElement;
+				string e_ = d_?.Value;
+				FhirString f_ = coding?.VersionElement;
+				string g_ = f_?.Value;
+				FhirString h_ = coding?.DisplayElement;
+				string i_ = h_?.Value;
+
+				return new CqlCode(c_, e_, g_, i_);
 			}
 		};
 
@@ -409,15 +436,18 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				CqlCode b_(Coding C)
+				List<Coding> b_ = concept?.Coding;
+				CqlCode c_(Coding C)
 				{
-					var d_ = this.ToCode(C);
+					CqlCode g_ = this.ToCode(C);
 
-					return d_;
+					return g_;
 				};
-				var c_ = context.Operators.Select<Coding, CqlCode>((IEnumerable<Coding>)concept?.Coding, b_);
+				IEnumerable<CqlCode> d_ = context.Operators.Select<Coding, CqlCode>((IEnumerable<Coding>)b_, c_);
+				FhirString e_ = concept?.TextElement;
+				string f_ = e_?.Value;
 
-				return new CqlConcept(c_, concept?.TextElement?.Value);
+				return new CqlConcept(d_, f_);
 			}
 		};
 
@@ -436,7 +466,7 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				var b_ = new CqlValueSet
+				CqlValueSet b_ = new CqlValueSet
 				{
 					id = uri,
 				};
@@ -460,11 +490,11 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				var b_ = new FhirString
+				FhirString b_ = new FhirString
 				{
 					Value = reference,
 				};
-				var c_ = new ResourceReference
+				ResourceReference c_ = new ResourceReference
 				{
 					ReferenceElement = b_,
 				};
@@ -489,179 +519,179 @@ public class FHIRHelpers_4_3_000
 		{
 			if (value is Base64Binary)
 			{
-				var b_ = (value as Base64Binary)?.Value;
-				var c_ = context.Operators.Convert<string>(b_);
+				byte[] b_ = (value as Base64Binary)?.Value;
+				string c_ = context.Operators.Convert<string>(b_);
 
 				return (c_ as object);
 			}
 			else if (value is FhirBoolean)
 			{
-				var d_ = (value as FhirBoolean)?.Value;
+				bool? d_ = (value as FhirBoolean)?.Value;
 
 				return d_;
 			}
 			else if (value is Canonical)
 			{
-				var e_ = (value as Canonical)?.Value;
+				string e_ = (value as Canonical)?.Value;
 
 				return (e_ as object);
 			}
 			else if (value is Code)
 			{
-				var f_ = (value as Code)?.Value;
+				string f_ = (value as Code)?.Value;
 
 				return (f_ as object);
 			}
 			else if (value is Date)
 			{
-				var g_ = (value as Date)?.Value;
-				var h_ = context.Operators.ConvertStringToDate(g_);
+				string g_ = (value as Date)?.Value;
+				CqlDate h_ = context.Operators.ConvertStringToDate(g_);
 
 				return (h_ as object);
 			}
 			else if (value is FhirDateTime)
 			{
-				var i_ = context.Operators.Convert<CqlDateTime>((value as FhirDateTime));
+				CqlDateTime i_ = context.Operators.Convert<CqlDateTime>((value as FhirDateTime));
 
 				return (i_ as object);
 			}
 			else if (value is FhirDecimal)
 			{
-				var j_ = (value as FhirDecimal)?.Value;
+				decimal? j_ = (value as FhirDecimal)?.Value;
 
 				return j_;
 			}
 			else if (value is Id)
 			{
-				var k_ = (value as Id)?.Value;
+				string k_ = (value as Id)?.Value;
 
 				return (k_ as object);
 			}
 			else if (value is Instant)
 			{
-				var l_ = (value as Instant)?.Value;
-				var m_ = context.Operators.Convert<CqlDateTime>(l_);
+				DateTimeOffset? l_ = (value as Instant)?.Value;
+				CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
 
 				return (m_ as object);
 			}
 			else if (value is Integer)
 			{
-				var n_ = (value as Integer)?.Value;
+				int? n_ = (value as Integer)?.Value;
 
 				return n_;
 			}
 			else if (value is Markdown)
 			{
-				var o_ = (value as Markdown)?.Value;
+				string o_ = (value as Markdown)?.Value;
 
 				return (o_ as object);
 			}
 			else if (value is Oid)
 			{
-				var p_ = (value as Oid)?.Value;
+				string p_ = (value as Oid)?.Value;
 
 				return (p_ as object);
 			}
 			else if (value is Integer)
 			{
-				var q_ = (value as Integer)?.Value;
+				int? q_ = (value as Integer)?.Value;
 
 				return q_;
 			}
 			else if (value is FhirString)
 			{
-				var r_ = (value as FhirString)?.Value;
+				string r_ = (value as FhirString)?.Value;
 
 				return (r_ as object);
 			}
 			else if (value is Time)
 			{
-				var s_ = (value as Time)?.Value;
-				var t_ = context.Operators.ConvertStringToTime(s_);
+				string s_ = (value as Time)?.Value;
+				CqlTime t_ = context.Operators.ConvertStringToTime(s_);
 
 				return (t_ as object);
 			}
 			else if (value is Integer)
 			{
-				var u_ = (value as Integer)?.Value;
+				int? u_ = (value as Integer)?.Value;
 
 				return u_;
 			}
 			else if (value is FhirUri)
 			{
-				var v_ = (value as FhirUri)?.Value;
+				string v_ = (value as FhirUri)?.Value;
 
 				return (v_ as object);
 			}
 			else if (value is FhirUrl)
 			{
-				var w_ = (value as FhirUrl)?.Value;
+				string w_ = (value as FhirUrl)?.Value;
 
 				return (w_ as object);
 			}
 			else if (value is Uuid)
 			{
-				var x_ = (value as Uuid)?.Value;
+				string x_ = (value as Uuid)?.Value;
 
 				return (x_ as object);
 			}
 			else if (value is Age)
 			{
-				var y_ = this.ToQuantity((Quantity)(value as Age));
+				CqlQuantity y_ = this.ToQuantity((Quantity)(value as Age));
 
 				return (y_ as object);
 			}
 			else if (value is CodeableConcept)
 			{
-				var z_ = this.ToConcept((value as CodeableConcept));
+				CqlConcept z_ = this.ToConcept((value as CodeableConcept));
 
 				return (z_ as object);
 			}
 			else if (value is Coding)
 			{
-				var aa_ = this.ToCode((value as Coding));
+				CqlCode aa_ = this.ToCode((value as Coding));
 
 				return (aa_ as object);
 			}
 			else if (value is Count)
 			{
-				var ab_ = this.ToQuantity((Quantity)(value as Count));
+				CqlQuantity ab_ = this.ToQuantity((Quantity)(value as Count));
 
 				return (ab_ as object);
 			}
 			else if (value is Distance)
 			{
-				var ac_ = this.ToQuantity((Quantity)(value as Distance));
+				CqlQuantity ac_ = this.ToQuantity((Quantity)(value as Distance));
 
 				return (ac_ as object);
 			}
 			else if (value is Duration)
 			{
-				var ad_ = this.ToQuantity((Quantity)(value as Duration));
+				CqlQuantity ad_ = this.ToQuantity((Quantity)(value as Duration));
 
 				return (ad_ as object);
 			}
 			else if (value is Quantity)
 			{
-				var ae_ = this.ToQuantity((value as Quantity));
+				CqlQuantity ae_ = this.ToQuantity((value as Quantity));
 
 				return (ae_ as object);
 			}
 			else if (value is Range)
 			{
-				var af_ = this.ToInterval((value as Range));
+				CqlInterval<CqlQuantity> af_ = this.ToInterval((value as Range));
 
 				return (af_ as object);
 			}
 			else if (value is Period)
 			{
-				var ag_ = this.ToInterval((value as Period));
+				CqlInterval<CqlDateTime> ag_ = this.ToInterval((value as Period));
 
 				return (ag_ as object);
 			}
 			else if (value is Ratio)
 			{
-				var ah_ = this.ToRatio((value as Ratio));
+				CqlRatio ah_ = this.ToRatio((value as Ratio));
 
 				return (ah_ as object);
 			}
@@ -781,1739 +811,1973 @@ public class FHIRHelpers_4_3_000
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Account.AccountStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Account.AccountStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionCardinalityBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionCardinalityBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionConditionKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionConditionKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionGroupingBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionGroupingBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionParticipantType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionParticipantType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionPrecheckBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionPrecheckBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionRelationshipType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionRelationshipType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionRequiredBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionRequiredBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionSelectionBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionSelectionBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActivityDefinition.RequestResourceType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActivityDefinition.RequestResourceType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Address.AddressType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Address.AddressType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Address.AddressUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Address.AddressUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AdministrativeGender> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AdministrativeGender? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AdverseEvent.AdverseEventActuality> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AdverseEvent.AdverseEventActuality? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.AggregationMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.AggregationMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AllergyIntolerance.AllergyIntoleranceCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AllergyIntolerance.AllergyIntoleranceCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AllergyIntolerance.AllergyIntoleranceCriticality> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AllergyIntolerance.AllergyIntoleranceCriticality? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AllergyIntolerance.AllergyIntoleranceSeverity> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AllergyIntolerance.AllergyIntoleranceSeverity? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AllergyIntolerance.AllergyIntoleranceType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AllergyIntolerance.AllergyIntoleranceType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Appointment.AppointmentStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Appointment.AppointmentStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestScript.AssertionDirectionType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestScript.AssertionDirectionType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestScript.AssertionOperatorType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestScript.AssertionOperatorType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestScript.AssertionResponseTypes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestScript.AssertionResponseTypes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AuditEvent.AuditEventAction> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AuditEvent.AuditEventAction? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AuditEvent.AuditEventAgentNetworkType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AuditEvent.AuditEventAgentNetworkType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AuditEvent.AuditEventOutcome> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AuditEvent.AuditEventOutcome? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<BindingStrength> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		BindingStrength? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<BiologicallyDerivedProduct.BiologicallyDerivedProductCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		BiologicallyDerivedProduct.BiologicallyDerivedProductCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<BiologicallyDerivedProduct.BiologicallyDerivedProductStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		BiologicallyDerivedProduct.BiologicallyDerivedProductStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<BiologicallyDerivedProduct.BiologicallyDerivedProductStorageScale> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		BiologicallyDerivedProduct.BiologicallyDerivedProductStorageScale? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Bundle.BundleType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Bundle.BundleType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatementKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatementKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CarePlan.CarePlanActivityKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CarePlan.CarePlanActivityKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CarePlan.CarePlanActivityStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CarePlan.CarePlanActivityStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CarePlan.CarePlanIntent> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CarePlan.CarePlanIntent? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<RequestStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		RequestStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CareTeam.CareTeamStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CareTeam.CareTeamStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CatalogEntry.CatalogEntryRelationType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CatalogEntry.CatalogEntryRelationType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<InvoicePriceComponentType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		InvoicePriceComponentType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ChargeItem.ChargeItemStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ChargeItem.ChargeItemStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FinancialResourceStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FinancialResourceStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ClinicalImpression.ClinicalImpressionStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ClinicalImpression.ClinicalImpressionStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TerminologyCapabilities.CodeSearchSupport> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TerminologyCapabilities.CodeSearchSupport? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CodeSystemContentMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CodeSystemContentMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CodeSystem.CodeSystemHierarchyMeaning> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CodeSystem.CodeSystemHierarchyMeaning? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<RequestPriority> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		RequestPriority? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<EventStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		EventStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CompartmentType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CompartmentType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Composition.CompositionAttestationMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Composition.CompositionAttestationMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CompositionStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CompositionStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ConceptMapEquivalence> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ConceptMapEquivalence? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ConceptMap.ConceptMapGroupUnmappedMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ConceptMap.ConceptMapGroupUnmappedMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.ConditionalDeleteStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.ConditionalDeleteStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.ConditionalReadStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.ConditionalReadStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Consent.ConsentDataMeaning> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Consent.ConsentDataMeaning? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Consent.ConsentProvisionType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Consent.ConsentProvisionType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Consent.ConsentState> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Consent.ConsentState? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ConstraintSeverity> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ConstraintSeverity? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ContactPoint.ContactPointSystem> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ContactPoint.ContactPointSystem? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ContactPoint.ContactPointUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ContactPoint.ContactPointUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Contract.ContractResourcePublicationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Contract.ContractResourcePublicationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Contract.ContractResourceStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Contract.ContractResourceStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Contributor.ContributorType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Contributor.ContributorType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Money.Currencies> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Money.Currencies? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DaysOfWeek> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DaysOfWeek? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DetectedIssue.DetectedIssueSeverity> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DetectedIssue.DetectedIssueSeverity? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ObservationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ObservationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricCalibrationState> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricCalibrationState? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricCalibrationType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricCalibrationType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricColor> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricColor? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricOperationalStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricOperationalStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceNameType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceNameType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceUseStatement.DeviceUseStatementStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceUseStatement.DeviceUseStatementStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DiagnosticReport.DiagnosticReportStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DiagnosticReport.DiagnosticReportStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.DiscriminatorType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.DiscriminatorType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Composition.V3ConfidentialityClassification> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Composition.V3ConfidentialityClassification? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.DocumentMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.DocumentMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DocumentReferenceStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DocumentReferenceStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DocumentRelationshipType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DocumentRelationshipType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CoverageEligibilityRequest.EligibilityRequestPurpose> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CoverageEligibilityRequest.EligibilityRequestPurpose? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CoverageEligibilityResponse.EligibilityResponsePurpose> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CoverageEligibilityResponse.EligibilityResponsePurpose? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Questionnaire.EnableWhenBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Questionnaire.EnableWhenBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Encounter.EncounterLocationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Encounter.EncounterLocationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Encounter.EncounterStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Encounter.EncounterStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Endpoint.EndpointStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Endpoint.EndpointStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<EpisodeOfCare.EpisodeOfCareStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		EpisodeOfCare.EpisodeOfCareStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.EventCapabilityMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.EventCapabilityMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Timing.EventTiming> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Timing.EventTiming? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<VariableTypeCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		VariableTypeCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ExampleScenario.ExampleScenarioActorType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ExampleScenario.ExampleScenarioActorType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ExplanationOfBenefit.ExplanationOfBenefitStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ExplanationOfBenefit.ExplanationOfBenefitStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<EffectEvidenceSynthesis.ExposureStateCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		EffectEvidenceSynthesis.ExposureStateCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureDefinition.ExtensionContextType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureDefinition.ExtensionContextType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FHIRAllTypes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FHIRAllTypes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FHIRDefinedType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FHIRDefinedType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Device.FHIRDeviceStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Device.FHIRDeviceStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ResourceType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ResourceType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Substance.FHIRSubstanceStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Substance.FHIRSubstanceStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FHIRVersion> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FHIRVersion? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FamilyMemberHistory.FamilyHistoryStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FamilyMemberHistory.FamilyHistoryStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FilterOperator> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FilterOperator? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Flag.FlagStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Flag.FlagStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Goal.GoalLifecycleStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Goal.GoalLifecycleStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<GraphDefinition.GraphCompartmentRule> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		GraphDefinition.GraphCompartmentRule? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<GraphDefinition.GraphCompartmentUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		GraphDefinition.GraphCompartmentUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<GroupMeasureCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		GroupMeasureCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Group.GroupType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Group.GroupType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<GuidanceResponse.GuidanceResponseStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		GuidanceResponse.GuidanceResponseStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImplementationGuide.GuidePageGeneration> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImplementationGuide.GuidePageGeneration? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImplementationGuide.GuideParameterCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImplementationGuide.GuideParameterCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Bundle.HTTPVerb> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Bundle.HTTPVerb? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Identifier.IdentifierUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Identifier.IdentifierUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Person.IdentityAssuranceLevel> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Person.IdentityAssuranceLevel? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImagingStudy.ImagingStudyStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImagingStudy.ImagingStudyStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImmunizationEvaluation.ImmunizationEvaluationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImmunizationEvaluation.ImmunizationEvaluationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Immunization.ImmunizationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Immunization.ImmunizationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Invoice.InvoiceStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Invoice.InvoiceStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<OperationOutcome.IssueSeverity> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		OperationOutcome.IssueSeverity? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<OperationOutcome.IssueType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		OperationOutcome.IssueType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Patient.LinkType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Patient.LinkType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Linkage.LinkageType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Linkage.LinkageType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ListMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ListMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<List.ListStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		List.ListStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Location.LocationMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Location.LocationMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Location.LocationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Location.LocationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MeasureReport.MeasureReportStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MeasureReport.MeasureReportStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MeasureReport.MeasureReportType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MeasureReport.MeasureReportType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationAdministration.MedicationAdministrationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationAdministration.MedicationAdministrationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationDispense.MedicationDispenseStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationDispense.MedicationDispenseStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationKnowledge.MedicationKnowledgeStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationKnowledge.MedicationKnowledgeStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationRequest.MedicationRequestIntent> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationRequest.MedicationRequestIntent? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationRequest.MedicationrequestStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationRequest.MedicationrequestStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationStatement.MedicationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationStatement.MedicationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Medication.MedicationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Medication.MedicationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MessageDefinition.MessageSignificanceCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MessageDefinition.MessageSignificanceCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MessageheaderResponseRequest> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MessageheaderResponseRequest? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("ToString")]
+	public string ToString(Code value)
+	{
+		string a_ = value?.Value;
 
 		return a_;
 	}
 
     [CqlDeclaration("ToString")]
-	public string ToString(Code value) => 
-		value?.Value;
-
-    [CqlDeclaration("ToString")]
 	public string ToString(Code<HumanName.NameUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		HumanName.NameUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<NamingSystem.NamingSystemIdentifierType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		NamingSystem.NamingSystemIdentifierType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<NamingSystem.NamingSystemType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		NamingSystem.NamingSystemType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Narrative.NarrativeStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Narrative.NarrativeStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<NoteType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		NoteType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<RequestIntent> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		RequestIntent? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ObservationDefinition.ObservationDataType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ObservationDefinition.ObservationDataType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ObservationDefinition.ObservationRangeCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ObservationDefinition.ObservationRangeCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<OperationDefinition.OperationKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		OperationDefinition.OperationKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<OperationParameterUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		OperationParameterUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.OrientationType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.OrientationType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Appointment.ParticipantRequired> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Appointment.ParticipantRequired? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ParticipationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ParticipationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.PropertyRepresentation> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.PropertyRepresentation? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CodeSystem.PropertyType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CodeSystem.PropertyType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Provenance.ProvenanceEntityRole> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Provenance.ProvenanceEntityRole? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<PublicationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		PublicationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.QualityType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.QualityType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Quantity.QuantityComparator> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Quantity.QuantityComparator? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Questionnaire.QuestionnaireItemOperator> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Questionnaire.QuestionnaireItemOperator? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Questionnaire.QuestionnaireItemType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Questionnaire.QuestionnaireItemType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<QuestionnaireResponse.QuestionnaireResponseStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		QuestionnaireResponse.QuestionnaireResponseStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.ReferenceHandlingPolicy> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.ReferenceHandlingPolicy? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.ReferenceVersionRules> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.ReferenceVersionRules? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<RelatedArtifact.RelatedArtifactType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		RelatedArtifact.RelatedArtifactType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ClaimProcessingCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ClaimProcessingCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.RepositoryType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.RepositoryType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ResearchElementDefinition.ResearchElementType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ResearchElementDefinition.ResearchElementType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ResearchStudy.ResearchStudyStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ResearchStudy.ResearchStudyStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ResearchSubject.ResearchSubjectStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ResearchSubject.ResearchSubjectStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.ResourceVersionPolicy> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.ResourceVersionPolicy? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MessageHeader.ResponseType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MessageHeader.ResponseType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.RestfulCapabilityMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.RestfulCapabilityMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImplementationGuide.SPDXLicense> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImplementationGuide.SPDXLicense? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SearchParameter.SearchComparator> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SearchParameter.SearchComparator? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Bundle.SearchEntryMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Bundle.SearchEntryMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SearchParameter.SearchModifierCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SearchParameter.SearchModifierCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SearchParamType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SearchParamType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.SequenceType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.SequenceType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.SlicingRules> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.SlicingRules? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Slot.SlotStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Slot.SlotStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DataRequirement.SortDirection> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DataRequirement.SortDirection? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SpecimenDefinition.SpecimenContainedPreference> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SpecimenDefinition.SpecimenContainedPreference? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Specimen.SpecimenStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Specimen.SpecimenStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<VerificationResult.StatusCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		VerificationResult.StatusCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.StrandType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.StrandType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureDefinition.StructureDefinitionKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureDefinition.StructureDefinitionKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapContextType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapContextType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapGroupTypeMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapGroupTypeMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapInputMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapInputMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapModelMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapModelMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapSourceListMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapSourceListMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapTargetListMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapTargetListMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapTransform> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapTransform? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Subscription.SubscriptionChannelType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Subscription.SubscriptionChannelType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Subscription.SubscriptionStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Subscription.SubscriptionStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SupplyDelivery.SupplyDeliveryStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SupplyDelivery.SupplyDeliveryStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SupplyRequest.SupplyRequestStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SupplyRequest.SupplyRequestStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.SystemRestfulInteraction> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.SystemRestfulInteraction? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Task.TaskIntent> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Task.TaskIntent? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Task.TaskStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Task.TaskStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestReport.TestReportActionResult> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestReport.TestReportActionResult? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestReport.TestReportParticipantType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestReport.TestReportParticipantType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestReport.TestReportResult> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestReport.TestReportResult? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestReport.TestReportStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestReport.TestReportStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestScript.TestScriptRequestMethodCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestScript.TestScriptRequestMethodCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TriggerDefinition.TriggerType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TriggerDefinition.TriggerType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureDefinition.TypeDerivationRule> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureDefinition.TypeDerivationRule? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.TypeRestfulInteraction> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.TypeRestfulInteraction? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Device.UDIEntryType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Device.UDIEntryType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Timing.UnitsOfTime> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Timing.UnitsOfTime? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ClaimUseCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ClaimUseCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<VisionPrescription.VisionBase> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		VisionPrescription.VisionBase? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<VisionPrescription.VisionEyes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		VisionPrescription.VisionEyes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SearchParameter.XPathUsageType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SearchParameter.XPathUsageType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Base64Binary value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		byte[] a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("ToString")]
+	public string ToString(FhirString value)
+	{
+		string a_ = value?.Value;
 
 		return a_;
 	}
 
     [CqlDeclaration("ToString")]
-	public string ToString(FhirString value) => 
-		value?.Value;
+	public string ToString(FhirUri value)
+	{
+		string a_ = value?.Value;
+
+		return a_;
+	}
 
     [CqlDeclaration("ToString")]
-	public string ToString(FhirUri value) => 
-		value?.Value;
+	public string ToString(XHtml value)
+	{
+		string a_ = value?.Value;
 
-    [CqlDeclaration("ToString")]
-	public string ToString(XHtml value) => 
-		value?.Value;
+		return a_;
+	}
 
     [CqlDeclaration("ToBoolean")]
-	public bool? ToBoolean(FhirBoolean value) => 
-		value?.Value;
+	public bool? ToBoolean(FhirBoolean value)
+	{
+		bool? a_ = value?.Value;
+
+		return a_;
+	}
 
     [CqlDeclaration("ToDate")]
 	public CqlDate ToDate(Date value)
 	{
-		var a_ = context.Operators.ConvertStringToDate(value?.Value);
+		string a_ = value?.Value;
+		CqlDate b_ = context.Operators.ConvertStringToDate(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToDateTime")]
 	public CqlDateTime ToDateTime(FhirDateTime value)
 	{
-		var a_ = context.Operators.Convert<CqlDateTime>(value);
+		CqlDateTime a_ = context.Operators.Convert<CqlDateTime>(value);
 
 		return a_;
 	}
@@ -2521,25 +2785,35 @@ public class FHIRHelpers_4_3_000
     [CqlDeclaration("ToDateTime")]
 	public CqlDateTime ToDateTime(Instant value)
 	{
-		var a_ = context.Operators.Convert<CqlDateTime>(value?.Value);
+		DateTimeOffset? a_ = value?.Value;
+		CqlDateTime b_ = context.Operators.Convert<CqlDateTime>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("ToDecimal")]
+	public decimal? ToDecimal(FhirDecimal value)
+	{
+		decimal? a_ = value?.Value;
 
 		return a_;
 	}
 
-    [CqlDeclaration("ToDecimal")]
-	public decimal? ToDecimal(FhirDecimal value) => 
-		value?.Value;
-
     [CqlDeclaration("ToInteger")]
-	public int? ToInteger(Integer value) => 
-		value?.Value;
+	public int? ToInteger(Integer value)
+	{
+		int? a_ = value?.Value;
+
+		return a_;
+	}
 
     [CqlDeclaration("ToTime")]
 	public CqlTime ToTime(Time value)
 	{
-		var a_ = context.Operators.ConvertStringToTime(value?.Value);
+		string a_ = value?.Value;
+		CqlTime b_ = context.Operators.ConvertStringToTime(a_);
 
-		return a_;
+		return b_;
 	}
 
 }

--- a/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
@@ -100,333 +100,389 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Annual_Wellness_Visit"/>
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
+    /// <seealso cref="Annual_Wellness_Visit_Value"/>
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
 	public CqlValueSet Annual_Wellness_Visit() => 
 		__Annual_Wellness_Visit.Value;
 
+    /// <seealso cref="Audiology_Visit"/>
 	private CqlValueSet Audiology_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066", null);
 
+    /// <seealso cref="Audiology_Visit_Value"/>
     [CqlDeclaration("Audiology Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066")]
 	public CqlValueSet Audiology_Visit() => 
 		__Audiology_Visit.Value;
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility"/>
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility_Value"/>
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
 	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
+    /// <seealso cref="Discharge_Services_Nursing_Facility"/>
 	private CqlValueSet Discharge_Services_Nursing_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", null);
 
+    /// <seealso cref="Discharge_Services_Nursing_Facility_Value"/>
     [CqlDeclaration("Discharge Services Nursing Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013")]
 	public CqlValueSet Discharge_Services_Nursing_Facility() => 
 		__Discharge_Services_Nursing_Facility.Value;
 
+    /// <seealso cref="Falls_Screening"/>
 	private CqlValueSet Falls_Screening_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028", null);
 
+    /// <seealso cref="Falls_Screening_Value"/>
     [CqlDeclaration("Falls Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028")]
 	public CqlValueSet Falls_Screening() => 
 		__Falls_Screening.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Nursing_Facility_Visit"/>
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
+    /// <seealso cref="Nursing_Facility_Visit_Value"/>
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
 	public CqlValueSet Nursing_Facility_Visit() => 
 		__Nursing_Facility_Visit.Value;
 
+    /// <seealso cref="Occupational_Therapy_Evaluation"/>
 	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", null);
 
+    /// <seealso cref="Occupational_Therapy_Evaluation_Value"/>
     [CqlDeclaration("Occupational Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
 	public CqlValueSet Occupational_Therapy_Evaluation() => 
 		__Occupational_Therapy_Evaluation.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Ophthalmological_Services"/>
 	private CqlValueSet Ophthalmological_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
 
+    /// <seealso cref="Ophthalmological_Services_Value"/>
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
 	public CqlValueSet Ophthalmological_Services() => 
 		__Ophthalmological_Services.Value;
 
+    /// <seealso cref="Physical_Therapy_Evaluation"/>
 	private CqlValueSet Physical_Therapy_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", null);
 
+    /// <seealso cref="Physical_Therapy_Evaluation_Value"/>
     [CqlDeclaration("Physical Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022")]
 	public CqlValueSet Physical_Therapy_Evaluation() => 
 		__Physical_Therapy_Evaluation.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
 	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("FallsScreeningForFutureFallRiskFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("FallsScreeningForFutureFallRiskFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounter"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Annual_Wellness_Visit();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Home_Healthcare_Services();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Ophthalmological_Services();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Preventive_Care_Services_Individual_Counseling();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Discharge_Services_Nursing_Facility();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
-		var x_ = this.Nursing_Facility_Visit();
-		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
-		var z_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
-		var ab_ = context.Operators.Union<Encounter>(y_, aa_);
-		var ac_ = context.Operators.Union<Encounter>(w_, ab_);
-		var ad_ = this.Audiology_Visit();
-		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
-		var af_ = this.Telephone_Visits();
-		var ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
-		var ah_ = context.Operators.Union<Encounter>(ae_, ag_);
-		var ai_ = context.Operators.Union<Encounter>(ac_, ah_);
-		var aj_ = this.Online_Assessments();
-		var ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, null);
-		var al_ = this.Physical_Therapy_Evaluation();
-		var am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
-		var an_ = context.Operators.Union<Encounter>(ak_, am_);
-		var ao_ = context.Operators.Union<Encounter>(ai_, an_);
-		var ap_ = this.Occupational_Therapy_Evaluation();
-		var aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, null);
-		var ar_ = context.Operators.Union<Encounter>(ao_, aq_);
-		var as_ = Status_1_6_000.Finished_Encounter(ar_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Ophthalmological_Services();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Preventive_Care_Services_Individual_Counseling();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Discharge_Services_Nursing_Facility();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
+		CqlValueSet x_ = this.Nursing_Facility_Visit();
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		CqlValueSet z_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
+		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
+		CqlValueSet ad_ = this.Audiology_Visit();
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		CqlValueSet af_ = this.Telephone_Visits();
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		IEnumerable<Encounter> ah_ = context.Operators.Union<Encounter>(ae_, ag_);
+		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(ac_, ah_);
+		CqlValueSet aj_ = this.Online_Assessments();
+		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, null);
+		CqlValueSet al_ = this.Physical_Therapy_Evaluation();
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
+		IEnumerable<Encounter> ao_ = context.Operators.Union<Encounter>(ai_, an_);
+		CqlValueSet ap_ = this.Occupational_Therapy_Evaluation();
+		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, null);
+		IEnumerable<Encounter> ar_ = context.Operators.Union<Encounter>(ao_, aq_);
+		IEnumerable<Encounter> as_ = Status_1_6_000.Finished_Encounter(ar_);
 		bool? at_(Encounter ValidEncounter)
 		{
-			var av_ = this.Measurement_Period();
-			var aw_ = ValidEncounter?.Period;
-			var ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-			var ay_ = QICoreCommon_2_0_000.ToInterval((ax_ as object));
-			var az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(av_, ay_, "day");
+			CqlInterval<CqlDateTime> av_ = this.Measurement_Period();
+			Period aw_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+			CqlInterval<CqlDateTime> ay_ = QICoreCommon_2_0_000.ToInterval((ax_ as object));
+			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(av_, ay_, "day");
 
 			return az_;
 		};
-		var au_ = context.Operators.Where<Encounter>(as_, at_);
+		IEnumerable<Encounter> au_ = context.Operators.Where<Encounter>(as_, at_);
 
 		return au_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_Value"/>
     [CqlDeclaration("Qualifying Encounter")]
 	public IEnumerable<Encounter> Qualifying_Encounter() => 
 		__Qualifying_Encounter.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 65);
-		var h_ = this.Qualifying_Encounter();
-		var i_ = context.Operators.Exists<Encounter>(h_);
-		var j_ = context.Operators.And(g_, i_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 65);
+		IEnumerable<Encounter> j_ = this.Qualifying_Encounter();
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
+		bool? l_ = context.Operators.And(i_, k_);
 
-		return j_;
+		return l_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Falls_Screening();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		CqlValueSet a_ = this.Falls_Screening();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation FallsScreening)
 		{
-			var g_ = this.Measurement_Period();
-			var h_ = FallsScreening?.Effective;
-			var i_ = FHIRHelpers_4_3_000.ToValue(h_);
-			var j_ = QICoreCommon_2_0_000.ToInterval(i_);
-			var k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			DataType h_ = FallsScreening?.Effective;
+			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
+			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval(i_);
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
 
 			return k_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
-		var f_ = context.Operators.Exists<Observation>(e_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
+		bool? f_ = context.Operators.Exists<Observation>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
@@ -166,223 +166,278 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Ambulatory"/>
 	private CqlValueSet Ambulatory_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003", null);
 
+    /// <seealso cref="Ambulatory_Value"/>
     [CqlDeclaration("Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003")]
 	public CqlValueSet Ambulatory() => 
 		__Ambulatory.Value;
 
+    /// <seealso cref="Atomoxetine"/>
 	private CqlValueSet Atomoxetine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170", null);
 
+    /// <seealso cref="Atomoxetine_Value"/>
     [CqlDeclaration("Atomoxetine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170")]
 	public CqlValueSet Atomoxetine() => 
 		__Atomoxetine.Value;
 
+    /// <seealso cref="Behavioral_Health_Follow_up_Visit"/>
 	private CqlValueSet Behavioral_Health_Follow_up_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054", null);
 
+    /// <seealso cref="Behavioral_Health_Follow_up_Visit_Value"/>
     [CqlDeclaration("Behavioral Health Follow up Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054")]
 	public CqlValueSet Behavioral_Health_Follow_up_Visit() => 
 		__Behavioral_Health_Follow_up_Visit.Value;
 
+    /// <seealso cref="Clonidine"/>
 	private CqlValueSet Clonidine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171", null);
 
+    /// <seealso cref="Clonidine_Value"/>
     [CqlDeclaration("Clonidine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171")]
 	public CqlValueSet Clonidine() => 
 		__Clonidine.Value;
 
+    /// <seealso cref="Dexmethylphenidate"/>
 	private CqlValueSet Dexmethylphenidate_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172", null);
 
+    /// <seealso cref="Dexmethylphenidate_Value"/>
     [CqlDeclaration("Dexmethylphenidate")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172")]
 	public CqlValueSet Dexmethylphenidate() => 
 		__Dexmethylphenidate.Value;
 
+    /// <seealso cref="Dextroamphetamine"/>
 	private CqlValueSet Dextroamphetamine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173", null);
 
+    /// <seealso cref="Dextroamphetamine_Value"/>
     [CqlDeclaration("Dextroamphetamine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173")]
 	public CqlValueSet Dextroamphetamine() => 
 		__Dextroamphetamine.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Guanfacine"/>
 	private CqlValueSet Guanfacine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252", null);
 
+    /// <seealso cref="Guanfacine_Value"/>
     [CqlDeclaration("Guanfacine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252")]
 	public CqlValueSet Guanfacine() => 
 		__Guanfacine.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Initial_Hospital_Observation_Care"/>
 	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", null);
 
+    /// <seealso cref="Initial_Hospital_Observation_Care_Value"/>
     [CqlDeclaration("Initial Hospital Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
 	public CqlValueSet Initial_Hospital_Observation_Care() => 
 		__Initial_Hospital_Observation_Care.Value;
 
+    /// <seealso cref="Lisdexamfetamine"/>
 	private CqlValueSet Lisdexamfetamine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174", null);
 
+    /// <seealso cref="Lisdexamfetamine_Value"/>
     [CqlDeclaration("Lisdexamfetamine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174")]
 	public CqlValueSet Lisdexamfetamine() => 
 		__Lisdexamfetamine.Value;
 
+    /// <seealso cref="Mental_Behavioral_and_Neurodevelopmental_Disorders"/>
 	private CqlValueSet Mental_Behavioral_and_Neurodevelopmental_Disorders_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203", null);
 
+    /// <seealso cref="Mental_Behavioral_and_Neurodevelopmental_Disorders_Value"/>
     [CqlDeclaration("Mental Behavioral and Neurodevelopmental Disorders")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203")]
 	public CqlValueSet Mental_Behavioral_and_Neurodevelopmental_Disorders() => 
 		__Mental_Behavioral_and_Neurodevelopmental_Disorders.Value;
 
+    /// <seealso cref="Methylphenidate"/>
 	private CqlValueSet Methylphenidate_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176", null);
 
+    /// <seealso cref="Methylphenidate_Value"/>
     [CqlDeclaration("Methylphenidate")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176")]
 	public CqlValueSet Methylphenidate() => 
 		__Methylphenidate.Value;
 
+    /// <seealso cref="Narcolepsy"/>
 	private CqlValueSet Narcolepsy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011", null);
 
+    /// <seealso cref="Narcolepsy_Value"/>
     [CqlDeclaration("Narcolepsy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011")]
 	public CqlValueSet Narcolepsy() => 
 		__Narcolepsy.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Group_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
 
+    /// <seealso cref="Preventive_Care_Services_Group_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
 	public CqlValueSet Preventive_Care_Services_Group_Counseling() => 
 		__Preventive_Care_Services_Group_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
 	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
 	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
 	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation"/>
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation_Value"/>
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
 	public CqlValueSet Psych_Visit_Diagnostic_Evaluation() => 
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
+    /// <seealso cref="Psych_Visit_Psychotherapy"/>
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
 
+    /// <seealso cref="Psych_Visit_Psychotherapy_Value"/>
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
 	public CqlValueSet Psych_Visit_Psychotherapy() => 
 		__Psych_Visit_Psychotherapy.Value;
 
+    /// <seealso cref="Psychotherapy_and_Pharmacologic_Management"/>
 	private CqlValueSet Psychotherapy_and_Pharmacologic_Management_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055", null);
 
+    /// <seealso cref="Psychotherapy_and_Pharmacologic_Management_Value"/>
     [CqlDeclaration("Psychotherapy and Pharmacologic Management")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055")]
 	public CqlValueSet Psychotherapy_and_Pharmacologic_Management() => 
 		__Psychotherapy_and_Pharmacologic_Management.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="_24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule"/>
 	private CqlCode _24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule_Value() => 
 		new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="_24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule_Value"/>
     [CqlDeclaration("24 HR dexmethylphenidate hydrochloride 40 MG Extended Release Oral Capsule")]
 	public CqlCode _24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule() => 
 		___24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule.Value;
 
+    /// <seealso cref="methamphetamine_hydrochloride_5_MG_Oral_Tablet"/>
 	private CqlCode methamphetamine_hydrochloride_5_MG_Oral_Tablet_Value() => 
 		new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="methamphetamine_hydrochloride_5_MG_Oral_Tablet_Value"/>
     [CqlDeclaration("methamphetamine hydrochloride 5 MG Oral Tablet")]
 	public CqlCode methamphetamine_hydrochloride_5_MG_Oral_Tablet() => 
 		__methamphetamine_hydrochloride_5_MG_Oral_Tablet.Value;
 
+    /// <seealso cref="RXNORM"/>
 	private CqlCode[] RXNORM_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
 			new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
@@ -391,358 +446,377 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="RXNORM_Value"/>
     [CqlDeclaration("RXNORM")]
 	public CqlCode[] RXNORM() => 
 		__RXNORM.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="March_1_of_Year_Prior_to_Measurement_Period"/>
 	private CqlDateTime March_1_of_Year_Prior_to_Measurement_Period_Value()
 	{
-		var a_ = this.Measurement_Period();
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateTimeComponentFrom(b_, "year");
-		var d_ = context.Operators.Subtract(c_, 1);
-		var e_ = context.Operators.ConvertIntegerToDecimal(0);
-		var f_ = context.Operators.DateTime(d_, 3, 1, 0, 0, 0, 0, e_);
+		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
+		CqlDateTime b_ = context.Operators.Start(a_);
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? d_ = context.Operators.Subtract(c_, 1);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
+		CqlDateTime f_ = context.Operators.DateTime(d_, 3, 1, 0, 0, 0, 0, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="March_1_of_Year_Prior_to_Measurement_Period_Value"/>
     [CqlDeclaration("March 1 of Year Prior to Measurement Period")]
 	public CqlDateTime March_1_of_Year_Prior_to_Measurement_Period() => 
 		__March_1_of_Year_Prior_to_Measurement_Period.Value;
 
+    /// <seealso cref="Last_Calendar_Day_of_February_of_Measurement_Period"/>
 	private CqlDateTime Last_Calendar_Day_of_February_of_Measurement_Period_Value()
 	{
-		var a_ = this.Measurement_Period();
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateTimeComponentFrom(b_, "year");
-		var d_ = context.Operators.ConvertIntegerToDecimal(0);
-		var e_ = context.Operators.DateTime(c_, 3, 1, 23, 59, 59, 0, d_);
-		var f_ = context.Operators.Quantity(1m, "day");
-		var g_ = context.Operators.Subtract(e_, f_);
+		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
+		CqlDateTime b_ = context.Operators.Start(a_);
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		decimal? d_ = context.Operators.ConvertIntegerToDecimal(0);
+		CqlDateTime e_ = context.Operators.DateTime(c_, 3, 1, 23, 59, 59, 0, d_);
+		CqlQuantity f_ = context.Operators.Quantity(1m, "day");
+		CqlDateTime g_ = context.Operators.Subtract(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Last_Calendar_Day_of_February_of_Measurement_Period_Value"/>
     [CqlDeclaration("Last Calendar Day of February of Measurement Period")]
 	public CqlDateTime Last_Calendar_Day_of_February_of_Measurement_Period() => 
 		__Last_Calendar_Day_of_February_of_Measurement_Period.Value;
 
+    /// <seealso cref="Intake_Period"/>
 	private CqlInterval<CqlDateTime> Intake_Period_Value()
 	{
-		var a_ = this.March_1_of_Year_Prior_to_Measurement_Period();
-		var b_ = this.Last_Calendar_Day_of_February_of_Measurement_Period();
-		var c_ = context.Operators.Interval(a_, b_, true, true);
+		CqlDateTime a_ = this.March_1_of_Year_Prior_to_Measurement_Period();
+		CqlDateTime b_ = this.Last_Calendar_Day_of_February_of_Measurement_Period();
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, true);
 
 		return c_;
 	}
 
+    /// <seealso cref="Intake_Period_Value"/>
     [CqlDeclaration("Intake Period")]
 	public CqlInterval<CqlDateTime> Intake_Period() => 
 		__Intake_Period.Value;
 
+    /// <seealso cref="ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication"/>
 	private IEnumerable<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW> ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication_Value()
 	{
-		var a_ = this.Atomoxetine();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = this.Clonidine();
-		var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		var j_ = context.Operators.Union<MedicationRequest>(g_, i_);
-		var k_ = context.Operators.Union<MedicationRequest>(e_, j_);
-		var l_ = this.Dexmethylphenidate();
-		var m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
-		var o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
-		var p_ = context.Operators.Union<MedicationRequest>(m_, o_);
-		var q_ = context.Operators.Union<MedicationRequest>(k_, p_);
-		var r_ = this.Dextroamphetamine();
-		var s_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
-		var u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
-		var v_ = context.Operators.Union<MedicationRequest>(s_, u_);
-		var w_ = context.Operators.Union<MedicationRequest>(q_, v_);
-		var x_ = this.Lisdexamfetamine();
-		var y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
-		var aa_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
-		var ab_ = context.Operators.Union<MedicationRequest>(y_, aa_);
-		var ac_ = context.Operators.Union<MedicationRequest>(w_, ab_);
-		var ad_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
-		var ae_ = context.Operators.ToList<CqlCode>(ad_);
-		var af_ = context.Operators.RetrieveByCodes<MedicationRequest>(ae_, null);
-		var ah_ = context.Operators.ToList<CqlCode>(ad_);
-		var ai_ = context.Operators.RetrieveByCodes<MedicationRequest>(ah_, null);
-		var aj_ = context.Operators.Union<MedicationRequest>(af_, ai_);
-		var ak_ = context.Operators.Union<MedicationRequest>(ac_, aj_);
-		var al_ = this.Methylphenidate();
-		var am_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
-		var ao_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
-		var ap_ = context.Operators.Union<MedicationRequest>(am_, ao_);
-		var aq_ = context.Operators.Union<MedicationRequest>(ak_, ap_);
-		var ar_ = this.Guanfacine();
-		var as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
-		var au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
-		var av_ = context.Operators.Union<MedicationRequest>(as_, au_);
-		var aw_ = context.Operators.Union<MedicationRequest>(aq_, av_);
+		CqlValueSet a_ = this.Atomoxetine();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet f_ = this.Clonidine();
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
+		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(e_, j_);
+		CqlValueSet l_ = this.Dexmethylphenidate();
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(m_, o_);
+		IEnumerable<MedicationRequest> q_ = context.Operators.Union<MedicationRequest>(k_, p_);
+		CqlValueSet r_ = this.Dextroamphetamine();
+		IEnumerable<MedicationRequest> s_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		IEnumerable<MedicationRequest> v_ = context.Operators.Union<MedicationRequest>(s_, u_);
+		IEnumerable<MedicationRequest> w_ = context.Operators.Union<MedicationRequest>(q_, v_);
+		CqlValueSet x_ = this.Lisdexamfetamine();
+		IEnumerable<MedicationRequest> y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		IEnumerable<MedicationRequest> aa_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		IEnumerable<MedicationRequest> ab_ = context.Operators.Union<MedicationRequest>(y_, aa_);
+		IEnumerable<MedicationRequest> ac_ = context.Operators.Union<MedicationRequest>(w_, ab_);
+		CqlCode ad_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
+		IEnumerable<CqlCode> ae_ = context.Operators.ToList<CqlCode>(ad_);
+		IEnumerable<MedicationRequest> af_ = context.Operators.RetrieveByCodes<MedicationRequest>(ae_, null);
+		IEnumerable<CqlCode> ah_ = context.Operators.ToList<CqlCode>(ad_);
+		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByCodes<MedicationRequest>(ah_, null);
+		IEnumerable<MedicationRequest> aj_ = context.Operators.Union<MedicationRequest>(af_, ai_);
+		IEnumerable<MedicationRequest> ak_ = context.Operators.Union<MedicationRequest>(ac_, aj_);
+		CqlValueSet al_ = this.Methylphenidate();
+		IEnumerable<MedicationRequest> am_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		IEnumerable<MedicationRequest> ao_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		IEnumerable<MedicationRequest> ap_ = context.Operators.Union<MedicationRequest>(am_, ao_);
+		IEnumerable<MedicationRequest> aq_ = context.Operators.Union<MedicationRequest>(ak_, ap_);
+		CqlValueSet ar_ = this.Guanfacine();
+		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		IEnumerable<MedicationRequest> av_ = context.Operators.Union<MedicationRequest>(as_, au_);
+		IEnumerable<MedicationRequest> aw_ = context.Operators.Union<MedicationRequest>(aq_, av_);
 		bool? ax_(MedicationRequest ADHDMedications)
 		{
-			var df_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ADHDMedications);
-			var dg_ = context.Operators.Start(df_);
-			var dh_ = context.Operators.ConvertDateToDateTime(dg_);
-			var di_ = this.Intake_Period();
-			var dj_ = context.Operators.In<CqlDateTime>(dh_, di_, null);
+			CqlInterval<CqlDate> df_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ADHDMedications);
+			CqlDate dg_ = context.Operators.Start(df_);
+			CqlDateTime dh_ = context.Operators.ConvertDateToDateTime(dg_);
+			CqlInterval<CqlDateTime> di_ = this.Intake_Period();
+			bool? dj_ = context.Operators.In<CqlDateTime>(dh_, di_, null);
 
 			return dj_;
 		};
-		var ay_ = context.Operators.Where<MedicationRequest>(aw_, ax_);
-		var ba_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var bc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var bd_ = context.Operators.Union<MedicationRequest>(ba_, bc_);
-		var bf_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		var bh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		var bi_ = context.Operators.Union<MedicationRequest>(bf_, bh_);
-		var bj_ = context.Operators.Union<MedicationRequest>(bd_, bi_);
-		var bl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
-		var bn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
-		var bo_ = context.Operators.Union<MedicationRequest>(bl_, bn_);
-		var bp_ = context.Operators.Union<MedicationRequest>(bj_, bo_);
-		var br_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
-		var bt_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
-		var bu_ = context.Operators.Union<MedicationRequest>(br_, bt_);
-		var bv_ = context.Operators.Union<MedicationRequest>(bp_, bu_);
-		var bx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
-		var bz_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
-		var ca_ = context.Operators.Union<MedicationRequest>(bx_, bz_);
-		var cb_ = context.Operators.Union<MedicationRequest>(bv_, ca_);
-		var cd_ = context.Operators.ToList<CqlCode>(ad_);
-		var ce_ = context.Operators.RetrieveByCodes<MedicationRequest>(cd_, null);
-		var cg_ = context.Operators.ToList<CqlCode>(ad_);
-		var ch_ = context.Operators.RetrieveByCodes<MedicationRequest>(cg_, null);
-		var ci_ = context.Operators.Union<MedicationRequest>(ce_, ch_);
-		var cj_ = context.Operators.Union<MedicationRequest>(cb_, ci_);
-		var cl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
-		var cn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
-		var co_ = context.Operators.Union<MedicationRequest>(cl_, cn_);
-		var cp_ = context.Operators.Union<MedicationRequest>(cj_, co_);
-		var cr_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
-		var ct_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
-		var cu_ = context.Operators.Union<MedicationRequest>(cr_, ct_);
-		var cv_ = context.Operators.Union<MedicationRequest>(cp_, cu_);
+		IEnumerable<MedicationRequest> ay_ = context.Operators.Where<MedicationRequest>(aw_, ax_);
+		IEnumerable<MedicationRequest> ba_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> bc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> bd_ = context.Operators.Union<MedicationRequest>(ba_, bc_);
+		IEnumerable<MedicationRequest> bf_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> bh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> bi_ = context.Operators.Union<MedicationRequest>(bf_, bh_);
+		IEnumerable<MedicationRequest> bj_ = context.Operators.Union<MedicationRequest>(bd_, bi_);
+		IEnumerable<MedicationRequest> bl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		IEnumerable<MedicationRequest> bn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		IEnumerable<MedicationRequest> bo_ = context.Operators.Union<MedicationRequest>(bl_, bn_);
+		IEnumerable<MedicationRequest> bp_ = context.Operators.Union<MedicationRequest>(bj_, bo_);
+		IEnumerable<MedicationRequest> br_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		IEnumerable<MedicationRequest> bt_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		IEnumerable<MedicationRequest> bu_ = context.Operators.Union<MedicationRequest>(br_, bt_);
+		IEnumerable<MedicationRequest> bv_ = context.Operators.Union<MedicationRequest>(bp_, bu_);
+		IEnumerable<MedicationRequest> bx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		IEnumerable<MedicationRequest> bz_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		IEnumerable<MedicationRequest> ca_ = context.Operators.Union<MedicationRequest>(bx_, bz_);
+		IEnumerable<MedicationRequest> cb_ = context.Operators.Union<MedicationRequest>(bv_, ca_);
+		IEnumerable<CqlCode> cd_ = context.Operators.ToList<CqlCode>(ad_);
+		IEnumerable<MedicationRequest> ce_ = context.Operators.RetrieveByCodes<MedicationRequest>(cd_, null);
+		IEnumerable<CqlCode> cg_ = context.Operators.ToList<CqlCode>(ad_);
+		IEnumerable<MedicationRequest> ch_ = context.Operators.RetrieveByCodes<MedicationRequest>(cg_, null);
+		IEnumerable<MedicationRequest> ci_ = context.Operators.Union<MedicationRequest>(ce_, ch_);
+		IEnumerable<MedicationRequest> cj_ = context.Operators.Union<MedicationRequest>(cb_, ci_);
+		IEnumerable<MedicationRequest> cl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		IEnumerable<MedicationRequest> cn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		IEnumerable<MedicationRequest> co_ = context.Operators.Union<MedicationRequest>(cl_, cn_);
+		IEnumerable<MedicationRequest> cp_ = context.Operators.Union<MedicationRequest>(cj_, co_);
+		IEnumerable<MedicationRequest> cr_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		IEnumerable<MedicationRequest> ct_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		IEnumerable<MedicationRequest> cu_ = context.Operators.Union<MedicationRequest>(cr_, ct_);
+		IEnumerable<MedicationRequest> cv_ = context.Operators.Union<MedicationRequest>(cp_, cu_);
 		bool? cw_(MedicationRequest ADHDMedications)
 		{
-			var dk_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ADHDMedications);
-			var dl_ = context.Operators.Start(dk_);
-			var dm_ = context.Operators.ConvertDateToDateTime(dl_);
-			var dn_ = this.Intake_Period();
-			var do_ = context.Operators.In<CqlDateTime>(dm_, dn_, null);
+			CqlInterval<CqlDate> dk_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ADHDMedications);
+			CqlDate dl_ = context.Operators.Start(dk_);
+			CqlDateTime dm_ = context.Operators.ConvertDateToDateTime(dl_);
+			CqlInterval<CqlDateTime> dn_ = this.Intake_Period();
+			bool? do_ = context.Operators.In<CqlDateTime>(dm_, dn_, null);
 
 			return do_;
 		};
-		var cx_ = context.Operators.Where<MedicationRequest>(cv_, cw_);
+		IEnumerable<MedicationRequest> cx_ = context.Operators.Where<MedicationRequest>(cv_, cw_);
 		IEnumerable<MedicationRequest> cy_(MedicationRequest ADHDMedicationOrder)
 		{
-			var dp_ = this.Atomoxetine();
-			var dq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, null);
-			var ds_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, null);
-			var dt_ = context.Operators.Union<MedicationRequest>(dq_, ds_);
-			var du_ = this.Clonidine();
-			var dv_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, null);
-			var dx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, null);
-			var dy_ = context.Operators.Union<MedicationRequest>(dv_, dx_);
-			var dz_ = context.Operators.Union<MedicationRequest>(dt_, dy_);
-			var ea_ = this.Dexmethylphenidate();
-			var eb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, null);
-			var ed_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, null);
-			var ee_ = context.Operators.Union<MedicationRequest>(eb_, ed_);
-			var ef_ = context.Operators.Union<MedicationRequest>(dz_, ee_);
-			var eg_ = this.Dextroamphetamine();
-			var eh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, null);
-			var ej_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, null);
-			var ek_ = context.Operators.Union<MedicationRequest>(eh_, ej_);
-			var el_ = context.Operators.Union<MedicationRequest>(ef_, ek_);
-			var em_ = this.Lisdexamfetamine();
-			var en_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, null);
-			var ep_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, null);
-			var eq_ = context.Operators.Union<MedicationRequest>(en_, ep_);
-			var er_ = context.Operators.Union<MedicationRequest>(el_, eq_);
-			var es_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
-			var et_ = context.Operators.ToList<CqlCode>(es_);
-			var eu_ = context.Operators.RetrieveByCodes<MedicationRequest>(et_, null);
-			var ew_ = context.Operators.ToList<CqlCode>(es_);
-			var ex_ = context.Operators.RetrieveByCodes<MedicationRequest>(ew_, null);
-			var ey_ = context.Operators.Union<MedicationRequest>(eu_, ex_);
-			var ez_ = context.Operators.Union<MedicationRequest>(er_, ey_);
-			var fa_ = this.Methylphenidate();
-			var fb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, null);
-			var fd_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, null);
-			var fe_ = context.Operators.Union<MedicationRequest>(fb_, fd_);
-			var ff_ = context.Operators.Union<MedicationRequest>(ez_, fe_);
-			var fg_ = this.Guanfacine();
-			var fh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, null);
-			var fj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, null);
-			var fk_ = context.Operators.Union<MedicationRequest>(fh_, fj_);
-			var fl_ = context.Operators.Union<MedicationRequest>(ff_, fk_);
+			CqlValueSet dp_ = this.Atomoxetine();
+			IEnumerable<MedicationRequest> dq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, null);
+			IEnumerable<MedicationRequest> ds_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, null);
+			IEnumerable<MedicationRequest> dt_ = context.Operators.Union<MedicationRequest>(dq_, ds_);
+			CqlValueSet du_ = this.Clonidine();
+			IEnumerable<MedicationRequest> dv_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, null);
+			IEnumerable<MedicationRequest> dx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, null);
+			IEnumerable<MedicationRequest> dy_ = context.Operators.Union<MedicationRequest>(dv_, dx_);
+			IEnumerable<MedicationRequest> dz_ = context.Operators.Union<MedicationRequest>(dt_, dy_);
+			CqlValueSet ea_ = this.Dexmethylphenidate();
+			IEnumerable<MedicationRequest> eb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, null);
+			IEnumerable<MedicationRequest> ed_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, null);
+			IEnumerable<MedicationRequest> ee_ = context.Operators.Union<MedicationRequest>(eb_, ed_);
+			IEnumerable<MedicationRequest> ef_ = context.Operators.Union<MedicationRequest>(dz_, ee_);
+			CqlValueSet eg_ = this.Dextroamphetamine();
+			IEnumerable<MedicationRequest> eh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, null);
+			IEnumerable<MedicationRequest> ej_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, null);
+			IEnumerable<MedicationRequest> ek_ = context.Operators.Union<MedicationRequest>(eh_, ej_);
+			IEnumerable<MedicationRequest> el_ = context.Operators.Union<MedicationRequest>(ef_, ek_);
+			CqlValueSet em_ = this.Lisdexamfetamine();
+			IEnumerable<MedicationRequest> en_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, null);
+			IEnumerable<MedicationRequest> ep_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, null);
+			IEnumerable<MedicationRequest> eq_ = context.Operators.Union<MedicationRequest>(en_, ep_);
+			IEnumerable<MedicationRequest> er_ = context.Operators.Union<MedicationRequest>(el_, eq_);
+			CqlCode es_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
+			IEnumerable<CqlCode> et_ = context.Operators.ToList<CqlCode>(es_);
+			IEnumerable<MedicationRequest> eu_ = context.Operators.RetrieveByCodes<MedicationRequest>(et_, null);
+			IEnumerable<CqlCode> ew_ = context.Operators.ToList<CqlCode>(es_);
+			IEnumerable<MedicationRequest> ex_ = context.Operators.RetrieveByCodes<MedicationRequest>(ew_, null);
+			IEnumerable<MedicationRequest> ey_ = context.Operators.Union<MedicationRequest>(eu_, ex_);
+			IEnumerable<MedicationRequest> ez_ = context.Operators.Union<MedicationRequest>(er_, ey_);
+			CqlValueSet fa_ = this.Methylphenidate();
+			IEnumerable<MedicationRequest> fb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, null);
+			IEnumerable<MedicationRequest> fd_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, null);
+			IEnumerable<MedicationRequest> fe_ = context.Operators.Union<MedicationRequest>(fb_, fd_);
+			IEnumerable<MedicationRequest> ff_ = context.Operators.Union<MedicationRequest>(ez_, fe_);
+			CqlValueSet fg_ = this.Guanfacine();
+			IEnumerable<MedicationRequest> fh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, null);
+			IEnumerable<MedicationRequest> fj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, null);
+			IEnumerable<MedicationRequest> fk_ = context.Operators.Union<MedicationRequest>(fh_, fj_);
+			IEnumerable<MedicationRequest> fl_ = context.Operators.Union<MedicationRequest>(ff_, fk_);
 			bool? fm_(MedicationRequest ActiveADHDMedication)
 			{
-				var fq_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ActiveADHDMedication);
-				var fr_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ADHDMedicationOrder);
-				var fs_ = context.Operators.Start(fr_);
-				var ft_ = context.Operators.ConvertDateToDateTime(fs_);
-				var fu_ = context.Operators.DateFrom(ft_);
-				var fv_ = context.Operators.Quantity(120m, "days");
-				var fw_ = context.Operators.Subtract(fu_, fv_);
-				var fy_ = context.Operators.Start(fr_);
-				var fz_ = context.Operators.ConvertDateToDateTime(fy_);
-				var ga_ = context.Operators.DateFrom(fz_);
-				var gb_ = context.Operators.Interval(fw_, ga_, true, false);
-				var gc_ = context.Operators.Overlaps(fq_, gb_, null);
+				CqlInterval<CqlDate> fq_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ActiveADHDMedication);
+				CqlInterval<CqlDate> fr_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ADHDMedicationOrder);
+				CqlDate fs_ = context.Operators.Start(fr_);
+				CqlDateTime ft_ = context.Operators.ConvertDateToDateTime(fs_);
+				CqlDate fu_ = context.Operators.DateFrom(ft_);
+				CqlQuantity fv_ = context.Operators.Quantity(120m, "days");
+				CqlDate fw_ = context.Operators.Subtract(fu_, fv_);
+				CqlDate fy_ = context.Operators.Start(fr_);
+				CqlDateTime fz_ = context.Operators.ConvertDateToDateTime(fy_);
+				CqlDate ga_ = context.Operators.DateFrom(fz_);
+				CqlInterval<CqlDate> gb_ = context.Operators.Interval(fw_, ga_, true, false);
+				bool? gc_ = context.Operators.Overlaps(fq_, gb_, null);
 
 				return gc_;
 			};
-			var fn_ = context.Operators.Where<MedicationRequest>(fl_, fm_);
+			IEnumerable<MedicationRequest> fn_ = context.Operators.Where<MedicationRequest>(fl_, fm_);
 			MedicationRequest fo_(MedicationRequest ActiveADHDMedication) => 
 				ADHDMedicationOrder;
-			var fp_ = context.Operators.Select<MedicationRequest, MedicationRequest>(fn_, fo_);
+			IEnumerable<MedicationRequest> fp_ = context.Operators.Select<MedicationRequest, MedicationRequest>(fn_, fo_);
 
 			return fp_;
 		};
-		var cz_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(cx_, cy_);
-		var da_ = context.Operators.Except<MedicationRequest>(ay_, cz_);
+		IEnumerable<MedicationRequest> cz_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(cx_, cy_);
+		IEnumerable<MedicationRequest> da_ = context.Operators.Except<MedicationRequest>(ay_, cz_);
 		Tuple_CVELXTjiMTaGQEjMfJXBdUHjW db_(MedicationRequest QualifyingMed)
 		{
-			var gd_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(QualifyingMed);
-			var ge_ = context.Operators.Start(gd_);
-			var gf_ = new Tuple_CVELXTjiMTaGQEjMfJXBdUHjW
+			CqlInterval<CqlDate> gd_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(QualifyingMed);
+			CqlDate ge_ = context.Operators.Start(gd_);
+			Tuple_CVELXTjiMTaGQEjMfJXBdUHjW gf_ = new Tuple_CVELXTjiMTaGQEjMfJXBdUHjW
 			{
 				startDate = ge_,
 			};
 
 			return gf_;
 		};
-		var dc_ = context.Operators.Select<MedicationRequest, Tuple_CVELXTjiMTaGQEjMfJXBdUHjW>(da_, db_);
+		IEnumerable<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW> dc_ = context.Operators.Select<MedicationRequest, Tuple_CVELXTjiMTaGQEjMfJXBdUHjW>(da_, db_);
 		object dd_(Tuple_CVELXTjiMTaGQEjMfJXBdUHjW @this)
 		{
-			var gg_ = @this?.startDate;
+			CqlDate gg_ = @this?.startDate;
 
 			return gg_;
 		};
-		var de_ = context.Operators.SortBy<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW>(dc_, dd_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW> de_ = context.Operators.SortBy<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW>(dc_, dd_, System.ComponentModel.ListSortDirection.Ascending);
 
 		return de_;
 	}
 
+    /// <seealso cref="ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication_Value"/>
     [CqlDeclaration("ADHD Medication Prescribed During Intake Period and Not Previously on ADHD Medication")]
 	public IEnumerable<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW> ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication() => 
 		__ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication.Value;
 
+    /// <seealso cref="First_ADHD_Medication_Prescribed_During_Intake_Period"/>
 	private CqlDate First_ADHD_Medication_Prescribed_During_Intake_Period_Value()
 	{
-		var a_ = this.ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication();
+		IEnumerable<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW> a_ = this.ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication();
 		bool? b_(Tuple_CVELXTjiMTaGQEjMfJXBdUHjW @this)
 		{
-			var g_ = @this?.startDate;
-			var h_ = context.Operators.Not((bool?)(g_ is null));
+			CqlDate g_ = @this?.startDate;
+			bool? h_ = context.Operators.Not((bool?)(g_ is null));
 
 			return h_;
 		};
-		var c_ = context.Operators.Where<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW>(a_, b_);
+		IEnumerable<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW> c_ = context.Operators.Where<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW>(a_, b_);
 		CqlDate d_(Tuple_CVELXTjiMTaGQEjMfJXBdUHjW @this)
 		{
-			var i_ = @this?.startDate;
+			CqlDate i_ = @this?.startDate;
 
 			return i_;
 		};
-		var e_ = context.Operators.Select<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW, CqlDate>(c_, d_);
-		var f_ = context.Operators.First<CqlDate>(e_);
+		IEnumerable<CqlDate> e_ = context.Operators.Select<Tuple_CVELXTjiMTaGQEjMfJXBdUHjW, CqlDate>(c_, d_);
+		CqlDate f_ = context.Operators.First<CqlDate>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="First_ADHD_Medication_Prescribed_During_Intake_Period_Value"/>
     [CqlDeclaration("First ADHD Medication Prescribed During Intake Period")]
 	public CqlDate First_ADHD_Medication_Prescribed_During_Intake_Period() => 
 		__First_ADHD_Medication_Prescribed_During_Intake_Period.Value;
 
+    /// <seealso cref="IPSD"/>
 	private CqlDate IPSD_Value()
 	{
-		var a_ = this.First_ADHD_Medication_Prescribed_During_Intake_Period();
+		CqlDate a_ = this.First_ADHD_Medication_Prescribed_During_Intake_Period();
 
 		return a_;
 	}
 
+    /// <seealso cref="IPSD_Value"/>
     [CqlDeclaration("IPSD")]
 	public CqlDate IPSD() => 
 		__IPSD.Value;
 
+    /// <seealso cref="Qualifying_Encounter"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Home_Healthcare_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		bool? l_(Encounter ValidEncounters)
 		{
-			var n_ = this.IPSD();
-			var o_ = context.Operators.Quantity(6m, "months");
-			var p_ = context.Operators.Subtract(n_, o_);
-			var r_ = context.Operators.Interval(p_, n_, true, true);
-			var s_ = r_?.low;
-			var t_ = context.Operators.ConvertDateToDateTime(s_);
-			var w_ = context.Operators.Subtract(n_, o_);
-			var y_ = context.Operators.Interval(w_, n_, true, true);
-			var z_ = y_?.high;
-			var aa_ = context.Operators.ConvertDateToDateTime(z_);
-			var ad_ = context.Operators.Subtract(n_, o_);
-			var af_ = context.Operators.Interval(ad_, n_, true, true);
-			var ag_ = af_?.lowClosed;
-			var aj_ = context.Operators.Subtract(n_, o_);
-			var al_ = context.Operators.Interval(aj_, n_, true, true);
-			var am_ = al_?.highClosed;
-			var an_ = context.Operators.Interval(t_, aa_, ag_, am_);
-			var ao_ = ValidEncounters?.Period;
-			var ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
-			var aq_ = QICoreCommon_2_0_000.ToInterval((ap_ as object));
-			var ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(an_, aq_, "day");
+			CqlDate n_ = this.IPSD();
+			CqlQuantity o_ = context.Operators.Quantity(6m, "months");
+			CqlDate p_ = context.Operators.Subtract(n_, o_);
+			CqlInterval<CqlDate> r_ = context.Operators.Interval(p_, n_, true, true);
+			CqlDate s_ = r_?.low;
+			CqlDateTime t_ = context.Operators.ConvertDateToDateTime(s_);
+			CqlDate w_ = context.Operators.Subtract(n_, o_);
+			CqlInterval<CqlDate> y_ = context.Operators.Interval(w_, n_, true, true);
+			CqlDate z_ = y_?.high;
+			CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+			CqlDate ad_ = context.Operators.Subtract(n_, o_);
+			CqlInterval<CqlDate> af_ = context.Operators.Interval(ad_, n_, true, true);
+			bool? ag_ = af_?.lowClosed;
+			CqlDate aj_ = context.Operators.Subtract(n_, o_);
+			CqlInterval<CqlDate> al_ = context.Operators.Interval(aj_, n_, true, true);
+			bool? am_ = al_?.highClosed;
+			CqlInterval<CqlDateTime> an_ = context.Operators.Interval(t_, aa_, ag_, am_);
+			Period ao_ = ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
+			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.ToInterval((ap_ as object));
+			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(an_, aq_, "day");
 
 			return ar_;
 		};
-		var m_ = context.Operators.Where<Encounter>(k_, l_);
+		IEnumerable<Encounter> m_ = context.Operators.Where<Encounter>(k_, l_);
 
 		return m_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_Value"/>
     [CqlDeclaration("Qualifying Encounter")]
 	public IEnumerable<Encounter> Qualifying_Encounter() => 
 		__Qualifying_Encounter.Value;
@@ -750,304 +824,328 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
     [CqlDeclaration("PrincipalDiagnosis")]
 	public IEnumerable<Condition> PrincipalDiagnosis(Encounter Encounter)
 	{
-		bool? a_(Encounter.DiagnosisComponent D)
+		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
+		bool? b_(Encounter.DiagnosisComponent D)
 		{
-			var e_ = D?.RankElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.Equal(f_, 1);
-
-			return g_;
-		};
-		var b_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)Encounter?.Diagnosis, a_);
-		Condition c_(Encounter.DiagnosisComponent PD)
-		{
-			var h_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-			bool? i_(Condition C)
-			{
-				var l_ = C?.IdElement;
-				var m_ = l_?.Value;
-				var n_ = PD?.Condition;
-				var o_ = n_?.ReferenceElement;
-				var p_ = o_?.Value;
-				var q_ = QICoreCommon_2_0_000.getId(p_);
-				var r_ = context.Operators.Equal(m_, q_);
-
-				return r_;
-			};
-			var j_ = context.Operators.Where<Condition>(h_, i_);
-			var k_ = context.Operators.SingletonFrom<Condition>(j_);
-
-			return k_;
-		};
-		var d_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(b_, c_);
-
-		return d_;
-	}
-
-	private IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_Value()
-	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		bool? c_(Encounter InpatientStay)
-		{
-			var e_ = this.PrincipalDiagnosis(InpatientStay);
-			bool? f_(Condition EncounterDiagnosis)
-			{
-				var i_ = EncounterDiagnosis?.Code;
-				var j_ = FHIRHelpers_4_3_000.ToConcept(i_);
-				var k_ = this.Mental_Behavioral_and_Neurodevelopmental_Disorders();
-				var l_ = context.Operators.ConceptInValueSet(j_, k_);
-
-				return l_;
-			};
-			var g_ = context.Operators.Where<Condition>(e_, f_);
-			var h_ = context.Operators.Exists<Condition>(g_);
+			PositiveInt f_ = D?.RankElement;
+			int? g_ = f_?.Value;
+			bool? h_ = context.Operators.Equal(g_, 1);
 
 			return h_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
+		Condition d_(Encounter.DiagnosisComponent PD)
+		{
+			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? j_(Condition C)
+			{
+				Id m_ = C?.IdElement;
+				string n_ = m_?.Value;
+				ResourceReference o_ = PD?.Condition;
+				FhirString p_ = o_?.ReferenceElement;
+				string q_ = p_?.Value;
+				string r_ = QICoreCommon_2_0_000.getId(q_);
+				bool? s_ = context.Operators.Equal(n_, r_);
+
+				return s_;
+			};
+			IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
+			Condition l_ = context.Operators.SingletonFrom<Condition>(k_);
+
+			return l_;
+		};
+		IEnumerable<Condition> e_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(c_, d_);
+
+		return e_;
+	}
+
+    /// <seealso cref="Inpatient_Stay_with_Qualifying_Diagnosis"/>
+	private IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_Value()
+	{
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter InpatientStay)
+		{
+			IEnumerable<Condition> e_ = this.PrincipalDiagnosis(InpatientStay);
+			bool? f_(Condition EncounterDiagnosis)
+			{
+				CodeableConcept i_ = EncounterDiagnosis?.Code;
+				CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
+				CqlValueSet k_ = this.Mental_Behavioral_and_Neurodevelopmental_Disorders();
+				bool? l_ = context.Operators.ConceptInValueSet(j_, k_);
+
+				return l_;
+			};
+			IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+			bool? h_ = context.Operators.Exists<Condition>(g_);
+
+			return h_;
+		};
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Inpatient_Stay_with_Qualifying_Diagnosis_Value"/>
     [CqlDeclaration("Inpatient Stay with Qualifying Diagnosis")]
 	public IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis() => 
 		__Inpatient_Stay_with_Qualifying_Diagnosis.Value;
 
+    /// <seealso cref="Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase"/>
 	private IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase_Value()
 	{
-		var a_ = this.Inpatient_Stay_with_Qualifying_Diagnosis();
+		IEnumerable<Encounter> a_ = this.Inpatient_Stay_with_Qualifying_Diagnosis();
 		bool? b_(Encounter InpatientStay)
 		{
-			var d_ = InpatientStay?.Period;
-			var e_ = FHIRHelpers_4_3_000.ToInterval(d_);
-			var f_ = CQMCommon_2_0_000.ToDateInterval(e_);
-			var g_ = context.Operators.Start(f_);
-			var h_ = this.IPSD();
-			var j_ = context.Operators.Quantity(30m, "days");
-			var k_ = context.Operators.Add(h_, j_);
-			var l_ = context.Operators.Interval(h_, k_, false, true);
-			var m_ = context.Operators.In<CqlDate>(g_, l_, "day");
-			var o_ = context.Operators.Not((bool?)(h_ is null));
-			var p_ = context.Operators.And(m_, o_);
+			Period d_ = InpatientStay?.Period;
+			CqlInterval<CqlDateTime> e_ = FHIRHelpers_4_3_000.ToInterval(d_);
+			CqlInterval<CqlDate> f_ = CQMCommon_2_0_000.ToDateInterval(e_);
+			CqlDate g_ = context.Operators.Start(f_);
+			CqlDate h_ = this.IPSD();
+			CqlQuantity j_ = context.Operators.Quantity(30m, "days");
+			CqlDate k_ = context.Operators.Add(h_, j_);
+			CqlInterval<CqlDate> l_ = context.Operators.Interval(h_, k_, false, true);
+			bool? m_ = context.Operators.In<CqlDate>(g_, l_, "day");
+			bool? o_ = context.Operators.Not((bool?)(h_ is null));
+			bool? p_ = context.Operators.And(m_, o_);
 
 			return p_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase_Value"/>
     [CqlDeclaration("Inpatient Stay with Qualifying Diagnosis During Initiation Phase")]
 	public IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase() => 
 		__Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase.Value;
 
+    /// <seealso cref="Initial_Population_1"/>
 	private bool? Initial_Population_1_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Intake_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 6);
-		var i_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var k_ = context.Operators.End(c_);
-		var l_ = context.Operators.DateFrom(k_);
-		var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-		var n_ = context.Operators.LessOrEqual(m_, 12);
-		var o_ = context.Operators.And(g_, n_);
-		var p_ = this.Qualifying_Encounter();
-		var q_ = context.Operators.Exists<Encounter>(p_);
-		var r_ = context.Operators.And(o_, q_);
-		var s_ = this.First_ADHD_Medication_Prescribed_During_Intake_Period();
-		var t_ = context.Operators.Not((bool?)(s_ is null));
-		var u_ = context.Operators.And(r_, t_);
-		var v_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase();
-		var w_ = context.Operators.Exists<Encounter>(v_);
-		var x_ = context.Operators.Not(w_);
-		var y_ = context.Operators.And(u_, x_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Intake_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 6);
+		Date k_ = a_?.BirthDateElement;
+		string l_ = k_?.Value;
+		CqlDate m_ = context.Operators.Convert<CqlDate>(l_);
+		CqlDateTime o_ = context.Operators.End(e_);
+		CqlDate p_ = context.Operators.DateFrom(o_);
+		int? q_ = context.Operators.CalculateAgeAt(m_, p_, "year");
+		bool? r_ = context.Operators.LessOrEqual(q_, 12);
+		bool? s_ = context.Operators.And(i_, r_);
+		IEnumerable<Encounter> t_ = this.Qualifying_Encounter();
+		bool? u_ = context.Operators.Exists<Encounter>(t_);
+		bool? v_ = context.Operators.And(s_, u_);
+		CqlDate w_ = this.First_ADHD_Medication_Prescribed_During_Intake_Period();
+		bool? x_ = context.Operators.Not((bool?)(w_ is null));
+		bool? y_ = context.Operators.And(v_, x_);
+		IEnumerable<Encounter> z_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Initiation_Phase();
+		bool? aa_ = context.Operators.Exists<Encounter>(z_);
+		bool? ab_ = context.Operators.Not(aa_);
+		bool? ac_ = context.Operators.And(y_, ab_);
 
-		return y_;
+		return ac_;
 	}
 
+    /// <seealso cref="Initial_Population_1_Value"/>
     [CqlDeclaration("Initial Population 1")]
 	public bool? Initial_Population_1() => 
 		__Initial_Population_1.Value;
 
+    /// <seealso cref="Denominator_1"/>
 	private bool? Denominator_1_Value()
 	{
-		var a_ = this.Initial_Population_1();
+		bool? a_ = this.Initial_Population_1();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_1_Value"/>
     [CqlDeclaration("Denominator 1")]
 	public bool? Denominator_1() => 
 		__Denominator_1.Value;
 
+    /// <seealso cref="Narcolepsy_Exclusion"/>
 	private IEnumerable<Condition> Narcolepsy_Exclusion_Value()
 	{
-		var a_ = this.Narcolepsy();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Narcolepsy();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition Narcolepsy)
 		{
-			var e_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Narcolepsy);
-			var f_ = context.Operators.Start(e_);
-			var g_ = this.Measurement_Period();
-			var h_ = context.Operators.End(g_);
-			var i_ = context.Operators.SameOrBefore(f_, h_, null);
+			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Narcolepsy);
+			CqlDateTime f_ = context.Operators.Start(e_);
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			CqlDateTime h_ = context.Operators.End(g_);
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, null);
 
 			return i_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Narcolepsy_Exclusion_Value"/>
     [CqlDeclaration("Narcolepsy Exclusion")]
 	public IEnumerable<Condition> Narcolepsy_Exclusion() => 
 		__Narcolepsy_Exclusion.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = this.Narcolepsy_Exclusion();
-		var c_ = context.Operators.Exists<Condition>(b_);
-		var d_ = context.Operators.Or(a_, c_);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		IEnumerable<Condition> b_ = this.Narcolepsy_Exclusion();
+		bool? c_ = context.Operators.Exists<Condition>(b_);
+		bool? d_ = context.Operators.Or(a_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Qualifying_Numerator_Encounter"/>
 	private IEnumerable<Encounter> Qualifying_Numerator_Encounter_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Initial_Hospital_Observation_Care();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Group_Counseling();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Behavioral_Health_Follow_up_Visit();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Preventive_Care_Services_Individual_Counseling();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Psychotherapy_and_Pharmacologic_Management();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Initial_Hospital_Observation_Care();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Group_Counseling();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Behavioral_Health_Follow_up_Visit();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Preventive_Care_Services_Individual_Counseling();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Psychotherapy_and_Pharmacologic_Management();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
 		bool? p_(Encounter PsychPharmManagement)
 		{
-			var ao_ = PsychPharmManagement?.Location;
+			List<Encounter.LocationComponent> ao_ = PsychPharmManagement?.Location;
 			bool? ap_(Encounter.LocationComponent Location)
 			{
-				var as_ = Location?.Location;
-				var at_ = CQMCommon_2_0_000.GetLocation(as_);
-				var au_ = at_?.Type;
+				ResourceReference as_ = Location?.Location;
+				Location at_ = CQMCommon_2_0_000.GetLocation(as_);
+				List<CodeableConcept> au_ = at_?.Type;
 				CqlConcept av_(CodeableConcept @this)
 				{
-					var az_ = FHIRHelpers_4_3_000.ToConcept(@this);
+					CqlConcept az_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 					return az_;
 				};
-				var aw_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)au_, av_);
-				var ax_ = this.Ambulatory();
-				var ay_ = context.Operators.ConceptsInValueSet(aw_, ax_);
+				IEnumerable<CqlConcept> aw_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)au_, av_);
+				CqlValueSet ax_ = this.Ambulatory();
+				bool? ay_ = context.Operators.ConceptsInValueSet(aw_, ax_);
 
 				return ay_;
 			};
-			var aq_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)ao_, ap_);
-			var ar_ = context.Operators.Exists<Encounter.LocationComponent>(aq_);
+			IEnumerable<Encounter.LocationComponent> aq_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)ao_, ap_);
+			bool? ar_ = context.Operators.Exists<Encounter.LocationComponent>(aq_);
 
 			return ar_;
 		};
-		var q_ = context.Operators.Where<Encounter>(o_, p_);
-		var r_ = context.Operators.Union<Encounter>(m_, q_);
-		var s_ = context.Operators.Union<Encounter>(k_, r_);
-		var t_ = this.Outpatient_Consultation();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = this.Home_Healthcare_Services();
-		var w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
-		var x_ = context.Operators.Union<Encounter>(u_, w_);
-		var y_ = context.Operators.Union<Encounter>(s_, x_);
-		var z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
-		var ab_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, null);
-		var ad_ = context.Operators.Union<Encounter>(aa_, ac_);
-		var ae_ = context.Operators.Union<Encounter>(y_, ad_);
-		var af_ = this.Psych_Visit_Diagnostic_Evaluation();
-		var ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
-		var ah_ = this.Psych_Visit_Psychotherapy();
-		var ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, null);
-		var aj_ = context.Operators.Union<Encounter>(ag_, ai_);
-		var ak_ = context.Operators.Union<Encounter>(ae_, aj_);
-		var al_ = this.Telephone_Visits();
-		var am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
-		var an_ = context.Operators.Union<Encounter>(ak_, am_);
+		IEnumerable<Encounter> q_ = context.Operators.Where<Encounter>(o_, p_);
+		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(m_, q_);
+		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(k_, r_);
+		CqlValueSet t_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		CqlValueSet v_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
+		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(u_, w_);
+		IEnumerable<Encounter> y_ = context.Operators.Union<Encounter>(s_, x_);
+		CqlValueSet z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		CqlValueSet ab_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, null);
+		IEnumerable<Encounter> ad_ = context.Operators.Union<Encounter>(aa_, ac_);
+		IEnumerable<Encounter> ae_ = context.Operators.Union<Encounter>(y_, ad_);
+		CqlValueSet af_ = this.Psych_Visit_Diagnostic_Evaluation();
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		CqlValueSet ah_ = this.Psych_Visit_Psychotherapy();
+		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, null);
+		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ag_, ai_);
+		IEnumerable<Encounter> ak_ = context.Operators.Union<Encounter>(ae_, aj_);
+		CqlValueSet al_ = this.Telephone_Visits();
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
 
 		return an_;
 	}
 
+    /// <seealso cref="Qualifying_Numerator_Encounter_Value"/>
     [CqlDeclaration("Qualifying Numerator Encounter")]
 	public IEnumerable<Encounter> Qualifying_Numerator_Encounter() => 
 		__Qualifying_Numerator_Encounter.Value;
 
+    /// <seealso cref="Encounter_During_Initiation_Phase"/>
 	private IEnumerable<Encounter> Encounter_During_Initiation_Phase_Value()
 	{
-		var a_ = this.Qualifying_Numerator_Encounter();
+		IEnumerable<Encounter> a_ = this.Qualifying_Numerator_Encounter();
 		bool? b_(Encounter ValidNumeratorEncounter)
 		{
-			var d_ = ValidNumeratorEncounter?.Period;
-			var e_ = FHIRHelpers_4_3_000.ToInterval(d_);
-			var f_ = CQMCommon_2_0_000.ToDateInterval(e_);
-			var g_ = context.Operators.Start(f_);
-			var h_ = this.IPSD();
-			var j_ = context.Operators.Quantity(30m, "days");
-			var k_ = context.Operators.Add(h_, j_);
-			var l_ = context.Operators.Interval(h_, k_, false, true);
-			var m_ = context.Operators.In<CqlDate>(g_, l_, "day");
-			var o_ = context.Operators.Not((bool?)(h_ is null));
-			var p_ = context.Operators.And(m_, o_);
+			Period d_ = ValidNumeratorEncounter?.Period;
+			CqlInterval<CqlDateTime> e_ = FHIRHelpers_4_3_000.ToInterval(d_);
+			CqlInterval<CqlDate> f_ = CQMCommon_2_0_000.ToDateInterval(e_);
+			CqlDate g_ = context.Operators.Start(f_);
+			CqlDate h_ = this.IPSD();
+			CqlQuantity j_ = context.Operators.Quantity(30m, "days");
+			CqlDate k_ = context.Operators.Add(h_, j_);
+			CqlInterval<CqlDate> l_ = context.Operators.Interval(h_, k_, false, true);
+			bool? m_ = context.Operators.In<CqlDate>(g_, l_, "day");
+			bool? o_ = context.Operators.Not((bool?)(h_ is null));
+			bool? p_ = context.Operators.And(m_, o_);
 
 			return p_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_During_Initiation_Phase_Value"/>
     [CqlDeclaration("Encounter During Initiation Phase")]
 	public IEnumerable<Encounter> Encounter_During_Initiation_Phase() => 
 		__Encounter_During_Initiation_Phase.Value;
 
+    /// <seealso cref="Numerator_1"/>
 	private bool? Numerator_1_Value()
 	{
-		var a_ = this.Encounter_During_Initiation_Phase();
-		var b_ = context.Operators.Exists<Encounter>(a_);
+		IEnumerable<Encounter> a_ = this.Encounter_During_Initiation_Phase();
+		bool? b_ = context.Operators.Exists<Encounter>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Numerator_1_Value"/>
     [CqlDeclaration("Numerator 1")]
 	public bool? Numerator_1() => 
 		__Numerator_1.Value;
 
+    /// <seealso cref="ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase"/>
 	private IEnumerable<CqlInterval<CqlDate>> ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase_Value()
 	{
-		var a_ = this.Atomoxetine();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet a_ = this.Atomoxetine();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		Tuple_EhMLLfWeOaeVhYfBZeiQfaefD f_(MedicationRequest AtomoxetineMed)
 		{
-			var dt_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(AtomoxetineMed);
-			var dv_ = context.Operators.Start(dt_);
-			var dw_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
+			CqlInterval<CqlDate> dt_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(AtomoxetineMed);
+			CqlDate dv_ = context.Operators.Start(dt_);
+			Tuple_EhMLLfWeOaeVhYfBZeiQfaefD dw_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
 			{
 				period = dt_,
 				periodStart = dv_,
@@ -1055,39 +1153,39 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 			return dw_;
 		};
-		var g_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(e_, f_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> g_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(e_, f_);
 		object h_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var dx_ = @this?.periodStart;
+			CqlDate dx_ = @this?.periodStart;
 
 			return dx_;
 		};
-		var i_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(g_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> i_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(g_, h_, System.ComponentModel.ListSortDirection.Ascending);
 		bool? j_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var dy_ = @this?.period;
-			var dz_ = context.Operators.Not((bool?)(dy_ is null));
+			CqlInterval<CqlDate> dy_ = @this?.period;
+			bool? dz_ = context.Operators.Not((bool?)(dy_ is null));
 
 			return dz_;
 		};
-		var k_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(i_, j_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> k_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(i_, j_);
 		CqlInterval<CqlDate> l_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var ea_ = @this?.period;
+			CqlInterval<CqlDate> ea_ = @this?.period;
 
 			return ea_;
 		};
-		var m_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(k_, l_);
-		var n_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(m_);
-		var o_ = this.Clonidine();
-		var p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, null);
-		var r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, null);
-		var s_ = context.Operators.Union<MedicationRequest>(p_, r_);
+		IEnumerable<CqlInterval<CqlDate>> m_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(k_, l_);
+		IEnumerable<CqlInterval<CqlDate>> n_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(m_);
+		CqlValueSet o_ = this.Clonidine();
+		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, null);
+		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, null);
+		IEnumerable<MedicationRequest> s_ = context.Operators.Union<MedicationRequest>(p_, r_);
 		Tuple_EhMLLfWeOaeVhYfBZeiQfaefD t_(MedicationRequest ClonidineMed)
 		{
-			var eb_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ClonidineMed);
-			var ed_ = context.Operators.Start(eb_);
-			var ee_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
+			CqlInterval<CqlDate> eb_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ClonidineMed);
+			CqlDate ed_ = context.Operators.Start(eb_);
+			Tuple_EhMLLfWeOaeVhYfBZeiQfaefD ee_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
 			{
 				period = eb_,
 				periodStart = ed_,
@@ -1095,40 +1193,40 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 			return ee_;
 		};
-		var u_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(s_, t_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> u_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(s_, t_);
 		object v_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var ef_ = @this?.periodStart;
+			CqlDate ef_ = @this?.periodStart;
 
 			return ef_;
 		};
-		var w_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(u_, v_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> w_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(u_, v_, System.ComponentModel.ListSortDirection.Ascending);
 		bool? x_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var eg_ = @this?.period;
-			var eh_ = context.Operators.Not((bool?)(eg_ is null));
+			CqlInterval<CqlDate> eg_ = @this?.period;
+			bool? eh_ = context.Operators.Not((bool?)(eg_ is null));
 
 			return eh_;
 		};
-		var y_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(w_, x_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> y_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(w_, x_);
 		CqlInterval<CqlDate> z_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var ei_ = @this?.period;
+			CqlInterval<CqlDate> ei_ = @this?.period;
 
 			return ei_;
 		};
-		var aa_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(y_, z_);
-		var ab_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(aa_);
-		var ac_ = context.Operators.Union<CqlInterval<CqlDate>>(n_, ab_);
-		var ad_ = this.Dexmethylphenidate();
-		var ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, null);
-		var ag_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, null);
-		var ah_ = context.Operators.Union<MedicationRequest>(ae_, ag_);
+		IEnumerable<CqlInterval<CqlDate>> aa_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(y_, z_);
+		IEnumerable<CqlInterval<CqlDate>> ab_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(aa_);
+		IEnumerable<CqlInterval<CqlDate>> ac_ = context.Operators.Union<CqlInterval<CqlDate>>(n_, ab_);
+		CqlValueSet ad_ = this.Dexmethylphenidate();
+		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, null);
+		IEnumerable<MedicationRequest> ag_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, null);
+		IEnumerable<MedicationRequest> ah_ = context.Operators.Union<MedicationRequest>(ae_, ag_);
 		Tuple_EhMLLfWeOaeVhYfBZeiQfaefD ai_(MedicationRequest DexmethylphenidateMed)
 		{
-			var ej_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(DexmethylphenidateMed);
-			var el_ = context.Operators.Start(ej_);
-			var em_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
+			CqlInterval<CqlDate> ej_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(DexmethylphenidateMed);
+			CqlDate el_ = context.Operators.Start(ej_);
+			Tuple_EhMLLfWeOaeVhYfBZeiQfaefD em_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
 			{
 				period = ej_,
 				periodStart = el_,
@@ -1136,39 +1234,39 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 			return em_;
 		};
-		var aj_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(ah_, ai_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> aj_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(ah_, ai_);
 		object ak_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var en_ = @this?.periodStart;
+			CqlDate en_ = @this?.periodStart;
 
 			return en_;
 		};
-		var al_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(aj_, ak_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> al_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(aj_, ak_, System.ComponentModel.ListSortDirection.Ascending);
 		bool? am_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var eo_ = @this?.period;
-			var ep_ = context.Operators.Not((bool?)(eo_ is null));
+			CqlInterval<CqlDate> eo_ = @this?.period;
+			bool? ep_ = context.Operators.Not((bool?)(eo_ is null));
 
 			return ep_;
 		};
-		var an_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(al_, am_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> an_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(al_, am_);
 		CqlInterval<CqlDate> ao_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var eq_ = @this?.period;
+			CqlInterval<CqlDate> eq_ = @this?.period;
 
 			return eq_;
 		};
-		var ap_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(an_, ao_);
-		var aq_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(ap_);
-		var ar_ = this.Dextroamphetamine();
-		var as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
-		var au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
-		var av_ = context.Operators.Union<MedicationRequest>(as_, au_);
+		IEnumerable<CqlInterval<CqlDate>> ap_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(an_, ao_);
+		IEnumerable<CqlInterval<CqlDate>> aq_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(ap_);
+		CqlValueSet ar_ = this.Dextroamphetamine();
+		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		IEnumerable<MedicationRequest> av_ = context.Operators.Union<MedicationRequest>(as_, au_);
 		Tuple_EhMLLfWeOaeVhYfBZeiQfaefD aw_(MedicationRequest DextroamphetamineMed)
 		{
-			var er_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(DextroamphetamineMed);
-			var et_ = context.Operators.Start(er_);
-			var eu_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
+			CqlInterval<CqlDate> er_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(DextroamphetamineMed);
+			CqlDate et_ = context.Operators.Start(er_);
+			Tuple_EhMLLfWeOaeVhYfBZeiQfaefD eu_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
 			{
 				period = er_,
 				periodStart = et_,
@@ -1176,41 +1274,41 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 			return eu_;
 		};
-		var ax_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(av_, aw_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> ax_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(av_, aw_);
 		object ay_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var ev_ = @this?.periodStart;
+			CqlDate ev_ = @this?.periodStart;
 
 			return ev_;
 		};
-		var az_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(ax_, ay_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> az_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(ax_, ay_, System.ComponentModel.ListSortDirection.Ascending);
 		bool? ba_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var ew_ = @this?.period;
-			var ex_ = context.Operators.Not((bool?)(ew_ is null));
+			CqlInterval<CqlDate> ew_ = @this?.period;
+			bool? ex_ = context.Operators.Not((bool?)(ew_ is null));
 
 			return ex_;
 		};
-		var bb_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(az_, ba_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> bb_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(az_, ba_);
 		CqlInterval<CqlDate> bc_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var ey_ = @this?.period;
+			CqlInterval<CqlDate> ey_ = @this?.period;
 
 			return ey_;
 		};
-		var bd_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(bb_, bc_);
-		var be_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(bd_);
-		var bf_ = context.Operators.Union<CqlInterval<CqlDate>>(aq_, be_);
-		var bg_ = context.Operators.Union<CqlInterval<CqlDate>>(ac_, bf_);
-		var bh_ = this.Lisdexamfetamine();
-		var bi_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, null);
-		var bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, null);
-		var bl_ = context.Operators.Union<MedicationRequest>(bi_, bk_);
+		IEnumerable<CqlInterval<CqlDate>> bd_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(bb_, bc_);
+		IEnumerable<CqlInterval<CqlDate>> be_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(bd_);
+		IEnumerable<CqlInterval<CqlDate>> bf_ = context.Operators.Union<CqlInterval<CqlDate>>(aq_, be_);
+		IEnumerable<CqlInterval<CqlDate>> bg_ = context.Operators.Union<CqlInterval<CqlDate>>(ac_, bf_);
+		CqlValueSet bh_ = this.Lisdexamfetamine();
+		IEnumerable<MedicationRequest> bi_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, null);
+		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, null);
+		IEnumerable<MedicationRequest> bl_ = context.Operators.Union<MedicationRequest>(bi_, bk_);
 		Tuple_EhMLLfWeOaeVhYfBZeiQfaefD bm_(MedicationRequest LisdexamfetamineMed)
 		{
-			var ez_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(LisdexamfetamineMed);
-			var fb_ = context.Operators.Start(ez_);
-			var fc_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
+			CqlInterval<CqlDate> ez_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(LisdexamfetamineMed);
+			CqlDate fb_ = context.Operators.Start(ez_);
+			Tuple_EhMLLfWeOaeVhYfBZeiQfaefD fc_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
 			{
 				period = ez_,
 				periodStart = fb_,
@@ -1218,39 +1316,39 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 			return fc_;
 		};
-		var bn_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(bl_, bm_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> bn_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(bl_, bm_);
 		object bo_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var fd_ = @this?.periodStart;
+			CqlDate fd_ = @this?.periodStart;
 
 			return fd_;
 		};
-		var bp_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(bn_, bo_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> bp_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(bn_, bo_, System.ComponentModel.ListSortDirection.Ascending);
 		bool? bq_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var fe_ = @this?.period;
-			var ff_ = context.Operators.Not((bool?)(fe_ is null));
+			CqlInterval<CqlDate> fe_ = @this?.period;
+			bool? ff_ = context.Operators.Not((bool?)(fe_ is null));
 
 			return ff_;
 		};
-		var br_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(bp_, bq_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> br_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(bp_, bq_);
 		CqlInterval<CqlDate> bs_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var fg_ = @this?.period;
+			CqlInterval<CqlDate> fg_ = @this?.period;
 
 			return fg_;
 		};
-		var bt_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(br_, bs_);
-		var bu_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(bt_);
-		var bv_ = this.Methylphenidate();
-		var bw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, null);
-		var by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, null);
-		var bz_ = context.Operators.Union<MedicationRequest>(bw_, by_);
+		IEnumerable<CqlInterval<CqlDate>> bt_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(br_, bs_);
+		IEnumerable<CqlInterval<CqlDate>> bu_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(bt_);
+		CqlValueSet bv_ = this.Methylphenidate();
+		IEnumerable<MedicationRequest> bw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, null);
+		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, null);
+		IEnumerable<MedicationRequest> bz_ = context.Operators.Union<MedicationRequest>(bw_, by_);
 		Tuple_EhMLLfWeOaeVhYfBZeiQfaefD ca_(MedicationRequest MethylphenidateMed)
 		{
-			var fh_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(MethylphenidateMed);
-			var fj_ = context.Operators.Start(fh_);
-			var fk_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
+			CqlInterval<CqlDate> fh_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(MethylphenidateMed);
+			CqlDate fj_ = context.Operators.Start(fh_);
+			Tuple_EhMLLfWeOaeVhYfBZeiQfaefD fk_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
 			{
 				period = fh_,
 				periodStart = fj_,
@@ -1258,41 +1356,41 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 			return fk_;
 		};
-		var cb_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(bz_, ca_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> cb_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(bz_, ca_);
 		object cc_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var fl_ = @this?.periodStart;
+			CqlDate fl_ = @this?.periodStart;
 
 			return fl_;
 		};
-		var cd_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(cb_, cc_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> cd_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(cb_, cc_, System.ComponentModel.ListSortDirection.Ascending);
 		bool? ce_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var fm_ = @this?.period;
-			var fn_ = context.Operators.Not((bool?)(fm_ is null));
+			CqlInterval<CqlDate> fm_ = @this?.period;
+			bool? fn_ = context.Operators.Not((bool?)(fm_ is null));
 
 			return fn_;
 		};
-		var cf_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(cd_, ce_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> cf_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(cd_, ce_);
 		CqlInterval<CqlDate> cg_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var fo_ = @this?.period;
+			CqlInterval<CqlDate> fo_ = @this?.period;
 
 			return fo_;
 		};
-		var ch_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(cf_, cg_);
-		var ci_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(ch_);
-		var cj_ = context.Operators.Union<CqlInterval<CqlDate>>(bu_, ci_);
-		var ck_ = context.Operators.Union<CqlInterval<CqlDate>>(bg_, cj_);
-		var cl_ = this.Guanfacine();
-		var cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
-		var co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
-		var cp_ = context.Operators.Union<MedicationRequest>(cm_, co_);
+		IEnumerable<CqlInterval<CqlDate>> ch_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(cf_, cg_);
+		IEnumerable<CqlInterval<CqlDate>> ci_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(ch_);
+		IEnumerable<CqlInterval<CqlDate>> cj_ = context.Operators.Union<CqlInterval<CqlDate>>(bu_, ci_);
+		IEnumerable<CqlInterval<CqlDate>> ck_ = context.Operators.Union<CqlInterval<CqlDate>>(bg_, cj_);
+		CqlValueSet cl_ = this.Guanfacine();
+		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		IEnumerable<MedicationRequest> cp_ = context.Operators.Union<MedicationRequest>(cm_, co_);
 		Tuple_EhMLLfWeOaeVhYfBZeiQfaefD cq_(MedicationRequest GuanfacineMed)
 		{
-			var fp_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(GuanfacineMed);
-			var fr_ = context.Operators.Start(fp_);
-			var fs_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
+			CqlInterval<CqlDate> fp_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(GuanfacineMed);
+			CqlDate fr_ = context.Operators.Start(fp_);
+			Tuple_EhMLLfWeOaeVhYfBZeiQfaefD fs_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
 			{
 				period = fp_,
 				periodStart = fr_,
@@ -1300,41 +1398,41 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 			return fs_;
 		};
-		var cr_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(cp_, cq_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> cr_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(cp_, cq_);
 		object cs_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var ft_ = @this?.periodStart;
+			CqlDate ft_ = @this?.periodStart;
 
 			return ft_;
 		};
-		var ct_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(cr_, cs_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> ct_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(cr_, cs_, System.ComponentModel.ListSortDirection.Ascending);
 		bool? cu_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var fu_ = @this?.period;
-			var fv_ = context.Operators.Not((bool?)(fu_ is null));
+			CqlInterval<CqlDate> fu_ = @this?.period;
+			bool? fv_ = context.Operators.Not((bool?)(fu_ is null));
 
 			return fv_;
 		};
-		var cv_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(ct_, cu_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> cv_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(ct_, cu_);
 		CqlInterval<CqlDate> cw_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var fw_ = @this?.period;
+			CqlInterval<CqlDate> fw_ = @this?.period;
 
 			return fw_;
 		};
-		var cx_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(cv_, cw_);
-		var cy_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(cx_);
-		var cz_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
-		var da_ = context.Operators.ToList<CqlCode>(cz_);
-		var db_ = context.Operators.RetrieveByCodes<MedicationRequest>(da_, null);
-		var dd_ = context.Operators.ToList<CqlCode>(cz_);
-		var de_ = context.Operators.RetrieveByCodes<MedicationRequest>(dd_, null);
-		var df_ = context.Operators.Union<MedicationRequest>(db_, de_);
+		IEnumerable<CqlInterval<CqlDate>> cx_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(cv_, cw_);
+		IEnumerable<CqlInterval<CqlDate>> cy_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(cx_);
+		CqlCode cz_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
+		IEnumerable<CqlCode> da_ = context.Operators.ToList<CqlCode>(cz_);
+		IEnumerable<MedicationRequest> db_ = context.Operators.RetrieveByCodes<MedicationRequest>(da_, null);
+		IEnumerable<CqlCode> dd_ = context.Operators.ToList<CqlCode>(cz_);
+		IEnumerable<MedicationRequest> de_ = context.Operators.RetrieveByCodes<MedicationRequest>(dd_, null);
+		IEnumerable<MedicationRequest> df_ = context.Operators.Union<MedicationRequest>(db_, de_);
 		Tuple_EhMLLfWeOaeVhYfBZeiQfaefD dg_(MedicationRequest MethamphetamineMed)
 		{
-			var fx_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(MethamphetamineMed);
-			var fz_ = context.Operators.Start(fx_);
-			var ga_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
+			CqlInterval<CqlDate> fx_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(MethamphetamineMed);
+			CqlDate fz_ = context.Operators.Start(fx_);
+			Tuple_EhMLLfWeOaeVhYfBZeiQfaefD ga_ = new Tuple_EhMLLfWeOaeVhYfBZeiQfaefD
 			{
 				period = fx_,
 				periodStart = fz_,
@@ -1342,318 +1440,349 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 			return ga_;
 		};
-		var dh_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(df_, dg_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> dh_ = context.Operators.Select<MedicationRequest, Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(df_, dg_);
 		object di_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var gb_ = @this?.periodStart;
+			CqlDate gb_ = @this?.periodStart;
 
 			return gb_;
 		};
-		var dj_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(dh_, di_, System.ComponentModel.ListSortDirection.Ascending);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> dj_ = context.Operators.SortBy<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(dh_, di_, System.ComponentModel.ListSortDirection.Ascending);
 		bool? dk_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var gc_ = @this?.period;
-			var gd_ = context.Operators.Not((bool?)(gc_ is null));
+			CqlInterval<CqlDate> gc_ = @this?.period;
+			bool? gd_ = context.Operators.Not((bool?)(gc_ is null));
 
 			return gd_;
 		};
-		var dl_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(dj_, dk_);
+		IEnumerable<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD> dl_ = context.Operators.Where<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD>(dj_, dk_);
 		CqlInterval<CqlDate> dm_(Tuple_EhMLLfWeOaeVhYfBZeiQfaefD @this)
 		{
-			var ge_ = @this?.period;
+			CqlInterval<CqlDate> ge_ = @this?.period;
 
 			return ge_;
 		};
-		var dn_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(dl_, dm_);
-		var do_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(dn_);
-		var dp_ = context.Operators.Union<CqlInterval<CqlDate>>(cy_, do_);
-		var dq_ = context.Operators.Union<CqlInterval<CqlDate>>(ck_, dp_);
+		IEnumerable<CqlInterval<CqlDate>> dn_ = context.Operators.Select<Tuple_EhMLLfWeOaeVhYfBZeiQfaefD, CqlInterval<CqlDate>>(dl_, dm_);
+		IEnumerable<CqlInterval<CqlDate>> do_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(dn_);
+		IEnumerable<CqlInterval<CqlDate>> dp_ = context.Operators.Union<CqlInterval<CqlDate>>(cy_, do_);
+		IEnumerable<CqlInterval<CqlDate>> dq_ = context.Operators.Union<CqlInterval<CqlDate>>(ck_, dp_);
 		CqlInterval<CqlDate> dr_(CqlInterval<CqlDate> ADHDMedication)
 		{
-			var gf_ = this.IPSD();
-			var gh_ = context.Operators.Quantity(300m, "days");
-			var gi_ = context.Operators.Add(gf_, gh_);
-			var gj_ = context.Operators.Interval(gf_, gi_, true, true);
-			var gk_ = context.Operators.Intersect<CqlDate>(ADHDMedication, gj_);
+			CqlDate gf_ = this.IPSD();
+			CqlQuantity gh_ = context.Operators.Quantity(300m, "days");
+			CqlDate gi_ = context.Operators.Add(gf_, gh_);
+			CqlInterval<CqlDate> gj_ = context.Operators.Interval(gf_, gi_, true, true);
+			CqlInterval<CqlDate> gk_ = context.Operators.Intersect<CqlDate>(ADHDMedication, gj_);
 
 			return gk_;
 		};
-		var ds_ = context.Operators.Select<CqlInterval<CqlDate>, CqlInterval<CqlDate>>(dq_, dr_);
+		IEnumerable<CqlInterval<CqlDate>> ds_ = context.Operators.Select<CqlInterval<CqlDate>, CqlInterval<CqlDate>>(dq_, dr_);
 
 		return ds_;
 	}
 
+    /// <seealso cref="ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase_Value"/>
     [CqlDeclaration("ADHD Medications Taken on IPSD or During Continuation and Maintenance Phase")]
 	public IEnumerable<CqlInterval<CqlDate>> ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase() => 
 		__ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase.Value;
 
+    /// <seealso cref="ADHD_Cumulative_Medication_Duration"/>
 	private int? ADHD_Cumulative_Medication_Duration_Value()
 	{
-		var a_ = this.ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase();
-		var b_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(a_);
+		IEnumerable<CqlInterval<CqlDate>> a_ = this.ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase();
+		int? b_ = CumulativeMedicationDuration_4_0_000.CumulativeDuration(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="ADHD_Cumulative_Medication_Duration_Value"/>
     [CqlDeclaration("ADHD Cumulative Medication Duration")]
 	public int? ADHD_Cumulative_Medication_Duration() => 
 		__ADHD_Cumulative_Medication_Duration.Value;
 
+    /// <seealso cref="Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days"/>
 	private bool? Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days_Value()
 	{
-		var a_ = this.ADHD_Cumulative_Medication_Duration();
-		var b_ = context.Operators.GreaterOrEqual(a_, 210);
+		int? a_ = this.ADHD_Cumulative_Medication_Duration();
+		bool? b_ = context.Operators.GreaterOrEqual(a_, 210);
 
 		return b_;
 	}
 
+    /// <seealso cref="Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days_Value"/>
     [CqlDeclaration("Has ADHD Cumulative Medication Duration Greater Than or Equal to 210 Days")]
 	public bool? Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days() => 
 		__Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days.Value;
 
+    /// <seealso cref="Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase"/>
 	private IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase_Value()
 	{
-		var a_ = this.Inpatient_Stay_with_Qualifying_Diagnosis();
+		IEnumerable<Encounter> a_ = this.Inpatient_Stay_with_Qualifying_Diagnosis();
 		bool? b_(Encounter InpatientStay)
 		{
-			var d_ = InpatientStay?.Period;
-			var e_ = FHIRHelpers_4_3_000.ToInterval(d_);
-			var f_ = CQMCommon_2_0_000.ToDateInterval(e_);
-			var g_ = context.Operators.Start(f_);
-			var h_ = this.IPSD();
-			var j_ = context.Operators.Quantity(300m, "days");
-			var k_ = context.Operators.Add(h_, j_);
-			var l_ = context.Operators.Interval(h_, k_, false, true);
-			var m_ = context.Operators.In<CqlDate>(g_, l_, "day");
-			var o_ = context.Operators.Not((bool?)(h_ is null));
-			var p_ = context.Operators.And(m_, o_);
+			Period d_ = InpatientStay?.Period;
+			CqlInterval<CqlDateTime> e_ = FHIRHelpers_4_3_000.ToInterval(d_);
+			CqlInterval<CqlDate> f_ = CQMCommon_2_0_000.ToDateInterval(e_);
+			CqlDate g_ = context.Operators.Start(f_);
+			CqlDate h_ = this.IPSD();
+			CqlQuantity j_ = context.Operators.Quantity(300m, "days");
+			CqlDate k_ = context.Operators.Add(h_, j_);
+			CqlInterval<CqlDate> l_ = context.Operators.Interval(h_, k_, false, true);
+			bool? m_ = context.Operators.In<CqlDate>(g_, l_, "day");
+			bool? o_ = context.Operators.Not((bool?)(h_ is null));
+			bool? p_ = context.Operators.And(m_, o_);
 
 			return p_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase_Value"/>
     [CqlDeclaration("Inpatient Stay with Qualifying Diagnosis During Continuation and Maintenance Phase")]
 	public IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase() => 
 		__Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase.Value;
 
+    /// <seealso cref="Initial_Population_2"/>
 	private bool? Initial_Population_2_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Intake_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 6);
-		var i_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var k_ = context.Operators.End(c_);
-		var l_ = context.Operators.DateFrom(k_);
-		var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
-		var n_ = context.Operators.LessOrEqual(m_, 12);
-		var o_ = context.Operators.And(g_, n_);
-		var p_ = this.Qualifying_Encounter();
-		var q_ = context.Operators.Exists<Encounter>(p_);
-		var r_ = context.Operators.And(o_, q_);
-		var s_ = this.First_ADHD_Medication_Prescribed_During_Intake_Period();
-		var t_ = context.Operators.Not((bool?)(s_ is null));
-		var u_ = context.Operators.And(r_, t_);
-		var v_ = this.Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days();
-		var w_ = context.Operators.And(u_, v_);
-		var x_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase();
-		var y_ = context.Operators.Exists<Encounter>(x_);
-		var z_ = context.Operators.Not(y_);
-		var aa_ = context.Operators.And(w_, z_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Intake_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 6);
+		Date k_ = a_?.BirthDateElement;
+		string l_ = k_?.Value;
+		CqlDate m_ = context.Operators.Convert<CqlDate>(l_);
+		CqlDateTime o_ = context.Operators.End(e_);
+		CqlDate p_ = context.Operators.DateFrom(o_);
+		int? q_ = context.Operators.CalculateAgeAt(m_, p_, "year");
+		bool? r_ = context.Operators.LessOrEqual(q_, 12);
+		bool? s_ = context.Operators.And(i_, r_);
+		IEnumerable<Encounter> t_ = this.Qualifying_Encounter();
+		bool? u_ = context.Operators.Exists<Encounter>(t_);
+		bool? v_ = context.Operators.And(s_, u_);
+		CqlDate w_ = this.First_ADHD_Medication_Prescribed_During_Intake_Period();
+		bool? x_ = context.Operators.Not((bool?)(w_ is null));
+		bool? y_ = context.Operators.And(v_, x_);
+		bool? z_ = this.Has_ADHD_Cumulative_Medication_Duration_Greater_Than_or_Equal_to_210_Days();
+		bool? aa_ = context.Operators.And(y_, z_);
+		IEnumerable<Encounter> ab_ = this.Inpatient_Stay_with_Qualifying_Diagnosis_During_Continuation_and_Maintenance_Phase();
+		bool? ac_ = context.Operators.Exists<Encounter>(ab_);
+		bool? ad_ = context.Operators.Not(ac_);
+		bool? ae_ = context.Operators.And(aa_, ad_);
 
-		return aa_;
+		return ae_;
 	}
 
+    /// <seealso cref="Initial_Population_2_Value"/>
     [CqlDeclaration("Initial Population 2")]
 	public bool? Initial_Population_2() => 
 		__Initial_Population_2.Value;
 
+    /// <seealso cref="Denominator_2"/>
 	private bool? Denominator_2_Value()
 	{
-		var a_ = this.Initial_Population_2();
+		bool? a_ = this.Initial_Population_2();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_2_Value"/>
     [CqlDeclaration("Denominator 2")]
 	public bool? Denominator_2() => 
 		__Denominator_2.Value;
 
+    /// <seealso cref="Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase"/>
 	private IEnumerable<CqlDate> Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value()
 	{
-		var a_ = this.Qualifying_Numerator_Encounter();
+		IEnumerable<Encounter> a_ = this.Qualifying_Numerator_Encounter();
 		bool? b_(Encounter ValidNumeratorEncounter)
 		{
-			var f_ = ValidNumeratorEncounter?.Period;
-			var g_ = FHIRHelpers_4_3_000.ToInterval(f_);
-			var h_ = CQMCommon_2_0_000.ToDateInterval(g_);
-			var i_ = context.Operators.Start(h_);
-			var j_ = this.IPSD();
-			var k_ = context.Operators.Quantity(31m, "days");
-			var l_ = context.Operators.Add(j_, k_);
-			var n_ = context.Operators.Quantity(300m, "days");
-			var o_ = context.Operators.Add(j_, n_);
-			var p_ = context.Operators.Interval(l_, o_, true, true);
-			var q_ = context.Operators.In<CqlDate>(i_, p_, "day");
+			Period f_ = ValidNumeratorEncounter?.Period;
+			CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_3_000.ToInterval(f_);
+			CqlInterval<CqlDate> h_ = CQMCommon_2_0_000.ToDateInterval(g_);
+			CqlDate i_ = context.Operators.Start(h_);
+			CqlDate j_ = this.IPSD();
+			CqlQuantity k_ = context.Operators.Quantity(31m, "days");
+			CqlDate l_ = context.Operators.Add(j_, k_);
+			CqlQuantity n_ = context.Operators.Quantity(300m, "days");
+			CqlDate o_ = context.Operators.Add(j_, n_);
+			CqlInterval<CqlDate> p_ = context.Operators.Interval(l_, o_, true, true);
+			bool? q_ = context.Operators.In<CqlDate>(i_, p_, "day");
 
 			return q_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		CqlDate d_(Encounter ValidNumeratorEncounter)
 		{
-			var r_ = ValidNumeratorEncounter?.Period;
-			var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var t_ = context.Operators.Start(s_);
-			var u_ = context.Operators.DateFrom(t_);
+			Period r_ = ValidNumeratorEncounter?.Period;
+			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			CqlDateTime t_ = context.Operators.Start(s_);
+			CqlDate u_ = context.Operators.DateFrom(t_);
 
 			return u_;
 		};
-		var e_ = context.Operators.Select<Encounter, CqlDate>(c_, d_);
+		IEnumerable<CqlDate> e_ = context.Operators.Select<Encounter, CqlDate>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value"/>
     [CqlDeclaration("Encounter 31 to 300 Days into Continuation and Maintenance Phase")]
 	public IEnumerable<CqlDate> Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase() => 
 		__Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase.Value;
 
+    /// <seealso cref="Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase"/>
 	private bool? Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value()
 	{
-		var a_ = this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
-		var b_ = context.Operators.Count<CqlDate>(a_);
-		var c_ = context.Operators.GreaterOrEqual(b_, 2);
+		IEnumerable<CqlDate> a_ = this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
+		int? b_ = context.Operators.Count<CqlDate>(a_);
+		bool? c_ = context.Operators.GreaterOrEqual(b_, 2);
 
 		return c_;
 	}
 
+    /// <seealso cref="Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value"/>
     [CqlDeclaration("Two or More Encounters 31 to 300 Days into Continuation and Maintenance Phase")]
 	public bool? Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase() => 
 		__Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase.Value;
 
+    /// <seealso cref="Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase"/>
 	private IEnumerable<CqlDate> Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value()
 	{
-		var a_ = this.Online_Assessments();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Online_Assessments();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter OnlineAssessment)
 		{
-			var g_ = OnlineAssessment?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = CQMCommon_2_0_000.ToDateInterval(h_);
-			var j_ = context.Operators.Start(i_);
-			var k_ = this.IPSD();
-			var l_ = context.Operators.Quantity(31m, "days");
-			var m_ = context.Operators.Add(k_, l_);
-			var o_ = context.Operators.Quantity(300m, "days");
-			var p_ = context.Operators.Add(k_, o_);
-			var q_ = context.Operators.Interval(m_, p_, true, true);
-			var r_ = context.Operators.In<CqlDate>(j_, q_, "day");
+			Period g_ = OnlineAssessment?.Period;
+			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+			CqlInterval<CqlDate> i_ = CQMCommon_2_0_000.ToDateInterval(h_);
+			CqlDate j_ = context.Operators.Start(i_);
+			CqlDate k_ = this.IPSD();
+			CqlQuantity l_ = context.Operators.Quantity(31m, "days");
+			CqlDate m_ = context.Operators.Add(k_, l_);
+			CqlQuantity o_ = context.Operators.Quantity(300m, "days");
+			CqlDate p_ = context.Operators.Add(k_, o_);
+			CqlInterval<CqlDate> q_ = context.Operators.Interval(m_, p_, true, true);
+			bool? r_ = context.Operators.In<CqlDate>(j_, q_, "day");
 
 			return r_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 		CqlDate e_(Encounter OnlineAssessment)
 		{
-			var s_ = OnlineAssessment?.Period;
-			var t_ = FHIRHelpers_4_3_000.ToInterval(s_);
-			var u_ = context.Operators.Start(t_);
-			var v_ = context.Operators.DateFrom(u_);
+			Period s_ = OnlineAssessment?.Period;
+			CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(s_);
+			CqlDateTime u_ = context.Operators.Start(t_);
+			CqlDate v_ = context.Operators.DateFrom(u_);
 
 			return v_;
 		};
-		var f_ = context.Operators.Select<Encounter, CqlDate>(d_, e_);
+		IEnumerable<CqlDate> f_ = context.Operators.Select<Encounter, CqlDate>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value"/>
     [CqlDeclaration("Online Assessment 31 to 300 Days into Continuation and Maintenance Phase")]
 	public IEnumerable<CqlDate> Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase() => 
 		__Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase.Value;
 
+    /// <seealso cref="Numerator_2"/>
 	private bool? Numerator_2_Value()
 	{
-		var a_ = this.Encounter_During_Initiation_Phase();
-		var b_ = context.Operators.Exists<Encounter>(a_);
-		var c_ = this.Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
-		var d_ = this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
+		IEnumerable<Encounter> a_ = this.Encounter_During_Initiation_Phase();
+		bool? b_ = context.Operators.Exists<Encounter>(a_);
+		bool? c_ = this.Two_or_More_Encounters_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
+		IEnumerable<CqlDate> d_ = this.Encounter_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
 		IEnumerable<CqlDate> e_(CqlDate Encounter1)
 		{
-			var j_ = this.Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
+			IEnumerable<CqlDate> j_ = this.Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase();
 			bool? k_(CqlDate Encounter2)
 			{
-				var o_ = context.Operators.Not((bool?)(Encounter1 is null));
-				var p_ = context.Operators.Not((bool?)(Encounter2 is null));
-				var q_ = context.Operators.And(o_, p_);
-				var r_ = context.Operators.Equivalent(Encounter1, Encounter2);
-				var s_ = context.Operators.Not(r_);
-				var t_ = context.Operators.And(q_, s_);
+				bool? o_ = context.Operators.Not((bool?)(Encounter1 is null));
+				bool? p_ = context.Operators.Not((bool?)(Encounter2 is null));
+				bool? q_ = context.Operators.And(o_, p_);
+				bool? r_ = context.Operators.Equivalent(Encounter1, Encounter2);
+				bool? s_ = context.Operators.Not(r_);
+				bool? t_ = context.Operators.And(q_, s_);
 
 				return t_;
 			};
-			var l_ = context.Operators.Where<CqlDate>(j_, k_);
+			IEnumerable<CqlDate> l_ = context.Operators.Where<CqlDate>(j_, k_);
 			CqlDate m_(CqlDate Encounter2) => 
 				Encounter1;
-			var n_ = context.Operators.Select<CqlDate, CqlDate>(l_, m_);
+			IEnumerable<CqlDate> n_ = context.Operators.Select<CqlDate, CqlDate>(l_, m_);
 
 			return n_;
 		};
-		var f_ = context.Operators.SelectMany<CqlDate, CqlDate>(d_, e_);
-		var g_ = context.Operators.Exists<CqlDate>(f_);
-		var h_ = context.Operators.Or(c_, g_);
-		var i_ = context.Operators.And(b_, h_);
+		IEnumerable<CqlDate> f_ = context.Operators.SelectMany<CqlDate, CqlDate>(d_, e_);
+		bool? g_ = context.Operators.Exists<CqlDate>(f_);
+		bool? h_ = context.Operators.Or(c_, g_);
+		bool? i_ = context.Operators.And(b_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Numerator_2_Value"/>
     [CqlDeclaration("Numerator 2")]
 	public bool? Numerator_2() => 
 		__Numerator_2.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
@@ -192,269 +192,340 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 
     #endregion
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Ethnicity"/>
 	private CqlValueSet Ethnicity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
 
+    /// <seealso cref="Ethnicity_Value"/>
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
 	public CqlValueSet Ethnicity() => 
 		__Ethnicity.Value;
 
+    /// <seealso cref="Lower_Body_Fractures_Excluding_Ankle_and_Foot"/>
 	private CqlValueSet Lower_Body_Fractures_Excluding_Ankle_and_Foot_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178", null);
 
+    /// <seealso cref="Lower_Body_Fractures_Excluding_Ankle_and_Foot_Value"/>
     [CqlDeclaration("Lower Body Fractures Excluding Ankle and Foot")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178")]
 	public CqlValueSet Lower_Body_Fractures_Excluding_Ankle_and_Foot() => 
 		__Lower_Body_Fractures_Excluding_Ankle_and_Foot.Value;
 
+    /// <seealso cref="Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs"/>
 	private CqlValueSet Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180", null);
 
+    /// <seealso cref="Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs_Value"/>
     [CqlDeclaration("Malignant Neoplasms of Lower and Unspecified Limbs")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180")]
 	public CqlValueSet Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs() => 
 		__Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs.Value;
 
+    /// <seealso cref="Mechanical_Complications_Excluding_Upper_Body"/>
 	private CqlValueSet Mechanical_Complications_Excluding_Upper_Body_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182", null);
 
+    /// <seealso cref="Mechanical_Complications_Excluding_Upper_Body_Value"/>
     [CqlDeclaration("Mechanical Complications Excluding Upper Body")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182")]
 	public CqlValueSet Mechanical_Complications_Excluding_Upper_Body() => 
 		__Mechanical_Complications_Excluding_Upper_Body.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="ONC_Administrative_Sex"/>
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
 
+    /// <seealso cref="ONC_Administrative_Sex_Value"/>
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
 	public CqlValueSet ONC_Administrative_Sex() => 
 		__ONC_Administrative_Sex.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Partial_Arthroplasty_of_Hip"/>
 	private CqlValueSet Partial_Arthroplasty_of_Hip_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184", null);
 
+    /// <seealso cref="Partial_Arthroplasty_of_Hip_Value"/>
     [CqlDeclaration("Partial Arthroplasty of Hip")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184")]
 	public CqlValueSet Partial_Arthroplasty_of_Hip() => 
 		__Partial_Arthroplasty_of_Hip.Value;
 
+    /// <seealso cref="Payer"/>
 	private CqlValueSet Payer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
 
+    /// <seealso cref="Payer_Value"/>
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
 	public CqlValueSet Payer() => 
 		__Payer.Value;
 
+    /// <seealso cref="Primary_THA_Procedure"/>
 	private CqlValueSet Primary_THA_Procedure_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006", null);
 
+    /// <seealso cref="Primary_THA_Procedure_Value"/>
     [CqlDeclaration("Primary THA Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006")]
 	public CqlValueSet Primary_THA_Procedure() => 
 		__Primary_THA_Procedure.Value;
 
+    /// <seealso cref="Race"/>
 	private CqlValueSet Race_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
 
+    /// <seealso cref="Race_Value"/>
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
 	public CqlValueSet Race() => 
 		__Race.Value;
 
+    /// <seealso cref="Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine"/>
 	private CqlValueSet Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189", null);
 
+    /// <seealso cref="Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine_Value"/>
     [CqlDeclaration("Removal, Revision and Supplement Procedures of the Lower Body and Spine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189")]
 	public CqlValueSet Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine() => 
 		__Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Activities_of_daily_living_score__HOOS_"/>
 	private CqlCode Activities_of_daily_living_score__HOOS__Value() => 
 		new CqlCode("72095-3", "http://loinc.org", null, null);
 
+    /// <seealso cref="Activities_of_daily_living_score__HOOS__Value"/>
     [CqlDeclaration("Activities of daily living score [HOOS]")]
 	public CqlCode Activities_of_daily_living_score__HOOS_() => 
 		__Activities_of_daily_living_score__HOOS_.Value;
 
+    /// <seealso cref="Dead__finding_"/>
 	private CqlCode Dead__finding__Value() => 
 		new CqlCode("419099009", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Dead__finding__Value"/>
     [CqlDeclaration("Dead (finding)")]
 	public CqlCode Dead__finding_() => 
 		__Dead__finding_.Value;
 
+    /// <seealso cref="Discharge_to_healthcare_facility_for_hospice_care__procedure_"/>
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
 		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Discharge_to_healthcare_facility_for_hospice_care__procedure__Value"/>
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
+    /// <seealso cref="Discharge_to_home_for_hospice_care__procedure_"/>
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
 		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Discharge_to_home_for_hospice_care__procedure__Value"/>
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
+    /// <seealso cref="Hospice_care__Minimum_Data_Set_"/>
 	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
 		new CqlCode("45755-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Hospice_care__Minimum_Data_Set__Value"/>
     [CqlDeclaration("Hospice care [Minimum Data Set]")]
 	public CqlCode Hospice_care__Minimum_Data_Set_() => 
 		__Hospice_care__Minimum_Data_Set_.Value;
 
+    /// <seealso cref="Pain_score__HOOS_"/>
 	private CqlCode Pain_score__HOOS__Value() => 
 		new CqlCode("72097-9", "http://loinc.org", null, null);
 
+    /// <seealso cref="Pain_score__HOOS__Value"/>
     [CqlDeclaration("Pain score [HOOS]")]
 	public CqlCode Pain_score__HOOS_() => 
 		__Pain_score__HOOS_.Value;
 
+    /// <seealso cref="Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure"/>
 	private CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value() => 
 		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value"/>
     [CqlDeclaration("Postoperative follow-up visit, normally included in the surgical package, to indicate that an evaluation and management service was performed during a postoperative period for a reason(s) related to the original procedure")]
 	public CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure() => 
 		__Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure.Value;
 
+    /// <seealso cref="PROMIS_10_Global_Mental_Health__GMH__score_T_score"/>
 	private CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value() => 
 		new CqlCode("71969-0", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value"/>
     [CqlDeclaration("PROMIS-10 Global Mental Health (GMH) score T-score")]
 	public CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score() => 
 		__PROMIS_10_Global_Mental_Health__GMH__score_T_score.Value;
 
+    /// <seealso cref="PROMIS_10_Global_Physical_Health__GPH__score_T_score"/>
 	private CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value() => 
 		new CqlCode("71971-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value"/>
     [CqlDeclaration("PROMIS-10 Global Physical Health (GPH) score T-score")]
 	public CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score() => 
 		__PROMIS_10_Global_Physical_Health__GPH__score_T_score.Value;
 
+    /// <seealso cref="Quality_of_life_score__HOOS_"/>
 	private CqlCode Quality_of_life_score__HOOS__Value() => 
 		new CqlCode("72093-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Quality_of_life_score__HOOS__Value"/>
     [CqlDeclaration("Quality of life score [HOOS]")]
 	public CqlCode Quality_of_life_score__HOOS_() => 
 		__Quality_of_life_score__HOOS_.Value;
 
+    /// <seealso cref="Severe_cognitive_impairment__finding_"/>
 	private CqlCode Severe_cognitive_impairment__finding__Value() => 
 		new CqlCode("702956004", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Severe_cognitive_impairment__finding__Value"/>
     [CqlDeclaration("Severe cognitive impairment (finding)")]
 	public CqlCode Severe_cognitive_impairment__finding_() => 
 		__Severe_cognitive_impairment__finding_.Value;
 
+    /// <seealso cref="Sport_recreation_score__HOOS_"/>
 	private CqlCode Sport_recreation_score__HOOS__Value() => 
 		new CqlCode("72094-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Sport_recreation_score__HOOS__Value"/>
     [CqlDeclaration("Sport-recreation score [HOOS]")]
 	public CqlCode Sport_recreation_score__HOOS_() => 
 		__Sport_recreation_score__HOOS_.Value;
 
+    /// <seealso cref="survey"/>
 	private CqlCode survey_Value() => 
 		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", null, null);
 
+    /// <seealso cref="survey_Value"/>
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
+    /// <seealso cref="Symptoms_score__HOOS_"/>
 	private CqlCode Symptoms_score__HOOS__Value() => 
 		new CqlCode("72096-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="Symptoms_score__HOOS__Value"/>
     [CqlDeclaration("Symptoms score [HOOS]")]
 	public CqlCode Symptoms_score__HOOS_() => 
 		__Symptoms_score__HOOS_.Value;
 
+    /// <seealso cref="Total_interval_score__HOOSJR_"/>
 	private CqlCode Total_interval_score__HOOSJR__Value() => 
 		new CqlCode("82323-7", "http://loinc.org", null, null);
 
+    /// <seealso cref="Total_interval_score__HOOSJR__Value"/>
     [CqlDeclaration("Total interval score [HOOSJR]")]
 	public CqlCode Total_interval_score__HOOSJR_() => 
 		__Total_interval_score__HOOSJR_.Value;
 
+    /// <seealso cref="VR_12_Mental_component_summary__MCS__score___oblique_method_T_score"/>
 	private CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
 		new CqlCode("72026-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value"/>
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - oblique method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
 
+    /// <seealso cref="VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score"/>
 	private CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
 		new CqlCode("72028-4", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value"/>
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
 
+    /// <seealso cref="VR_12_Physical_component_summary__PCS__score___oblique_method_T_score"/>
 	private CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
 		new CqlCode("72025-0", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value"/>
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - oblique method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
 
+    /// <seealso cref="VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score"/>
 	private CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
 		new CqlCode("72027-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value"/>
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
 
+    /// <seealso cref="Yes__qualifier_value_"/>
 	private CqlCode Yes__qualifier_value__Value() => 
 		new CqlCode("373066001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Yes__qualifier_value__Value"/>
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
 		__Yes__qualifier_value_.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("72095-3", "http://loinc.org", null, null),
 			new CqlCode("45755-6", "http://loinc.org", null, null),
@@ -474,13 +545,15 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null),
 		};
@@ -488,25 +561,29 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="ConditionCategoryCodes"/>
 	private CqlCode[] ConditionCategoryCodes_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="ConditionCategoryCodes_Value"/>
     [CqlDeclaration("ConditionCategoryCodes")]
 	public CqlCode[] ConditionCategoryCodes() => 
 		__ConditionCategoryCodes.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("419099009", "http://snomed.info/sct", null, null),
 			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
@@ -518,13 +595,15 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="ObservationCategoryCodes"/>
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", null, null),
 		};
@@ -532,604 +611,652 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		return a_;
 	}
 
+    /// <seealso cref="ObservationCategoryCodes_Value"/>
     [CqlDeclaration("ObservationCategoryCodes")]
 	public CqlCode[] ObservationCategoryCodes() => 
 		__ObservationCategoryCodes.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="November_1_Year_Prior_to_the_Measurement_Period"/>
 	private CqlDateTime November_1_Year_Prior_to_the_Measurement_Period_Value()
 	{
-		var a_ = this.Measurement_Period();
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateTimeComponentFrom(b_, "year");
-		var d_ = context.Operators.Subtract(c_, 1);
-		var e_ = context.Operators.ConvertIntegerToDecimal(0);
-		var f_ = context.Operators.DateTime(d_, 11, 1, 0, 0, 0, 0, e_);
+		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
+		CqlDateTime b_ = context.Operators.Start(a_);
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? d_ = context.Operators.Subtract(c_, 1);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
+		CqlDateTime f_ = context.Operators.DateTime(d_, 11, 1, 0, 0, 0, 0, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="November_1_Year_Prior_to_the_Measurement_Period_Value"/>
     [CqlDeclaration("November 1 Year Prior to the Measurement Period")]
 	public CqlDateTime November_1_Year_Prior_to_the_Measurement_Period() => 
 		__November_1_Year_Prior_to_the_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Qualifying_Encounter"/>
 	private bool? Has_Qualifying_Encounter_Value()
 	{
-		var a_ = this.Outpatient_Consultation();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Office_Visit();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		CqlValueSet a_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Office_Visit();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
 		bool? g_(Encounter E)
 		{
-			var t_ = E?.Type;
+			List<CodeableConcept> t_ = E?.Type;
 			CqlConcept u_(CodeableConcept @this)
 			{
-				var z_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept z_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return z_;
 			};
-			var v_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)t_, u_);
+			IEnumerable<CqlConcept> v_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)t_, u_);
 			bool? w_(CqlConcept T)
 			{
-				var aa_ = this.Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure();
-				var ab_ = context.Operators.ConvertCodeToConcept(aa_);
-				var ac_ = context.Operators.Equivalent(T, ab_);
+				CqlCode aa_ = this.Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure();
+				CqlConcept ab_ = context.Operators.ConvertCodeToConcept(aa_);
+				bool? ac_ = context.Operators.Equivalent(T, ab_);
 
 				return ac_;
 			};
-			var x_ = context.Operators.Where<CqlConcept>(v_, w_);
-			var y_ = context.Operators.Exists<CqlConcept>(x_);
+			IEnumerable<CqlConcept> x_ = context.Operators.Where<CqlConcept>(v_, w_);
+			bool? y_ = context.Operators.Exists<CqlConcept>(x_);
 
 			return y_;
 		};
-		var h_ = context.Operators.Where<Encounter>(f_, g_);
-		var i_ = this.Telephone_Visits();
-		var j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
-		var k_ = context.Operators.Union<Encounter>(h_, j_);
-		var l_ = context.Operators.Union<Encounter>(e_, k_);
-		var m_ = this.Online_Assessments();
-		var n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
-		var o_ = context.Operators.Union<Encounter>(l_, n_);
-		var p_ = Status_1_6_000.isEncounterPerformed(o_);
+		IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
+		CqlValueSet i_ = this.Telephone_Visits();
+		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(h_, j_);
+		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(e_, k_);
+		CqlValueSet m_ = this.Online_Assessments();
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		IEnumerable<Encounter> o_ = context.Operators.Union<Encounter>(l_, n_);
+		IEnumerable<Encounter> p_ = Status_1_6_000.isEncounterPerformed(o_);
 		bool? q_(Encounter ValidEncounters)
 		{
-			var ad_ = this.November_1_Year_Prior_to_the_Measurement_Period();
-			var ae_ = this.Measurement_Period();
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ad_, af_, true, true);
-			var ah_ = ValidEncounters?.Period;
-			var ai_ = FHIRHelpers_4_3_000.ToInterval(ah_);
-			var aj_ = QICoreCommon_2_0_000.toInterval((ai_ as object));
-			var ak_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ag_, aj_, "day");
+			CqlDateTime ad_ = this.November_1_Year_Prior_to_the_Measurement_Period();
+			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ad_, af_, true, true);
+			Period ah_ = ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_3_000.ToInterval(ah_);
+			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval((ai_ as object));
+			bool? ak_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ag_, aj_, "day");
 
 			return ak_;
 		};
-		var r_ = context.Operators.Where<Encounter>(p_, q_);
-		var s_ = context.Operators.Exists<Encounter>(r_);
+		IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
+		bool? s_ = context.Operators.Exists<Encounter>(r_);
 
 		return s_;
 	}
 
+    /// <seealso cref="Has_Qualifying_Encounter_Value"/>
     [CqlDeclaration("Has Qualifying Encounter")]
 	public bool? Has_Qualifying_Encounter() => 
 		__Has_Qualifying_Encounter.Value;
 
+    /// <seealso cref="November_1_Two_Years_Prior_to_the_Measurement_Period"/>
 	private CqlDateTime November_1_Two_Years_Prior_to_the_Measurement_Period_Value()
 	{
-		var a_ = this.Measurement_Period();
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateTimeComponentFrom(b_, "year");
-		var d_ = context.Operators.Subtract(c_, 2);
-		var e_ = context.Operators.ConvertIntegerToDecimal(0);
-		var f_ = context.Operators.DateTime(d_, 11, 1, 0, 0, 0, 0, e_);
+		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
+		CqlDateTime b_ = context.Operators.Start(a_);
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? d_ = context.Operators.Subtract(c_, 2);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
+		CqlDateTime f_ = context.Operators.DateTime(d_, 11, 1, 0, 0, 0, 0, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="November_1_Two_Years_Prior_to_the_Measurement_Period_Value"/>
     [CqlDeclaration("November 1 Two Years Prior to the Measurement Period")]
 	public CqlDateTime November_1_Two_Years_Prior_to_the_Measurement_Period() => 
 		__November_1_Two_Years_Prior_to_the_Measurement_Period.Value;
 
+    /// <seealso cref="October_31_Year_Prior_to_the_Measurement_Period"/>
 	private CqlDateTime October_31_Year_Prior_to_the_Measurement_Period_Value()
 	{
-		var a_ = this.Measurement_Period();
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateTimeComponentFrom(b_, "year");
-		var d_ = context.Operators.Subtract(c_, 1);
-		var e_ = context.Operators.ConvertIntegerToDecimal(0);
-		var f_ = context.Operators.DateTime(d_, 10, 31, 23, 59, 59, 0, e_);
+		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
+		CqlDateTime b_ = context.Operators.Start(a_);
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? d_ = context.Operators.Subtract(c_, 1);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
+		CqlDateTime f_ = context.Operators.DateTime(d_, 10, 31, 23, 59, 59, 0, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="October_31_Year_Prior_to_the_Measurement_Period_Value"/>
     [CqlDeclaration("October 31 Year Prior to the Measurement Period")]
 	public CqlDateTime October_31_Year_Prior_to_the_Measurement_Period() => 
 		__October_31_Year_Prior_to_the_Measurement_Period.Value;
 
+    /// <seealso cref="Total_Hip_Arthroplasty_Procedure"/>
 	private IEnumerable<Procedure> Total_Hip_Arthroplasty_Procedure_Value()
 	{
-		var a_ = this.Primary_THA_Procedure();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.isProcedurePerformed(b_);
+		CqlValueSet a_ = this.Primary_THA_Procedure();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		bool? d_(Procedure THAProcedure)
 		{
-			var f_ = THAProcedure?.Performed;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.toInterval(g_);
-			var i_ = context.Operators.Start(h_);
-			var j_ = this.November_1_Two_Years_Prior_to_the_Measurement_Period();
-			var k_ = this.October_31_Year_Prior_to_the_Measurement_Period();
-			var l_ = context.Operators.Interval(j_, k_, true, true);
-			var m_ = context.Operators.In<CqlDateTime>(i_, l_, "day");
+			DataType f_ = THAProcedure?.Performed;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.toInterval(g_);
+			CqlDateTime i_ = context.Operators.Start(h_);
+			CqlDateTime j_ = this.November_1_Two_Years_Prior_to_the_Measurement_Period();
+			CqlDateTime k_ = this.October_31_Year_Prior_to_the_Measurement_Period();
+			CqlInterval<CqlDateTime> l_ = context.Operators.Interval(j_, k_, true, true);
+			bool? m_ = context.Operators.In<CqlDateTime>(i_, l_, "day");
 
 			return m_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Total_Hip_Arthroplasty_Procedure_Value"/>
     [CqlDeclaration("Total Hip Arthroplasty Procedure")]
 	public IEnumerable<Procedure> Total_Hip_Arthroplasty_Procedure() => 
 		__Total_Hip_Arthroplasty_Procedure.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Has_Qualifying_Encounter();
-		var b_ = this.Total_Hip_Arthroplasty_Procedure();
-		var c_ = context.Operators.Exists<Procedure>(b_);
-		var d_ = context.Operators.And(a_, c_);
-		var e_ = this.Patient();
-		var f_ = context.Operators.Convert<CqlDate>(e_?.BirthDateElement?.Value);
-		var g_ = this.Measurement_Period();
-		var h_ = context.Operators.Start(g_);
-		var i_ = context.Operators.DateFrom(h_);
-		var j_ = context.Operators.CalculateAgeAt(f_, i_, "year");
-		var k_ = context.Operators.GreaterOrEqual(j_, 19);
-		var l_ = context.Operators.And(d_, k_);
+		bool? a_ = this.Has_Qualifying_Encounter();
+		IEnumerable<Procedure> b_ = this.Total_Hip_Arthroplasty_Procedure();
+		bool? c_ = context.Operators.Exists<Procedure>(b_);
+		bool? d_ = context.Operators.And(a_, c_);
+		Patient e_ = this.Patient();
+		Date f_ = e_?.BirthDateElement;
+		string g_ = f_?.Value;
+		CqlDate h_ = context.Operators.Convert<CqlDate>(g_);
+		CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
+		CqlDateTime j_ = context.Operators.Start(i_);
+		CqlDate k_ = context.Operators.DateFrom(j_);
+		int? l_ = context.Operators.CalculateAgeAt(h_, k_, "year");
+		bool? m_ = context.Operators.GreaterOrEqual(l_, 19);
+		bool? n_ = context.Operators.And(d_, m_);
 
-		return l_;
+		return n_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Has_Severe_Cognitive_Impairment"/>
 	private bool? Has_Severe_Cognitive_Impairment_Value()
 	{
-		var a_ = this.Severe_cognitive_impairment__finding_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		CqlCode a_ = this.Severe_cognitive_impairment__finding_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
 		bool? d_(Condition Dementia)
 		{
-			var g_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.Overlaps(g_, h_, null);
+			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			bool? i_ = context.Operators.Overlaps(g_, h_, null);
 
 			return i_;
 		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
-		var f_ = context.Operators.Exists<Condition>(e_);
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
+		bool? f_ = context.Operators.Exists<Condition>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Has_Severe_Cognitive_Impairment_Value"/>
     [CqlDeclaration("Has Severe Cognitive Impairment")]
 	public bool? Has_Severe_Cognitive_Impairment() => 
 		__Has_Severe_Cognitive_Impairment.Value;
 
+    /// <seealso cref="Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures"/>
 	private bool? Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures_Value()
 	{
-		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure();
 		IEnumerable<Procedure> b_(Procedure THAProcedure)
 		{
-			var e_ = this.Lower_Body_Fractures_Excluding_Ankle_and_Foot();
-			var f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
+			CqlValueSet e_ = this.Lower_Body_Fractures_Excluding_Ankle_and_Foot();
+			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
 			bool? g_(Condition LowerBodyFracture)
 			{
-				var k_ = QICoreCommon_2_0_000.prevalenceInterval(LowerBodyFracture);
-				var l_ = context.Operators.Start(k_);
-				var m_ = THAProcedure?.Performed;
-				var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var o_ = QICoreCommon_2_0_000.toInterval(n_);
-				var p_ = context.Operators.Start(o_);
-				var q_ = context.Operators.Quantity(24m, "hours");
-				var r_ = context.Operators.Subtract(p_, q_);
-				var t_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var u_ = QICoreCommon_2_0_000.toInterval(t_);
-				var v_ = context.Operators.Start(u_);
-				var w_ = context.Operators.Interval(r_, v_, true, true);
-				var x_ = context.Operators.In<CqlDateTime>(l_, w_, null);
-				var z_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var aa_ = QICoreCommon_2_0_000.toInterval(z_);
-				var ab_ = context.Operators.Start(aa_);
-				var ac_ = context.Operators.Not((bool?)(ab_ is null));
-				var ad_ = context.Operators.And(x_, ac_);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.prevalenceInterval(LowerBodyFracture);
+				CqlDateTime l_ = context.Operators.Start(k_);
+				DataType m_ = THAProcedure?.Performed;
+				object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlQuantity q_ = context.Operators.Quantity(24m, "hours");
+				CqlDateTime r_ = context.Operators.Subtract(p_, q_);
+				object t_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
+				CqlDateTime v_ = context.Operators.Start(u_);
+				CqlInterval<CqlDateTime> w_ = context.Operators.Interval(r_, v_, true, true);
+				bool? x_ = context.Operators.In<CqlDateTime>(l_, w_, null);
+				object z_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> aa_ = QICoreCommon_2_0_000.toInterval(z_);
+				CqlDateTime ab_ = context.Operators.Start(aa_);
+				bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
+				bool? ad_ = context.Operators.And(x_, ac_);
 
 				return ad_;
 			};
-			var h_ = context.Operators.Where<Condition>(f_, g_);
+			IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
 			Procedure i_(Condition LowerBodyFracture) => 
 				THAProcedure;
-			var j_ = context.Operators.Select<Condition, Procedure>(h_, i_);
+			IEnumerable<Procedure> j_ = context.Operators.Select<Condition, Procedure>(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
-		var d_ = context.Operators.Exists<Procedure>(c_);
+		IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
+		bool? d_ = context.Operators.Exists<Procedure>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures_Value"/>
     [CqlDeclaration("Has Total Hip Arthroplasty with 1 or More Lower Body Fractures")]
 	public bool? Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures() => 
 		__Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures.Value;
 
+    /// <seealso cref="Has_Partial_Hip_Arthroplasty_Procedure"/>
 	private bool? Has_Partial_Hip_Arthroplasty_Procedure_Value()
 	{
-		var a_ = this.Partial_Arthroplasty_of_Hip();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.isProcedurePerformed(b_);
+		CqlValueSet a_ = this.Partial_Arthroplasty_of_Hip();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		IEnumerable<Procedure> d_(Procedure PartialTHAProcedure)
 		{
-			var g_ = this.Total_Hip_Arthroplasty_Procedure();
+			IEnumerable<Procedure> g_ = this.Total_Hip_Arthroplasty_Procedure();
 			bool? h_(Procedure THAProcedure)
 			{
-				var l_ = THAProcedure?.Performed;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = QICoreCommon_2_0_000.toInterval(m_);
-				var o_ = PartialTHAProcedure?.Performed;
-				var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-				var q_ = QICoreCommon_2_0_000.toInterval(p_);
-				var r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, "day");
+				DataType l_ = THAProcedure?.Performed;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
+				DataType o_ = PartialTHAProcedure?.Performed;
+				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+				CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
+				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, "day");
 
 				return r_;
 			};
-			var i_ = context.Operators.Where<Procedure>(g_, h_);
+			IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
 			Procedure j_(Procedure THAProcedure) => 
 				PartialTHAProcedure;
-			var k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
+			IEnumerable<Procedure> k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
 
 			return k_;
 		};
-		var e_ = context.Operators.SelectMany<Procedure, Procedure>(c_, d_);
-		var f_ = context.Operators.Exists<Procedure>(e_);
+		IEnumerable<Procedure> e_ = context.Operators.SelectMany<Procedure, Procedure>(c_, d_);
+		bool? f_ = context.Operators.Exists<Procedure>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Has_Partial_Hip_Arthroplasty_Procedure_Value"/>
     [CqlDeclaration("Has Partial Hip Arthroplasty Procedure")]
 	public bool? Has_Partial_Hip_Arthroplasty_Procedure() => 
 		__Has_Partial_Hip_Arthroplasty_Procedure.Value;
 
+    /// <seealso cref="Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure"/>
 	private bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Value()
 	{
-		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure();
 		IEnumerable<Procedure> b_(Procedure THAProcedure)
 		{
-			var e_ = this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine();
-			var f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
-			var g_ = Status_1_6_000.isProcedurePerformed(f_);
+			CqlValueSet e_ = this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine();
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
+			IEnumerable<Procedure> g_ = Status_1_6_000.isProcedurePerformed(f_);
 			bool? h_(Procedure RevisionTHAProcedure)
 			{
-				var l_ = THAProcedure?.Performed;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = QICoreCommon_2_0_000.toInterval(m_);
-				var o_ = RevisionTHAProcedure?.Performed;
-				var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-				var q_ = QICoreCommon_2_0_000.toInterval(p_);
-				var r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, "day");
+				DataType l_ = THAProcedure?.Performed;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
+				DataType o_ = RevisionTHAProcedure?.Performed;
+				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+				CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
+				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, "day");
 
 				return r_;
 			};
-			var i_ = context.Operators.Where<Procedure>(g_, h_);
+			IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
 			Procedure j_(Procedure RevisionTHAProcedure) => 
 				THAProcedure;
-			var k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
+			IEnumerable<Procedure> k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
-		var d_ = context.Operators.Exists<Procedure>(c_);
+		IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
+		bool? d_ = context.Operators.Exists<Procedure>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure_Value"/>
     [CqlDeclaration("Has Revision Hip Arthroplasty Procedure or Implanted Device or Prosthesis Removal Procedure")]
 	public bool? Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure() => 
 		__Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure.Value;
 
+    /// <seealso cref="Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs"/>
 	private bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Value()
 	{
-		var a_ = this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		IEnumerable<Condition> c_(Condition MalignantNeoplasm)
 		{
-			var f_ = this.Total_Hip_Arthroplasty_Procedure();
+			IEnumerable<Procedure> f_ = this.Total_Hip_Arthroplasty_Procedure();
 			bool? g_(Procedure THAProcedure)
 			{
-				var k_ = QICoreCommon_2_0_000.prevalenceInterval(MalignantNeoplasm);
-				var l_ = THAProcedure?.Performed;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = QICoreCommon_2_0_000.toInterval(m_);
-				var o_ = context.Operators.Overlaps(k_, n_, null);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.prevalenceInterval(MalignantNeoplasm);
+				DataType l_ = THAProcedure?.Performed;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
+				bool? o_ = context.Operators.Overlaps(k_, n_, null);
 
 				return o_;
 			};
-			var h_ = context.Operators.Where<Procedure>(f_, g_);
+			IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
 			Condition i_(Procedure THAProcedure) => 
 				MalignantNeoplasm;
-			var j_ = context.Operators.Select<Procedure, Condition>(h_, i_);
+			IEnumerable<Condition> j_ = context.Operators.Select<Procedure, Condition>(h_, i_);
 
 			return j_;
 		};
-		var d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Value"/>
     [CqlDeclaration("Has Malignant Neoplasm of Lower and Unspecified Limbs")]
 	public bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs() => 
 		__Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs.Value;
 
+    /// <seealso cref="Has_Mechanical_Complication"/>
 	private bool? Has_Mechanical_Complication_Value()
 	{
-		var a_ = this.Mechanical_Complications_Excluding_Upper_Body();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Mechanical_Complications_Excluding_Upper_Body();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		IEnumerable<Condition> c_(Condition MechanicalComplications)
 		{
-			var f_ = this.Total_Hip_Arthroplasty_Procedure();
+			IEnumerable<Procedure> f_ = this.Total_Hip_Arthroplasty_Procedure();
 			bool? g_(Procedure THAProcedure)
 			{
-				var k_ = QICoreCommon_2_0_000.prevalenceInterval(MechanicalComplications);
-				var l_ = THAProcedure?.Performed;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = QICoreCommon_2_0_000.toInterval(m_);
-				var o_ = context.Operators.Overlaps(k_, n_, null);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.prevalenceInterval(MechanicalComplications);
+				DataType l_ = THAProcedure?.Performed;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
+				bool? o_ = context.Operators.Overlaps(k_, n_, null);
 
 				return o_;
 			};
-			var h_ = context.Operators.Where<Procedure>(f_, g_);
+			IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
 			Condition i_(Procedure THAProcedure) => 
 				MechanicalComplications;
-			var j_ = context.Operators.Select<Procedure, Condition>(h_, i_);
+			IEnumerable<Condition> j_ = context.Operators.Select<Procedure, Condition>(h_, i_);
 
 			return j_;
 		};
-		var d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Mechanical_Complication_Value"/>
     [CqlDeclaration("Has Mechanical Complication")]
 	public bool? Has_Mechanical_Complication() => 
 		__Has_Mechanical_Complication.Value;
 
+    /// <seealso cref="Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed"/>
 	private bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Value()
 	{
-		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure();
 		IEnumerable<Procedure> b_(Procedure THAProcedure)
 		{
-			var e_ = this.Primary_THA_Procedure();
-			var f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
-			var g_ = Status_1_6_000.isProcedurePerformed(f_);
+			CqlValueSet e_ = this.Primary_THA_Procedure();
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
+			IEnumerable<Procedure> g_ = Status_1_6_000.isProcedurePerformed(f_);
 			bool? h_(Procedure ElectiveTHAProcedure)
 			{
-				var l_ = THAProcedure?.IdElement;
-				var m_ = l_?.Value;
-				var n_ = ElectiveTHAProcedure?.IdElement;
-				var o_ = n_?.Value;
-				var p_ = context.Operators.Equivalent(m_, o_);
-				var q_ = context.Operators.Not(p_);
-				var r_ = ElectiveTHAProcedure?.Performed;
-				var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var t_ = QICoreCommon_2_0_000.toInterval(s_);
-				var u_ = context.Operators.Start(t_);
-				var v_ = THAProcedure?.Performed;
-				var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-				var x_ = QICoreCommon_2_0_000.toInterval(w_);
-				var y_ = context.Operators.Start(x_);
-				var z_ = context.Operators.Quantity(1m, "year");
-				var aa_ = context.Operators.Subtract(y_, z_);
-				var ac_ = FHIRHelpers_4_3_000.ToValue(v_);
-				var ad_ = QICoreCommon_2_0_000.toInterval(ac_);
-				var ae_ = context.Operators.Start(ad_);
-				var ag_ = context.Operators.Add(ae_, z_);
-				var ah_ = context.Operators.Interval(aa_, ag_, true, true);
-				var ai_ = context.Operators.In<CqlDateTime>(u_, ah_, "day");
-				var aj_ = context.Operators.And(q_, ai_);
+				Id l_ = THAProcedure?.IdElement;
+				string m_ = l_?.Value;
+				Id n_ = ElectiveTHAProcedure?.IdElement;
+				string o_ = n_?.Value;
+				bool? p_ = context.Operators.Equivalent(m_, o_);
+				bool? q_ = context.Operators.Not(p_);
+				DataType r_ = ElectiveTHAProcedure?.Performed;
+				object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+				CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.toInterval(s_);
+				CqlDateTime u_ = context.Operators.Start(t_);
+				DataType v_ = THAProcedure?.Performed;
+				object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+				CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.toInterval(w_);
+				CqlDateTime y_ = context.Operators.Start(x_);
+				CqlQuantity z_ = context.Operators.Quantity(1m, "year");
+				CqlDateTime aa_ = context.Operators.Subtract(y_, z_);
+				object ac_ = FHIRHelpers_4_3_000.ToValue(v_);
+				CqlInterval<CqlDateTime> ad_ = QICoreCommon_2_0_000.toInterval(ac_);
+				CqlDateTime ae_ = context.Operators.Start(ad_);
+				CqlDateTime ag_ = context.Operators.Add(ae_, z_);
+				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(aa_, ag_, true, true);
+				bool? ai_ = context.Operators.In<CqlDateTime>(u_, ah_, "day");
+				bool? aj_ = context.Operators.And(q_, ai_);
 
 				return aj_;
 			};
-			var i_ = context.Operators.Where<Procedure>(g_, h_);
+			IEnumerable<Procedure> i_ = context.Operators.Where<Procedure>(g_, h_);
 			Procedure j_(Procedure ElectiveTHAProcedure) => 
 				THAProcedure;
-			var k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
+			IEnumerable<Procedure> k_ = context.Operators.Select<Procedure, Procedure>(i_, j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
-		var d_ = context.Operators.Exists<Procedure>(c_);
+		IEnumerable<Procedure> c_ = context.Operators.SelectMany<Procedure, Procedure>(a_, b_);
+		bool? d_ = context.Operators.Exists<Procedure>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed_Value"/>
     [CqlDeclaration("Has More Than One Elective Primary Total Hip Arthroplasty Performed")]
 	public bool? Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed() => 
 		__Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed.Value;
 
+    /// <seealso cref="Death_Within_300_Days_of_the_THA_Procedure"/>
 	private bool? Death_Within_300_Days_of_the_THA_Procedure_Value()
 	{
-		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure();
 		bool? b_(Procedure THAProcedure)
 		{
-			var e_ = this.Patient();
-			var f_ = e_?.Deceased;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = context.Operators.DateFrom((g_ as CqlDateTime));
-			var i_ = THAProcedure?.Performed;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = QICoreCommon_2_0_000.toInterval(j_);
-			var l_ = context.Operators.Start(k_);
-			var m_ = context.Operators.DateFrom(l_);
-			var o_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var p_ = QICoreCommon_2_0_000.toInterval(o_);
-			var q_ = context.Operators.Start(p_);
-			var r_ = context.Operators.DateFrom(q_);
-			var s_ = context.Operators.Quantity(300m, "days");
-			var t_ = context.Operators.Add(r_, s_);
-			var u_ = context.Operators.Interval(m_, t_, true, true);
-			var v_ = context.Operators.In<CqlDate>(h_, u_, "day");
+			Patient e_ = this.Patient();
+			DataType f_ = e_?.Deceased;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlDate h_ = context.Operators.DateFrom((g_ as CqlDateTime));
+			DataType i_ = THAProcedure?.Performed;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
+			CqlDateTime l_ = context.Operators.Start(k_);
+			CqlDate m_ = context.Operators.DateFrom(l_);
+			object o_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+			CqlDateTime q_ = context.Operators.Start(p_);
+			CqlDate r_ = context.Operators.DateFrom(q_);
+			CqlQuantity s_ = context.Operators.Quantity(300m, "days");
+			CqlDate t_ = context.Operators.Add(r_, s_);
+			CqlInterval<CqlDate> u_ = context.Operators.Interval(m_, t_, true, true);
+			bool? v_ = context.Operators.In<CqlDate>(h_, u_, "day");
 
 			return v_;
 		};
-		var c_ = context.Operators.Where<Procedure>(a_, b_);
-		var d_ = context.Operators.Exists<Procedure>(c_);
+		IEnumerable<Procedure> c_ = context.Operators.Where<Procedure>(a_, b_);
+		bool? d_ = context.Operators.Exists<Procedure>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Death_Within_300_Days_of_the_THA_Procedure_Value"/>
     [CqlDeclaration("Death Within 300 Days of the THA Procedure")]
 	public bool? Death_Within_300_Days_of_the_THA_Procedure() => 
 		__Death_Within_300_Days_of_the_THA_Procedure.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = this.Has_Severe_Cognitive_Impairment();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures();
-		var e_ = context.Operators.Or(c_, d_);
-		var f_ = this.Has_Partial_Hip_Arthroplasty_Procedure();
-		var g_ = context.Operators.Or(e_, f_);
-		var h_ = this.Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure();
-		var i_ = context.Operators.Or(g_, h_);
-		var j_ = this.Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs();
-		var k_ = context.Operators.Or(i_, j_);
-		var l_ = this.Has_Mechanical_Complication();
-		var m_ = context.Operators.Or(k_, l_);
-		var n_ = this.Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed();
-		var o_ = context.Operators.Or(m_, n_);
-		var p_ = this.Death_Within_300_Days_of_the_THA_Procedure();
-		var q_ = context.Operators.Or(o_, p_);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? b_ = this.Has_Severe_Cognitive_Impairment();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = this.Has_Total_Hip_Arthroplasty_with_1_or_More_Lower_Body_Fractures();
+		bool? e_ = context.Operators.Or(c_, d_);
+		bool? f_ = this.Has_Partial_Hip_Arthroplasty_Procedure();
+		bool? g_ = context.Operators.Or(e_, f_);
+		bool? h_ = this.Has_Revision_Hip_Arthroplasty_Procedure_or_Implanted_Device_or_Prosthesis_Removal_Procedure();
+		bool? i_ = context.Operators.Or(g_, h_);
+		bool? j_ = this.Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs();
+		bool? k_ = context.Operators.Or(i_, j_);
+		bool? l_ = this.Has_Mechanical_Complication();
+		bool? m_ = context.Operators.Or(k_, l_);
+		bool? n_ = this.Has_More_Than_One_Elective_Primary_Total_Hip_Arthroplasty_Performed();
+		bool? o_ = context.Operators.Or(m_, n_);
+		bool? p_ = this.Death_Within_300_Days_of_the_THA_Procedure();
+		bool? q_ = context.Operators.Or(o_, p_);
 
 		return q_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Date_HOOS_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_HOOS_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.Quality_of_life_score__HOOS_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.isAssessmentPerformed(c_);
-		var e_ = this.Sport_recreation_score__HOOS_();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.isAssessmentPerformed(g_);
-		var i_ = this.Activities_of_daily_living_score__HOOS_();
-		var j_ = context.Operators.ToList<CqlCode>(i_);
-		var k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
-		var l_ = Status_1_6_000.isAssessmentPerformed(k_);
-		var m_ = this.Symptoms_score__HOOS_();
-		var n_ = context.Operators.ToList<CqlCode>(m_);
-		var o_ = context.Operators.RetrieveByCodes<Observation>(n_, null);
-		var p_ = Status_1_6_000.isAssessmentPerformed(o_);
-		var q_ = this.Pain_score__HOOS_();
-		var r_ = context.Operators.ToList<CqlCode>(q_);
-		var s_ = context.Operators.RetrieveByCodes<Observation>(r_, null);
-		var t_ = Status_1_6_000.isAssessmentPerformed(s_);
-		var u_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_);
+		CqlCode a_ = this.Quality_of_life_score__HOOS_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.isAssessmentPerformed(c_);
+		CqlCode e_ = this.Sport_recreation_score__HOOS_();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.isAssessmentPerformed(g_);
+		CqlCode i_ = this.Activities_of_daily_living_score__HOOS_();
+		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
+		IEnumerable<Observation> l_ = Status_1_6_000.isAssessmentPerformed(k_);
+		CqlCode m_ = this.Symptoms_score__HOOS_();
+		IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
+		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, null);
+		IEnumerable<Observation> p_ = Status_1_6_000.isAssessmentPerformed(o_);
+		CqlCode q_ = this.Pain_score__HOOS_();
+		IEnumerable<CqlCode> r_ = context.Operators.ToList<CqlCode>(q_);
+		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, null);
+		IEnumerable<Observation> t_ = Status_1_6_000.isAssessmentPerformed(s_);
+		IEnumerable<ValueTuple<Observation, Observation, Observation, Observation, Observation>> u_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_);
 		Tuple_EIPfMaZVhFScjijaOFHiCPVMb v_(ValueTuple<Observation, Observation, Observation, Observation, Observation> _valueTuple)
 		{
-			var ab_ = new Tuple_EIPfMaZVhFScjijaOFHiCPVMb
+			Tuple_EIPfMaZVhFScjijaOFHiCPVMb ab_ = new Tuple_EIPfMaZVhFScjijaOFHiCPVMb
 			{
 				HOOSLifeQuality = _valueTuple.Item1,
 				HOOSSport = _valueTuple.Item2,
@@ -1140,105 +1267,105 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 
 			return ab_;
 		};
-		var w_ = context.Operators.Select<ValueTuple<Observation, Observation, Observation, Observation, Observation>, Tuple_EIPfMaZVhFScjijaOFHiCPVMb>(u_, v_);
+		IEnumerable<Tuple_EIPfMaZVhFScjijaOFHiCPVMb> w_ = context.Operators.Select<ValueTuple<Observation, Observation, Observation, Observation, Observation>, Tuple_EIPfMaZVhFScjijaOFHiCPVMb>(u_, v_);
 		bool? x_(Tuple_EIPfMaZVhFScjijaOFHiCPVMb tuple_eipfmazvhfscjijaofhicpvmb)
 		{
-			var ac_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSLifeQuality?.Effective;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = QICoreCommon_2_0_000.toInterval(ad_);
-			var af_ = context.Operators.Start(ae_);
-			var ag_ = context.Operators.DateFrom(af_);
-			var ah_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSport?.Effective;
-			var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-			var aj_ = QICoreCommon_2_0_000.toInterval(ai_);
-			var ak_ = context.Operators.Start(aj_);
-			var al_ = context.Operators.DateFrom(ak_);
-			var am_ = context.Operators.SameAs(ag_, al_, "day");
-			var an_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSport?.Value;
-			var ao_ = FHIRHelpers_4_3_000.ToValue(an_);
-			var ap_ = context.Operators.Not((bool?)(ao_ is null));
-			var aq_ = context.Operators.And(am_, ap_);
-			var as_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var at_ = QICoreCommon_2_0_000.toInterval(as_);
-			var au_ = context.Operators.Start(at_);
-			var av_ = context.Operators.DateFrom(au_);
-			var aw_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSActivityScore?.Effective;
-			var ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
-			var ay_ = QICoreCommon_2_0_000.toInterval(ax_);
-			var az_ = context.Operators.Start(ay_);
-			var ba_ = context.Operators.DateFrom(az_);
-			var bb_ = context.Operators.SameAs(av_, ba_, "day");
-			var bc_ = context.Operators.And(aq_, bb_);
-			var bd_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSActivityScore?.Value;
-			var be_ = FHIRHelpers_4_3_000.ToValue(bd_);
-			var bf_ = context.Operators.Not((bool?)(be_ is null));
-			var bg_ = context.Operators.And(bc_, bf_);
-			var bi_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var bj_ = QICoreCommon_2_0_000.toInterval(bi_);
-			var bk_ = context.Operators.Start(bj_);
-			var bl_ = context.Operators.DateFrom(bk_);
-			var bm_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSymptoms?.Effective;
-			var bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
-			var bo_ = QICoreCommon_2_0_000.toInterval(bn_);
-			var bp_ = context.Operators.Start(bo_);
-			var bq_ = context.Operators.DateFrom(bp_);
-			var br_ = context.Operators.SameAs(bl_, bq_, "day");
-			var bs_ = context.Operators.And(bg_, br_);
-			var bt_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSymptoms?.Value;
-			var bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
-			var bv_ = context.Operators.Not((bool?)(bu_ is null));
-			var bw_ = context.Operators.And(bs_, bv_);
-			var by_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var bz_ = QICoreCommon_2_0_000.toInterval(by_);
-			var ca_ = context.Operators.Start(bz_);
-			var cb_ = context.Operators.DateFrom(ca_);
-			var cc_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSPain?.Effective;
-			var cd_ = FHIRHelpers_4_3_000.ToValue(cc_);
-			var ce_ = QICoreCommon_2_0_000.toInterval(cd_);
-			var cf_ = context.Operators.Start(ce_);
-			var cg_ = context.Operators.DateFrom(cf_);
-			var ch_ = context.Operators.SameAs(cb_, cg_, "day");
-			var ci_ = context.Operators.And(bw_, ch_);
-			var cj_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSPain?.Value;
-			var ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
-			var cl_ = context.Operators.Not((bool?)(ck_ is null));
-			var cm_ = context.Operators.And(ci_, cl_);
-			var cn_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSLifeQuality?.Value;
-			var co_ = FHIRHelpers_4_3_000.ToValue(cn_);
-			var cp_ = context.Operators.Not((bool?)(co_ is null));
-			var cq_ = context.Operators.And(cm_, cp_);
+			DataType ac_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSLifeQuality?.Effective;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.toInterval(ad_);
+			CqlDateTime af_ = context.Operators.Start(ae_);
+			CqlDate ag_ = context.Operators.DateFrom(af_);
+			DataType ah_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSport?.Effective;
+			object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlDate al_ = context.Operators.DateFrom(ak_);
+			bool? am_ = context.Operators.SameAs(ag_, al_, "day");
+			DataType an_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSport?.Value;
+			object ao_ = FHIRHelpers_4_3_000.ToValue(an_);
+			bool? ap_ = context.Operators.Not((bool?)(ao_ is null));
+			bool? aq_ = context.Operators.And(am_, ap_);
+			object as_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlInterval<CqlDateTime> at_ = QICoreCommon_2_0_000.toInterval(as_);
+			CqlDateTime au_ = context.Operators.Start(at_);
+			CqlDate av_ = context.Operators.DateFrom(au_);
+			DataType aw_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSActivityScore?.Effective;
+			object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+			CqlInterval<CqlDateTime> ay_ = QICoreCommon_2_0_000.toInterval(ax_);
+			CqlDateTime az_ = context.Operators.Start(ay_);
+			CqlDate ba_ = context.Operators.DateFrom(az_);
+			bool? bb_ = context.Operators.SameAs(av_, ba_, "day");
+			bool? bc_ = context.Operators.And(aq_, bb_);
+			DataType bd_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSActivityScore?.Value;
+			object be_ = FHIRHelpers_4_3_000.ToValue(bd_);
+			bool? bf_ = context.Operators.Not((bool?)(be_ is null));
+			bool? bg_ = context.Operators.And(bc_, bf_);
+			object bi_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlInterval<CqlDateTime> bj_ = QICoreCommon_2_0_000.toInterval(bi_);
+			CqlDateTime bk_ = context.Operators.Start(bj_);
+			CqlDate bl_ = context.Operators.DateFrom(bk_);
+			DataType bm_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSymptoms?.Effective;
+			object bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
+			CqlInterval<CqlDateTime> bo_ = QICoreCommon_2_0_000.toInterval(bn_);
+			CqlDateTime bp_ = context.Operators.Start(bo_);
+			CqlDate bq_ = context.Operators.DateFrom(bp_);
+			bool? br_ = context.Operators.SameAs(bl_, bq_, "day");
+			bool? bs_ = context.Operators.And(bg_, br_);
+			DataType bt_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSymptoms?.Value;
+			object bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
+			bool? bv_ = context.Operators.Not((bool?)(bu_ is null));
+			bool? bw_ = context.Operators.And(bs_, bv_);
+			object by_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlInterval<CqlDateTime> bz_ = QICoreCommon_2_0_000.toInterval(by_);
+			CqlDateTime ca_ = context.Operators.Start(bz_);
+			CqlDate cb_ = context.Operators.DateFrom(ca_);
+			DataType cc_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSPain?.Effective;
+			object cd_ = FHIRHelpers_4_3_000.ToValue(cc_);
+			CqlInterval<CqlDateTime> ce_ = QICoreCommon_2_0_000.toInterval(cd_);
+			CqlDateTime cf_ = context.Operators.Start(ce_);
+			CqlDate cg_ = context.Operators.DateFrom(cf_);
+			bool? ch_ = context.Operators.SameAs(cb_, cg_, "day");
+			bool? ci_ = context.Operators.And(bw_, ch_);
+			DataType cj_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSPain?.Value;
+			object ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
+			bool? cl_ = context.Operators.Not((bool?)(ck_ is null));
+			bool? cm_ = context.Operators.And(ci_, cl_);
+			DataType cn_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSLifeQuality?.Value;
+			object co_ = FHIRHelpers_4_3_000.ToValue(cn_);
+			bool? cp_ = context.Operators.Not((bool?)(co_ is null));
+			bool? cq_ = context.Operators.And(cm_, cp_);
 
 			return cq_;
 		};
-		var y_ = context.Operators.Where<Tuple_EIPfMaZVhFScjijaOFHiCPVMb>(w_, x_);
+		IEnumerable<Tuple_EIPfMaZVhFScjijaOFHiCPVMb> y_ = context.Operators.Where<Tuple_EIPfMaZVhFScjijaOFHiCPVMb>(w_, x_);
 		CqlDate z_(Tuple_EIPfMaZVhFScjijaOFHiCPVMb tuple_eipfmazvhfscjijaofhicpvmb)
 		{
-			var cr_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSLifeQuality?.Effective;
-			var cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
-			var ct_ = QICoreCommon_2_0_000.toInterval(cs_);
-			var cu_ = context.Operators.Start(ct_);
-			var cv_ = context.Operators.DateFrom(cu_);
-			var cw_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSport?.Effective;
-			var cx_ = FHIRHelpers_4_3_000.ToValue(cw_);
-			var cy_ = QICoreCommon_2_0_000.toInterval(cx_);
-			var cz_ = context.Operators.Start(cy_);
-			var da_ = context.Operators.DateFrom(cz_);
-			var db_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSActivityScore?.Effective;
-			var dc_ = FHIRHelpers_4_3_000.ToValue(db_);
-			var dd_ = QICoreCommon_2_0_000.toInterval(dc_);
-			var de_ = context.Operators.Start(dd_);
-			var df_ = context.Operators.DateFrom(de_);
-			var dg_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSymptoms?.Effective;
-			var dh_ = FHIRHelpers_4_3_000.ToValue(dg_);
-			var di_ = QICoreCommon_2_0_000.toInterval(dh_);
-			var dj_ = context.Operators.Start(di_);
-			var dk_ = context.Operators.DateFrom(dj_);
-			var dl_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSPain?.Effective;
-			var dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
-			var dn_ = QICoreCommon_2_0_000.toInterval(dm_);
-			var do_ = context.Operators.Start(dn_);
-			var dp_ = context.Operators.DateFrom(do_);
-			var dq_ = new CqlDate[]
+			DataType cr_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSLifeQuality?.Effective;
+			object cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
+			CqlInterval<CqlDateTime> ct_ = QICoreCommon_2_0_000.toInterval(cs_);
+			CqlDateTime cu_ = context.Operators.Start(ct_);
+			CqlDate cv_ = context.Operators.DateFrom(cu_);
+			DataType cw_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSport?.Effective;
+			object cx_ = FHIRHelpers_4_3_000.ToValue(cw_);
+			CqlInterval<CqlDateTime> cy_ = QICoreCommon_2_0_000.toInterval(cx_);
+			CqlDateTime cz_ = context.Operators.Start(cy_);
+			CqlDate da_ = context.Operators.DateFrom(cz_);
+			DataType db_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSActivityScore?.Effective;
+			object dc_ = FHIRHelpers_4_3_000.ToValue(db_);
+			CqlInterval<CqlDateTime> dd_ = QICoreCommon_2_0_000.toInterval(dc_);
+			CqlDateTime de_ = context.Operators.Start(dd_);
+			CqlDate df_ = context.Operators.DateFrom(de_);
+			DataType dg_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSymptoms?.Effective;
+			object dh_ = FHIRHelpers_4_3_000.ToValue(dg_);
+			CqlInterval<CqlDateTime> di_ = QICoreCommon_2_0_000.toInterval(dh_);
+			CqlDateTime dj_ = context.Operators.Start(di_);
+			CqlDate dk_ = context.Operators.DateFrom(dj_);
+			DataType dl_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSPain?.Effective;
+			object dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
+			CqlInterval<CqlDateTime> dn_ = QICoreCommon_2_0_000.toInterval(dm_);
+			CqlDateTime do_ = context.Operators.Start(dn_);
+			CqlDate dp_ = context.Operators.DateFrom(do_);
+			CqlDate[] dq_ = new CqlDate[]
 			{
 				cv_,
 				da_,
@@ -1246,232 +1373,240 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				dk_,
 				dp_,
 			};
-			var dr_ = context.Operators.Max<CqlDate>((dq_ as IEnumerable<CqlDate>));
+			CqlDate dr_ = context.Operators.Max<CqlDate>((dq_ as IEnumerable<CqlDate>));
 
 			return dr_;
 		};
-		var aa_ = context.Operators.Select<Tuple_EIPfMaZVhFScjijaOFHiCPVMb, CqlDate>(y_, z_);
+		IEnumerable<CqlDate> aa_ = context.Operators.Select<Tuple_EIPfMaZVhFScjijaOFHiCPVMb, CqlDate>(y_, z_);
 
 		return aa_;
 	}
 
+    /// <seealso cref="Date_HOOS_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date HOOS Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_HOOS_Total_Assessment_Completed() => 
 		__Date_HOOS_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments"/>
 	private bool? Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments_Value()
 	{
-		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure();
 		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
 		{
-			var i_ = THAProcedure?.Performed;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = QICoreCommon_2_0_000.toInterval(j_);
+			DataType i_ = THAProcedure?.Performed;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
 		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var l_ = this.Date_HOOS_Total_Assessment_Completed();
+			IEnumerable<CqlDate> l_ = this.Date_HOOS_Total_Assessment_Completed();
 			bool? m_(CqlDate InitialHipAssessmentHOOS)
 			{
-				var q_ = context.Operators.Start(TotalHip);
-				var r_ = context.Operators.Quantity(90m, "days");
-				var s_ = context.Operators.Add(InitialHipAssessmentHOOS, r_);
-				var t_ = context.Operators.Interval(InitialHipAssessmentHOOS, s_, true, true);
-				var u_ = t_?.low;
-				var v_ = context.Operators.ConvertDateToDateTime(u_);
-				var x_ = context.Operators.Add(InitialHipAssessmentHOOS, r_);
-				var y_ = context.Operators.Interval(InitialHipAssessmentHOOS, x_, true, true);
-				var z_ = y_?.high;
-				var aa_ = context.Operators.ConvertDateToDateTime(z_);
-				var ac_ = context.Operators.Add(InitialHipAssessmentHOOS, r_);
-				var ad_ = context.Operators.Interval(InitialHipAssessmentHOOS, ac_, true, true);
-				var ae_ = ad_?.lowClosed;
-				var ag_ = context.Operators.Add(InitialHipAssessmentHOOS, r_);
-				var ah_ = context.Operators.Interval(InitialHipAssessmentHOOS, ag_, true, true);
-				var ai_ = ah_?.highClosed;
-				var aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				var ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
-				var al_ = context.Operators.Not((bool?)(InitialHipAssessmentHOOS is null));
-				var am_ = context.Operators.And(ak_, al_);
+				CqlDateTime q_ = context.Operators.Start(TotalHip);
+				CqlQuantity r_ = context.Operators.Quantity(90m, "days");
+				CqlDate s_ = context.Operators.Add(InitialHipAssessmentHOOS, r_);
+				CqlInterval<CqlDate> t_ = context.Operators.Interval(InitialHipAssessmentHOOS, s_, true, true);
+				CqlDate u_ = t_?.low;
+				CqlDateTime v_ = context.Operators.ConvertDateToDateTime(u_);
+				CqlDate x_ = context.Operators.Add(InitialHipAssessmentHOOS, r_);
+				CqlInterval<CqlDate> y_ = context.Operators.Interval(InitialHipAssessmentHOOS, x_, true, true);
+				CqlDate z_ = y_?.high;
+				CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+				CqlDate ac_ = context.Operators.Add(InitialHipAssessmentHOOS, r_);
+				CqlInterval<CqlDate> ad_ = context.Operators.Interval(InitialHipAssessmentHOOS, ac_, true, true);
+				bool? ae_ = ad_?.lowClosed;
+				CqlDate ag_ = context.Operators.Add(InitialHipAssessmentHOOS, r_);
+				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessmentHOOS, ag_, true, true);
+				bool? ai_ = ah_?.highClosed;
+				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessmentHOOS is null));
+				bool? am_ = context.Operators.And(ak_, al_);
 
 				return am_;
 			};
-			var n_ = context.Operators.Where<CqlDate>(l_, m_);
+			IEnumerable<CqlDate> n_ = context.Operators.Where<CqlDate>(l_, m_);
 			CqlInterval<CqlDateTime> o_(CqlDate InitialHipAssessmentHOOS) => 
 				TotalHip;
-			var p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
+			IEnumerable<CqlInterval<CqlDateTime>> p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
 
 			return p_;
 		};
-		var e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
 		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var an_ = this.Date_HOOS_Total_Assessment_Completed();
+			IEnumerable<CqlDate> an_ = this.Date_HOOS_Total_Assessment_Completed();
 			bool? ao_(CqlDate FollowUpHipAssessmentHOOS)
 			{
-				var as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentHOOS);
-				var at_ = context.Operators.DateFrom(as_);
-				var au_ = context.Operators.End(TotalHip);
-				var av_ = context.Operators.DateFrom(au_);
-				var aw_ = context.Operators.Quantity(300m, "days");
-				var ax_ = context.Operators.Add(av_, aw_);
-				var az_ = context.Operators.DateFrom(au_);
-				var ba_ = context.Operators.Quantity(425m, "days");
-				var bb_ = context.Operators.Add(az_, ba_);
-				var bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				var bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				CqlDateTime as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentHOOS);
+				CqlDate at_ = context.Operators.DateFrom(as_);
+				CqlDateTime au_ = context.Operators.End(TotalHip);
+				CqlDate av_ = context.Operators.DateFrom(au_);
+				CqlQuantity aw_ = context.Operators.Quantity(300m, "days");
+				CqlDate ax_ = context.Operators.Add(av_, aw_);
+				CqlDate az_ = context.Operators.DateFrom(au_);
+				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
+				CqlDate bb_ = context.Operators.Add(az_, ba_);
+				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
 
 				return bd_;
 			};
-			var ap_ = context.Operators.Where<CqlDate>(an_, ao_);
+			IEnumerable<CqlDate> ap_ = context.Operators.Where<CqlDate>(an_, ao_);
 			CqlInterval<CqlDateTime> aq_(CqlDate FollowUpHipAssessmentHOOS) => 
 				TotalHip;
-			var ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
+			IEnumerable<CqlInterval<CqlDateTime>> ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
 
 			return ar_;
 		};
-		var g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
-		var h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
+		IEnumerable<CqlInterval<CqlDateTime>> g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		bool? h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments_Value"/>
     [CqlDeclaration("Has THA with Initial and Follow Up HOOS Assessments")]
 	public bool? Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments() => 
 		__Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments.Value;
 
+    /// <seealso cref="Date_HOOSJr_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_HOOSJr_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.Total_interval_score__HOOSJR_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.Total_interval_score__HOOSJR_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation HOOSJr)
 		{
-			var h_ = HOOSJr?.Value;
-			var i_ = FHIRHelpers_4_3_000.ToValue(h_);
-			var j_ = context.Operators.Not((bool?)(i_ is null));
+			DataType h_ = HOOSJr?.Value;
+			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
+			bool? j_ = context.Operators.Not((bool?)(i_ is null));
 
 			return j_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		CqlDate f_(Observation DocumentedHOOSJr)
 		{
-			var k_ = DocumentedHOOSJr?.Effective;
-			var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-			var m_ = QICoreCommon_2_0_000.toInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = context.Operators.DateFrom(n_);
+			DataType k_ = DocumentedHOOSJr?.Effective;
+			object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+			CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.toInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlDate o_ = context.Operators.DateFrom(n_);
 
 			return o_;
 		};
-		var g_ = context.Operators.Select<Observation, CqlDate>(e_, f_);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Observation, CqlDate>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Date_HOOSJr_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date HOOSJr Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_HOOSJr_Total_Assessment_Completed() => 
 		__Date_HOOSJr_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments"/>
 	private bool? Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments_Value()
 	{
-		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure();
 		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
 		{
-			var i_ = THAProcedure?.Performed;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = QICoreCommon_2_0_000.toInterval(j_);
+			DataType i_ = THAProcedure?.Performed;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
 		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var l_ = this.Date_HOOSJr_Total_Assessment_Completed();
+			IEnumerable<CqlDate> l_ = this.Date_HOOSJr_Total_Assessment_Completed();
 			bool? m_(CqlDate InitialHipAssessment)
 			{
-				var q_ = context.Operators.Start(TotalHip);
-				var r_ = context.Operators.Quantity(90m, "days");
-				var s_ = context.Operators.Add(InitialHipAssessment, r_);
-				var t_ = context.Operators.Interval(InitialHipAssessment, s_, true, true);
-				var u_ = t_?.low;
-				var v_ = context.Operators.ConvertDateToDateTime(u_);
-				var x_ = context.Operators.Add(InitialHipAssessment, r_);
-				var y_ = context.Operators.Interval(InitialHipAssessment, x_, true, true);
-				var z_ = y_?.high;
-				var aa_ = context.Operators.ConvertDateToDateTime(z_);
-				var ac_ = context.Operators.Add(InitialHipAssessment, r_);
-				var ad_ = context.Operators.Interval(InitialHipAssessment, ac_, true, true);
-				var ae_ = ad_?.lowClosed;
-				var ag_ = context.Operators.Add(InitialHipAssessment, r_);
-				var ah_ = context.Operators.Interval(InitialHipAssessment, ag_, true, true);
-				var ai_ = ah_?.highClosed;
-				var aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				var ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
-				var al_ = context.Operators.Not((bool?)(InitialHipAssessment is null));
-				var am_ = context.Operators.And(ak_, al_);
+				CqlDateTime q_ = context.Operators.Start(TotalHip);
+				CqlQuantity r_ = context.Operators.Quantity(90m, "days");
+				CqlDate s_ = context.Operators.Add(InitialHipAssessment, r_);
+				CqlInterval<CqlDate> t_ = context.Operators.Interval(InitialHipAssessment, s_, true, true);
+				CqlDate u_ = t_?.low;
+				CqlDateTime v_ = context.Operators.ConvertDateToDateTime(u_);
+				CqlDate x_ = context.Operators.Add(InitialHipAssessment, r_);
+				CqlInterval<CqlDate> y_ = context.Operators.Interval(InitialHipAssessment, x_, true, true);
+				CqlDate z_ = y_?.high;
+				CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+				CqlDate ac_ = context.Operators.Add(InitialHipAssessment, r_);
+				CqlInterval<CqlDate> ad_ = context.Operators.Interval(InitialHipAssessment, ac_, true, true);
+				bool? ae_ = ad_?.lowClosed;
+				CqlDate ag_ = context.Operators.Add(InitialHipAssessment, r_);
+				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessment, ag_, true, true);
+				bool? ai_ = ah_?.highClosed;
+				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessment is null));
+				bool? am_ = context.Operators.And(ak_, al_);
 
 				return am_;
 			};
-			var n_ = context.Operators.Where<CqlDate>(l_, m_);
+			IEnumerable<CqlDate> n_ = context.Operators.Where<CqlDate>(l_, m_);
 			CqlInterval<CqlDateTime> o_(CqlDate InitialHipAssessment) => 
 				TotalHip;
-			var p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
+			IEnumerable<CqlInterval<CqlDateTime>> p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
 
 			return p_;
 		};
-		var e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
 		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var an_ = this.Date_HOOSJr_Total_Assessment_Completed();
+			IEnumerable<CqlDate> an_ = this.Date_HOOSJr_Total_Assessment_Completed();
 			bool? ao_(CqlDate FollowUpHipAssessment)
 			{
-				var as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessment);
-				var at_ = context.Operators.DateFrom(as_);
-				var au_ = context.Operators.End(TotalHip);
-				var av_ = context.Operators.DateFrom(au_);
-				var aw_ = context.Operators.Quantity(300m, "days");
-				var ax_ = context.Operators.Add(av_, aw_);
-				var az_ = context.Operators.DateFrom(au_);
-				var ba_ = context.Operators.Quantity(425m, "days");
-				var bb_ = context.Operators.Add(az_, ba_);
-				var bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				var bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				CqlDateTime as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessment);
+				CqlDate at_ = context.Operators.DateFrom(as_);
+				CqlDateTime au_ = context.Operators.End(TotalHip);
+				CqlDate av_ = context.Operators.DateFrom(au_);
+				CqlQuantity aw_ = context.Operators.Quantity(300m, "days");
+				CqlDate ax_ = context.Operators.Add(av_, aw_);
+				CqlDate az_ = context.Operators.DateFrom(au_);
+				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
+				CqlDate bb_ = context.Operators.Add(az_, ba_);
+				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
 
 				return bd_;
 			};
-			var ap_ = context.Operators.Where<CqlDate>(an_, ao_);
+			IEnumerable<CqlDate> ap_ = context.Operators.Where<CqlDate>(an_, ao_);
 			CqlInterval<CqlDateTime> aq_(CqlDate FollowUpHipAssessment) => 
 				TotalHip;
-			var ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
+			IEnumerable<CqlInterval<CqlDateTime>> ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
 
 			return ar_;
 		};
-		var g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
-		var h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
+		IEnumerable<CqlInterval<CqlDateTime>> g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		bool? h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments_Value"/>
     [CqlDeclaration("Has THA with Initial and Follow Up HOOSJr Assessments")]
 	public bool? Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments() => 
 		__Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments.Value;
 
+    /// <seealso cref="Date_PROMIS10_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_PROMIS10_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
-		var e_ = context.Operators.ToList<CqlCode>(d_);
-		var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
-		var g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
+		CqlCode a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode d_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
+		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+		IEnumerable<ValueTuple<Observation, Observation>> g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
 		Tuple_DDTAOdcFieSJbGgRLLZPYbGQb h_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var n_ = new Tuple_DDTAOdcFieSJbGgRLLZPYbGQb
+			Tuple_DDTAOdcFieSJbGgRLLZPYbGQb n_ = new Tuple_DDTAOdcFieSJbGgRLLZPYbGQb
 			{
 				PROMIS10MentalScore = _valueTuple.Item1,
 				PROMIS10PhysicalScore = _valueTuple.Item2,
@@ -1479,158 +1614,162 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 
 			return n_;
 		};
-		var i_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DDTAOdcFieSJbGgRLLZPYbGQb>(g_, h_);
+		IEnumerable<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb> i_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DDTAOdcFieSJbGgRLLZPYbGQb>(g_, h_);
 		bool? j_(Tuple_DDTAOdcFieSJbGgRLLZPYbGQb tuple_ddtaodcfiesjbggrllzpybgqb)
 		{
-			var o_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Effective;
-			var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-			var q_ = QICoreCommon_2_0_000.toInterval(p_);
-			var r_ = context.Operators.Start(q_);
-			var s_ = context.Operators.DateFrom(r_);
-			var t_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Effective;
-			var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-			var v_ = QICoreCommon_2_0_000.toInterval(u_);
-			var w_ = context.Operators.Start(v_);
-			var x_ = context.Operators.DateFrom(w_);
-			var y_ = context.Operators.SameAs(s_, x_, "day");
-			var z_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Value;
-			var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
-			var ab_ = context.Operators.Not((bool?)(aa_ is null));
-			var ac_ = context.Operators.And(y_, ab_);
-			var ad_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Value;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = context.Operators.Not((bool?)(ae_ is null));
-			var ag_ = context.Operators.And(ac_, af_);
+			DataType o_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Effective;
+			object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+			CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
+			CqlDateTime r_ = context.Operators.Start(q_);
+			CqlDate s_ = context.Operators.DateFrom(r_);
+			DataType t_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Effective;
+			object u_ = FHIRHelpers_4_3_000.ToValue(t_);
+			CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.toInterval(u_);
+			CqlDateTime w_ = context.Operators.Start(v_);
+			CqlDate x_ = context.Operators.DateFrom(w_);
+			bool? y_ = context.Operators.SameAs(s_, x_, "day");
+			DataType z_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Value;
+			object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+			bool? ac_ = context.Operators.And(y_, ab_);
+			DataType ad_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Value;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			bool? af_ = context.Operators.Not((bool?)(ae_ is null));
+			bool? ag_ = context.Operators.And(ac_, af_);
 
 			return ag_;
 		};
-		var k_ = context.Operators.Where<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb>(i_, j_);
+		IEnumerable<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb> k_ = context.Operators.Where<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb>(i_, j_);
 		CqlDate l_(Tuple_DDTAOdcFieSJbGgRLLZPYbGQb tuple_ddtaodcfiesjbggrllzpybgqb)
 		{
-			var ah_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Effective;
-			var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-			var aj_ = QICoreCommon_2_0_000.toInterval(ai_);
-			var ak_ = context.Operators.Start(aj_);
-			var al_ = context.Operators.DateFrom(ak_);
-			var am_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Effective;
-			var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-			var ao_ = QICoreCommon_2_0_000.toInterval(an_);
-			var ap_ = context.Operators.Start(ao_);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var ar_ = new CqlDate[]
+			DataType ah_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Effective;
+			object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlDate al_ = context.Operators.DateFrom(ak_);
+			DataType am_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Effective;
+			object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+			CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_0_000.toInterval(an_);
+			CqlDateTime ap_ = context.Operators.Start(ao_);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate[] ar_ = new CqlDate[]
 			{
 				al_,
 				aq_,
 			};
-			var as_ = context.Operators.Max<CqlDate>((ar_ as IEnumerable<CqlDate>));
+			CqlDate as_ = context.Operators.Max<CqlDate>((ar_ as IEnumerable<CqlDate>));
 
 			return as_;
 		};
-		var m_ = context.Operators.Select<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb, CqlDate>(k_, l_);
+		IEnumerable<CqlDate> m_ = context.Operators.Select<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb, CqlDate>(k_, l_);
 
 		return m_;
 	}
 
+    /// <seealso cref="Date_PROMIS10_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date PROMIS10 Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_PROMIS10_Total_Assessment_Completed() => 
 		__Date_PROMIS10_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments"/>
 	private bool? Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments_Value()
 	{
-		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure();
 		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
 		{
-			var i_ = THAProcedure?.Performed;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = QICoreCommon_2_0_000.toInterval(j_);
+			DataType i_ = THAProcedure?.Performed;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
 		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var l_ = this.Date_PROMIS10_Total_Assessment_Completed();
+			IEnumerable<CqlDate> l_ = this.Date_PROMIS10_Total_Assessment_Completed();
 			bool? m_(CqlDate InitialHipAssessmentPROMIS10)
 			{
-				var q_ = context.Operators.Start(TotalHip);
-				var r_ = context.Operators.Quantity(90m, "days");
-				var s_ = context.Operators.Add(InitialHipAssessmentPROMIS10, r_);
-				var t_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, s_, true, true);
-				var u_ = t_?.low;
-				var v_ = context.Operators.ConvertDateToDateTime(u_);
-				var x_ = context.Operators.Add(InitialHipAssessmentPROMIS10, r_);
-				var y_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, x_, true, true);
-				var z_ = y_?.high;
-				var aa_ = context.Operators.ConvertDateToDateTime(z_);
-				var ac_ = context.Operators.Add(InitialHipAssessmentPROMIS10, r_);
-				var ad_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ac_, true, true);
-				var ae_ = ad_?.lowClosed;
-				var ag_ = context.Operators.Add(InitialHipAssessmentPROMIS10, r_);
-				var ah_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ag_, true, true);
-				var ai_ = ah_?.highClosed;
-				var aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				var ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
-				var al_ = context.Operators.Not((bool?)(InitialHipAssessmentPROMIS10 is null));
-				var am_ = context.Operators.And(ak_, al_);
+				CqlDateTime q_ = context.Operators.Start(TotalHip);
+				CqlQuantity r_ = context.Operators.Quantity(90m, "days");
+				CqlDate s_ = context.Operators.Add(InitialHipAssessmentPROMIS10, r_);
+				CqlInterval<CqlDate> t_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, s_, true, true);
+				CqlDate u_ = t_?.low;
+				CqlDateTime v_ = context.Operators.ConvertDateToDateTime(u_);
+				CqlDate x_ = context.Operators.Add(InitialHipAssessmentPROMIS10, r_);
+				CqlInterval<CqlDate> y_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, x_, true, true);
+				CqlDate z_ = y_?.high;
+				CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+				CqlDate ac_ = context.Operators.Add(InitialHipAssessmentPROMIS10, r_);
+				CqlInterval<CqlDate> ad_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ac_, true, true);
+				bool? ae_ = ad_?.lowClosed;
+				CqlDate ag_ = context.Operators.Add(InitialHipAssessmentPROMIS10, r_);
+				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ag_, true, true);
+				bool? ai_ = ah_?.highClosed;
+				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessmentPROMIS10 is null));
+				bool? am_ = context.Operators.And(ak_, al_);
 
 				return am_;
 			};
-			var n_ = context.Operators.Where<CqlDate>(l_, m_);
+			IEnumerable<CqlDate> n_ = context.Operators.Where<CqlDate>(l_, m_);
 			CqlInterval<CqlDateTime> o_(CqlDate InitialHipAssessmentPROMIS10) => 
 				TotalHip;
-			var p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
+			IEnumerable<CqlInterval<CqlDateTime>> p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
 
 			return p_;
 		};
-		var e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
 		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var an_ = this.Date_PROMIS10_Total_Assessment_Completed();
+			IEnumerable<CqlDate> an_ = this.Date_PROMIS10_Total_Assessment_Completed();
 			bool? ao_(CqlDate FollowUpHipAssessmentPROMIS10)
 			{
-				var as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentPROMIS10);
-				var at_ = context.Operators.DateFrom(as_);
-				var au_ = context.Operators.End(TotalHip);
-				var av_ = context.Operators.DateFrom(au_);
-				var aw_ = context.Operators.Quantity(300m, "days");
-				var ax_ = context.Operators.Add(av_, aw_);
-				var az_ = context.Operators.DateFrom(au_);
-				var ba_ = context.Operators.Quantity(425m, "days");
-				var bb_ = context.Operators.Add(az_, ba_);
-				var bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				var bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				CqlDateTime as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentPROMIS10);
+				CqlDate at_ = context.Operators.DateFrom(as_);
+				CqlDateTime au_ = context.Operators.End(TotalHip);
+				CqlDate av_ = context.Operators.DateFrom(au_);
+				CqlQuantity aw_ = context.Operators.Quantity(300m, "days");
+				CqlDate ax_ = context.Operators.Add(av_, aw_);
+				CqlDate az_ = context.Operators.DateFrom(au_);
+				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
+				CqlDate bb_ = context.Operators.Add(az_, ba_);
+				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
 
 				return bd_;
 			};
-			var ap_ = context.Operators.Where<CqlDate>(an_, ao_);
+			IEnumerable<CqlDate> ap_ = context.Operators.Where<CqlDate>(an_, ao_);
 			CqlInterval<CqlDateTime> aq_(CqlDate FollowUpHipAssessmentPROMIS10) => 
 				TotalHip;
-			var ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
+			IEnumerable<CqlInterval<CqlDateTime>> ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
 
 			return ar_;
 		};
-		var g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
-		var h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
+		IEnumerable<CqlInterval<CqlDateTime>> g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		bool? h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments_Value"/>
     [CqlDeclaration("Has THA with Initial and Follow Up PROMIS10 Assessments")]
 	public bool? Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments() => 
 		__Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments.Value;
 
+    /// <seealso cref="Date_VR12_Oblique_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_VR12_Oblique_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
-		var e_ = context.Operators.ToList<CqlCode>(d_);
-		var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
-		var g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
+		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode d_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
+		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+		IEnumerable<ValueTuple<Observation, Observation>> g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
 		Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH h_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var n_ = new Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH
+			Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH n_ = new Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH
 			{
 				VR12MentalAssessment = _valueTuple.Item1,
 				VR12PhysicalAssessment = _valueTuple.Item2,
@@ -1638,158 +1777,162 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 
 			return n_;
 		};
-		var i_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(g_, h_);
+		IEnumerable<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH> i_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(g_, h_);
 		bool? j_(Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH tuple_gadrfkrahuugjcvhwqwrujhrh)
 		{
-			var o_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
-			var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-			var q_ = QICoreCommon_2_0_000.toInterval(p_);
-			var r_ = context.Operators.Start(q_);
-			var s_ = context.Operators.DateFrom(r_);
-			var t_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
-			var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-			var v_ = QICoreCommon_2_0_000.toInterval(u_);
-			var w_ = context.Operators.Start(v_);
-			var x_ = context.Operators.DateFrom(w_);
-			var y_ = context.Operators.SameAs(s_, x_, "day");
-			var z_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
-			var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
-			var ab_ = context.Operators.Not((bool?)(aa_ is null));
-			var ac_ = context.Operators.And(y_, ab_);
-			var ad_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Value;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = context.Operators.Not((bool?)(ae_ is null));
-			var ag_ = context.Operators.And(ac_, af_);
+			DataType o_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
+			object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+			CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
+			CqlDateTime r_ = context.Operators.Start(q_);
+			CqlDate s_ = context.Operators.DateFrom(r_);
+			DataType t_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
+			object u_ = FHIRHelpers_4_3_000.ToValue(t_);
+			CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.toInterval(u_);
+			CqlDateTime w_ = context.Operators.Start(v_);
+			CqlDate x_ = context.Operators.DateFrom(w_);
+			bool? y_ = context.Operators.SameAs(s_, x_, "day");
+			DataType z_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
+			object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+			bool? ac_ = context.Operators.And(y_, ab_);
+			DataType ad_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Value;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			bool? af_ = context.Operators.Not((bool?)(ae_ is null));
+			bool? ag_ = context.Operators.And(ac_, af_);
 
 			return ag_;
 		};
-		var k_ = context.Operators.Where<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(i_, j_);
+		IEnumerable<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH> k_ = context.Operators.Where<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(i_, j_);
 		CqlDate l_(Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH tuple_gadrfkrahuugjcvhwqwrujhrh)
 		{
-			var ah_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
-			var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-			var aj_ = QICoreCommon_2_0_000.toInterval(ai_);
-			var ak_ = context.Operators.Start(aj_);
-			var al_ = context.Operators.DateFrom(ak_);
-			var am_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
-			var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-			var ao_ = QICoreCommon_2_0_000.toInterval(an_);
-			var ap_ = context.Operators.Start(ao_);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var ar_ = new CqlDate[]
+			DataType ah_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
+			object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlDate al_ = context.Operators.DateFrom(ak_);
+			DataType am_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
+			object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+			CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_0_000.toInterval(an_);
+			CqlDateTime ap_ = context.Operators.Start(ao_);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate[] ar_ = new CqlDate[]
 			{
 				al_,
 				aq_,
 			};
-			var as_ = context.Operators.Max<CqlDate>((ar_ as IEnumerable<CqlDate>));
+			CqlDate as_ = context.Operators.Max<CqlDate>((ar_ as IEnumerable<CqlDate>));
 
 			return as_;
 		};
-		var m_ = context.Operators.Select<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH, CqlDate>(k_, l_);
+		IEnumerable<CqlDate> m_ = context.Operators.Select<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH, CqlDate>(k_, l_);
 
 		return m_;
 	}
 
+    /// <seealso cref="Date_VR12_Oblique_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date VR12 Oblique Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_VR12_Oblique_Total_Assessment_Completed() => 
 		__Date_VR12_Oblique_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments"/>
 	private bool? Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments_Value()
 	{
-		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure();
 		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
 		{
-			var i_ = THAProcedure?.Performed;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = QICoreCommon_2_0_000.toInterval(j_);
+			DataType i_ = THAProcedure?.Performed;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
 		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var l_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
+			IEnumerable<CqlDate> l_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
 			bool? m_(CqlDate InitialHipAssessmentOblique)
 			{
-				var q_ = context.Operators.Start(TotalHip);
-				var r_ = context.Operators.Quantity(90m, "days");
-				var s_ = context.Operators.Add(InitialHipAssessmentOblique, r_);
-				var t_ = context.Operators.Interval(InitialHipAssessmentOblique, s_, true, true);
-				var u_ = t_?.low;
-				var v_ = context.Operators.ConvertDateToDateTime(u_);
-				var x_ = context.Operators.Add(InitialHipAssessmentOblique, r_);
-				var y_ = context.Operators.Interval(InitialHipAssessmentOblique, x_, true, true);
-				var z_ = y_?.high;
-				var aa_ = context.Operators.ConvertDateToDateTime(z_);
-				var ac_ = context.Operators.Add(InitialHipAssessmentOblique, r_);
-				var ad_ = context.Operators.Interval(InitialHipAssessmentOblique, ac_, true, true);
-				var ae_ = ad_?.lowClosed;
-				var ag_ = context.Operators.Add(InitialHipAssessmentOblique, r_);
-				var ah_ = context.Operators.Interval(InitialHipAssessmentOblique, ag_, true, true);
-				var ai_ = ah_?.highClosed;
-				var aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				var ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
-				var al_ = context.Operators.Not((bool?)(InitialHipAssessmentOblique is null));
-				var am_ = context.Operators.And(ak_, al_);
+				CqlDateTime q_ = context.Operators.Start(TotalHip);
+				CqlQuantity r_ = context.Operators.Quantity(90m, "days");
+				CqlDate s_ = context.Operators.Add(InitialHipAssessmentOblique, r_);
+				CqlInterval<CqlDate> t_ = context.Operators.Interval(InitialHipAssessmentOblique, s_, true, true);
+				CqlDate u_ = t_?.low;
+				CqlDateTime v_ = context.Operators.ConvertDateToDateTime(u_);
+				CqlDate x_ = context.Operators.Add(InitialHipAssessmentOblique, r_);
+				CqlInterval<CqlDate> y_ = context.Operators.Interval(InitialHipAssessmentOblique, x_, true, true);
+				CqlDate z_ = y_?.high;
+				CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+				CqlDate ac_ = context.Operators.Add(InitialHipAssessmentOblique, r_);
+				CqlInterval<CqlDate> ad_ = context.Operators.Interval(InitialHipAssessmentOblique, ac_, true, true);
+				bool? ae_ = ad_?.lowClosed;
+				CqlDate ag_ = context.Operators.Add(InitialHipAssessmentOblique, r_);
+				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessmentOblique, ag_, true, true);
+				bool? ai_ = ah_?.highClosed;
+				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessmentOblique is null));
+				bool? am_ = context.Operators.And(ak_, al_);
 
 				return am_;
 			};
-			var n_ = context.Operators.Where<CqlDate>(l_, m_);
+			IEnumerable<CqlDate> n_ = context.Operators.Where<CqlDate>(l_, m_);
 			CqlInterval<CqlDateTime> o_(CqlDate InitialHipAssessmentOblique) => 
 				TotalHip;
-			var p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
+			IEnumerable<CqlInterval<CqlDateTime>> p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
 
 			return p_;
 		};
-		var e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
 		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var an_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
+			IEnumerable<CqlDate> an_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
 			bool? ao_(CqlDate FollowUpHipAssessmentOblique)
 			{
-				var as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOblique);
-				var at_ = context.Operators.DateFrom(as_);
-				var au_ = context.Operators.End(TotalHip);
-				var av_ = context.Operators.DateFrom(au_);
-				var aw_ = context.Operators.Quantity(300m, "days");
-				var ax_ = context.Operators.Add(av_, aw_);
-				var az_ = context.Operators.DateFrom(au_);
-				var ba_ = context.Operators.Quantity(425m, "days");
-				var bb_ = context.Operators.Add(az_, ba_);
-				var bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				var bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				CqlDateTime as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOblique);
+				CqlDate at_ = context.Operators.DateFrom(as_);
+				CqlDateTime au_ = context.Operators.End(TotalHip);
+				CqlDate av_ = context.Operators.DateFrom(au_);
+				CqlQuantity aw_ = context.Operators.Quantity(300m, "days");
+				CqlDate ax_ = context.Operators.Add(av_, aw_);
+				CqlDate az_ = context.Operators.DateFrom(au_);
+				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
+				CqlDate bb_ = context.Operators.Add(az_, ba_);
+				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
 
 				return bd_;
 			};
-			var ap_ = context.Operators.Where<CqlDate>(an_, ao_);
+			IEnumerable<CqlDate> ap_ = context.Operators.Where<CqlDate>(an_, ao_);
 			CqlInterval<CqlDateTime> aq_(CqlDate FollowUpHipAssessmentOblique) => 
 				TotalHip;
-			var ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
+			IEnumerable<CqlInterval<CqlDateTime>> ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
 
 			return ar_;
 		};
-		var g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
-		var h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
+		IEnumerable<CqlInterval<CqlDateTime>> g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		bool? h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments_Value"/>
     [CqlDeclaration("Has THA with Initial and Follow Up VR12 Oblique Assessments")]
 	public bool? Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments() => 
 		__Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments.Value;
 
+    /// <seealso cref="Date_VR12_Orthogonal_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_VR12_Orthogonal_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
-		var e_ = context.Operators.ToList<CqlCode>(d_);
-		var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
-		var g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
+		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode d_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
+		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+		IEnumerable<ValueTuple<Observation, Observation>> g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
 		Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH h_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var n_ = new Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH
+			Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH n_ = new Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH
 			{
 				VR12MentalAssessment = _valueTuple.Item1,
 				VR12PhysicalAssessment = _valueTuple.Item2,
@@ -1797,161 +1940,166 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 
 			return n_;
 		};
-		var i_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(g_, h_);
+		IEnumerable<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH> i_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(g_, h_);
 		bool? j_(Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH tuple_gadrfkrahuugjcvhwqwrujhrh)
 		{
-			var o_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
-			var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-			var q_ = QICoreCommon_2_0_000.toInterval(p_);
-			var r_ = context.Operators.Start(q_);
-			var s_ = context.Operators.DateFrom(r_);
-			var t_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
-			var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-			var v_ = QICoreCommon_2_0_000.toInterval(u_);
-			var w_ = context.Operators.Start(v_);
-			var x_ = context.Operators.DateFrom(w_);
-			var y_ = context.Operators.SameAs(s_, x_, "day");
-			var z_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
-			var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
-			var ab_ = context.Operators.Not((bool?)(aa_ is null));
-			var ac_ = context.Operators.And(y_, ab_);
-			var ad_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Value;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = context.Operators.Not((bool?)(ae_ is null));
-			var ag_ = context.Operators.And(ac_, af_);
+			DataType o_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
+			object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+			CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
+			CqlDateTime r_ = context.Operators.Start(q_);
+			CqlDate s_ = context.Operators.DateFrom(r_);
+			DataType t_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
+			object u_ = FHIRHelpers_4_3_000.ToValue(t_);
+			CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.toInterval(u_);
+			CqlDateTime w_ = context.Operators.Start(v_);
+			CqlDate x_ = context.Operators.DateFrom(w_);
+			bool? y_ = context.Operators.SameAs(s_, x_, "day");
+			DataType z_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
+			object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+			bool? ac_ = context.Operators.And(y_, ab_);
+			DataType ad_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Value;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			bool? af_ = context.Operators.Not((bool?)(ae_ is null));
+			bool? ag_ = context.Operators.And(ac_, af_);
 
 			return ag_;
 		};
-		var k_ = context.Operators.Where<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(i_, j_);
+		IEnumerable<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH> k_ = context.Operators.Where<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(i_, j_);
 		CqlDate l_(Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH tuple_gadrfkrahuugjcvhwqwrujhrh)
 		{
-			var ah_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
-			var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-			var aj_ = QICoreCommon_2_0_000.toInterval(ai_);
-			var ak_ = context.Operators.Start(aj_);
-			var al_ = context.Operators.DateFrom(ak_);
-			var am_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
-			var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-			var ao_ = QICoreCommon_2_0_000.toInterval(an_);
-			var ap_ = context.Operators.Start(ao_);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var ar_ = new CqlDate[]
+			DataType ah_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
+			object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlDate al_ = context.Operators.DateFrom(ak_);
+			DataType am_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
+			object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+			CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_0_000.toInterval(an_);
+			CqlDateTime ap_ = context.Operators.Start(ao_);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate[] ar_ = new CqlDate[]
 			{
 				al_,
 				aq_,
 			};
-			var as_ = context.Operators.Max<CqlDate>((ar_ as IEnumerable<CqlDate>));
+			CqlDate as_ = context.Operators.Max<CqlDate>((ar_ as IEnumerable<CqlDate>));
 
 			return as_;
 		};
-		var m_ = context.Operators.Select<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH, CqlDate>(k_, l_);
+		IEnumerable<CqlDate> m_ = context.Operators.Select<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH, CqlDate>(k_, l_);
 
 		return m_;
 	}
 
+    /// <seealso cref="Date_VR12_Orthogonal_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date VR12 Orthogonal Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_VR12_Orthogonal_Total_Assessment_Completed() => 
 		__Date_VR12_Orthogonal_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments"/>
 	private bool? Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments_Value()
 	{
-		var a_ = this.Total_Hip_Arthroplasty_Procedure();
+		IEnumerable<Procedure> a_ = this.Total_Hip_Arthroplasty_Procedure();
 		CqlInterval<CqlDateTime> b_(Procedure THAProcedure)
 		{
-			var i_ = THAProcedure?.Performed;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = QICoreCommon_2_0_000.toInterval(j_);
+			DataType i_ = THAProcedure?.Performed;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Procedure, CqlInterval<CqlDateTime>>(a_, b_);
 		IEnumerable<CqlInterval<CqlDateTime>> d_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var l_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
+			IEnumerable<CqlDate> l_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
 			bool? m_(CqlDate InitialHipAssessmentOrthogonal)
 			{
-				var q_ = context.Operators.Start(TotalHip);
-				var r_ = context.Operators.Quantity(90m, "days");
-				var s_ = context.Operators.Add(InitialHipAssessmentOrthogonal, r_);
-				var t_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, s_, true, true);
-				var u_ = t_?.low;
-				var v_ = context.Operators.ConvertDateToDateTime(u_);
-				var x_ = context.Operators.Add(InitialHipAssessmentOrthogonal, r_);
-				var y_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, x_, true, true);
-				var z_ = y_?.high;
-				var aa_ = context.Operators.ConvertDateToDateTime(z_);
-				var ac_ = context.Operators.Add(InitialHipAssessmentOrthogonal, r_);
-				var ad_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ac_, true, true);
-				var ae_ = ad_?.lowClosed;
-				var ag_ = context.Operators.Add(InitialHipAssessmentOrthogonal, r_);
-				var ah_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ag_, true, true);
-				var ai_ = ah_?.highClosed;
-				var aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				var ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
-				var al_ = context.Operators.Not((bool?)(InitialHipAssessmentOrthogonal is null));
-				var am_ = context.Operators.And(ak_, al_);
+				CqlDateTime q_ = context.Operators.Start(TotalHip);
+				CqlQuantity r_ = context.Operators.Quantity(90m, "days");
+				CqlDate s_ = context.Operators.Add(InitialHipAssessmentOrthogonal, r_);
+				CqlInterval<CqlDate> t_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, s_, true, true);
+				CqlDate u_ = t_?.low;
+				CqlDateTime v_ = context.Operators.ConvertDateToDateTime(u_);
+				CqlDate x_ = context.Operators.Add(InitialHipAssessmentOrthogonal, r_);
+				CqlInterval<CqlDate> y_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, x_, true, true);
+				CqlDate z_ = y_?.high;
+				CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+				CqlDate ac_ = context.Operators.Add(InitialHipAssessmentOrthogonal, r_);
+				CqlInterval<CqlDate> ad_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ac_, true, true);
+				bool? ae_ = ad_?.lowClosed;
+				CqlDate ag_ = context.Operators.Add(InitialHipAssessmentOrthogonal, r_);
+				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ag_, true, true);
+				bool? ai_ = ah_?.highClosed;
+				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessmentOrthogonal is null));
+				bool? am_ = context.Operators.And(ak_, al_);
 
 				return am_;
 			};
-			var n_ = context.Operators.Where<CqlDate>(l_, m_);
+			IEnumerable<CqlDate> n_ = context.Operators.Where<CqlDate>(l_, m_);
 			CqlInterval<CqlDateTime> o_(CqlDate InitialHipAssessmentOrthogonal) => 
 				TotalHip;
-			var p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
+			IEnumerable<CqlInterval<CqlDateTime>> p_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(n_, o_);
 
 			return p_;
 		};
-		var e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
+		IEnumerable<CqlInterval<CqlDateTime>> e_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(c_, d_);
 		IEnumerable<CqlInterval<CqlDateTime>> f_(CqlInterval<CqlDateTime> TotalHip)
 		{
-			var an_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
+			IEnumerable<CqlDate> an_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
 			bool? ao_(CqlDate FollowUpHipAssessmentOrthogonal)
 			{
-				var as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOrthogonal);
-				var at_ = context.Operators.DateFrom(as_);
-				var au_ = context.Operators.End(TotalHip);
-				var av_ = context.Operators.DateFrom(au_);
-				var aw_ = context.Operators.Quantity(300m, "days");
-				var ax_ = context.Operators.Add(av_, aw_);
-				var az_ = context.Operators.DateFrom(au_);
-				var ba_ = context.Operators.Quantity(425m, "days");
-				var bb_ = context.Operators.Add(az_, ba_);
-				var bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				var bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				CqlDateTime as_ = context.Operators.ConvertDateToDateTime(FollowUpHipAssessmentOrthogonal);
+				CqlDate at_ = context.Operators.DateFrom(as_);
+				CqlDateTime au_ = context.Operators.End(TotalHip);
+				CqlDate av_ = context.Operators.DateFrom(au_);
+				CqlQuantity aw_ = context.Operators.Quantity(300m, "days");
+				CqlDate ax_ = context.Operators.Add(av_, aw_);
+				CqlDate az_ = context.Operators.DateFrom(au_);
+				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
+				CqlDate bb_ = context.Operators.Add(az_, ba_);
+				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
 
 				return bd_;
 			};
-			var ap_ = context.Operators.Where<CqlDate>(an_, ao_);
+			IEnumerable<CqlDate> ap_ = context.Operators.Where<CqlDate>(an_, ao_);
 			CqlInterval<CqlDateTime> aq_(CqlDate FollowUpHipAssessmentOrthogonal) => 
 				TotalHip;
-			var ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
+			IEnumerable<CqlInterval<CqlDateTime>> ar_ = context.Operators.Select<CqlDate, CqlInterval<CqlDateTime>>(ap_, aq_);
 
 			return ar_;
 		};
-		var g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
-		var h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
+		IEnumerable<CqlInterval<CqlDateTime>> g_ = context.Operators.SelectMany<CqlInterval<CqlDateTime>, CqlInterval<CqlDateTime>>(e_, f_);
+		bool? h_ = context.Operators.Exists<CqlInterval<CqlDateTime>>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments_Value"/>
     [CqlDeclaration("Has THA with Initial and Follow Up VR12 Orthogonal Assessments")]
 	public bool? Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments() => 
 		__Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments();
-		var b_ = this.Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments();
-		var e_ = context.Operators.Or(c_, d_);
-		var f_ = this.Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments();
-		var g_ = context.Operators.Or(e_, f_);
-		var h_ = this.Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments();
-		var i_ = context.Operators.Or(g_, h_);
+		bool? a_ = this.Has_THA_with_Initial_and_Follow_Up_HOOS_Assessments();
+		bool? b_ = this.Has_THA_with_Initial_and_Follow_Up_HOOSJr_Assessments();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = this.Has_THA_with_Initial_and_Follow_Up_PROMIS10_Assessments();
+		bool? e_ = context.Operators.Or(c_, d_);
+		bool? f_ = this.Has_THA_with_Initial_and_Follow_Up_VR12_Oblique_Assessments();
+		bool? g_ = context.Operators.Or(e_, f_);
+		bool? h_ = this.Has_THA_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments();
+		bool? i_ = context.Operators.Or(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
@@ -182,251 +182,320 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Heart_Failure"/>
 	private CqlValueSet Heart_Failure_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", null);
 
+    /// <seealso cref="Heart_Failure_Value"/>
     [CqlDeclaration("Heart Failure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376")]
 	public CqlValueSet Heart_Failure() => 
 		__Heart_Failure.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Emotional_score__MLHFQ_"/>
 	private CqlCode Emotional_score__MLHFQ__Value() => 
 		new CqlCode("85609-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Emotional_score__MLHFQ__Value"/>
     [CqlDeclaration("Emotional score [MLHFQ]")]
 	public CqlCode Emotional_score__MLHFQ_() => 
 		__Emotional_score__MLHFQ_.Value;
 
+    /// <seealso cref="Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_"/>
 	private CqlCode Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12__Value() => 
 		new CqlCode("86923-0", "http://loinc.org", null, null);
 
+    /// <seealso cref="Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12__Value"/>
     [CqlDeclaration("Kansas City Cardiomyopathy Questionnaire - 12 item [KCCQ-12]")]
 	public CqlCode Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_() => 
 		__Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_.Value;
 
+    /// <seealso cref="Overall_summary_score__KCCQ_12_"/>
 	private CqlCode Overall_summary_score__KCCQ_12__Value() => 
 		new CqlCode("86924-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Overall_summary_score__KCCQ_12__Value"/>
     [CqlDeclaration("Overall summary score [KCCQ-12]")]
 	public CqlCode Overall_summary_score__KCCQ_12_() => 
 		__Overall_summary_score__KCCQ_12_.Value;
 
+    /// <seealso cref="Overall_summary_score__KCCQ_"/>
 	private CqlCode Overall_summary_score__KCCQ__Value() => 
 		new CqlCode("71940-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="Overall_summary_score__KCCQ__Value"/>
     [CqlDeclaration("Overall summary score [KCCQ]")]
 	public CqlCode Overall_summary_score__KCCQ_() => 
 		__Overall_summary_score__KCCQ_.Value;
 
+    /// <seealso cref="Physical_limitation_score__KCCQ_"/>
 	private CqlCode Physical_limitation_score__KCCQ__Value() => 
 		new CqlCode("72195-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="Physical_limitation_score__KCCQ__Value"/>
     [CqlDeclaration("Physical limitation score [KCCQ]")]
 	public CqlCode Physical_limitation_score__KCCQ_() => 
 		__Physical_limitation_score__KCCQ_.Value;
 
+    /// <seealso cref="Physical_score__MLHFQ_"/>
 	private CqlCode Physical_score__MLHFQ__Value() => 
 		new CqlCode("85618-7", "http://loinc.org", null, null);
 
+    /// <seealso cref="Physical_score__MLHFQ__Value"/>
     [CqlDeclaration("Physical score [MLHFQ]")]
 	public CqlCode Physical_score__MLHFQ_() => 
 		__Physical_score__MLHFQ_.Value;
 
+    /// <seealso cref="PROMIS_10_Global_Mental_Health__GMH__score_T_score"/>
 	private CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value() => 
 		new CqlCode("71969-0", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value"/>
     [CqlDeclaration("PROMIS-10 Global Mental Health (GMH) score T-score")]
 	public CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score() => 
 		__PROMIS_10_Global_Mental_Health__GMH__score_T_score.Value;
 
+    /// <seealso cref="PROMIS_10_Global_Physical_Health__GPH__score_T_score"/>
 	private CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value() => 
 		new CqlCode("71971-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value"/>
     [CqlDeclaration("PROMIS-10 Global Physical Health (GPH) score T-score")]
 	public CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score() => 
 		__PROMIS_10_Global_Physical_Health__GPH__score_T_score.Value;
 
+    /// <seealso cref="PROMIS_29_Anxiety_score_T_score"/>
 	private CqlCode PROMIS_29_Anxiety_score_T_score_Value() => 
 		new CqlCode("71967-4", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_29_Anxiety_score_T_score_Value"/>
     [CqlDeclaration("PROMIS-29 Anxiety score T-score")]
 	public CqlCode PROMIS_29_Anxiety_score_T_score() => 
 		__PROMIS_29_Anxiety_score_T_score.Value;
 
+    /// <seealso cref="PROMIS_29_Depression_score_T_score"/>
 	private CqlCode PROMIS_29_Depression_score_T_score_Value() => 
 		new CqlCode("71965-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_29_Depression_score_T_score_Value"/>
     [CqlDeclaration("PROMIS-29 Depression score T-score")]
 	public CqlCode PROMIS_29_Depression_score_T_score() => 
 		__PROMIS_29_Depression_score_T_score.Value;
 
+    /// <seealso cref="PROMIS_29_Fatigue_score_T_score"/>
 	private CqlCode PROMIS_29_Fatigue_score_T_score_Value() => 
 		new CqlCode("71963-3", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_29_Fatigue_score_T_score_Value"/>
     [CqlDeclaration("PROMIS-29 Fatigue score T-score")]
 	public CqlCode PROMIS_29_Fatigue_score_T_score() => 
 		__PROMIS_29_Fatigue_score_T_score.Value;
 
+    /// <seealso cref="PROMIS_29_Pain_interference_score_T_score"/>
 	private CqlCode PROMIS_29_Pain_interference_score_T_score_Value() => 
 		new CqlCode("71961-7", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_29_Pain_interference_score_T_score_Value"/>
     [CqlDeclaration("PROMIS-29 Pain interference score T-score")]
 	public CqlCode PROMIS_29_Pain_interference_score_T_score() => 
 		__PROMIS_29_Pain_interference_score_T_score.Value;
 
+    /// <seealso cref="PROMIS_29_Physical_function_score_T_score"/>
 	private CqlCode PROMIS_29_Physical_function_score_T_score_Value() => 
 		new CqlCode("71959-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_29_Physical_function_score_T_score_Value"/>
     [CqlDeclaration("PROMIS-29 Physical function score T-score")]
 	public CqlCode PROMIS_29_Physical_function_score_T_score() => 
 		__PROMIS_29_Physical_function_score_T_score.Value;
 
+    /// <seealso cref="PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score"/>
 	private CqlCode PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score_Value() => 
 		new CqlCode("71957-5", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score_Value"/>
     [CqlDeclaration("PROMIS-29 Satisfaction with participation in social roles score T-score")]
 	public CqlCode PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score() => 
 		__PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score.Value;
 
+    /// <seealso cref="PROMIS_29_Sleep_disturbance_score_T_score"/>
 	private CqlCode PROMIS_29_Sleep_disturbance_score_T_score_Value() => 
 		new CqlCode("71955-9", "http://loinc.org", null, null);
 
+    /// <seealso cref="PROMIS_29_Sleep_disturbance_score_T_score_Value"/>
     [CqlDeclaration("PROMIS-29 Sleep disturbance score T-score")]
 	public CqlCode PROMIS_29_Sleep_disturbance_score_T_score() => 
 		__PROMIS_29_Sleep_disturbance_score_T_score.Value;
 
+    /// <seealso cref="Quality_of_life_score__KCCQ_"/>
 	private CqlCode Quality_of_life_score__KCCQ__Value() => 
 		new CqlCode("72189-4", "http://loinc.org", null, null);
 
+    /// <seealso cref="Quality_of_life_score__KCCQ__Value"/>
     [CqlDeclaration("Quality of life score [KCCQ]")]
 	public CqlCode Quality_of_life_score__KCCQ_() => 
 		__Quality_of_life_score__KCCQ_.Value;
 
+    /// <seealso cref="Self_efficacy_score__KCCQ_"/>
 	private CqlCode Self_efficacy_score__KCCQ__Value() => 
 		new CqlCode("72190-2", "http://loinc.org", null, null);
 
+    /// <seealso cref="Self_efficacy_score__KCCQ__Value"/>
     [CqlDeclaration("Self-efficacy score [KCCQ]")]
 	public CqlCode Self_efficacy_score__KCCQ_() => 
 		__Self_efficacy_score__KCCQ_.Value;
 
+    /// <seealso cref="Severe_cognitive_impairment__finding_"/>
 	private CqlCode Severe_cognitive_impairment__finding__Value() => 
 		new CqlCode("702956004", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Severe_cognitive_impairment__finding__Value"/>
     [CqlDeclaration("Severe cognitive impairment (finding)")]
 	public CqlCode Severe_cognitive_impairment__finding_() => 
 		__Severe_cognitive_impairment__finding_.Value;
 
+    /// <seealso cref="Social_limitation_score__KCCQ_"/>
 	private CqlCode Social_limitation_score__KCCQ__Value() => 
 		new CqlCode("72196-9", "http://loinc.org", null, null);
 
+    /// <seealso cref="Social_limitation_score__KCCQ__Value"/>
     [CqlDeclaration("Social limitation score [KCCQ]")]
 	public CqlCode Social_limitation_score__KCCQ_() => 
 		__Social_limitation_score__KCCQ_.Value;
 
+    /// <seealso cref="Symptom_stability_score__KCCQ_"/>
 	private CqlCode Symptom_stability_score__KCCQ__Value() => 
 		new CqlCode("72194-4", "http://loinc.org", null, null);
 
+    /// <seealso cref="Symptom_stability_score__KCCQ__Value"/>
     [CqlDeclaration("Symptom stability score [KCCQ]")]
 	public CqlCode Symptom_stability_score__KCCQ_() => 
 		__Symptom_stability_score__KCCQ_.Value;
 
+    /// <seealso cref="Total_score__MLHFQ_"/>
 	private CqlCode Total_score__MLHFQ__Value() => 
 		new CqlCode("71938-5", "http://loinc.org", null, null);
 
+    /// <seealso cref="Total_score__MLHFQ__Value"/>
     [CqlDeclaration("Total score [MLHFQ]")]
 	public CqlCode Total_score__MLHFQ_() => 
 		__Total_score__MLHFQ_.Value;
 
+    /// <seealso cref="Total_symptom_score__KCCQ_"/>
 	private CqlCode Total_symptom_score__KCCQ__Value() => 
 		new CqlCode("72191-0", "http://loinc.org", null, null);
 
+    /// <seealso cref="Total_symptom_score__KCCQ__Value"/>
     [CqlDeclaration("Total symptom score [KCCQ]")]
 	public CqlCode Total_symptom_score__KCCQ_() => 
 		__Total_symptom_score__KCCQ_.Value;
 
+    /// <seealso cref="VR_12_Mental_component_summary__MCS__score___oblique_method_T_score"/>
 	private CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
 		new CqlCode("72026-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value"/>
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - oblique method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
 
+    /// <seealso cref="VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score"/>
 	private CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
 		new CqlCode("72028-4", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value"/>
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
 
+    /// <seealso cref="VR_12_Physical_component_summary__PCS__score___oblique_method_T_score"/>
 	private CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
 		new CqlCode("72025-0", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value"/>
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - oblique method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
 
+    /// <seealso cref="VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score"/>
 	private CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
 		new CqlCode("72027-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value"/>
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
 
+    /// <seealso cref="VR_36_Mental_component_summary__MCS__score___oblique_method_T_score"/>
 	private CqlCode VR_36_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
 		new CqlCode("71990-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_36_Mental_component_summary__MCS__score___oblique_method_T_score_Value"/>
     [CqlDeclaration("VR-36 Mental component summary (MCS) score - oblique method T-score")]
 	public CqlCode VR_36_Mental_component_summary__MCS__score___oblique_method_T_score() => 
 		__VR_36_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
 
+    /// <seealso cref="VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score"/>
 	private CqlCode VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
 		new CqlCode("72008-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value"/>
     [CqlDeclaration("VR-36 Mental component summary (MCS) score - orthogonal method T-score")]
 	public CqlCode VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
 		__VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
 
+    /// <seealso cref="VR_36_Physical_component_summary__PCS__score___oblique_method_T_score"/>
 	private CqlCode VR_36_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
 		new CqlCode("71989-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_36_Physical_component_summary__PCS__score___oblique_method_T_score_Value"/>
     [CqlDeclaration("VR-36 Physical component summary (PCS) score - oblique method T-score")]
 	public CqlCode VR_36_Physical_component_summary__PCS__score___oblique_method_T_score() => 
 		__VR_36_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
 
+    /// <seealso cref="VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score"/>
 	private CqlCode VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
 		new CqlCode("72007-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value"/>
     [CqlDeclaration("VR-36 Physical component summary (PCS) score - orthogonal method T-score")]
 	public CqlCode VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
 		__VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("85609-6", "http://loinc.org", null, null),
 			new CqlCode("86923-0", "http://loinc.org", null, null),
@@ -462,13 +531,15 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("702956004", "http://snomed.info/sct", null, null),
 		};
@@ -476,117 +547,133 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Telephone_Visits();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Online_Assessments();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = context.Operators.Union<Encounter>(e_, g_);
-		var i_ = Status_1_6_000.Finished_Encounter(h_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Telephone_Visits();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Online_Assessments();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> h_ = context.Operators.Union<Encounter>(e_, g_);
+		IEnumerable<Encounter> i_ = Status_1_6_000.Finished_Encounter(h_);
 		bool? j_(Encounter ValidEncounter)
 		{
-			var l_ = this.Measurement_Period();
-			var m_ = ValidEncounter?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
+			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
+			Period m_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
 
 			return p_;
 		};
-		var k_ = context.Operators.Where<Encounter>(i_, j_);
+		IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Two_Outpatient_Encounters_during_Measurement_Period"/>
 	private IEnumerable<Encounter> Two_Outpatient_Encounters_during_Measurement_Period_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var c_ = context.Operators.CrossJoin<Encounter, Encounter>(a_, a_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<ValueTuple<Encounter, Encounter>> c_ = context.Operators.CrossJoin<Encounter, Encounter>(a_, a_);
 		Tuple_DbNMMZBTISSRTNdiShceSFVih d_(ValueTuple<Encounter, Encounter> _valueTuple)
 		{
-			var j_ = new Tuple_DbNMMZBTISSRTNdiShceSFVih
+			Tuple_DbNMMZBTISSRTNdiShceSFVih j_ = new Tuple_DbNMMZBTISSRTNdiShceSFVih
 			{
 				OfficeVisit1 = _valueTuple.Item1,
 				OfficeVisit2 = _valueTuple.Item2,
@@ -594,118 +681,128 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return j_;
 		};
-		var e_ = context.Operators.Select<ValueTuple<Encounter, Encounter>, Tuple_DbNMMZBTISSRTNdiShceSFVih>(c_, d_);
+		IEnumerable<Tuple_DbNMMZBTISSRTNdiShceSFVih> e_ = context.Operators.Select<ValueTuple<Encounter, Encounter>, Tuple_DbNMMZBTISSRTNdiShceSFVih>(c_, d_);
 		bool? f_(Tuple_DbNMMZBTISSRTNdiShceSFVih tuple_dbnmmzbtissrtndishcesfvih)
 		{
-			var k_ = tuple_dbnmmzbtissrtndishcesfvih.OfficeVisit2?.Period;
-			var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-			var m_ = QICoreCommon_2_0_000.ToInterval((l_ as object));
-			var n_ = context.Operators.Start(m_);
-			var o_ = tuple_dbnmmzbtissrtndishcesfvih.OfficeVisit1?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = QICoreCommon_2_0_000.ToInterval((p_ as object));
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(1m, "day");
-			var t_ = context.Operators.Add(r_, s_);
-			var u_ = context.Operators.SameOrAfter(n_, t_, "day");
+			Period k_ = tuple_dbnmmzbtissrtndishcesfvih.OfficeVisit2?.Period;
+			CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+			CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.ToInterval((l_ as object));
+			CqlDateTime n_ = context.Operators.Start(m_);
+			Period o_ = tuple_dbnmmzbtissrtndishcesfvih.OfficeVisit1?.Period;
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.ToInterval((p_ as object));
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(1m, "day");
+			CqlDateTime t_ = context.Operators.Add(r_, s_);
+			bool? u_ = context.Operators.SameOrAfter(n_, t_, "day");
 
 			return u_;
 		};
-		var g_ = context.Operators.Where<Tuple_DbNMMZBTISSRTNdiShceSFVih>(e_, f_);
+		IEnumerable<Tuple_DbNMMZBTISSRTNdiShceSFVih> g_ = context.Operators.Where<Tuple_DbNMMZBTISSRTNdiShceSFVih>(e_, f_);
 		Encounter h_(Tuple_DbNMMZBTISSRTNdiShceSFVih tuple_dbnmmzbtissrtndishcesfvih) => 
 			tuple_dbnmmzbtissrtndishcesfvih.OfficeVisit1;
-		var i_ = context.Operators.Select<Tuple_DbNMMZBTISSRTNdiShceSFVih, Encounter>(g_, h_);
+		IEnumerable<Encounter> i_ = context.Operators.Select<Tuple_DbNMMZBTISSRTNdiShceSFVih, Encounter>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Two_Outpatient_Encounters_during_Measurement_Period_Value"/>
     [CqlDeclaration("Two Outpatient Encounters during Measurement Period")]
 	public IEnumerable<Encounter> Two_Outpatient_Encounters_during_Measurement_Period() => 
 		__Two_Outpatient_Encounters_during_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 18);
-		var h_ = this.Heart_Failure();
-		var i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
-		bool? j_(Condition HeartFailure)
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+		CqlValueSet j_ = this.Heart_Failure();
+		IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, null);
+		bool? l_(Condition HeartFailure)
 		{
-			var q_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HeartFailure);
-			var r_ = this.Measurement_Period();
-			var s_ = context.Operators.OverlapsBefore(q_, r_, null);
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HeartFailure);
+			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
+			bool? u_ = context.Operators.OverlapsBefore(s_, t_, null);
 
-			return s_;
+			return u_;
 		};
-		var k_ = context.Operators.Where<Condition>(i_, j_);
-		var l_ = context.Operators.Exists<Condition>(k_);
-		var m_ = context.Operators.And(g_, l_);
-		var n_ = this.Two_Outpatient_Encounters_during_Measurement_Period();
-		var o_ = context.Operators.Exists<Encounter>(n_);
-		var p_ = context.Operators.And(m_, o_);
+		IEnumerable<Condition> m_ = context.Operators.Where<Condition>(k_, l_);
+		bool? n_ = context.Operators.Exists<Condition>(m_);
+		bool? o_ = context.Operators.And(i_, n_);
+		IEnumerable<Encounter> p_ = this.Two_Outpatient_Encounters_during_Measurement_Period();
+		bool? q_ = context.Operators.Exists<Encounter>(p_);
+		bool? r_ = context.Operators.And(o_, q_);
 
-		return p_;
+		return r_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = this.Severe_cognitive_impairment__finding_();
-		var c_ = context.Operators.ToList<CqlCode>(b_);
-		var d_ = context.Operators.RetrieveByCodes<Condition>(c_, null);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		CqlCode b_ = this.Severe_cognitive_impairment__finding_();
+		IEnumerable<CqlCode> c_ = context.Operators.ToList<CqlCode>(b_);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByCodes<Condition>(c_, null);
 		bool? e_(Condition Dementia)
 		{
-			var i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Dementia);
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.Overlaps(i_, j_, null);
+			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Dementia);
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			bool? k_ = context.Operators.Overlaps(i_, j_, null);
 
 			return k_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
-		var g_ = context.Operators.Exists<Condition>(f_);
-		var h_ = context.Operators.Or(a_, g_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+		bool? g_ = context.Operators.Exists<Condition>(f_);
+		bool? h_ = context.Operators.Or(a_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Date_PROMIS10_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_PROMIS10_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
-		var e_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.Final_Survey_Observation(g_);
-		var i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
+		CqlCode a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode e_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
+		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		Tuple_DDTAOdcFieSJbGgRLLZPYbGQb j_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var p_ = new Tuple_DDTAOdcFieSJbGgRLLZPYbGQb
+			Tuple_DDTAOdcFieSJbGgRLLZPYbGQb p_ = new Tuple_DDTAOdcFieSJbGgRLLZPYbGQb
 			{
 				PROMIS10MentalScore = _valueTuple.Item1,
 				PROMIS10PhysicalScore = _valueTuple.Item2,
@@ -713,70 +810,72 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return p_;
 		};
-		var k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DDTAOdcFieSJbGgRLLZPYbGQb>(i_, j_);
+		IEnumerable<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb> k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DDTAOdcFieSJbGgRLLZPYbGQb>(i_, j_);
 		bool? l_(Tuple_DDTAOdcFieSJbGgRLLZPYbGQb tuple_ddtaodcfiesjbggrllzpybgqb)
 		{
-			var q_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Effective;
-			var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
-			var t_ = context.Operators.Start(s_);
-			var u_ = context.Operators.DateFrom(t_);
-			var v_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Effective;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.ToInterval(w_);
-			var y_ = context.Operators.Start(x_);
-			var z_ = context.Operators.DateFrom(y_);
-			var aa_ = context.Operators.SameAs(u_, z_, "day");
-			var ab_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
-			var af_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Value;
-			var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
-			var ah_ = context.Operators.Not((bool?)(ag_ is null));
-			var ai_ = context.Operators.And(ae_, ah_);
+			DataType q_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Effective;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			CqlDateTime t_ = context.Operators.Start(s_);
+			CqlDate u_ = context.Operators.DateFrom(t_);
+			DataType v_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Effective;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
+			CqlDateTime y_ = context.Operators.Start(x_);
+			CqlDate z_ = context.Operators.DateFrom(y_);
+			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			DataType ab_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Value;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+			bool? ae_ = context.Operators.And(aa_, ad_);
+			DataType af_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Value;
+			object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+			bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+			bool? ai_ = context.Operators.And(ae_, ah_);
 
 			return ai_;
 		};
-		var m_ = context.Operators.Where<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb>(k_, l_);
+		IEnumerable<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb> m_ = context.Operators.Where<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb>(k_, l_);
 		CqlDate n_(Tuple_DDTAOdcFieSJbGgRLLZPYbGQb tuple_ddtaodcfiesjbggrllzpybgqb)
 		{
-			var aj_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Effective;
-			var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-			var al_ = QICoreCommon_2_0_000.ToInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.DateFrom(am_);
-			var ao_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Effective;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
-			var ar_ = context.Operators.Start(aq_);
-			var as_ = context.Operators.DateFrom(ar_);
-			var at_ = new CqlDate[]
+			DataType aj_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Effective;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval(ak_);
+			CqlDateTime am_ = context.Operators.Start(al_);
+			CqlDate an_ = context.Operators.DateFrom(am_);
+			DataType ao_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Effective;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
+			CqlDateTime ar_ = context.Operators.Start(aq_);
+			CqlDate as_ = context.Operators.DateFrom(ar_);
+			CqlDate[] at_ = new CqlDate[]
 			{
 				an_,
 				as_,
 			};
-			var au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
+			CqlDate au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
 
 			return au_;
 		};
-		var o_ = context.Operators.Select<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb, CqlDate>(m_, n_);
+		IEnumerable<CqlDate> o_ = context.Operators.Select<Tuple_DDTAOdcFieSJbGgRLLZPYbGQb, CqlDate>(m_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Date_PROMIS10_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date PROMIS10 Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_PROMIS10_Total_Assessment_Completed() => 
 		__Date_PROMIS10_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_PROMIS10_Total_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_PROMIS10_Total_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj
+			Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj l_ = new Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialPROMIS10Date = _valueTuple.Item2,
@@ -785,95 +884,97 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj>(d_, e_);
+		IEnumerable<Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj>(d_, e_);
 		bool? g_(Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj tuple_dzhwgxhmbfavmzfaszbeksohj)
 		{
-			var m_ = tuple_dzhwgxhmbfavmzfaszbeksohj.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj.InitialPROMIS10Date);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj.FollowupPROMIS10Date);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_dzhwgxhmbfavmzfaszbeksohj.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj.InitialPROMIS10Date);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj.FollowupPROMIS10Date);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj>(f_, g_);
+		IEnumerable<Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj> h_ = context.Operators.Where<Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj>(f_, g_);
 		Encounter i_(Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj tuple_dzhwgxhmbfavmzfaszbeksohj) => 
 			tuple_dzhwgxhmbfavmzfaszbeksohj.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_DZhWGXhMBfAVMZfaSZbEKSOHj, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up PROMIS10 Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments.Value;
 
+    /// <seealso cref="Date_PROMIS29_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_PROMIS29_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.PROMIS_29_Sleep_disturbance_score_T_score();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
-		var e_ = this.PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.Final_Survey_Observation(g_);
-		var i_ = this.PROMIS_29_Physical_function_score_T_score();
-		var j_ = context.Operators.ToList<CqlCode>(i_);
-		var k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
-		var l_ = Status_1_6_000.Final_Survey_Observation(k_);
-		var m_ = this.PROMIS_29_Pain_interference_score_T_score();
-		var n_ = context.Operators.ToList<CqlCode>(m_);
-		var o_ = context.Operators.RetrieveByCodes<Observation>(n_, null);
-		var p_ = Status_1_6_000.Final_Survey_Observation(o_);
-		var q_ = this.PROMIS_29_Fatigue_score_T_score();
-		var r_ = context.Operators.ToList<CqlCode>(q_);
-		var s_ = context.Operators.RetrieveByCodes<Observation>(r_, null);
-		var t_ = Status_1_6_000.Final_Survey_Observation(s_);
-		var u_ = this.PROMIS_29_Depression_score_T_score();
-		var v_ = context.Operators.ToList<CqlCode>(u_);
-		var w_ = context.Operators.RetrieveByCodes<Observation>(v_, null);
-		var x_ = Status_1_6_000.Final_Survey_Observation(w_);
-		var y_ = this.PROMIS_29_Anxiety_score_T_score();
-		var z_ = context.Operators.ToList<CqlCode>(y_);
-		var aa_ = context.Operators.RetrieveByCodes<Observation>(z_, null);
-		var ab_ = Status_1_6_000.Final_Survey_Observation(aa_);
-		var ac_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_, x_, ab_);
+		CqlCode a_ = this.PROMIS_29_Sleep_disturbance_score_T_score();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode e_ = this.PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
+		CqlCode i_ = this.PROMIS_29_Physical_function_score_T_score();
+		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
+		IEnumerable<Observation> l_ = Status_1_6_000.Final_Survey_Observation(k_);
+		CqlCode m_ = this.PROMIS_29_Pain_interference_score_T_score();
+		IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
+		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, null);
+		IEnumerable<Observation> p_ = Status_1_6_000.Final_Survey_Observation(o_);
+		CqlCode q_ = this.PROMIS_29_Fatigue_score_T_score();
+		IEnumerable<CqlCode> r_ = context.Operators.ToList<CqlCode>(q_);
+		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, null);
+		IEnumerable<Observation> t_ = Status_1_6_000.Final_Survey_Observation(s_);
+		CqlCode u_ = this.PROMIS_29_Depression_score_T_score();
+		IEnumerable<CqlCode> v_ = context.Operators.ToList<CqlCode>(u_);
+		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, null);
+		IEnumerable<Observation> x_ = Status_1_6_000.Final_Survey_Observation(w_);
+		CqlCode y_ = this.PROMIS_29_Anxiety_score_T_score();
+		IEnumerable<CqlCode> z_ = context.Operators.ToList<CqlCode>(y_);
+		IEnumerable<Observation> aa_ = context.Operators.RetrieveByCodes<Observation>(z_, null);
+		IEnumerable<Observation> ab_ = Status_1_6_000.Final_Survey_Observation(aa_);
+		IEnumerable<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation, Observation>> ac_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_, x_, ab_);
 		Tuple_CbgPSARVWRSeWLgLehiNjaNiM ad_(ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation, Observation> _valueTuple)
 		{
-			var aj_ = new Tuple_CbgPSARVWRSeWLgLehiNjaNiM
+			Tuple_CbgPSARVWRSeWLgLehiNjaNiM aj_ = new Tuple_CbgPSARVWRSeWLgLehiNjaNiM
 			{
 				Promis29Sleep = _valueTuple.Item1,
 				Promis29SocialRoles = _valueTuple.Item2,
@@ -886,145 +987,145 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return aj_;
 		};
-		var ae_ = context.Operators.Select<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation, Observation>, Tuple_CbgPSARVWRSeWLgLehiNjaNiM>(ac_, ad_);
+		IEnumerable<Tuple_CbgPSARVWRSeWLgLehiNjaNiM> ae_ = context.Operators.Select<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation, Observation>, Tuple_CbgPSARVWRSeWLgLehiNjaNiM>(ac_, ad_);
 		bool? af_(Tuple_CbgPSARVWRSeWLgLehiNjaNiM tuple_cbgpsarvwrsewlglehinjanim)
 		{
-			var ak_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Sleep?.Effective;
-			var al_ = FHIRHelpers_4_3_000.ToValue(ak_);
-			var am_ = QICoreCommon_2_0_000.ToInterval(al_);
-			var an_ = context.Operators.Start(am_);
-			var ao_ = context.Operators.DateFrom(an_);
-			var ap_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29SocialRoles?.Effective;
-			var aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
-			var ar_ = QICoreCommon_2_0_000.ToInterval(aq_);
-			var as_ = context.Operators.Start(ar_);
-			var at_ = context.Operators.DateFrom(as_);
-			var au_ = context.Operators.SameAs(ao_, at_, "day");
-			var av_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29SocialRoles?.Value;
-			var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-			var ax_ = context.Operators.Not((bool?)(aw_ is null));
-			var ay_ = context.Operators.And(au_, ax_);
-			var ba_ = FHIRHelpers_4_3_000.ToValue(ak_);
-			var bb_ = QICoreCommon_2_0_000.ToInterval(ba_);
-			var bc_ = context.Operators.Start(bb_);
-			var bd_ = context.Operators.DateFrom(bc_);
-			var be_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Physical?.Effective;
-			var bf_ = FHIRHelpers_4_3_000.ToValue(be_);
-			var bg_ = QICoreCommon_2_0_000.ToInterval(bf_);
-			var bh_ = context.Operators.Start(bg_);
-			var bi_ = context.Operators.DateFrom(bh_);
-			var bj_ = context.Operators.SameAs(bd_, bi_, "day");
-			var bk_ = context.Operators.And(ay_, bj_);
-			var bl_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Physical?.Value;
-			var bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
-			var bn_ = context.Operators.Not((bool?)(bm_ is null));
-			var bo_ = context.Operators.And(bk_, bn_);
-			var bq_ = FHIRHelpers_4_3_000.ToValue(ak_);
-			var br_ = QICoreCommon_2_0_000.ToInterval(bq_);
-			var bs_ = context.Operators.Start(br_);
-			var bt_ = context.Operators.DateFrom(bs_);
-			var bu_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Pain?.Effective;
-			var bv_ = FHIRHelpers_4_3_000.ToValue(bu_);
-			var bw_ = QICoreCommon_2_0_000.ToInterval(bv_);
-			var bx_ = context.Operators.Start(bw_);
-			var by_ = context.Operators.DateFrom(bx_);
-			var bz_ = context.Operators.SameAs(bt_, by_, "day");
-			var ca_ = context.Operators.And(bo_, bz_);
-			var cb_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Pain?.Value;
-			var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
-			var cd_ = context.Operators.Not((bool?)(cc_ is null));
-			var ce_ = context.Operators.And(ca_, cd_);
-			var cg_ = FHIRHelpers_4_3_000.ToValue(ak_);
-			var ch_ = QICoreCommon_2_0_000.ToInterval(cg_);
-			var ci_ = context.Operators.Start(ch_);
-			var cj_ = context.Operators.DateFrom(ci_);
-			var ck_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Fatigue?.Effective;
-			var cl_ = FHIRHelpers_4_3_000.ToValue(ck_);
-			var cm_ = QICoreCommon_2_0_000.ToInterval(cl_);
-			var cn_ = context.Operators.Start(cm_);
-			var co_ = context.Operators.DateFrom(cn_);
-			var cp_ = context.Operators.SameAs(cj_, co_, "day");
-			var cq_ = context.Operators.And(ce_, cp_);
-			var cr_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Fatigue?.Value;
-			var cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
-			var ct_ = context.Operators.Not((bool?)(cs_ is null));
-			var cu_ = context.Operators.And(cq_, ct_);
-			var cw_ = FHIRHelpers_4_3_000.ToValue(ak_);
-			var cx_ = QICoreCommon_2_0_000.ToInterval(cw_);
-			var cy_ = context.Operators.Start(cx_);
-			var cz_ = context.Operators.DateFrom(cy_);
-			var da_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Depression?.Effective;
-			var db_ = FHIRHelpers_4_3_000.ToValue(da_);
-			var dc_ = QICoreCommon_2_0_000.ToInterval(db_);
-			var dd_ = context.Operators.Start(dc_);
-			var de_ = context.Operators.DateFrom(dd_);
-			var df_ = context.Operators.SameAs(cz_, de_, "day");
-			var dg_ = context.Operators.And(cu_, df_);
-			var dh_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Depression?.Value;
-			var di_ = FHIRHelpers_4_3_000.ToValue(dh_);
-			var dj_ = context.Operators.Not((bool?)(di_ is null));
-			var dk_ = context.Operators.And(dg_, dj_);
-			var dm_ = FHIRHelpers_4_3_000.ToValue(ak_);
-			var dn_ = QICoreCommon_2_0_000.ToInterval(dm_);
-			var do_ = context.Operators.Start(dn_);
-			var dp_ = context.Operators.DateFrom(do_);
-			var dq_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Anxiety?.Effective;
-			var dr_ = FHIRHelpers_4_3_000.ToValue(dq_);
-			var ds_ = QICoreCommon_2_0_000.ToInterval(dr_);
-			var dt_ = context.Operators.Start(ds_);
-			var du_ = context.Operators.DateFrom(dt_);
-			var dv_ = context.Operators.SameAs(dp_, du_, "day");
-			var dw_ = context.Operators.And(dk_, dv_);
-			var dx_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Anxiety?.Value;
-			var dy_ = FHIRHelpers_4_3_000.ToValue(dx_);
-			var dz_ = context.Operators.Not((bool?)(dy_ is null));
-			var ea_ = context.Operators.And(dw_, dz_);
-			var eb_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Sleep?.Value;
-			var ec_ = FHIRHelpers_4_3_000.ToValue(eb_);
-			var ed_ = context.Operators.Not((bool?)(ec_ is null));
-			var ee_ = context.Operators.And(ea_, ed_);
+			DataType ak_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Sleep?.Effective;
+			object al_ = FHIRHelpers_4_3_000.ToValue(ak_);
+			CqlInterval<CqlDateTime> am_ = QICoreCommon_2_0_000.ToInterval(al_);
+			CqlDateTime an_ = context.Operators.Start(am_);
+			CqlDate ao_ = context.Operators.DateFrom(an_);
+			DataType ap_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29SocialRoles?.Effective;
+			object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+			CqlInterval<CqlDateTime> ar_ = QICoreCommon_2_0_000.ToInterval(aq_);
+			CqlDateTime as_ = context.Operators.Start(ar_);
+			CqlDate at_ = context.Operators.DateFrom(as_);
+			bool? au_ = context.Operators.SameAs(ao_, at_, "day");
+			DataType av_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29SocialRoles?.Value;
+			object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+			bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+			bool? ay_ = context.Operators.And(au_, ax_);
+			object ba_ = FHIRHelpers_4_3_000.ToValue(ak_);
+			CqlInterval<CqlDateTime> bb_ = QICoreCommon_2_0_000.ToInterval(ba_);
+			CqlDateTime bc_ = context.Operators.Start(bb_);
+			CqlDate bd_ = context.Operators.DateFrom(bc_);
+			DataType be_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Physical?.Effective;
+			object bf_ = FHIRHelpers_4_3_000.ToValue(be_);
+			CqlInterval<CqlDateTime> bg_ = QICoreCommon_2_0_000.ToInterval(bf_);
+			CqlDateTime bh_ = context.Operators.Start(bg_);
+			CqlDate bi_ = context.Operators.DateFrom(bh_);
+			bool? bj_ = context.Operators.SameAs(bd_, bi_, "day");
+			bool? bk_ = context.Operators.And(ay_, bj_);
+			DataType bl_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Physical?.Value;
+			object bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
+			bool? bn_ = context.Operators.Not((bool?)(bm_ is null));
+			bool? bo_ = context.Operators.And(bk_, bn_);
+			object bq_ = FHIRHelpers_4_3_000.ToValue(ak_);
+			CqlInterval<CqlDateTime> br_ = QICoreCommon_2_0_000.ToInterval(bq_);
+			CqlDateTime bs_ = context.Operators.Start(br_);
+			CqlDate bt_ = context.Operators.DateFrom(bs_);
+			DataType bu_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Pain?.Effective;
+			object bv_ = FHIRHelpers_4_3_000.ToValue(bu_);
+			CqlInterval<CqlDateTime> bw_ = QICoreCommon_2_0_000.ToInterval(bv_);
+			CqlDateTime bx_ = context.Operators.Start(bw_);
+			CqlDate by_ = context.Operators.DateFrom(bx_);
+			bool? bz_ = context.Operators.SameAs(bt_, by_, "day");
+			bool? ca_ = context.Operators.And(bo_, bz_);
+			DataType cb_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Pain?.Value;
+			object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+			bool? cd_ = context.Operators.Not((bool?)(cc_ is null));
+			bool? ce_ = context.Operators.And(ca_, cd_);
+			object cg_ = FHIRHelpers_4_3_000.ToValue(ak_);
+			CqlInterval<CqlDateTime> ch_ = QICoreCommon_2_0_000.ToInterval(cg_);
+			CqlDateTime ci_ = context.Operators.Start(ch_);
+			CqlDate cj_ = context.Operators.DateFrom(ci_);
+			DataType ck_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Fatigue?.Effective;
+			object cl_ = FHIRHelpers_4_3_000.ToValue(ck_);
+			CqlInterval<CqlDateTime> cm_ = QICoreCommon_2_0_000.ToInterval(cl_);
+			CqlDateTime cn_ = context.Operators.Start(cm_);
+			CqlDate co_ = context.Operators.DateFrom(cn_);
+			bool? cp_ = context.Operators.SameAs(cj_, co_, "day");
+			bool? cq_ = context.Operators.And(ce_, cp_);
+			DataType cr_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Fatigue?.Value;
+			object cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
+			bool? ct_ = context.Operators.Not((bool?)(cs_ is null));
+			bool? cu_ = context.Operators.And(cq_, ct_);
+			object cw_ = FHIRHelpers_4_3_000.ToValue(ak_);
+			CqlInterval<CqlDateTime> cx_ = QICoreCommon_2_0_000.ToInterval(cw_);
+			CqlDateTime cy_ = context.Operators.Start(cx_);
+			CqlDate cz_ = context.Operators.DateFrom(cy_);
+			DataType da_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Depression?.Effective;
+			object db_ = FHIRHelpers_4_3_000.ToValue(da_);
+			CqlInterval<CqlDateTime> dc_ = QICoreCommon_2_0_000.ToInterval(db_);
+			CqlDateTime dd_ = context.Operators.Start(dc_);
+			CqlDate de_ = context.Operators.DateFrom(dd_);
+			bool? df_ = context.Operators.SameAs(cz_, de_, "day");
+			bool? dg_ = context.Operators.And(cu_, df_);
+			DataType dh_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Depression?.Value;
+			object di_ = FHIRHelpers_4_3_000.ToValue(dh_);
+			bool? dj_ = context.Operators.Not((bool?)(di_ is null));
+			bool? dk_ = context.Operators.And(dg_, dj_);
+			object dm_ = FHIRHelpers_4_3_000.ToValue(ak_);
+			CqlInterval<CqlDateTime> dn_ = QICoreCommon_2_0_000.ToInterval(dm_);
+			CqlDateTime do_ = context.Operators.Start(dn_);
+			CqlDate dp_ = context.Operators.DateFrom(do_);
+			DataType dq_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Anxiety?.Effective;
+			object dr_ = FHIRHelpers_4_3_000.ToValue(dq_);
+			CqlInterval<CqlDateTime> ds_ = QICoreCommon_2_0_000.ToInterval(dr_);
+			CqlDateTime dt_ = context.Operators.Start(ds_);
+			CqlDate du_ = context.Operators.DateFrom(dt_);
+			bool? dv_ = context.Operators.SameAs(dp_, du_, "day");
+			bool? dw_ = context.Operators.And(dk_, dv_);
+			DataType dx_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Anxiety?.Value;
+			object dy_ = FHIRHelpers_4_3_000.ToValue(dx_);
+			bool? dz_ = context.Operators.Not((bool?)(dy_ is null));
+			bool? ea_ = context.Operators.And(dw_, dz_);
+			DataType eb_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Sleep?.Value;
+			object ec_ = FHIRHelpers_4_3_000.ToValue(eb_);
+			bool? ed_ = context.Operators.Not((bool?)(ec_ is null));
+			bool? ee_ = context.Operators.And(ea_, ed_);
 
 			return ee_;
 		};
-		var ag_ = context.Operators.Where<Tuple_CbgPSARVWRSeWLgLehiNjaNiM>(ae_, af_);
+		IEnumerable<Tuple_CbgPSARVWRSeWLgLehiNjaNiM> ag_ = context.Operators.Where<Tuple_CbgPSARVWRSeWLgLehiNjaNiM>(ae_, af_);
 		CqlDate ah_(Tuple_CbgPSARVWRSeWLgLehiNjaNiM tuple_cbgpsarvwrsewlglehinjanim)
 		{
-			var ef_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Sleep?.Effective;
-			var eg_ = FHIRHelpers_4_3_000.ToValue(ef_);
-			var eh_ = QICoreCommon_2_0_000.ToInterval(eg_);
-			var ei_ = context.Operators.Start(eh_);
-			var ej_ = context.Operators.DateFrom(ei_);
-			var ek_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29SocialRoles?.Effective;
-			var el_ = FHIRHelpers_4_3_000.ToValue(ek_);
-			var em_ = QICoreCommon_2_0_000.ToInterval(el_);
-			var en_ = context.Operators.Start(em_);
-			var eo_ = context.Operators.DateFrom(en_);
-			var ep_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Physical?.Effective;
-			var eq_ = FHIRHelpers_4_3_000.ToValue(ep_);
-			var er_ = QICoreCommon_2_0_000.ToInterval(eq_);
-			var es_ = context.Operators.Start(er_);
-			var et_ = context.Operators.DateFrom(es_);
-			var eu_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Pain?.Effective;
-			var ev_ = FHIRHelpers_4_3_000.ToValue(eu_);
-			var ew_ = QICoreCommon_2_0_000.ToInterval(ev_);
-			var ex_ = context.Operators.Start(ew_);
-			var ey_ = context.Operators.DateFrom(ex_);
-			var ez_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Fatigue?.Effective;
-			var fa_ = FHIRHelpers_4_3_000.ToValue(ez_);
-			var fb_ = QICoreCommon_2_0_000.ToInterval(fa_);
-			var fc_ = context.Operators.Start(fb_);
-			var fd_ = context.Operators.DateFrom(fc_);
-			var fe_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Depression?.Effective;
-			var ff_ = FHIRHelpers_4_3_000.ToValue(fe_);
-			var fg_ = QICoreCommon_2_0_000.ToInterval(ff_);
-			var fh_ = context.Operators.Start(fg_);
-			var fi_ = context.Operators.DateFrom(fh_);
-			var fj_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Anxiety?.Effective;
-			var fk_ = FHIRHelpers_4_3_000.ToValue(fj_);
-			var fl_ = QICoreCommon_2_0_000.ToInterval(fk_);
-			var fm_ = context.Operators.Start(fl_);
-			var fn_ = context.Operators.DateFrom(fm_);
-			var fo_ = new CqlDate[]
+			DataType ef_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Sleep?.Effective;
+			object eg_ = FHIRHelpers_4_3_000.ToValue(ef_);
+			CqlInterval<CqlDateTime> eh_ = QICoreCommon_2_0_000.ToInterval(eg_);
+			CqlDateTime ei_ = context.Operators.Start(eh_);
+			CqlDate ej_ = context.Operators.DateFrom(ei_);
+			DataType ek_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29SocialRoles?.Effective;
+			object el_ = FHIRHelpers_4_3_000.ToValue(ek_);
+			CqlInterval<CqlDateTime> em_ = QICoreCommon_2_0_000.ToInterval(el_);
+			CqlDateTime en_ = context.Operators.Start(em_);
+			CqlDate eo_ = context.Operators.DateFrom(en_);
+			DataType ep_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Physical?.Effective;
+			object eq_ = FHIRHelpers_4_3_000.ToValue(ep_);
+			CqlInterval<CqlDateTime> er_ = QICoreCommon_2_0_000.ToInterval(eq_);
+			CqlDateTime es_ = context.Operators.Start(er_);
+			CqlDate et_ = context.Operators.DateFrom(es_);
+			DataType eu_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Pain?.Effective;
+			object ev_ = FHIRHelpers_4_3_000.ToValue(eu_);
+			CqlInterval<CqlDateTime> ew_ = QICoreCommon_2_0_000.ToInterval(ev_);
+			CqlDateTime ex_ = context.Operators.Start(ew_);
+			CqlDate ey_ = context.Operators.DateFrom(ex_);
+			DataType ez_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Fatigue?.Effective;
+			object fa_ = FHIRHelpers_4_3_000.ToValue(ez_);
+			CqlInterval<CqlDateTime> fb_ = QICoreCommon_2_0_000.ToInterval(fa_);
+			CqlDateTime fc_ = context.Operators.Start(fb_);
+			CqlDate fd_ = context.Operators.DateFrom(fc_);
+			DataType fe_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Depression?.Effective;
+			object ff_ = FHIRHelpers_4_3_000.ToValue(fe_);
+			CqlInterval<CqlDateTime> fg_ = QICoreCommon_2_0_000.ToInterval(ff_);
+			CqlDateTime fh_ = context.Operators.Start(fg_);
+			CqlDate fi_ = context.Operators.DateFrom(fh_);
+			DataType fj_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Anxiety?.Effective;
+			object fk_ = FHIRHelpers_4_3_000.ToValue(fj_);
+			CqlInterval<CqlDateTime> fl_ = QICoreCommon_2_0_000.ToInterval(fk_);
+			CqlDateTime fm_ = context.Operators.Start(fl_);
+			CqlDate fn_ = context.Operators.DateFrom(fm_);
+			CqlDate[] fo_ = new CqlDate[]
 			{
 				ej_,
 				eo_,
@@ -1034,27 +1135,29 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 				fi_,
 				fn_,
 			};
-			var fp_ = context.Operators.Max<CqlDate>((fo_ as IEnumerable<CqlDate>));
+			CqlDate fp_ = context.Operators.Max<CqlDate>((fo_ as IEnumerable<CqlDate>));
 
 			return fp_;
 		};
-		var ai_ = context.Operators.Select<Tuple_CbgPSARVWRSeWLgLehiNjaNiM, CqlDate>(ag_, ah_);
+		IEnumerable<CqlDate> ai_ = context.Operators.Select<Tuple_CbgPSARVWRSeWLgLehiNjaNiM, CqlDate>(ag_, ah_);
 
 		return ai_;
 	}
 
+    /// <seealso cref="Date_PROMIS29_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date PROMIS29 Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_PROMIS29_Total_Assessment_Completed() => 
 		__Date_PROMIS29_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_PROMIS29_Total_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_PROMIS29_Total_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_KMPNTXjUhKPBcWGfTQIGieaO e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_KMPNTXjUhKPBcWGfTQIGieaO
+			Tuple_KMPNTXjUhKPBcWGfTQIGieaO l_ = new Tuple_KMPNTXjUhKPBcWGfTQIGieaO
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialPROMIS29Date = _valueTuple.Item2,
@@ -1063,75 +1166,77 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_KMPNTXjUhKPBcWGfTQIGieaO>(d_, e_);
+		IEnumerable<Tuple_KMPNTXjUhKPBcWGfTQIGieaO> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_KMPNTXjUhKPBcWGfTQIGieaO>(d_, e_);
 		bool? g_(Tuple_KMPNTXjUhKPBcWGfTQIGieaO tuple_kmpntxjuhkpbcwgftqigieao)
 		{
-			var m_ = tuple_kmpntxjuhkpbcwgftqigieao.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao.InitialPROMIS29Date);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao.FollowupPROMIS29Date);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_kmpntxjuhkpbcwgftqigieao.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao.InitialPROMIS29Date);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao.FollowupPROMIS29Date);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_KMPNTXjUhKPBcWGfTQIGieaO>(f_, g_);
+		IEnumerable<Tuple_KMPNTXjUhKPBcWGfTQIGieaO> h_ = context.Operators.Where<Tuple_KMPNTXjUhKPBcWGfTQIGieaO>(f_, g_);
 		Encounter i_(Tuple_KMPNTXjUhKPBcWGfTQIGieaO tuple_kmpntxjuhkpbcwgftqigieao) => 
 			tuple_kmpntxjuhkpbcwgftqigieao.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_KMPNTXjUhKPBcWGfTQIGieaO, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_KMPNTXjUhKPBcWGfTQIGieaO, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up PROMIS29 Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments.Value;
 
+    /// <seealso cref="Date_VR12_Oblique_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_VR12_Oblique_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
-		var e_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.Final_Survey_Observation(g_);
-		var i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
+		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode e_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
+		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH j_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var p_ = new Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH
+			Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH p_ = new Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH
 			{
 				VR12MentalAssessment = _valueTuple.Item1,
 				VR12PhysicalAssessment = _valueTuple.Item2,
@@ -1139,70 +1244,72 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return p_;
 		};
-		var k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(i_, j_);
+		IEnumerable<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH> k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(i_, j_);
 		bool? l_(Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH tuple_gadrfkrahuugjcvhwqwrujhrh)
 		{
-			var q_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
-			var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
-			var t_ = context.Operators.Start(s_);
-			var u_ = context.Operators.DateFrom(t_);
-			var v_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.ToInterval(w_);
-			var y_ = context.Operators.Start(x_);
-			var z_ = context.Operators.DateFrom(y_);
-			var aa_ = context.Operators.SameAs(u_, z_, "day");
-			var ab_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
-			var af_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Value;
-			var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
-			var ah_ = context.Operators.Not((bool?)(ag_ is null));
-			var ai_ = context.Operators.And(ae_, ah_);
+			DataType q_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			CqlDateTime t_ = context.Operators.Start(s_);
+			CqlDate u_ = context.Operators.DateFrom(t_);
+			DataType v_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
+			CqlDateTime y_ = context.Operators.Start(x_);
+			CqlDate z_ = context.Operators.DateFrom(y_);
+			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			DataType ab_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+			bool? ae_ = context.Operators.And(aa_, ad_);
+			DataType af_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Value;
+			object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+			bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+			bool? ai_ = context.Operators.And(ae_, ah_);
 
 			return ai_;
 		};
-		var m_ = context.Operators.Where<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(k_, l_);
+		IEnumerable<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH> m_ = context.Operators.Where<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(k_, l_);
 		CqlDate n_(Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH tuple_gadrfkrahuugjcvhwqwrujhrh)
 		{
-			var aj_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
-			var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-			var al_ = QICoreCommon_2_0_000.ToInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.DateFrom(am_);
-			var ao_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
-			var ar_ = context.Operators.Start(aq_);
-			var as_ = context.Operators.DateFrom(ar_);
-			var at_ = new CqlDate[]
+			DataType aj_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval(ak_);
+			CqlDateTime am_ = context.Operators.Start(al_);
+			CqlDate an_ = context.Operators.DateFrom(am_);
+			DataType ao_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
+			CqlDateTime ar_ = context.Operators.Start(aq_);
+			CqlDate as_ = context.Operators.DateFrom(ar_);
+			CqlDate[] at_ = new CqlDate[]
 			{
 				an_,
 				as_,
 			};
-			var au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
+			CqlDate au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
 
 			return au_;
 		};
-		var o_ = context.Operators.Select<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH, CqlDate>(m_, n_);
+		IEnumerable<CqlDate> o_ = context.Operators.Select<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH, CqlDate>(m_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Date_VR12_Oblique_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date VR12 Oblique Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_VR12_Oblique_Total_Assessment_Completed() => 
 		__Date_VR12_Oblique_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_VR12_Oblique_Total_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_FPPKTdIagiEKHPTNSBAcPSWH e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_FPPKTdIagiEKHPTNSBAcPSWH
+			Tuple_FPPKTdIagiEKHPTNSBAcPSWH l_ = new Tuple_FPPKTdIagiEKHPTNSBAcPSWH
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialVR12ObliqueDate = _valueTuple.Item2,
@@ -1211,75 +1318,77 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_FPPKTdIagiEKHPTNSBAcPSWH>(d_, e_);
+		IEnumerable<Tuple_FPPKTdIagiEKHPTNSBAcPSWH> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_FPPKTdIagiEKHPTNSBAcPSWH>(d_, e_);
 		bool? g_(Tuple_FPPKTdIagiEKHPTNSBAcPSWH tuple_fppktdiagiekhptnsbacpswh)
 		{
-			var m_ = tuple_fppktdiagiekhptnsbacpswh.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh.InitialVR12ObliqueDate);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh.FollowupVR12ObliqueDate);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_fppktdiagiekhptnsbacpswh.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh.InitialVR12ObliqueDate);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh.FollowupVR12ObliqueDate);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_FPPKTdIagiEKHPTNSBAcPSWH>(f_, g_);
+		IEnumerable<Tuple_FPPKTdIagiEKHPTNSBAcPSWH> h_ = context.Operators.Where<Tuple_FPPKTdIagiEKHPTNSBAcPSWH>(f_, g_);
 		Encounter i_(Tuple_FPPKTdIagiEKHPTNSBAcPSWH tuple_fppktdiagiekhptnsbacpswh) => 
 			tuple_fppktdiagiekhptnsbacpswh.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_FPPKTdIagiEKHPTNSBAcPSWH, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_FPPKTdIagiEKHPTNSBAcPSWH, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up VR12 Oblique Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments.Value;
 
+    /// <seealso cref="Date_VR12_Orthogonal_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_VR12_Orthogonal_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
-		var e_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.Final_Survey_Observation(g_);
-		var i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
+		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode e_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
+		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH j_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var p_ = new Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH
+			Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH p_ = new Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH
 			{
 				VR12MentalAssessment = _valueTuple.Item1,
 				VR12PhysicalAssessment = _valueTuple.Item2,
@@ -1287,70 +1396,72 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return p_;
 		};
-		var k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(i_, j_);
+		IEnumerable<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH> k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(i_, j_);
 		bool? l_(Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH tuple_gadrfkrahuugjcvhwqwrujhrh)
 		{
-			var q_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
-			var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
-			var t_ = context.Operators.Start(s_);
-			var u_ = context.Operators.DateFrom(t_);
-			var v_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.ToInterval(w_);
-			var y_ = context.Operators.Start(x_);
-			var z_ = context.Operators.DateFrom(y_);
-			var aa_ = context.Operators.SameAs(u_, z_, "day");
-			var ab_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
-			var af_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Value;
-			var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
-			var ah_ = context.Operators.Not((bool?)(ag_ is null));
-			var ai_ = context.Operators.And(ae_, ah_);
+			DataType q_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			CqlDateTime t_ = context.Operators.Start(s_);
+			CqlDate u_ = context.Operators.DateFrom(t_);
+			DataType v_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
+			CqlDateTime y_ = context.Operators.Start(x_);
+			CqlDate z_ = context.Operators.DateFrom(y_);
+			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			DataType ab_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+			bool? ae_ = context.Operators.And(aa_, ad_);
+			DataType af_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Value;
+			object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+			bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+			bool? ai_ = context.Operators.And(ae_, ah_);
 
 			return ai_;
 		};
-		var m_ = context.Operators.Where<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(k_, l_);
+		IEnumerable<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH> m_ = context.Operators.Where<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH>(k_, l_);
 		CqlDate n_(Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH tuple_gadrfkrahuugjcvhwqwrujhrh)
 		{
-			var aj_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
-			var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-			var al_ = QICoreCommon_2_0_000.ToInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.DateFrom(am_);
-			var ao_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
-			var ar_ = context.Operators.Start(aq_);
-			var as_ = context.Operators.DateFrom(ar_);
-			var at_ = new CqlDate[]
+			DataType aj_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Effective;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval(ak_);
+			CqlDateTime am_ = context.Operators.Start(al_);
+			CqlDate an_ = context.Operators.DateFrom(am_);
+			DataType ao_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12PhysicalAssessment?.Effective;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
+			CqlDateTime ar_ = context.Operators.Start(aq_);
+			CqlDate as_ = context.Operators.DateFrom(ar_);
+			CqlDate[] at_ = new CqlDate[]
 			{
 				an_,
 				as_,
 			};
-			var au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
+			CqlDate au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
 
 			return au_;
 		};
-		var o_ = context.Operators.Select<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH, CqlDate>(m_, n_);
+		IEnumerable<CqlDate> o_ = context.Operators.Select<Tuple_GAdRFKRaHUUGJcVHWQWRUjhRH, CqlDate>(m_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Date_VR12_Orthogonal_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date VR12 Orthogonal Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_VR12_Orthogonal_Total_Assessment_Completed() => 
 		__Date_VR12_Orthogonal_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_VR12_Orthogonal_Total_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_FaNSVMJaEDMVSdOYROZXdLSaI e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_FaNSVMJaEDMVSdOYROZXdLSaI
+			Tuple_FaNSVMJaEDMVSdOYROZXdLSaI l_ = new Tuple_FaNSVMJaEDMVSdOYROZXdLSaI
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialVR12OrthogonalDate = _valueTuple.Item2,
@@ -1359,75 +1470,77 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_FaNSVMJaEDMVSdOYROZXdLSaI>(d_, e_);
+		IEnumerable<Tuple_FaNSVMJaEDMVSdOYROZXdLSaI> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_FaNSVMJaEDMVSdOYROZXdLSaI>(d_, e_);
 		bool? g_(Tuple_FaNSVMJaEDMVSdOYROZXdLSaI tuple_fansvmjaedmvsdoyrozxdlsai)
 		{
-			var m_ = tuple_fansvmjaedmvsdoyrozxdlsai.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai.InitialVR12OrthogonalDate);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai.FollowupVR12OrthogonalDate);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_fansvmjaedmvsdoyrozxdlsai.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai.InitialVR12OrthogonalDate);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai.FollowupVR12OrthogonalDate);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_FaNSVMJaEDMVSdOYROZXdLSaI>(f_, g_);
+		IEnumerable<Tuple_FaNSVMJaEDMVSdOYROZXdLSaI> h_ = context.Operators.Where<Tuple_FaNSVMJaEDMVSdOYROZXdLSaI>(f_, g_);
 		Encounter i_(Tuple_FaNSVMJaEDMVSdOYROZXdLSaI tuple_fansvmjaedmvsdoyrozxdlsai) => 
 			tuple_fansvmjaedmvsdoyrozxdlsai.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_FaNSVMJaEDMVSdOYROZXdLSaI, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_FaNSVMJaEDMVSdOYROZXdLSaI, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up VR12 Orthogonal Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments.Value;
 
+    /// <seealso cref="Date_VR36_Oblique_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_VR36_Oblique_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.VR_36_Mental_component_summary__MCS__score___oblique_method_T_score();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
-		var e_ = this.VR_36_Physical_component_summary__PCS__score___oblique_method_T_score();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.Final_Survey_Observation(g_);
-		var i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
+		CqlCode a_ = this.VR_36_Mental_component_summary__MCS__score___oblique_method_T_score();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode e_ = this.VR_36_Physical_component_summary__PCS__score___oblique_method_T_score();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
+		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK j_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var p_ = new Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK
+			Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK p_ = new Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK
 			{
 				VR36MentalAssessment = _valueTuple.Item1,
 				VR36PhysicalAssessment = _valueTuple.Item2,
@@ -1435,70 +1548,72 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return p_;
 		};
-		var k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK>(i_, j_);
+		IEnumerable<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK> k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK>(i_, j_);
 		bool? l_(Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK tuple_ducftclcqewdggqdfcwthfauk)
 		{
-			var q_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Effective;
-			var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
-			var t_ = context.Operators.Start(s_);
-			var u_ = context.Operators.DateFrom(t_);
-			var v_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Effective;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.ToInterval(w_);
-			var y_ = context.Operators.Start(x_);
-			var z_ = context.Operators.DateFrom(y_);
-			var aa_ = context.Operators.SameAs(u_, z_, "day");
-			var ab_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
-			var af_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Value;
-			var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
-			var ah_ = context.Operators.Not((bool?)(ag_ is null));
-			var ai_ = context.Operators.And(ae_, ah_);
+			DataType q_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Effective;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			CqlDateTime t_ = context.Operators.Start(s_);
+			CqlDate u_ = context.Operators.DateFrom(t_);
+			DataType v_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Effective;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
+			CqlDateTime y_ = context.Operators.Start(x_);
+			CqlDate z_ = context.Operators.DateFrom(y_);
+			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			DataType ab_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Value;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+			bool? ae_ = context.Operators.And(aa_, ad_);
+			DataType af_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Value;
+			object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+			bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+			bool? ai_ = context.Operators.And(ae_, ah_);
 
 			return ai_;
 		};
-		var m_ = context.Operators.Where<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK>(k_, l_);
+		IEnumerable<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK> m_ = context.Operators.Where<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK>(k_, l_);
 		CqlDate n_(Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK tuple_ducftclcqewdggqdfcwthfauk)
 		{
-			var aj_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Effective;
-			var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-			var al_ = QICoreCommon_2_0_000.ToInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.DateFrom(am_);
-			var ao_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Effective;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
-			var ar_ = context.Operators.Start(aq_);
-			var as_ = context.Operators.DateFrom(ar_);
-			var at_ = new CqlDate[]
+			DataType aj_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Effective;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval(ak_);
+			CqlDateTime am_ = context.Operators.Start(al_);
+			CqlDate an_ = context.Operators.DateFrom(am_);
+			DataType ao_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Effective;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
+			CqlDateTime ar_ = context.Operators.Start(aq_);
+			CqlDate as_ = context.Operators.DateFrom(ar_);
+			CqlDate[] at_ = new CqlDate[]
 			{
 				an_,
 				as_,
 			};
-			var au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
+			CqlDate au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
 
 			return au_;
 		};
-		var o_ = context.Operators.Select<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK, CqlDate>(m_, n_);
+		IEnumerable<CqlDate> o_ = context.Operators.Select<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK, CqlDate>(m_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Date_VR36_Oblique_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date VR36 Oblique Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_VR36_Oblique_Total_Assessment_Completed() => 
 		__Date_VR36_Oblique_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_VR36_Oblique_Total_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_VR36_Oblique_Total_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA
+			Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA l_ = new Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialVR36ObliqueDate = _valueTuple.Item2,
@@ -1507,75 +1622,77 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA>(d_, e_);
+		IEnumerable<Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA>(d_, e_);
 		bool? g_(Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA tuple_elxicyhrdpyzpqyjphdifbiga)
 		{
-			var m_ = tuple_elxicyhrdpyzpqyjphdifbiga.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga.InitialVR36ObliqueDate);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga.FollowupVR36ObliqueDate);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_elxicyhrdpyzpqyjphdifbiga.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga.InitialVR36ObliqueDate);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga.FollowupVR36ObliqueDate);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA>(f_, g_);
+		IEnumerable<Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA> h_ = context.Operators.Where<Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA>(f_, g_);
 		Encounter i_(Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA tuple_elxicyhrdpyzpqyjphdifbiga) => 
 			tuple_elxicyhrdpyzpqyjphdifbiga.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_ELXIcYHRDPYZPQYJPHdiFBiGA, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up VR36 Oblique Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments.Value;
 
+    /// <seealso cref="Date_VR36_Orthogonal_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_VR36_Orthogonal_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
-		var e_ = this.VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.Final_Survey_Observation(g_);
-		var i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
+		CqlCode a_ = this.VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode e_ = this.VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
+		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK j_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var p_ = new Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK
+			Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK p_ = new Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK
 			{
 				VR36MentalAssessment = _valueTuple.Item1,
 				VR36PhysicalAssessment = _valueTuple.Item2,
@@ -1583,70 +1700,72 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return p_;
 		};
-		var k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK>(i_, j_);
+		IEnumerable<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK> k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK>(i_, j_);
 		bool? l_(Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK tuple_ducftclcqewdggqdfcwthfauk)
 		{
-			var q_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Effective;
-			var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
-			var t_ = context.Operators.Start(s_);
-			var u_ = context.Operators.DateFrom(t_);
-			var v_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Effective;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.ToInterval(w_);
-			var y_ = context.Operators.Start(x_);
-			var z_ = context.Operators.DateFrom(y_);
-			var aa_ = context.Operators.SameAs(u_, z_, "day");
-			var ab_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
-			var af_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Value;
-			var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
-			var ah_ = context.Operators.Not((bool?)(ag_ is null));
-			var ai_ = context.Operators.And(ae_, ah_);
+			DataType q_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Effective;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			CqlDateTime t_ = context.Operators.Start(s_);
+			CqlDate u_ = context.Operators.DateFrom(t_);
+			DataType v_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Effective;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
+			CqlDateTime y_ = context.Operators.Start(x_);
+			CqlDate z_ = context.Operators.DateFrom(y_);
+			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			DataType ab_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Value;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+			bool? ae_ = context.Operators.And(aa_, ad_);
+			DataType af_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Value;
+			object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+			bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+			bool? ai_ = context.Operators.And(ae_, ah_);
 
 			return ai_;
 		};
-		var m_ = context.Operators.Where<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK>(k_, l_);
+		IEnumerable<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK> m_ = context.Operators.Where<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK>(k_, l_);
 		CqlDate n_(Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK tuple_ducftclcqewdggqdfcwthfauk)
 		{
-			var aj_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Effective;
-			var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-			var al_ = QICoreCommon_2_0_000.ToInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.DateFrom(am_);
-			var ao_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Effective;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
-			var ar_ = context.Operators.Start(aq_);
-			var as_ = context.Operators.DateFrom(ar_);
-			var at_ = new CqlDate[]
+			DataType aj_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Effective;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval(ak_);
+			CqlDateTime am_ = context.Operators.Start(al_);
+			CqlDate an_ = context.Operators.DateFrom(am_);
+			DataType ao_ = tuple_ducftclcqewdggqdfcwthfauk.VR36PhysicalAssessment?.Effective;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
+			CqlDateTime ar_ = context.Operators.Start(aq_);
+			CqlDate as_ = context.Operators.DateFrom(ar_);
+			CqlDate[] at_ = new CqlDate[]
 			{
 				an_,
 				as_,
 			};
-			var au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
+			CqlDate au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
 
 			return au_;
 		};
-		var o_ = context.Operators.Select<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK, CqlDate>(m_, n_);
+		IEnumerable<CqlDate> o_ = context.Operators.Select<Tuple_DUcFTCLcQEWDGGQdFCWTHFaUK, CqlDate>(m_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Date_VR36_Orthogonal_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date VR36 Orthogonal Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_VR36_Orthogonal_Total_Assessment_Completed() => 
 		__Date_VR36_Orthogonal_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_VR36_Orthogonal_Total_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_VR36_Orthogonal_Total_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_fUCQUjAdjiZABIHDfFFORMHT e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_fUCQUjAdjiZABIHDfFFORMHT
+			Tuple_fUCQUjAdjiZABIHDfFFORMHT l_ = new Tuple_fUCQUjAdjiZABIHDfFFORMHT
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialVR36OrthogonalDate = _valueTuple.Item2,
@@ -1655,75 +1774,77 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_fUCQUjAdjiZABIHDfFFORMHT>(d_, e_);
+		IEnumerable<Tuple_fUCQUjAdjiZABIHDfFFORMHT> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_fUCQUjAdjiZABIHDfFFORMHT>(d_, e_);
 		bool? g_(Tuple_fUCQUjAdjiZABIHDfFFORMHT tuple_fucqujadjizabihdffformht)
 		{
-			var m_ = tuple_fucqujadjizabihdffformht.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht.InitialVR36OrthogonalDate);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht.FollowupVR36OrthogonalDate);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_fucqujadjizabihdffformht.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht.InitialVR36OrthogonalDate);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht.FollowupVR36OrthogonalDate);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_fUCQUjAdjiZABIHDfFFORMHT>(f_, g_);
+		IEnumerable<Tuple_fUCQUjAdjiZABIHDfFFORMHT> h_ = context.Operators.Where<Tuple_fUCQUjAdjiZABIHDfFFORMHT>(f_, g_);
 		Encounter i_(Tuple_fUCQUjAdjiZABIHDfFFORMHT tuple_fucqujadjizabihdffformht) => 
 			tuple_fucqujadjizabihdffformht.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_fUCQUjAdjiZABIHDfFFORMHT, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_fUCQUjAdjiZABIHDfFFORMHT, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up VR36 Orthogonal Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments.Value;
 
+    /// <seealso cref="Date_MLHFQ_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_MLHFQ_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.Physical_score__MLHFQ_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
-		var e_ = this.Emotional_score__MLHFQ_();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.Final_Survey_Observation(g_);
-		var i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
+		CqlCode a_ = this.Physical_score__MLHFQ_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode e_ = this.Emotional_score__MLHFQ_();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
+		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		Tuple_FNOFXCKadAeUSJERHBDQfOShE j_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var p_ = new Tuple_FNOFXCKadAeUSJERHBDQfOShE
+			Tuple_FNOFXCKadAeUSJERHBDQfOShE p_ = new Tuple_FNOFXCKadAeUSJERHBDQfOShE
 			{
 				MLHFQPhysical = _valueTuple.Item1,
 				MLHFQEmotional = _valueTuple.Item2,
@@ -1731,70 +1852,72 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return p_;
 		};
-		var k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_FNOFXCKadAeUSJERHBDQfOShE>(i_, j_);
+		IEnumerable<Tuple_FNOFXCKadAeUSJERHBDQfOShE> k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_FNOFXCKadAeUSJERHBDQfOShE>(i_, j_);
 		bool? l_(Tuple_FNOFXCKadAeUSJERHBDQfOShE tuple_fnofxckadaeusjerhbdqfoshe)
 		{
-			var q_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQPhysical?.Effective;
-			var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
-			var t_ = context.Operators.Start(s_);
-			var u_ = context.Operators.DateFrom(t_);
-			var v_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQEmotional?.Effective;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.ToInterval(w_);
-			var y_ = context.Operators.Start(x_);
-			var z_ = context.Operators.DateFrom(y_);
-			var aa_ = context.Operators.SameAs(u_, z_, "day");
-			var ab_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQPhysical?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
-			var af_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQEmotional?.Value;
-			var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
-			var ah_ = context.Operators.Not((bool?)(ag_ is null));
-			var ai_ = context.Operators.And(ae_, ah_);
+			DataType q_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQPhysical?.Effective;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			CqlDateTime t_ = context.Operators.Start(s_);
+			CqlDate u_ = context.Operators.DateFrom(t_);
+			DataType v_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQEmotional?.Effective;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
+			CqlDateTime y_ = context.Operators.Start(x_);
+			CqlDate z_ = context.Operators.DateFrom(y_);
+			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			DataType ab_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQPhysical?.Value;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+			bool? ae_ = context.Operators.And(aa_, ad_);
+			DataType af_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQEmotional?.Value;
+			object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+			bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+			bool? ai_ = context.Operators.And(ae_, ah_);
 
 			return ai_;
 		};
-		var m_ = context.Operators.Where<Tuple_FNOFXCKadAeUSJERHBDQfOShE>(k_, l_);
+		IEnumerable<Tuple_FNOFXCKadAeUSJERHBDQfOShE> m_ = context.Operators.Where<Tuple_FNOFXCKadAeUSJERHBDQfOShE>(k_, l_);
 		CqlDate n_(Tuple_FNOFXCKadAeUSJERHBDQfOShE tuple_fnofxckadaeusjerhbdqfoshe)
 		{
-			var aj_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQPhysical?.Effective;
-			var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-			var al_ = QICoreCommon_2_0_000.ToInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.DateFrom(am_);
-			var ao_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQEmotional?.Effective;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
-			var ar_ = context.Operators.Start(aq_);
-			var as_ = context.Operators.DateFrom(ar_);
-			var at_ = new CqlDate[]
+			DataType aj_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQPhysical?.Effective;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval(ak_);
+			CqlDateTime am_ = context.Operators.Start(al_);
+			CqlDate an_ = context.Operators.DateFrom(am_);
+			DataType ao_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQEmotional?.Effective;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
+			CqlDateTime ar_ = context.Operators.Start(aq_);
+			CqlDate as_ = context.Operators.DateFrom(ar_);
+			CqlDate[] at_ = new CqlDate[]
 			{
 				an_,
 				as_,
 			};
-			var au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
+			CqlDate au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
 
 			return au_;
 		};
-		var o_ = context.Operators.Select<Tuple_FNOFXCKadAeUSJERHBDQfOShE, CqlDate>(m_, n_);
+		IEnumerable<CqlDate> o_ = context.Operators.Select<Tuple_FNOFXCKadAeUSJERHBDQfOShE, CqlDate>(m_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Date_MLHFQ_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date MLHFQ Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_MLHFQ_Total_Assessment_Completed() => 
 		__Date_MLHFQ_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_MLHFQ_Total_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_MLHFQ_Total_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_NCDAWCTNMBFMTibMiHSFBAIG e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_NCDAWCTNMBFMTibMiHSFBAIG
+			Tuple_NCDAWCTNMBFMTibMiHSFBAIG l_ = new Tuple_NCDAWCTNMBFMTibMiHSFBAIG
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialMLHFQDate = _valueTuple.Item2,
@@ -1803,75 +1926,77 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_NCDAWCTNMBFMTibMiHSFBAIG>(d_, e_);
+		IEnumerable<Tuple_NCDAWCTNMBFMTibMiHSFBAIG> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_NCDAWCTNMBFMTibMiHSFBAIG>(d_, e_);
 		bool? g_(Tuple_NCDAWCTNMBFMTibMiHSFBAIG tuple_ncdawctnmbfmtibmihsfbaig)
 		{
-			var m_ = tuple_ncdawctnmbfmtibmihsfbaig.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig.InitialMLHFQDate);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig.FollowupMLHFQDate);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_ncdawctnmbfmtibmihsfbaig.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig.InitialMLHFQDate);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig.FollowupMLHFQDate);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_NCDAWCTNMBFMTibMiHSFBAIG>(f_, g_);
+		IEnumerable<Tuple_NCDAWCTNMBFMTibMiHSFBAIG> h_ = context.Operators.Where<Tuple_NCDAWCTNMBFMTibMiHSFBAIG>(f_, g_);
 		Encounter i_(Tuple_NCDAWCTNMBFMTibMiHSFBAIG tuple_ncdawctnmbfmtibmihsfbaig) => 
 			tuple_ncdawctnmbfmtibmihsfbaig.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_NCDAWCTNMBFMTibMiHSFBAIG, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_NCDAWCTNMBFMTibMiHSFBAIG, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up MLHFQ Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments.Value;
 
+    /// <seealso cref="Date_KCCQ12_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_KCCQ12_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
-		var e_ = this.Overall_summary_score__KCCQ_12_();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.Final_Survey_Observation(g_);
-		var i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
+		CqlCode a_ = this.Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode e_ = this.Overall_summary_score__KCCQ_12_();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
+		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		Tuple_DFKXORghhYafccUSbQaMfNTDj j_(ValueTuple<Observation, Observation> _valueTuple)
 		{
-			var p_ = new Tuple_DFKXORghhYafccUSbQaMfNTDj
+			Tuple_DFKXORghhYafccUSbQaMfNTDj p_ = new Tuple_DFKXORghhYafccUSbQaMfNTDj
 			{
 				KCCQ12Item = _valueTuple.Item1,
 				KCCQ12Summary = _valueTuple.Item2,
@@ -1879,70 +2004,72 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return p_;
 		};
-		var k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DFKXORghhYafccUSbQaMfNTDj>(i_, j_);
+		IEnumerable<Tuple_DFKXORghhYafccUSbQaMfNTDj> k_ = context.Operators.Select<ValueTuple<Observation, Observation>, Tuple_DFKXORghhYafccUSbQaMfNTDj>(i_, j_);
 		bool? l_(Tuple_DFKXORghhYafccUSbQaMfNTDj tuple_dfkxorghhyafccusbqamfntdj)
 		{
-			var q_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Item?.Effective;
-			var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
-			var t_ = context.Operators.Start(s_);
-			var u_ = context.Operators.DateFrom(t_);
-			var v_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Summary?.Effective;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.ToInterval(w_);
-			var y_ = context.Operators.Start(x_);
-			var z_ = context.Operators.DateFrom(y_);
-			var aa_ = context.Operators.SameAs(u_, z_, "day");
-			var ab_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Item?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = context.Operators.Not((bool?)(ac_ is null));
-			var ae_ = context.Operators.And(aa_, ad_);
-			var af_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Summary?.Value;
-			var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
-			var ah_ = context.Operators.Not((bool?)(ag_ is null));
-			var ai_ = context.Operators.And(ae_, ah_);
+			DataType q_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Item?.Effective;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			CqlDateTime t_ = context.Operators.Start(s_);
+			CqlDate u_ = context.Operators.DateFrom(t_);
+			DataType v_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Summary?.Effective;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
+			CqlDateTime y_ = context.Operators.Start(x_);
+			CqlDate z_ = context.Operators.DateFrom(y_);
+			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			DataType ab_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Item?.Value;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
+			bool? ae_ = context.Operators.And(aa_, ad_);
+			DataType af_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Summary?.Value;
+			object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+			bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+			bool? ai_ = context.Operators.And(ae_, ah_);
 
 			return ai_;
 		};
-		var m_ = context.Operators.Where<Tuple_DFKXORghhYafccUSbQaMfNTDj>(k_, l_);
+		IEnumerable<Tuple_DFKXORghhYafccUSbQaMfNTDj> m_ = context.Operators.Where<Tuple_DFKXORghhYafccUSbQaMfNTDj>(k_, l_);
 		CqlDate n_(Tuple_DFKXORghhYafccUSbQaMfNTDj tuple_dfkxorghhyafccusbqamfntdj)
 		{
-			var aj_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Item?.Effective;
-			var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-			var al_ = QICoreCommon_2_0_000.ToInterval(ak_);
-			var am_ = context.Operators.Start(al_);
-			var an_ = context.Operators.DateFrom(am_);
-			var ao_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Summary?.Effective;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
-			var ar_ = context.Operators.Start(aq_);
-			var as_ = context.Operators.DateFrom(ar_);
-			var at_ = new CqlDate[]
+			DataType aj_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Item?.Effective;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval(ak_);
+			CqlDateTime am_ = context.Operators.Start(al_);
+			CqlDate an_ = context.Operators.DateFrom(am_);
+			DataType ao_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Summary?.Effective;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.ToInterval(ap_);
+			CqlDateTime ar_ = context.Operators.Start(aq_);
+			CqlDate as_ = context.Operators.DateFrom(ar_);
+			CqlDate[] at_ = new CqlDate[]
 			{
 				an_,
 				as_,
 			};
-			var au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
+			CqlDate au_ = context.Operators.Max<CqlDate>((at_ as IEnumerable<CqlDate>));
 
 			return au_;
 		};
-		var o_ = context.Operators.Select<Tuple_DFKXORghhYafccUSbQaMfNTDj, CqlDate>(m_, n_);
+		IEnumerable<CqlDate> o_ = context.Operators.Select<Tuple_DFKXORghhYafccUSbQaMfNTDj, CqlDate>(m_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Date_KCCQ12_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date KCCQ12 Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_KCCQ12_Total_Assessment_Completed() => 
 		__Date_KCCQ12_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_KCCQ12_Total_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_KCCQ12_Total_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_EOaHGTWWdfQIJhCjZQNViDVUO e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_EOaHGTWWdfQIJhCjZQNViDVUO
+			Tuple_EOaHGTWWdfQIJhCjZQNViDVUO l_ = new Tuple_EOaHGTWWdfQIJhCjZQNViDVUO
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialKCCQ12Date = _valueTuple.Item2,
@@ -1951,91 +2078,93 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_EOaHGTWWdfQIJhCjZQNViDVUO>(d_, e_);
+		IEnumerable<Tuple_EOaHGTWWdfQIJhCjZQNViDVUO> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_EOaHGTWWdfQIJhCjZQNViDVUO>(d_, e_);
 		bool? g_(Tuple_EOaHGTWWdfQIJhCjZQNViDVUO tuple_eoahgtwwdfqijhcjzqnvidvuo)
 		{
-			var m_ = tuple_eoahgtwwdfqijhcjzqnvidvuo.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo.InitialKCCQ12Date);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo.FollowupKCCQ12Date);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_eoahgtwwdfqijhcjzqnvidvuo.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo.InitialKCCQ12Date);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo.FollowupKCCQ12Date);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_EOaHGTWWdfQIJhCjZQNViDVUO>(f_, g_);
+		IEnumerable<Tuple_EOaHGTWWdfQIJhCjZQNViDVUO> h_ = context.Operators.Where<Tuple_EOaHGTWWdfQIJhCjZQNViDVUO>(f_, g_);
 		Encounter i_(Tuple_EOaHGTWWdfQIJhCjZQNViDVUO tuple_eoahgtwwdfqijhcjzqnvidvuo) => 
 			tuple_eoahgtwwdfqijhcjzqnvidvuo.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_EOaHGTWWdfQIJhCjZQNViDVUO, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_EOaHGTWWdfQIJhCjZQNViDVUO, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up KCCQ12 Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments.Value;
 
+    /// <seealso cref="Date_KCCQ_Domain_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_KCCQ_Domain_Assessment_Completed_Value()
 	{
-		var a_ = this.Quality_of_life_score__KCCQ_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
-		var e_ = this.Symptom_stability_score__KCCQ_();
-		var f_ = context.Operators.ToList<CqlCode>(e_);
-		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = Status_1_6_000.Final_Survey_Observation(g_);
-		var i_ = this.Self_efficacy_score__KCCQ_();
-		var j_ = context.Operators.ToList<CqlCode>(i_);
-		var k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
-		var l_ = Status_1_6_000.Final_Survey_Observation(k_);
-		var m_ = this.Total_symptom_score__KCCQ_();
-		var n_ = context.Operators.ToList<CqlCode>(m_);
-		var o_ = context.Operators.RetrieveByCodes<Observation>(n_, null);
-		var p_ = Status_1_6_000.Final_Survey_Observation(o_);
-		var q_ = this.Physical_limitation_score__KCCQ_();
-		var r_ = context.Operators.ToList<CqlCode>(q_);
-		var s_ = context.Operators.RetrieveByCodes<Observation>(r_, null);
-		var t_ = Status_1_6_000.Final_Survey_Observation(s_);
-		var u_ = this.Social_limitation_score__KCCQ_();
-		var v_ = context.Operators.ToList<CqlCode>(u_);
-		var w_ = context.Operators.RetrieveByCodes<Observation>(v_, null);
-		var x_ = Status_1_6_000.Final_Survey_Observation(w_);
-		var y_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_, x_);
+		CqlCode a_ = this.Quality_of_life_score__KCCQ_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode e_ = this.Symptom_stability_score__KCCQ_();
+		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
+		CqlCode i_ = this.Self_efficacy_score__KCCQ_();
+		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
+		IEnumerable<Observation> l_ = Status_1_6_000.Final_Survey_Observation(k_);
+		CqlCode m_ = this.Total_symptom_score__KCCQ_();
+		IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
+		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, null);
+		IEnumerable<Observation> p_ = Status_1_6_000.Final_Survey_Observation(o_);
+		CqlCode q_ = this.Physical_limitation_score__KCCQ_();
+		IEnumerable<CqlCode> r_ = context.Operators.ToList<CqlCode>(q_);
+		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, null);
+		IEnumerable<Observation> t_ = Status_1_6_000.Final_Survey_Observation(s_);
+		CqlCode u_ = this.Social_limitation_score__KCCQ_();
+		IEnumerable<CqlCode> v_ = context.Operators.ToList<CqlCode>(u_);
+		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, null);
+		IEnumerable<Observation> x_ = Status_1_6_000.Final_Survey_Observation(w_);
+		IEnumerable<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation>> y_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_, x_);
 		Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN z_(ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation> _valueTuple)
 		{
-			var af_ = new Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN
+			Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN af_ = new Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN
 			{
 				KCCQLifeQuality = _valueTuple.Item1,
 				KCCQSymptomStability = _valueTuple.Item2,
@@ -2047,125 +2176,125 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return af_;
 		};
-		var aa_ = context.Operators.Select<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation>, Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN>(y_, z_);
+		IEnumerable<Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN> aa_ = context.Operators.Select<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation>, Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN>(y_, z_);
 		bool? ab_(Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN tuple_etfcawdpmcqfbnayqdmdqqsdn)
 		{
-			var ag_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQLifeQuality?.Effective;
-			var ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
-			var ai_ = QICoreCommon_2_0_000.ToInterval(ah_);
-			var aj_ = context.Operators.Start(ai_);
-			var ak_ = context.Operators.DateFrom(aj_);
-			var al_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptomStability?.Effective;
-			var am_ = FHIRHelpers_4_3_000.ToValue(al_);
-			var an_ = QICoreCommon_2_0_000.ToInterval(am_);
-			var ao_ = context.Operators.Start(an_);
-			var ap_ = context.Operators.DateFrom(ao_);
-			var aq_ = context.Operators.SameAs(ak_, ap_, "day");
-			var ar_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptomStability?.Value;
-			var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
-			var at_ = context.Operators.Not((bool?)(as_ is null));
-			var au_ = context.Operators.And(aq_, at_);
-			var aw_ = FHIRHelpers_4_3_000.ToValue(ag_);
-			var ax_ = QICoreCommon_2_0_000.ToInterval(aw_);
-			var ay_ = context.Operators.Start(ax_);
-			var az_ = context.Operators.DateFrom(ay_);
-			var ba_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSelfEfficacy?.Effective;
-			var bb_ = FHIRHelpers_4_3_000.ToValue(ba_);
-			var bc_ = QICoreCommon_2_0_000.ToInterval(bb_);
-			var bd_ = context.Operators.Start(bc_);
-			var be_ = context.Operators.DateFrom(bd_);
-			var bf_ = context.Operators.SameAs(az_, be_, "day");
-			var bg_ = context.Operators.And(au_, bf_);
-			var bh_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSelfEfficacy?.Value;
-			var bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
-			var bj_ = context.Operators.Not((bool?)(bi_ is null));
-			var bk_ = context.Operators.And(bg_, bj_);
-			var bm_ = FHIRHelpers_4_3_000.ToValue(ag_);
-			var bn_ = QICoreCommon_2_0_000.ToInterval(bm_);
-			var bo_ = context.Operators.Start(bn_);
-			var bp_ = context.Operators.DateFrom(bo_);
-			var bq_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptoms?.Effective;
-			var br_ = FHIRHelpers_4_3_000.ToValue(bq_);
-			var bs_ = QICoreCommon_2_0_000.ToInterval(br_);
-			var bt_ = context.Operators.Start(bs_);
-			var bu_ = context.Operators.DateFrom(bt_);
-			var bv_ = context.Operators.SameAs(bp_, bu_, "day");
-			var bw_ = context.Operators.And(bk_, bv_);
-			var bx_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptoms?.Value;
-			var by_ = FHIRHelpers_4_3_000.ToValue(bx_);
-			var bz_ = context.Operators.Not((bool?)(by_ is null));
-			var ca_ = context.Operators.And(bw_, bz_);
-			var cc_ = FHIRHelpers_4_3_000.ToValue(ag_);
-			var cd_ = QICoreCommon_2_0_000.ToInterval(cc_);
-			var ce_ = context.Operators.Start(cd_);
-			var cf_ = context.Operators.DateFrom(ce_);
-			var cg_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQPhysicalLimits?.Effective;
-			var ch_ = FHIRHelpers_4_3_000.ToValue(cg_);
-			var ci_ = QICoreCommon_2_0_000.ToInterval(ch_);
-			var cj_ = context.Operators.Start(ci_);
-			var ck_ = context.Operators.DateFrom(cj_);
-			var cl_ = context.Operators.SameAs(cf_, ck_, "day");
-			var cm_ = context.Operators.And(ca_, cl_);
-			var cn_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQPhysicalLimits?.Value;
-			var co_ = FHIRHelpers_4_3_000.ToValue(cn_);
-			var cp_ = context.Operators.Not((bool?)(co_ is null));
-			var cq_ = context.Operators.And(cm_, cp_);
-			var cs_ = FHIRHelpers_4_3_000.ToValue(ag_);
-			var ct_ = QICoreCommon_2_0_000.ToInterval(cs_);
-			var cu_ = context.Operators.Start(ct_);
-			var cv_ = context.Operators.DateFrom(cu_);
-			var cw_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSocialLimits?.Effective;
-			var cx_ = FHIRHelpers_4_3_000.ToValue(cw_);
-			var cy_ = QICoreCommon_2_0_000.ToInterval(cx_);
-			var cz_ = context.Operators.Start(cy_);
-			var da_ = context.Operators.DateFrom(cz_);
-			var db_ = context.Operators.SameAs(cv_, da_, "day");
-			var dc_ = context.Operators.And(cq_, db_);
-			var dd_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSocialLimits?.Value;
-			var de_ = FHIRHelpers_4_3_000.ToValue(dd_);
-			var df_ = context.Operators.Not((bool?)(de_ is null));
-			var dg_ = context.Operators.And(dc_, df_);
-			var dh_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQLifeQuality?.Value;
-			var di_ = FHIRHelpers_4_3_000.ToValue(dh_);
-			var dj_ = context.Operators.Not((bool?)(di_ is null));
-			var dk_ = context.Operators.And(dg_, dj_);
+			DataType ag_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQLifeQuality?.Effective;
+			object ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
+			CqlInterval<CqlDateTime> ai_ = QICoreCommon_2_0_000.ToInterval(ah_);
+			CqlDateTime aj_ = context.Operators.Start(ai_);
+			CqlDate ak_ = context.Operators.DateFrom(aj_);
+			DataType al_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptomStability?.Effective;
+			object am_ = FHIRHelpers_4_3_000.ToValue(al_);
+			CqlInterval<CqlDateTime> an_ = QICoreCommon_2_0_000.ToInterval(am_);
+			CqlDateTime ao_ = context.Operators.Start(an_);
+			CqlDate ap_ = context.Operators.DateFrom(ao_);
+			bool? aq_ = context.Operators.SameAs(ak_, ap_, "day");
+			DataType ar_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptomStability?.Value;
+			object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+			bool? at_ = context.Operators.Not((bool?)(as_ is null));
+			bool? au_ = context.Operators.And(aq_, at_);
+			object aw_ = FHIRHelpers_4_3_000.ToValue(ag_);
+			CqlInterval<CqlDateTime> ax_ = QICoreCommon_2_0_000.ToInterval(aw_);
+			CqlDateTime ay_ = context.Operators.Start(ax_);
+			CqlDate az_ = context.Operators.DateFrom(ay_);
+			DataType ba_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSelfEfficacy?.Effective;
+			object bb_ = FHIRHelpers_4_3_000.ToValue(ba_);
+			CqlInterval<CqlDateTime> bc_ = QICoreCommon_2_0_000.ToInterval(bb_);
+			CqlDateTime bd_ = context.Operators.Start(bc_);
+			CqlDate be_ = context.Operators.DateFrom(bd_);
+			bool? bf_ = context.Operators.SameAs(az_, be_, "day");
+			bool? bg_ = context.Operators.And(au_, bf_);
+			DataType bh_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSelfEfficacy?.Value;
+			object bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
+			bool? bj_ = context.Operators.Not((bool?)(bi_ is null));
+			bool? bk_ = context.Operators.And(bg_, bj_);
+			object bm_ = FHIRHelpers_4_3_000.ToValue(ag_);
+			CqlInterval<CqlDateTime> bn_ = QICoreCommon_2_0_000.ToInterval(bm_);
+			CqlDateTime bo_ = context.Operators.Start(bn_);
+			CqlDate bp_ = context.Operators.DateFrom(bo_);
+			DataType bq_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptoms?.Effective;
+			object br_ = FHIRHelpers_4_3_000.ToValue(bq_);
+			CqlInterval<CqlDateTime> bs_ = QICoreCommon_2_0_000.ToInterval(br_);
+			CqlDateTime bt_ = context.Operators.Start(bs_);
+			CqlDate bu_ = context.Operators.DateFrom(bt_);
+			bool? bv_ = context.Operators.SameAs(bp_, bu_, "day");
+			bool? bw_ = context.Operators.And(bk_, bv_);
+			DataType bx_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptoms?.Value;
+			object by_ = FHIRHelpers_4_3_000.ToValue(bx_);
+			bool? bz_ = context.Operators.Not((bool?)(by_ is null));
+			bool? ca_ = context.Operators.And(bw_, bz_);
+			object cc_ = FHIRHelpers_4_3_000.ToValue(ag_);
+			CqlInterval<CqlDateTime> cd_ = QICoreCommon_2_0_000.ToInterval(cc_);
+			CqlDateTime ce_ = context.Operators.Start(cd_);
+			CqlDate cf_ = context.Operators.DateFrom(ce_);
+			DataType cg_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQPhysicalLimits?.Effective;
+			object ch_ = FHIRHelpers_4_3_000.ToValue(cg_);
+			CqlInterval<CqlDateTime> ci_ = QICoreCommon_2_0_000.ToInterval(ch_);
+			CqlDateTime cj_ = context.Operators.Start(ci_);
+			CqlDate ck_ = context.Operators.DateFrom(cj_);
+			bool? cl_ = context.Operators.SameAs(cf_, ck_, "day");
+			bool? cm_ = context.Operators.And(ca_, cl_);
+			DataType cn_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQPhysicalLimits?.Value;
+			object co_ = FHIRHelpers_4_3_000.ToValue(cn_);
+			bool? cp_ = context.Operators.Not((bool?)(co_ is null));
+			bool? cq_ = context.Operators.And(cm_, cp_);
+			object cs_ = FHIRHelpers_4_3_000.ToValue(ag_);
+			CqlInterval<CqlDateTime> ct_ = QICoreCommon_2_0_000.ToInterval(cs_);
+			CqlDateTime cu_ = context.Operators.Start(ct_);
+			CqlDate cv_ = context.Operators.DateFrom(cu_);
+			DataType cw_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSocialLimits?.Effective;
+			object cx_ = FHIRHelpers_4_3_000.ToValue(cw_);
+			CqlInterval<CqlDateTime> cy_ = QICoreCommon_2_0_000.ToInterval(cx_);
+			CqlDateTime cz_ = context.Operators.Start(cy_);
+			CqlDate da_ = context.Operators.DateFrom(cz_);
+			bool? db_ = context.Operators.SameAs(cv_, da_, "day");
+			bool? dc_ = context.Operators.And(cq_, db_);
+			DataType dd_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSocialLimits?.Value;
+			object de_ = FHIRHelpers_4_3_000.ToValue(dd_);
+			bool? df_ = context.Operators.Not((bool?)(de_ is null));
+			bool? dg_ = context.Operators.And(dc_, df_);
+			DataType dh_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQLifeQuality?.Value;
+			object di_ = FHIRHelpers_4_3_000.ToValue(dh_);
+			bool? dj_ = context.Operators.Not((bool?)(di_ is null));
+			bool? dk_ = context.Operators.And(dg_, dj_);
 
 			return dk_;
 		};
-		var ac_ = context.Operators.Where<Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN>(aa_, ab_);
+		IEnumerable<Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN> ac_ = context.Operators.Where<Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN>(aa_, ab_);
 		CqlDate ad_(Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN tuple_etfcawdpmcqfbnayqdmdqqsdn)
 		{
-			var dl_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQLifeQuality?.Effective;
-			var dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
-			var dn_ = QICoreCommon_2_0_000.ToInterval(dm_);
-			var do_ = context.Operators.Start(dn_);
-			var dp_ = context.Operators.DateFrom(do_);
-			var dq_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptomStability?.Effective;
-			var dr_ = FHIRHelpers_4_3_000.ToValue(dq_);
-			var ds_ = QICoreCommon_2_0_000.ToInterval(dr_);
-			var dt_ = context.Operators.Start(ds_);
-			var du_ = context.Operators.DateFrom(dt_);
-			var dv_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSelfEfficacy?.Effective;
-			var dw_ = FHIRHelpers_4_3_000.ToValue(dv_);
-			var dx_ = QICoreCommon_2_0_000.ToInterval(dw_);
-			var dy_ = context.Operators.Start(dx_);
-			var dz_ = context.Operators.DateFrom(dy_);
-			var ea_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptoms?.Effective;
-			var eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
-			var ec_ = QICoreCommon_2_0_000.ToInterval(eb_);
-			var ed_ = context.Operators.Start(ec_);
-			var ee_ = context.Operators.DateFrom(ed_);
-			var ef_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQPhysicalLimits?.Effective;
-			var eg_ = FHIRHelpers_4_3_000.ToValue(ef_);
-			var eh_ = QICoreCommon_2_0_000.ToInterval(eg_);
-			var ei_ = context.Operators.Start(eh_);
-			var ej_ = context.Operators.DateFrom(ei_);
-			var ek_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSocialLimits?.Effective;
-			var el_ = FHIRHelpers_4_3_000.ToValue(ek_);
-			var em_ = QICoreCommon_2_0_000.ToInterval(el_);
-			var en_ = context.Operators.Start(em_);
-			var eo_ = context.Operators.DateFrom(en_);
-			var ep_ = new CqlDate[]
+			DataType dl_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQLifeQuality?.Effective;
+			object dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
+			CqlInterval<CqlDateTime> dn_ = QICoreCommon_2_0_000.ToInterval(dm_);
+			CqlDateTime do_ = context.Operators.Start(dn_);
+			CqlDate dp_ = context.Operators.DateFrom(do_);
+			DataType dq_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptomStability?.Effective;
+			object dr_ = FHIRHelpers_4_3_000.ToValue(dq_);
+			CqlInterval<CqlDateTime> ds_ = QICoreCommon_2_0_000.ToInterval(dr_);
+			CqlDateTime dt_ = context.Operators.Start(ds_);
+			CqlDate du_ = context.Operators.DateFrom(dt_);
+			DataType dv_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSelfEfficacy?.Effective;
+			object dw_ = FHIRHelpers_4_3_000.ToValue(dv_);
+			CqlInterval<CqlDateTime> dx_ = QICoreCommon_2_0_000.ToInterval(dw_);
+			CqlDateTime dy_ = context.Operators.Start(dx_);
+			CqlDate dz_ = context.Operators.DateFrom(dy_);
+			DataType ea_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptoms?.Effective;
+			object eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
+			CqlInterval<CqlDateTime> ec_ = QICoreCommon_2_0_000.ToInterval(eb_);
+			CqlDateTime ed_ = context.Operators.Start(ec_);
+			CqlDate ee_ = context.Operators.DateFrom(ed_);
+			DataType ef_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQPhysicalLimits?.Effective;
+			object eg_ = FHIRHelpers_4_3_000.ToValue(ef_);
+			CqlInterval<CqlDateTime> eh_ = QICoreCommon_2_0_000.ToInterval(eg_);
+			CqlDateTime ei_ = context.Operators.Start(eh_);
+			CqlDate ej_ = context.Operators.DateFrom(ei_);
+			DataType ek_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSocialLimits?.Effective;
+			object el_ = FHIRHelpers_4_3_000.ToValue(ek_);
+			CqlInterval<CqlDateTime> em_ = QICoreCommon_2_0_000.ToInterval(el_);
+			CqlDateTime en_ = context.Operators.Start(em_);
+			CqlDate eo_ = context.Operators.DateFrom(en_);
+			CqlDate[] ep_ = new CqlDate[]
 			{
 				dp_,
 				du_,
@@ -2174,27 +2303,29 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 				ej_,
 				eo_,
 			};
-			var eq_ = context.Operators.Max<CqlDate>((ep_ as IEnumerable<CqlDate>));
+			CqlDate eq_ = context.Operators.Max<CqlDate>((ep_ as IEnumerable<CqlDate>));
 
 			return eq_;
 		};
-		var ae_ = context.Operators.Select<Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN, CqlDate>(ac_, ad_);
+		IEnumerable<CqlDate> ae_ = context.Operators.Select<Tuple_ETfcAWdPMcQFBNAYQdMDQQSdN, CqlDate>(ac_, ad_);
 
 		return ae_;
 	}
 
+    /// <seealso cref="Date_KCCQ_Domain_Assessment_Completed_Value"/>
     [CqlDeclaration("Date KCCQ Domain Assessment Completed")]
 	public IEnumerable<CqlDate> Date_KCCQ_Domain_Assessment_Completed() => 
 		__Date_KCCQ_Domain_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_KCCQ_Domain_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_KCCQ_Domain_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_HRLUHbCfCSVNVRRNjajAHdcEA e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_HRLUHbCfCSVNVRRNjajAHdcEA
+			Tuple_HRLUHbCfCSVNVRRNjajAHdcEA l_ = new Tuple_HRLUHbCfCSVNVRRNjajAHdcEA
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialKCCQAssessmentDate = _valueTuple.Item2,
@@ -2203,108 +2334,112 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_HRLUHbCfCSVNVRRNjajAHdcEA>(d_, e_);
+		IEnumerable<Tuple_HRLUHbCfCSVNVRRNjajAHdcEA> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_HRLUHbCfCSVNVRRNjajAHdcEA>(d_, e_);
 		bool? g_(Tuple_HRLUHbCfCSVNVRRNjajAHdcEA tuple_hrluhbcfcsvnvrrnjajahdcea)
 		{
-			var m_ = tuple_hrluhbcfcsvnvrrnjajahdcea.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea.InitialKCCQAssessmentDate);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea.FollowupKCCQAssessmentDate);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_hrluhbcfcsvnvrrnjajahdcea.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea.InitialKCCQAssessmentDate);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea.FollowupKCCQAssessmentDate);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_HRLUHbCfCSVNVRRNjajAHdcEA>(f_, g_);
+		IEnumerable<Tuple_HRLUHbCfCSVNVRRNjajAHdcEA> h_ = context.Operators.Where<Tuple_HRLUHbCfCSVNVRRNjajAHdcEA>(f_, g_);
 		Encounter i_(Tuple_HRLUHbCfCSVNVRRNjajAHdcEA tuple_hrluhbcfcsvnvrrnjajahdcea) => 
 			tuple_hrluhbcfcsvnvrrnjajahdcea.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_HRLUHbCfCSVNVRRNjajAHdcEA, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_HRLUHbCfCSVNVRRNjajAHdcEA, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up KCCQ Domain Score Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments.Value;
 
+    /// <seealso cref="Date_KCCQ_Total_Assessment_Completed"/>
 	private IEnumerable<CqlDate> Date_KCCQ_Total_Assessment_Completed_Value()
 	{
-		var a_ = this.Overall_summary_score__KCCQ_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.Final_Survey_Observation(c_);
+		CqlCode a_ = this.Overall_summary_score__KCCQ_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation KCCQSummaryScore)
 		{
-			var i_ = KCCQSummaryScore?.Value;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = context.Operators.Not((bool?)(j_ is null));
+			DataType i_ = KCCQSummaryScore?.Value;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			bool? k_ = context.Operators.Not((bool?)(j_ is null));
 
 			return k_;
 		};
-		var f_ = context.Operators.Where<Observation>(d_, e_);
+		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 		CqlDate g_(Observation KCCQSummaryScore)
 		{
-			var l_ = KCCQSummaryScore?.Effective;
-			var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-			var n_ = QICoreCommon_2_0_000.ToInterval(m_);
-			var o_ = context.Operators.Start(n_);
-			var p_ = context.Operators.DateFrom(o_);
-			var q_ = new CqlDate[]
+			DataType l_ = KCCQSummaryScore?.Effective;
+			object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+			CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.ToInterval(m_);
+			CqlDateTime o_ = context.Operators.Start(n_);
+			CqlDate p_ = context.Operators.DateFrom(o_);
+			CqlDate[] q_ = new CqlDate[]
 			{
 				p_,
 			};
-			var r_ = context.Operators.Max<CqlDate>((q_ as IEnumerable<CqlDate>));
+			CqlDate r_ = context.Operators.Max<CqlDate>((q_ as IEnumerable<CqlDate>));
 
 			return r_;
 		};
-		var h_ = context.Operators.Select<Observation, CqlDate>(f_, g_);
+		IEnumerable<CqlDate> h_ = context.Operators.Select<Observation, CqlDate>(f_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Date_KCCQ_Total_Assessment_Completed_Value"/>
     [CqlDeclaration("Date KCCQ Total Assessment Completed")]
 	public IEnumerable<CqlDate> Date_KCCQ_Total_Assessment_Completed() => 
 		__Date_KCCQ_Total_Assessment_Completed.Value;
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments"/>
 	private bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments_Value()
 	{
-		var a_ = this.Qualifying_Encounters();
-		var b_ = this.Date_KCCQ_Total_Assessment_Completed();
-		var d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
+		IEnumerable<CqlDate> b_ = this.Date_KCCQ_Total_Assessment_Completed();
+		IEnumerable<ValueTuple<Encounter, CqlDate, CqlDate>> d_ = context.Operators.CrossJoin<Encounter, CqlDate, CqlDate>(a_, b_, b_);
 		Tuple_DGROjeEKDVIZSVYiSEPDjhJgj e_(ValueTuple<Encounter, CqlDate, CqlDate> _valueTuple)
 		{
-			var l_ = new Tuple_DGROjeEKDVIZSVYiSEPDjhJgj
+			Tuple_DGROjeEKDVIZSVYiSEPDjhJgj l_ = new Tuple_DGROjeEKDVIZSVYiSEPDjhJgj
 			{
 				ValidEncounters = _valueTuple.Item1,
 				InitialKCCQTotalScore = _valueTuple.Item2,
@@ -2313,86 +2448,89 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 			return l_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_DGROjeEKDVIZSVYiSEPDjhJgj>(d_, e_);
+		IEnumerable<Tuple_DGROjeEKDVIZSVYiSEPDjhJgj> f_ = context.Operators.Select<ValueTuple<Encounter, CqlDate, CqlDate>, Tuple_DGROjeEKDVIZSVYiSEPDjhJgj>(d_, e_);
 		bool? g_(Tuple_DGROjeEKDVIZSVYiSEPDjhJgj tuple_dgrojeekdvizsvyisepdjhjgj)
 		{
-			var m_ = tuple_dgrojeekdvizsvyisepdjhjgj.ValidEncounters?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			var p_ = context.Operators.End(o_);
-			var q_ = this.Measurement_Period();
-			var r_ = context.Operators.End(q_);
-			var s_ = context.Operators.Quantity(180m, "days");
-			var t_ = context.Operators.Subtract(r_, s_);
-			var u_ = context.Operators.SameOrBefore(p_, t_, "day");
-			var v_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj.InitialKCCQTotalScore);
-			var x_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.Quantity(14m, "days");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
-			var af_ = context.Operators.End(ae_);
-			var ag_ = context.Operators.Interval(ab_, af_, true, true);
-			var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ah_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj.FollowupKCCQTotalScore);
-			var aq_ = context.Operators.DateFrom(ap_);
-			var as_ = context.Operators.DateFrom(v_);
-			var at_ = context.Operators.Quantity(30m, "days");
-			var au_ = context.Operators.Add(as_, at_);
-			var aw_ = context.Operators.DateFrom(v_);
-			var ay_ = context.Operators.Add(aw_, s_);
-			var az_ = context.Operators.Interval(au_, ay_, true, true);
-			var ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
-			var bb_ = context.Operators.And(ao_, ba_);
+			Period m_ = tuple_dgrojeekdvizsvyisepdjhjgj.ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
+			CqlDateTime p_ = context.Operators.End(o_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			CqlDateTime r_ = context.Operators.End(q_);
+			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
+			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj.InitialKCCQTotalScore);
+			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
+			CqlDateTime z_ = context.Operators.End(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(14m, "days");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
+			CqlDateTime af_ = context.Operators.End(ae_);
+			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ah_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			CqlDateTime ap_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj.FollowupKCCQTotalScore);
+			CqlDate aq_ = context.Operators.DateFrom(ap_);
+			CqlDate as_ = context.Operators.DateFrom(v_);
+			CqlQuantity at_ = context.Operators.Quantity(30m, "days");
+			CqlDate au_ = context.Operators.Add(as_, at_);
+			CqlDate aw_ = context.Operators.DateFrom(v_);
+			CqlDate ay_ = context.Operators.Add(aw_, s_);
+			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
 		};
-		var h_ = context.Operators.Where<Tuple_DGROjeEKDVIZSVYiSEPDjhJgj>(f_, g_);
+		IEnumerable<Tuple_DGROjeEKDVIZSVYiSEPDjhJgj> h_ = context.Operators.Where<Tuple_DGROjeEKDVIZSVYiSEPDjhJgj>(f_, g_);
 		Encounter i_(Tuple_DGROjeEKDVIZSVYiSEPDjhJgj tuple_dgrojeekdvizsvyisepdjhjgj) => 
 			tuple_dgrojeekdvizsvyisepdjhjgj.ValidEncounters;
-		var j_ = context.Operators.Select<Tuple_DGROjeEKDVIZSVYiSEPDjhJgj, Encounter>(h_, i_);
-		var k_ = context.Operators.Exists<Encounter>(j_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_DGROjeEKDVIZSVYiSEPDjhJgj, Encounter>(h_, i_);
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments_Value"/>
     [CqlDeclaration("Has Encounter with Initial and Follow Up KCCQ Total Score Assessments")]
 	public bool? Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments() => 
 		__Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments();
-		var b_ = this.Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments();
-		var e_ = context.Operators.Or(c_, d_);
-		var f_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments();
-		var g_ = context.Operators.Or(e_, f_);
-		var h_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments();
-		var i_ = context.Operators.Or(g_, h_);
-		var j_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments();
-		var k_ = context.Operators.Or(i_, j_);
-		var l_ = this.Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments();
-		var m_ = context.Operators.Or(k_, l_);
-		var n_ = this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments();
-		var o_ = context.Operators.Or(m_, n_);
-		var p_ = this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments();
-		var q_ = context.Operators.Or(o_, p_);
-		var r_ = this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments();
-		var s_ = context.Operators.Or(q_, r_);
+		bool? a_ = this.Has_Encounter_with_Initial_and_Follow_Up_PROMIS10_Assessments();
+		bool? b_ = this.Has_Encounter_with_Initial_and_Follow_Up_PROMIS29_Assessments();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR12_Oblique_Assessments();
+		bool? e_ = context.Operators.Or(c_, d_);
+		bool? f_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR12_Orthogonal_Assessments();
+		bool? g_ = context.Operators.Or(e_, f_);
+		bool? h_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR36_Oblique_Assessments();
+		bool? i_ = context.Operators.Or(g_, h_);
+		bool? j_ = this.Has_Encounter_with_Initial_and_Follow_Up_VR36_Orthogonal_Assessments();
+		bool? k_ = context.Operators.Or(i_, j_);
+		bool? l_ = this.Has_Encounter_with_Initial_and_Follow_Up_MLHFQ_Assessments();
+		bool? m_ = context.Operators.Or(k_, l_);
+		bool? n_ = this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ12_Assessments();
+		bool? o_ = context.Operators.Or(m_, n_);
+		bool? p_ = this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Domain_Score_Assessments();
+		bool? q_ = context.Operators.Or(o_, p_);
+		bool? r_ = this.Has_Encounter_with_Initial_and_Follow_Up_KCCQ_Total_Score_Assessments();
+		bool? s_ = context.Operators.Or(q_, r_);
 
 		return s_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
@@ -122,136 +122,169 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Ethnicity"/>
 	private CqlValueSet Ethnicity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
 
+    /// <seealso cref="Ethnicity_Value"/>
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
 	public CqlValueSet Ethnicity() => 
 		__Ethnicity.Value;
 
+    /// <seealso cref="Hospital_Dietitian_Referral"/>
 	private CqlValueSet Hospital_Dietitian_Referral_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91", null);
 
+    /// <seealso cref="Hospital_Dietitian_Referral_Value"/>
     [CqlDeclaration("Hospital Dietitian Referral")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91")]
 	public CqlValueSet Hospital_Dietitian_Referral() => 
 		__Hospital_Dietitian_Referral.Value;
 
+    /// <seealso cref="Malnutrition_Diagnosis"/>
 	private CqlValueSet Malnutrition_Diagnosis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55", null);
 
+    /// <seealso cref="Malnutrition_Diagnosis_Value"/>
     [CqlDeclaration("Malnutrition Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55")]
 	public CqlValueSet Malnutrition_Diagnosis() => 
 		__Malnutrition_Diagnosis.Value;
 
+    /// <seealso cref="Malnutrition_Risk_Screening"/>
 	private CqlValueSet Malnutrition_Risk_Screening_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92", null);
 
+    /// <seealso cref="Malnutrition_Risk_Screening_Value"/>
     [CqlDeclaration("Malnutrition Risk Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92")]
 	public CqlValueSet Malnutrition_Risk_Screening() => 
 		__Malnutrition_Risk_Screening.Value;
 
+    /// <seealso cref="Malnutrition_Screening_At_Risk_Result"/>
 	private CqlValueSet Malnutrition_Screening_At_Risk_Result_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38", null);
 
+    /// <seealso cref="Malnutrition_Screening_At_Risk_Result_Value"/>
     [CqlDeclaration("Malnutrition Screening At Risk Result")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38")]
 	public CqlValueSet Malnutrition_Screening_At_Risk_Result() => 
 		__Malnutrition_Screening_At_Risk_Result.Value;
 
+    /// <seealso cref="Malnutrition_Screening_Not_At_Risk_Result"/>
 	private CqlValueSet Malnutrition_Screening_Not_At_Risk_Result_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34", null);
 
+    /// <seealso cref="Malnutrition_Screening_Not_At_Risk_Result_Value"/>
     [CqlDeclaration("Malnutrition Screening Not At Risk Result")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34")]
 	public CqlValueSet Malnutrition_Screening_Not_At_Risk_Result() => 
 		__Malnutrition_Screening_Not_At_Risk_Result.Value;
 
+    /// <seealso cref="Nutrition_Assessment"/>
 	private CqlValueSet Nutrition_Assessment_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21", null);
 
+    /// <seealso cref="Nutrition_Assessment_Value"/>
     [CqlDeclaration("Nutrition Assessment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21")]
 	public CqlValueSet Nutrition_Assessment() => 
 		__Nutrition_Assessment.Value;
 
+    /// <seealso cref="Nutrition_Assessment_Status_Moderately_Malnourished"/>
 	private CqlValueSet Nutrition_Assessment_Status_Moderately_Malnourished_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44", null);
 
+    /// <seealso cref="Nutrition_Assessment_Status_Moderately_Malnourished_Value"/>
     [CqlDeclaration("Nutrition Assessment Status Moderately Malnourished")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44")]
 	public CqlValueSet Nutrition_Assessment_Status_Moderately_Malnourished() => 
 		__Nutrition_Assessment_Status_Moderately_Malnourished.Value;
 
+    /// <seealso cref="Nutrition_Assessment_Status_Not_or_Mildly_Malnourished"/>
 	private CqlValueSet Nutrition_Assessment_Status_Not_or_Mildly_Malnourished_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48", null);
 
+    /// <seealso cref="Nutrition_Assessment_Status_Not_or_Mildly_Malnourished_Value"/>
     [CqlDeclaration("Nutrition Assessment Status Not or Mildly Malnourished")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48")]
 	public CqlValueSet Nutrition_Assessment_Status_Not_or_Mildly_Malnourished() => 
 		__Nutrition_Assessment_Status_Not_or_Mildly_Malnourished.Value;
 
+    /// <seealso cref="Nutrition_Assessment_Status_Severely_Malnourished"/>
 	private CqlValueSet Nutrition_Assessment_Status_Severely_Malnourished_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42", null);
 
+    /// <seealso cref="Nutrition_Assessment_Status_Severely_Malnourished_Value"/>
     [CqlDeclaration("Nutrition Assessment Status Severely Malnourished")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42")]
 	public CqlValueSet Nutrition_Assessment_Status_Severely_Malnourished() => 
 		__Nutrition_Assessment_Status_Severely_Malnourished.Value;
 
+    /// <seealso cref="Nutrition_Care_Plan"/>
 	private CqlValueSet Nutrition_Care_Plan_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93", null);
 
+    /// <seealso cref="Nutrition_Care_Plan_Value"/>
     [CqlDeclaration("Nutrition Care Plan")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93")]
 	public CqlValueSet Nutrition_Care_Plan() => 
 		__Nutrition_Care_Plan.Value;
 
+    /// <seealso cref="ONC_Administrative_Sex"/>
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
 
+    /// <seealso cref="ONC_Administrative_Sex_Value"/>
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
 	public CqlValueSet ONC_Administrative_Sex() => 
 		__ONC_Administrative_Sex.Value;
 
+    /// <seealso cref="Payer_Type"/>
 	private CqlValueSet Payer_Type_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
 
+    /// <seealso cref="Payer_Type_Value"/>
     [CqlDeclaration("Payer Type")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
 	public CqlValueSet Payer_Type() => 
 		__Payer_Type.Value;
 
+    /// <seealso cref="Race"/>
 	private CqlValueSet Race_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
 
+    /// <seealso cref="Race_Value"/>
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
 	public CqlValueSet Race() => 
 		__Race.Value;
 
+    /// <seealso cref="Birth_date"/>
 	private CqlCode Birth_date_Value() => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Birth_date_Value"/>
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("21112-8", "http://loinc.org", null, null),
 		};
@@ -259,180 +292,204 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="ICD10CM"/>
 	private CqlCode[] ICD10CM_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="ICD10CM_Value"/>
     [CqlDeclaration("ICD10CM")]
 	public CqlCode[] ICD10CM() => 
 		__ICD10CM.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("GlobalMalnutritionCompositeFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("GlobalMalnutritionCompositeFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer_Type"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Type_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Type_Value"/>
     [CqlDeclaration("SDE Payer Type")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Type() => 
 		__SDE_Payer_Type.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounter"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EncounterInpatient)
 		{
-			var e_ = EncounterInpatient?.Period;
-			var f_ = FHIRHelpers_4_3_000.ToInterval(e_);
-			var g_ = context.Operators.End(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
-			var j_ = this.Patient();
-			var k_ = j_?.BirthDateElement;
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<CqlDate>(l_);
-			var o_ = FHIRHelpers_4_3_000.ToInterval(e_);
-			var p_ = context.Operators.Start(o_);
-			var q_ = context.Operators.DateFrom(p_);
-			var r_ = context.Operators.CalculateAgeAt(m_, q_, "year");
-			var s_ = context.Operators.GreaterOrEqual(r_, 65);
-			var t_ = context.Operators.And(i_, s_);
-			var v_ = FHIRHelpers_4_3_000.ToInterval(e_);
-			var w_ = context.Operators.Start(v_);
-			var y_ = FHIRHelpers_4_3_000.ToInterval(e_);
-			var z_ = context.Operators.End(y_);
-			var aa_ = context.Operators.DurationBetween(w_, z_, "hour");
-			var ab_ = context.Operators.GreaterOrEqual(aa_, 24);
-			var ac_ = context.Operators.And(t_, ab_);
-			var ad_ = EncounterInpatient?.StatusElement;
-			var ae_ = ad_?.Value;
-			var af_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ae_);
-			var ag_ = context.Operators.Equal(af_, "finished");
-			var ah_ = context.Operators.And(ac_, ag_);
+			Period e_ = EncounterInpatient?.Period;
+			CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+			CqlDateTime g_ = context.Operators.End(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
+			Patient j_ = this.Patient();
+			Date k_ = j_?.BirthDateElement;
+			string l_ = k_?.Value;
+			CqlDate m_ = context.Operators.Convert<CqlDate>(l_);
+			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(e_);
+			CqlDateTime p_ = context.Operators.Start(o_);
+			CqlDate q_ = context.Operators.DateFrom(p_);
+			int? r_ = context.Operators.CalculateAgeAt(m_, q_, "year");
+			bool? s_ = context.Operators.GreaterOrEqual(r_, 65);
+			bool? t_ = context.Operators.And(i_, s_);
+			CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(e_);
+			CqlDateTime w_ = context.Operators.Start(v_);
+			CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(e_);
+			CqlDateTime z_ = context.Operators.End(y_);
+			int? aa_ = context.Operators.DurationBetween(w_, z_, "hour");
+			bool? ab_ = context.Operators.GreaterOrEqual(aa_, 24);
+			bool? ac_ = context.Operators.And(t_, ab_);
+			Code<Encounter.EncounterStatus> ad_ = EncounterInpatient?.StatusElement;
+			Encounter.EncounterStatus? ae_ = ad_?.Value;
+			Code<Encounter.EncounterStatus> af_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ae_);
+			bool? ag_ = context.Operators.Equal(af_, "finished");
+			bool? ah_ = context.Operators.And(ac_, ag_);
 
 			return ah_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_Value"/>
     [CqlDeclaration("Qualifying Encounter")]
 	public IEnumerable<Encounter> Qualifying_Encounter() => 
 		__Qualifying_Encounter.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Measure_Population"/>
 	private IEnumerable<Encounter> Measure_Population_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Measure_Population_Value"/>
     [CqlDeclaration("Measure Population")]
 	public IEnumerable<Encounter> Measure_Population() => 
 		__Measure_Population.Value;
 
+    /// <seealso cref="Encounter_with_Hospital_Dietitian_Referral"/>
 	private IEnumerable<Encounter> Encounter_with_Hospital_Dietitian_Referral_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
-		var b_ = this.Hospital_Dietitian_Referral();
-		var c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Procedure>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
+		CqlValueSet b_ = this.Hospital_Dietitian_Referral();
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Procedure>> d_ = context.Operators.CrossJoin<Encounter, Procedure>(a_, c_);
 		Tuple_BLOdcPfeecJFNOdFOfHFZLQfa e_(ValueTuple<Encounter, Procedure> _valueTuple)
 		{
-			var k_ = new Tuple_BLOdcPfeecJFNOdFOfHFZLQfa
+			Tuple_BLOdcPfeecJFNOdFOfHFZLQfa k_ = new Tuple_BLOdcPfeecJFNOdFOfHFZLQfa
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				HospitalDietitianReferral = _valueTuple.Item2,
@@ -440,54 +497,56 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Procedure>, Tuple_BLOdcPfeecJFNOdFOfHFZLQfa>(d_, e_);
+		IEnumerable<Tuple_BLOdcPfeecJFNOdFOfHFZLQfa> f_ = context.Operators.Select<ValueTuple<Encounter, Procedure>, Tuple_BLOdcPfeecJFNOdFOfHFZLQfa>(d_, e_);
 		bool? g_(Tuple_BLOdcPfeecJFNOdFOfHFZLQfa tuple_blodcpfeecjfnodfofhfzlqfa)
 		{
-			var l_ = tuple_blodcpfeecjfnodfofhfzlqfa.HospitalDietitianReferral?.Code;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = this.Hospital_Dietitian_Referral();
-			var o_ = context.Operators.ConceptInValueSet(m_, n_);
-			var p_ = tuple_blodcpfeecjfnodfofhfzlqfa.HospitalDietitianReferral?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<string>(q_);
-			var s_ = new string[]
+			CodeableConcept l_ = tuple_blodcpfeecjfnodfofhfzlqfa.HospitalDietitianReferral?.Code;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlValueSet n_ = this.Hospital_Dietitian_Referral();
+			bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+			Code<EventStatus> p_ = tuple_blodcpfeecjfnodfofhfzlqfa.HospitalDietitianReferral?.StatusElement;
+			EventStatus? q_ = p_?.Value;
+			string r_ = context.Operators.Convert<string>(q_);
+			string[] s_ = new string[]
 			{
 				"active",
 				"completed",
 				"in-progress",
 			};
-			var t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
-			var u_ = context.Operators.And(o_, t_);
-			var v_ = tuple_blodcpfeecjfnodfofhfzlqfa.HospitalDietitianReferral?.Performed;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.earliest(w_);
-			var y_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_blodcpfeecjfnodfofhfzlqfa.QualifyingEncounter);
-			var z_ = context.Operators.In<CqlDateTime>(x_, y_, null);
-			var aa_ = context.Operators.And(u_, z_);
+			bool? t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
+			bool? u_ = context.Operators.And(o_, t_);
+			DataType v_ = tuple_blodcpfeecjfnodfofhfzlqfa.HospitalDietitianReferral?.Performed;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlDateTime x_ = QICoreCommon_2_0_000.earliest(w_);
+			CqlInterval<CqlDateTime> y_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_blodcpfeecjfnodfofhfzlqfa.QualifyingEncounter);
+			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, null);
+			bool? aa_ = context.Operators.And(u_, z_);
 
 			return aa_;
 		};
-		var h_ = context.Operators.Where<Tuple_BLOdcPfeecJFNOdFOfHFZLQfa>(f_, g_);
+		IEnumerable<Tuple_BLOdcPfeecJFNOdFOfHFZLQfa> h_ = context.Operators.Where<Tuple_BLOdcPfeecJFNOdFOfHFZLQfa>(f_, g_);
 		Encounter i_(Tuple_BLOdcPfeecJFNOdFOfHFZLQfa tuple_blodcpfeecjfnodfofhfzlqfa) => 
 			tuple_blodcpfeecjfnodfofhfzlqfa.QualifyingEncounter;
-		var j_ = context.Operators.Select<Tuple_BLOdcPfeecJFNOdFOfHFZLQfa, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_BLOdcPfeecJFNOdFOfHFZLQfa, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Hospital_Dietitian_Referral_Value"/>
     [CqlDeclaration("Encounter with Hospital Dietitian Referral")]
 	public IEnumerable<Encounter> Encounter_with_Hospital_Dietitian_Referral() => 
 		__Encounter_with_Hospital_Dietitian_Referral.Value;
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening"/>
 	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
-		var b_ = this.Malnutrition_Risk_Screening();
-		var c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
+		CqlValueSet b_ = this.Malnutrition_Risk_Screening();
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		Tuple_BEjjTWeGPXJSNajSOdYBEfDdb e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
-			var k_ = new Tuple_BEjjTWeGPXJSNajSOdYBEfDdb
+			Tuple_BEjjTWeGPXJSNajSOdYBEfDdb k_ = new Tuple_BEjjTWeGPXJSNajSOdYBEfDdb
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				MalnutritionRiskScreening = _valueTuple.Item2,
@@ -495,89 +554,93 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(d_, e_);
+		IEnumerable<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb> f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(d_, e_);
 		bool? g_(Tuple_BEjjTWeGPXJSNajSOdYBEfDdb tuple_bejjtwegpxjsnajsodybefddb)
 		{
-			var l_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Code;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = this.Malnutrition_Risk_Screening();
-			var o_ = context.Operators.ConceptInValueSet(m_, n_);
-			var p_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
-			var s_ = context.Operators.Convert<string>(r_);
-			var t_ = new string[]
+			CodeableConcept l_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Code;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlValueSet n_ = this.Malnutrition_Risk_Screening();
+			bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+			Code<ObservationStatus> p_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.StatusElement;
+			ObservationStatus? q_ = p_?.Value;
+			Code<ObservationStatus> r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
+			string s_ = context.Operators.Convert<string>(r_);
+			string[] t_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
-			var v_ = context.Operators.And(o_, u_);
-			var w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_bejjtwegpxjsnajsodybefddb.QualifyingEncounter);
-			var x_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Effective;
-			var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-			var z_ = QICoreCommon_2_0_000.toInterval(y_);
-			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
-			var ab_ = context.Operators.And(v_, aa_);
-			var ac_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Value;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = this.Malnutrition_Screening_Not_At_Risk_Result();
-			var af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
-			var ah_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ai_ = this.Malnutrition_Screening_At_Risk_Result();
-			var aj_ = context.Operators.ConceptInValueSet((ah_ as CqlConcept), ai_);
-			var ak_ = context.Operators.Or(af_, aj_);
-			var al_ = context.Operators.And(ab_, ak_);
+			bool? u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
+			bool? v_ = context.Operators.And(o_, u_);
+			CqlInterval<CqlDateTime> w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_bejjtwegpxjsnajsodybefddb.QualifyingEncounter);
+			DataType x_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Effective;
+			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? ab_ = context.Operators.And(v_, aa_);
+			DataType ac_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Value;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet ae_ = this.Malnutrition_Screening_Not_At_Risk_Result();
+			bool? af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
+			object ah_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet ai_ = this.Malnutrition_Screening_At_Risk_Result();
+			bool? aj_ = context.Operators.ConceptInValueSet((ah_ as CqlConcept), ai_);
+			bool? ak_ = context.Operators.Or(af_, aj_);
+			bool? al_ = context.Operators.And(ab_, ak_);
 
 			return al_;
 		};
-		var h_ = context.Operators.Where<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(f_, g_);
+		IEnumerable<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb> h_ = context.Operators.Where<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(f_, g_);
 		Encounter i_(Tuple_BEjjTWeGPXJSNajSOdYBEfDdb tuple_bejjtwegpxjsnajsodybefddb) => 
 			tuple_bejjtwegpxjsnajsodybefddb.QualifyingEncounter;
-		var j_ = context.Operators.Select<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening_Value"/>
     [CqlDeclaration("Encounter with Malnutrition Risk Screening")]
 	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening() => 
 		__Encounter_with_Malnutrition_Risk_Screening.Value;
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral"/>
 	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var f_ = this.Encounter_with_Malnutrition_Risk_Screening();
-			var g_ = context.Operators.Contains<Encounter>(f_, QualifyingEncounter);
-			var h_ = this.Encounter_with_Hospital_Dietitian_Referral();
-			var i_ = context.Operators.Contains<Encounter>(h_, QualifyingEncounter);
-			var j_ = context.Operators.Or(g_, i_);
+			IEnumerable<Encounter> f_ = this.Encounter_with_Malnutrition_Risk_Screening();
+			bool? g_ = context.Operators.Contains<Encounter>(f_, QualifyingEncounter);
+			IEnumerable<Encounter> h_ = this.Encounter_with_Hospital_Dietitian_Referral();
+			bool? i_ = context.Operators.Contains<Encounter>(h_, QualifyingEncounter);
+			bool? j_ = context.Operators.Or(g_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter QualifyingEncounter) => 
 			QualifyingEncounter;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral_Value"/>
     [CqlDeclaration("Encounter with Malnutrition Risk Screening or with Hospital Dietitian Referral")]
 	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral() => 
 		__Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral.Value;
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk"/>
 	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
-		var b_ = this.Malnutrition_Risk_Screening();
-		var c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
+		CqlValueSet b_ = this.Malnutrition_Risk_Screening();
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		Tuple_BEjjTWeGPXJSNajSOdYBEfDdb e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
-			var k_ = new Tuple_BEjjTWeGPXJSNajSOdYBEfDdb
+			Tuple_BEjjTWeGPXJSNajSOdYBEfDdb k_ = new Tuple_BEjjTWeGPXJSNajSOdYBEfDdb
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				MalnutritionRiskScreening = _valueTuple.Item2,
@@ -585,86 +648,90 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(d_, e_);
+		IEnumerable<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb> f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(d_, e_);
 		bool? g_(Tuple_BEjjTWeGPXJSNajSOdYBEfDdb tuple_bejjtwegpxjsnajsodybefddb)
 		{
-			var l_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Code;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = this.Malnutrition_Risk_Screening();
-			var o_ = context.Operators.ConceptInValueSet(m_, n_);
-			var p_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
-			var s_ = context.Operators.Convert<string>(r_);
-			var t_ = new string[]
+			CodeableConcept l_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Code;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlValueSet n_ = this.Malnutrition_Risk_Screening();
+			bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+			Code<ObservationStatus> p_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.StatusElement;
+			ObservationStatus? q_ = p_?.Value;
+			Code<ObservationStatus> r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
+			string s_ = context.Operators.Convert<string>(r_);
+			string[] t_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
-			var v_ = context.Operators.And(o_, u_);
-			var w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_bejjtwegpxjsnajsodybefddb.QualifyingEncounter);
-			var x_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Effective;
-			var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-			var z_ = QICoreCommon_2_0_000.toInterval(y_);
-			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
-			var ab_ = context.Operators.And(v_, aa_);
-			var ac_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Value;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = this.Malnutrition_Screening_Not_At_Risk_Result();
-			var af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
-			var ag_ = context.Operators.And(ab_, af_);
+			bool? u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
+			bool? v_ = context.Operators.And(o_, u_);
+			CqlInterval<CqlDateTime> w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_bejjtwegpxjsnajsodybefddb.QualifyingEncounter);
+			DataType x_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Effective;
+			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? ab_ = context.Operators.And(v_, aa_);
+			DataType ac_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Value;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet ae_ = this.Malnutrition_Screening_Not_At_Risk_Result();
+			bool? af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
+			bool? ag_ = context.Operators.And(ab_, af_);
 
 			return ag_;
 		};
-		var h_ = context.Operators.Where<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(f_, g_);
+		IEnumerable<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb> h_ = context.Operators.Where<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(f_, g_);
 		Encounter i_(Tuple_BEjjTWeGPXJSNajSOdYBEfDdb tuple_bejjtwegpxjsnajsodybefddb) => 
 			tuple_bejjtwegpxjsnajsodybefddb.QualifyingEncounter;
-		var j_ = context.Operators.Select<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk_Value"/>
     [CqlDeclaration("Encounter with Malnutrition Risk Screening Not at Risk")]
 	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk() => 
 		__Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk.Value;
 
+    /// <seealso cref="Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral"/>
 	private IEnumerable<Encounter> Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var f_ = this.Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk();
-			var g_ = context.Operators.Contains<Encounter>(f_, QualifyingEncounter);
-			var h_ = this.Encounter_with_Hospital_Dietitian_Referral();
-			var i_ = context.Operators.Exists<Encounter>(h_);
-			var j_ = context.Operators.Not(i_);
-			var k_ = context.Operators.And(g_, j_);
+			IEnumerable<Encounter> f_ = this.Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk();
+			bool? g_ = context.Operators.Contains<Encounter>(f_, QualifyingEncounter);
+			IEnumerable<Encounter> h_ = this.Encounter_with_Hospital_Dietitian_Referral();
+			bool? i_ = context.Operators.Exists<Encounter>(h_);
+			bool? j_ = context.Operators.Not(i_);
+			bool? k_ = context.Operators.And(g_, j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter QualifyingEncounter) => 
 			QualifyingEncounter;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral_Value"/>
     [CqlDeclaration("Encounter with Malnutrition Not at Risk Screening and without Hospital Dietitian Referral")]
 	public IEnumerable<Encounter> Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral() => 
 		__Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral.Value;
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening_at_Risk"/>
 	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_at_Risk_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
-		var b_ = this.Malnutrition_Risk_Screening();
-		var c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
+		CqlValueSet b_ = this.Malnutrition_Risk_Screening();
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		Tuple_BEjjTWeGPXJSNajSOdYBEfDdb e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
-			var k_ = new Tuple_BEjjTWeGPXJSNajSOdYBEfDdb
+			Tuple_BEjjTWeGPXJSNajSOdYBEfDdb k_ = new Tuple_BEjjTWeGPXJSNajSOdYBEfDdb
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				MalnutritionRiskScreening = _valueTuple.Item2,
@@ -672,85 +739,89 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(d_, e_);
+		IEnumerable<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb> f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(d_, e_);
 		bool? g_(Tuple_BEjjTWeGPXJSNajSOdYBEfDdb tuple_bejjtwegpxjsnajsodybefddb)
 		{
-			var l_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Code;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = this.Malnutrition_Risk_Screening();
-			var o_ = context.Operators.ConceptInValueSet(m_, n_);
-			var p_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
-			var s_ = context.Operators.Convert<string>(r_);
-			var t_ = new string[]
+			CodeableConcept l_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Code;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlValueSet n_ = this.Malnutrition_Risk_Screening();
+			bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+			Code<ObservationStatus> p_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.StatusElement;
+			ObservationStatus? q_ = p_?.Value;
+			Code<ObservationStatus> r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
+			string s_ = context.Operators.Convert<string>(r_);
+			string[] t_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
-			var v_ = context.Operators.And(o_, u_);
-			var w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_bejjtwegpxjsnajsodybefddb.QualifyingEncounter);
-			var x_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Effective;
-			var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-			var z_ = QICoreCommon_2_0_000.toInterval(y_);
-			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
-			var ab_ = context.Operators.And(v_, aa_);
-			var ac_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Value;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = this.Malnutrition_Screening_At_Risk_Result();
-			var af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
-			var ag_ = context.Operators.And(ab_, af_);
+			bool? u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
+			bool? v_ = context.Operators.And(o_, u_);
+			CqlInterval<CqlDateTime> w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_bejjtwegpxjsnajsodybefddb.QualifyingEncounter);
+			DataType x_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Effective;
+			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? ab_ = context.Operators.And(v_, aa_);
+			DataType ac_ = tuple_bejjtwegpxjsnajsodybefddb.MalnutritionRiskScreening?.Value;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet ae_ = this.Malnutrition_Screening_At_Risk_Result();
+			bool? af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
+			bool? ag_ = context.Operators.And(ab_, af_);
 
 			return ag_;
 		};
-		var h_ = context.Operators.Where<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(f_, g_);
+		IEnumerable<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb> h_ = context.Operators.Where<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb>(f_, g_);
 		Encounter i_(Tuple_BEjjTWeGPXJSNajSOdYBEfDdb tuple_bejjtwegpxjsnajsodybefddb) => 
 			tuple_bejjtwegpxjsnajsodybefddb.QualifyingEncounter;
-		var j_ = context.Operators.Select<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_BEjjTWeGPXJSNajSOdYBEfDdb, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening_at_Risk_Value"/>
     [CqlDeclaration("Encounter with Malnutrition Risk Screening at Risk")]
 	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_at_Risk() => 
 		__Encounter_with_Malnutrition_Risk_Screening_at_Risk.Value;
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral"/>
 	private IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var f_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk();
-			var g_ = context.Operators.Contains<Encounter>(f_, QualifyingEncounter);
-			var h_ = this.Encounter_with_Hospital_Dietitian_Referral();
-			var i_ = context.Operators.Contains<Encounter>(h_, QualifyingEncounter);
-			var j_ = context.Operators.Or(g_, i_);
+			IEnumerable<Encounter> f_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk();
+			bool? g_ = context.Operators.Contains<Encounter>(f_, QualifyingEncounter);
+			IEnumerable<Encounter> h_ = this.Encounter_with_Hospital_Dietitian_Referral();
+			bool? i_ = context.Operators.Contains<Encounter>(h_, QualifyingEncounter);
+			bool? j_ = context.Operators.Or(g_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		Encounter d_(Encounter QualifyingEncounter) => 
 			QualifyingEncounter;
-		var e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Select<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral_Value"/>
     [CqlDeclaration("Encounter with Malnutrition Risk Screening at Risk or with Hospital Dietitian Referral")]
 	public IEnumerable<Encounter> Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral() => 
 		__Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral.Value;
 
+    /// <seealso cref="Encounter_with_Nutrition_Assessment_and_Identified_Status"/>
 	private IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_and_Identified_Status_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
-		var b_ = this.Nutrition_Assessment();
-		var c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
+		CqlValueSet b_ = this.Nutrition_Assessment();
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		Tuple_HHhYPFJVjUjiTMIZOceFUGCNE e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
-			var k_ = new Tuple_HHhYPFJVjUjiTMIZOceFUGCNE
+			Tuple_HHhYPFJVjUjiTMIZOceFUGCNE k_ = new Tuple_HHhYPFJVjUjiTMIZOceFUGCNE
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				NutritionAssessment = _valueTuple.Item2,
@@ -758,68 +829,70 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(d_, e_);
+		IEnumerable<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE> f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(d_, e_);
 		bool? g_(Tuple_HHhYPFJVjUjiTMIZOceFUGCNE tuple_hhhypfjvjujitmizocefugcne)
 		{
-			var l_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Code;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = this.Nutrition_Assessment();
-			var o_ = context.Operators.ConceptInValueSet(m_, n_);
-			var p_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
-			var s_ = context.Operators.Convert<string>(r_);
-			var t_ = new string[]
+			CodeableConcept l_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Code;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlValueSet n_ = this.Nutrition_Assessment();
+			bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+			Code<ObservationStatus> p_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.StatusElement;
+			ObservationStatus? q_ = p_?.Value;
+			Code<ObservationStatus> r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
+			string s_ = context.Operators.Convert<string>(r_);
+			string[] t_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
-			var v_ = context.Operators.And(o_, u_);
-			var w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_hhhypfjvjujitmizocefugcne.QualifyingEncounter);
-			var x_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Effective;
-			var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-			var z_ = QICoreCommon_2_0_000.toInterval(y_);
-			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
-			var ab_ = context.Operators.And(v_, aa_);
-			var ac_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Value;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = this.Nutrition_Assessment_Status_Moderately_Malnourished();
-			var af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
-			var ah_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ai_ = this.Nutrition_Assessment_Status_Not_or_Mildly_Malnourished();
-			var aj_ = context.Operators.ConceptInValueSet((ah_ as CqlConcept), ai_);
-			var ak_ = context.Operators.Or(af_, aj_);
-			var am_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var an_ = this.Nutrition_Assessment_Status_Severely_Malnourished();
-			var ao_ = context.Operators.ConceptInValueSet((am_ as CqlConcept), an_);
-			var ap_ = context.Operators.Or(ak_, ao_);
-			var aq_ = context.Operators.And(ab_, ap_);
+			bool? u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
+			bool? v_ = context.Operators.And(o_, u_);
+			CqlInterval<CqlDateTime> w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_hhhypfjvjujitmizocefugcne.QualifyingEncounter);
+			DataType x_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Effective;
+			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? ab_ = context.Operators.And(v_, aa_);
+			DataType ac_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Value;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet ae_ = this.Nutrition_Assessment_Status_Moderately_Malnourished();
+			bool? af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
+			object ah_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet ai_ = this.Nutrition_Assessment_Status_Not_or_Mildly_Malnourished();
+			bool? aj_ = context.Operators.ConceptInValueSet((ah_ as CqlConcept), ai_);
+			bool? ak_ = context.Operators.Or(af_, aj_);
+			object am_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet an_ = this.Nutrition_Assessment_Status_Severely_Malnourished();
+			bool? ao_ = context.Operators.ConceptInValueSet((am_ as CqlConcept), an_);
+			bool? ap_ = context.Operators.Or(ak_, ao_);
+			bool? aq_ = context.Operators.And(ab_, ap_);
 
 			return aq_;
 		};
-		var h_ = context.Operators.Where<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(f_, g_);
+		IEnumerable<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE> h_ = context.Operators.Where<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(f_, g_);
 		Encounter i_(Tuple_HHhYPFJVjUjiTMIZOceFUGCNE tuple_hhhypfjvjujitmizocefugcne) => 
 			tuple_hhhypfjvjujitmizocefugcne.QualifyingEncounter;
-		var j_ = context.Operators.Select<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Nutrition_Assessment_and_Identified_Status_Value"/>
     [CqlDeclaration("Encounter with Nutrition Assessment and Identified Status")]
 	public IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_and_Identified_Status() => 
 		__Encounter_with_Nutrition_Assessment_and_Identified_Status.Value;
 
+    /// <seealso cref="Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished"/>
 	private IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
-		var b_ = this.Nutrition_Assessment();
-		var c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
+		CqlValueSet b_ = this.Nutrition_Assessment();
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		Tuple_HHhYPFJVjUjiTMIZOceFUGCNE e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
-			var k_ = new Tuple_HHhYPFJVjUjiTMIZOceFUGCNE
+			Tuple_HHhYPFJVjUjiTMIZOceFUGCNE k_ = new Tuple_HHhYPFJVjUjiTMIZOceFUGCNE
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				NutritionAssessment = _valueTuple.Item2,
@@ -827,64 +900,66 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(d_, e_);
+		IEnumerable<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE> f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(d_, e_);
 		bool? g_(Tuple_HHhYPFJVjUjiTMIZOceFUGCNE tuple_hhhypfjvjujitmizocefugcne)
 		{
-			var l_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Code;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = this.Nutrition_Assessment();
-			var o_ = context.Operators.ConceptInValueSet(m_, n_);
-			var p_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
-			var s_ = context.Operators.Convert<string>(r_);
-			var t_ = new string[]
+			CodeableConcept l_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Code;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlValueSet n_ = this.Nutrition_Assessment();
+			bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+			Code<ObservationStatus> p_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.StatusElement;
+			ObservationStatus? q_ = p_?.Value;
+			Code<ObservationStatus> r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
+			string s_ = context.Operators.Convert<string>(r_);
+			string[] t_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
-			var v_ = context.Operators.And(o_, u_);
-			var w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_hhhypfjvjujitmizocefugcne.QualifyingEncounter);
-			var x_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Effective;
-			var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-			var z_ = QICoreCommon_2_0_000.toInterval(y_);
-			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
-			var ab_ = context.Operators.And(v_, aa_);
-			var ac_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Value;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = this.Nutrition_Assessment_Status_Moderately_Malnourished();
-			var af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
-			var ah_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ai_ = this.Nutrition_Assessment_Status_Severely_Malnourished();
-			var aj_ = context.Operators.ConceptInValueSet((ah_ as CqlConcept), ai_);
-			var ak_ = context.Operators.Or(af_, aj_);
-			var al_ = context.Operators.And(ab_, ak_);
+			bool? u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
+			bool? v_ = context.Operators.And(o_, u_);
+			CqlInterval<CqlDateTime> w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_hhhypfjvjujitmizocefugcne.QualifyingEncounter);
+			DataType x_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Effective;
+			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? ab_ = context.Operators.And(v_, aa_);
+			DataType ac_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Value;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet ae_ = this.Nutrition_Assessment_Status_Moderately_Malnourished();
+			bool? af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
+			object ah_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet ai_ = this.Nutrition_Assessment_Status_Severely_Malnourished();
+			bool? aj_ = context.Operators.ConceptInValueSet((ah_ as CqlConcept), ai_);
+			bool? ak_ = context.Operators.Or(af_, aj_);
+			bool? al_ = context.Operators.And(ab_, ak_);
 
 			return al_;
 		};
-		var h_ = context.Operators.Where<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(f_, g_);
+		IEnumerable<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE> h_ = context.Operators.Where<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(f_, g_);
 		Encounter i_(Tuple_HHhYPFJVjUjiTMIZOceFUGCNE tuple_hhhypfjvjujitmizocefugcne) => 
 			tuple_hhhypfjvjujitmizocefugcne.QualifyingEncounter;
-		var j_ = context.Operators.Select<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished_Value"/>
     [CqlDeclaration("Encounter with Nutrition Assessment Status Moderately Or Severely Malnourished")]
 	public IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished() => 
 		__Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished.Value;
 
+    /// <seealso cref="Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished"/>
 	private IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
-		var b_ = this.Nutrition_Assessment();
-		var c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
+		CqlValueSet b_ = this.Nutrition_Assessment();
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		Tuple_HHhYPFJVjUjiTMIZOceFUGCNE e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
-			var k_ = new Tuple_HHhYPFJVjUjiTMIZOceFUGCNE
+			Tuple_HHhYPFJVjUjiTMIZOceFUGCNE k_ = new Tuple_HHhYPFJVjUjiTMIZOceFUGCNE
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				NutritionAssessment = _valueTuple.Item2,
@@ -892,60 +967,62 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(d_, e_);
+		IEnumerable<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE> f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(d_, e_);
 		bool? g_(Tuple_HHhYPFJVjUjiTMIZOceFUGCNE tuple_hhhypfjvjujitmizocefugcne)
 		{
-			var l_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Code;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = this.Nutrition_Assessment();
-			var o_ = context.Operators.ConceptInValueSet(m_, n_);
-			var p_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
-			var s_ = context.Operators.Convert<string>(r_);
-			var t_ = new string[]
+			CodeableConcept l_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Code;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlValueSet n_ = this.Nutrition_Assessment();
+			bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+			Code<ObservationStatus> p_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.StatusElement;
+			ObservationStatus? q_ = p_?.Value;
+			Code<ObservationStatus> r_ = context.Operators.Convert<Code<ObservationStatus>>(q_);
+			string s_ = context.Operators.Convert<string>(r_);
+			string[] t_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
-			var v_ = context.Operators.And(o_, u_);
-			var w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_hhhypfjvjujitmizocefugcne.QualifyingEncounter);
-			var x_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Effective;
-			var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-			var z_ = QICoreCommon_2_0_000.toInterval(y_);
-			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
-			var ab_ = context.Operators.And(v_, aa_);
-			var ac_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Value;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = this.Nutrition_Assessment_Status_Not_or_Mildly_Malnourished();
-			var af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
-			var ag_ = context.Operators.And(ab_, af_);
+			bool? u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
+			bool? v_ = context.Operators.And(o_, u_);
+			CqlInterval<CqlDateTime> w_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_hhhypfjvjujitmizocefugcne.QualifyingEncounter);
+			DataType x_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Effective;
+			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? ab_ = context.Operators.And(v_, aa_);
+			DataType ac_ = tuple_hhhypfjvjujitmizocefugcne.NutritionAssessment?.Value;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlValueSet ae_ = this.Nutrition_Assessment_Status_Not_or_Mildly_Malnourished();
+			bool? af_ = context.Operators.ConceptInValueSet((ad_ as CqlConcept), ae_);
+			bool? ag_ = context.Operators.And(ab_, af_);
 
 			return ag_;
 		};
-		var h_ = context.Operators.Where<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(f_, g_);
+		IEnumerable<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE> h_ = context.Operators.Where<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE>(f_, g_);
 		Encounter i_(Tuple_HHhYPFJVjUjiTMIZOceFUGCNE tuple_hhhypfjvjujitmizocefugcne) => 
 			tuple_hhhypfjvjujitmizocefugcne.QualifyingEncounter;
-		var j_ = context.Operators.Select<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_HHhYPFJVjUjiTMIZOceFUGCNE, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished_Value"/>
     [CqlDeclaration("Encounter with Nutrition Assessment Not or Mildly Malnourished")]
 	public IEnumerable<Encounter> Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished() => 
 		__Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished.Value;
 
+    /// <seealso cref="Encounter_with_Malnutrition_Diagnosis"/>
 	private IEnumerable<Encounter> Encounter_with_Malnutrition_Diagnosis_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
-		var b_ = this.Malnutrition_Diagnosis();
-		var c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Condition>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
+		CqlValueSet b_ = this.Malnutrition_Diagnosis();
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Condition>> d_ = context.Operators.CrossJoin<Encounter, Condition>(a_, c_);
 		Tuple_GSiGYORNRKJGEXbhEjVIWNTMN e_(ValueTuple<Encounter, Condition> _valueTuple)
 		{
-			var k_ = new Tuple_GSiGYORNRKJGEXbhEjVIWNTMN
+			Tuple_GSiGYORNRKJGEXbhEjVIWNTMN k_ = new Tuple_GSiGYORNRKJGEXbhEjVIWNTMN
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				MalnutritionDiagnosis = _valueTuple.Item2,
@@ -953,42 +1030,44 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Condition>, Tuple_GSiGYORNRKJGEXbhEjVIWNTMN>(d_, e_);
+		IEnumerable<Tuple_GSiGYORNRKJGEXbhEjVIWNTMN> f_ = context.Operators.Select<ValueTuple<Encounter, Condition>, Tuple_GSiGYORNRKJGEXbhEjVIWNTMN>(d_, e_);
 		bool? g_(Tuple_GSiGYORNRKJGEXbhEjVIWNTMN tuple_gsigyornrkjgexbhejviwntmn)
 		{
-			var l_ = tuple_gsigyornrkjgexbhejviwntmn.MalnutritionDiagnosis?.Code;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = this.Malnutrition_Diagnosis();
-			var o_ = context.Operators.ConceptInValueSet(m_, n_);
-			var p_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_gsigyornrkjgexbhejviwntmn.MalnutritionDiagnosis);
-			var q_ = context.Operators.Start(p_);
-			var r_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_gsigyornrkjgexbhejviwntmn.QualifyingEncounter);
-			var s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
-			var t_ = context.Operators.And(o_, s_);
+			CodeableConcept l_ = tuple_gsigyornrkjgexbhejviwntmn.MalnutritionDiagnosis?.Code;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlValueSet n_ = this.Malnutrition_Diagnosis();
+			bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_gsigyornrkjgexbhejviwntmn.MalnutritionDiagnosis);
+			CqlDateTime q_ = context.Operators.Start(p_);
+			CqlInterval<CqlDateTime> r_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_gsigyornrkjgexbhejviwntmn.QualifyingEncounter);
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
+			bool? t_ = context.Operators.And(o_, s_);
 
 			return t_;
 		};
-		var h_ = context.Operators.Where<Tuple_GSiGYORNRKJGEXbhEjVIWNTMN>(f_, g_);
+		IEnumerable<Tuple_GSiGYORNRKJGEXbhEjVIWNTMN> h_ = context.Operators.Where<Tuple_GSiGYORNRKJGEXbhEjVIWNTMN>(f_, g_);
 		Encounter i_(Tuple_GSiGYORNRKJGEXbhEjVIWNTMN tuple_gsigyornrkjgexbhejviwntmn) => 
 			tuple_gsigyornrkjgexbhejviwntmn.QualifyingEncounter;
-		var j_ = context.Operators.Select<Tuple_GSiGYORNRKJGEXbhEjVIWNTMN, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_GSiGYORNRKJGEXbhEjVIWNTMN, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Malnutrition_Diagnosis_Value"/>
     [CqlDeclaration("Encounter with Malnutrition Diagnosis")]
 	public IEnumerable<Encounter> Encounter_with_Malnutrition_Diagnosis() => 
 		__Encounter_with_Malnutrition_Diagnosis.Value;
 
+    /// <seealso cref="Encounter_with_Nutrition_Care_Plan"/>
 	private IEnumerable<Encounter> Encounter_with_Nutrition_Care_Plan_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
-		var b_ = this.Nutrition_Care_Plan();
-		var c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, null);
-		var d_ = context.Operators.CrossJoin<Encounter, Procedure>(a_, c_);
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
+		CqlValueSet b_ = this.Nutrition_Care_Plan();
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, null);
+		IEnumerable<ValueTuple<Encounter, Procedure>> d_ = context.Operators.CrossJoin<Encounter, Procedure>(a_, c_);
 		Tuple_igUTMWHAUfJcWZMIjcGJEYSM e_(ValueTuple<Encounter, Procedure> _valueTuple)
 		{
-			var k_ = new Tuple_igUTMWHAUfJcWZMIjcGJEYSM
+			Tuple_igUTMWHAUfJcWZMIjcGJEYSM k_ = new Tuple_igUTMWHAUfJcWZMIjcGJEYSM
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				NutritionCarePlan = _valueTuple.Item2,
@@ -996,40 +1075,41 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<Encounter, Procedure>, Tuple_igUTMWHAUfJcWZMIjcGJEYSM>(d_, e_);
+		IEnumerable<Tuple_igUTMWHAUfJcWZMIjcGJEYSM> f_ = context.Operators.Select<ValueTuple<Encounter, Procedure>, Tuple_igUTMWHAUfJcWZMIjcGJEYSM>(d_, e_);
 		bool? g_(Tuple_igUTMWHAUfJcWZMIjcGJEYSM tuple_igutmwhaufjcwzmijcgjeysm)
 		{
-			var l_ = tuple_igutmwhaufjcwzmijcgjeysm.NutritionCarePlan?.Code;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = this.Nutrition_Care_Plan();
-			var o_ = context.Operators.ConceptInValueSet(m_, n_);
-			var p_ = tuple_igutmwhaufjcwzmijcgjeysm.NutritionCarePlan?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<string>(q_);
-			var s_ = new string[]
+			CodeableConcept l_ = tuple_igutmwhaufjcwzmijcgjeysm.NutritionCarePlan?.Code;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlValueSet n_ = this.Nutrition_Care_Plan();
+			bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
+			Code<EventStatus> p_ = tuple_igutmwhaufjcwzmijcgjeysm.NutritionCarePlan?.StatusElement;
+			EventStatus? q_ = p_?.Value;
+			string r_ = context.Operators.Convert<string>(q_);
+			string[] s_ = new string[]
 			{
 				"completed",
 				"in-progress",
 			};
-			var t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
-			var u_ = context.Operators.And(o_, t_);
-			var v_ = tuple_igutmwhaufjcwzmijcgjeysm.NutritionCarePlan?.Performed;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.earliest(w_);
-			var y_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_igutmwhaufjcwzmijcgjeysm.QualifyingEncounter);
-			var z_ = context.Operators.In<CqlDateTime>(x_, y_, null);
-			var aa_ = context.Operators.And(u_, z_);
+			bool? t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
+			bool? u_ = context.Operators.And(o_, t_);
+			DataType v_ = tuple_igutmwhaufjcwzmijcgjeysm.NutritionCarePlan?.Performed;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlDateTime x_ = QICoreCommon_2_0_000.earliest(w_);
+			CqlInterval<CqlDateTime> y_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_igutmwhaufjcwzmijcgjeysm.QualifyingEncounter);
+			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, null);
+			bool? aa_ = context.Operators.And(u_, z_);
 
 			return aa_;
 		};
-		var h_ = context.Operators.Where<Tuple_igUTMWHAUfJcWZMIjcGJEYSM>(f_, g_);
+		IEnumerable<Tuple_igUTMWHAUfJcWZMIjcGJEYSM> h_ = context.Operators.Where<Tuple_igUTMWHAUfJcWZMIjcGJEYSM>(f_, g_);
 		Encounter i_(Tuple_igUTMWHAUfJcWZMIjcGJEYSM tuple_igutmwhaufjcwzmijcgjeysm) => 
 			tuple_igutmwhaufjcwzmijcgjeysm.QualifyingEncounter;
-		var j_ = context.Operators.Select<Tuple_igUTMWHAUfJcWZMIjcGJEYSM, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_igUTMWHAUfJcWZMIjcGJEYSM, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Nutrition_Care_Plan_Value"/>
     [CqlDeclaration("Encounter with Nutrition Care Plan")]
 	public IEnumerable<Encounter> Encounter_with_Nutrition_Care_Plan() => 
 		__Encounter_with_Nutrition_Care_Plan.Value;
@@ -1047,15 +1127,15 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		{
 			bool b_()
 			{
-				var d_ = this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral();
-				var e_ = context.Operators.Contains<Encounter>(d_, NutritionAssessment);
+				IEnumerable<Encounter> d_ = this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral();
+				bool? e_ = context.Operators.Contains<Encounter>(d_, NutritionAssessment);
 
 				return (e_ ?? false);
 			};
 			bool c_()
 			{
-				var f_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral();
-				var g_ = context.Operators.Contains<Encounter>(f_, NutritionAssessment);
+				IEnumerable<Encounter> f_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral();
+				bool? g_ = context.Operators.Contains<Encounter>(f_, NutritionAssessment);
 
 				return (g_ ?? false);
 			};
@@ -1085,15 +1165,15 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		{
 			bool b_()
 			{
-				var d_ = this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral();
-				var e_ = context.Operators.Contains<Encounter>(d_, MalnutritionDiagonsis);
+				IEnumerable<Encounter> d_ = this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral();
+				bool? e_ = context.Operators.Contains<Encounter>(d_, MalnutritionDiagonsis);
 
 				return (e_ ?? false);
 			};
 			bool c_()
 			{
-				var f_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral();
-				var g_ = context.Operators.Contains<Encounter>(f_, MalnutritionDiagonsis);
+				IEnumerable<Encounter> f_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral();
+				bool? g_ = context.Operators.Contains<Encounter>(f_, MalnutritionDiagonsis);
 
 				return (g_ ?? false);
 			};
@@ -1107,8 +1187,8 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 				{
 					bool i_()
 					{
-						var j_ = this.Encounter_with_Malnutrition_Diagnosis();
-						var k_ = context.Operators.Contains<Encounter>(j_, MalnutritionDiagonsis);
+						IEnumerable<Encounter> j_ = this.Encounter_with_Malnutrition_Diagnosis();
+						bool? k_ = context.Operators.Contains<Encounter>(j_, MalnutritionDiagonsis);
 
 						return (k_ ?? false);
 					};
@@ -1118,15 +1198,15 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 						{
 							bool m_()
 							{
-								var o_ = this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished();
-								var p_ = context.Operators.Contains<Encounter>(o_, MalnutritionDiagonsis);
+								IEnumerable<Encounter> o_ = this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished();
+								bool? p_ = context.Operators.Contains<Encounter>(o_, MalnutritionDiagonsis);
 
 								return (p_ ?? false);
 							};
 							bool n_()
 							{
-								var q_ = this.Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished();
-								var r_ = context.Operators.Contains<Encounter>(q_, MalnutritionDiagonsis);
+								IEnumerable<Encounter> q_ = this.Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished();
+								bool? r_ = context.Operators.Contains<Encounter>(q_, MalnutritionDiagonsis);
 
 								return (r_ ?? false);
 							};
@@ -1170,15 +1250,15 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		{
 			bool b_()
 			{
-				var d_ = this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral();
-				var e_ = context.Operators.Contains<Encounter>(d_, NutritionCarePlan);
+				IEnumerable<Encounter> d_ = this.Encounter_with_Malnutrition_Not_at_Risk_Screening_and_without_Hospital_Dietitian_Referral();
+				bool? e_ = context.Operators.Contains<Encounter>(d_, NutritionCarePlan);
 
 				return (e_ ?? false);
 			};
 			bool c_()
 			{
-				var f_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral();
-				var g_ = context.Operators.Contains<Encounter>(f_, NutritionCarePlan);
+				IEnumerable<Encounter> f_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk_or_with_Hospital_Dietitian_Referral();
+				bool? g_ = context.Operators.Contains<Encounter>(f_, NutritionCarePlan);
 
 				return (g_ ?? false);
 			};
@@ -1192,8 +1272,8 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 				{
 					bool i_()
 					{
-						var j_ = this.Encounter_with_Nutrition_Care_Plan();
-						var k_ = context.Operators.Contains<Encounter>(j_, NutritionCarePlan);
+						IEnumerable<Encounter> j_ = this.Encounter_with_Nutrition_Care_Plan();
+						bool? k_ = context.Operators.Contains<Encounter>(j_, NutritionCarePlan);
 
 						return (k_ ?? false);
 					};
@@ -1203,15 +1283,15 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 						{
 							bool m_()
 							{
-								var o_ = this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished();
-								var p_ = context.Operators.Contains<Encounter>(o_, NutritionCarePlan);
+								IEnumerable<Encounter> o_ = this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished();
+								bool? p_ = context.Operators.Contains<Encounter>(o_, NutritionCarePlan);
 
 								return (p_ ?? false);
 							};
 							bool n_()
 							{
-								var q_ = this.Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished();
-								var r_ = context.Operators.Contains<Encounter>(q_, NutritionCarePlan);
+								IEnumerable<Encounter> q_ = this.Encounter_with_Nutrition_Assessment_Status_Moderately_Or_Severely_Malnourished();
+								bool? r_ = context.Operators.Contains<Encounter>(q_, NutritionCarePlan);
 
 								return (r_ ?? false);
 							};
@@ -1251,18 +1331,18 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
     [CqlDeclaration("Measure Observation TotalMalnutritionComponentsScore")]
 	public int? Measure_Observation_TotalMalnutritionComponentsScore(Encounter QualifyingEncounter)
 	{
-		var a_ = this.Measure_Observation_1(QualifyingEncounter);
-		var b_ = this.Measure_Observation_2(QualifyingEncounter);
-		var c_ = this.Measure_Observation_3(QualifyingEncounter);
-		var d_ = this.Measure_Observation_4(QualifyingEncounter);
-		var e_ = new int?[]
+		int? a_ = this.Measure_Observation_1(QualifyingEncounter);
+		int? b_ = this.Measure_Observation_2(QualifyingEncounter);
+		int? c_ = this.Measure_Observation_3(QualifyingEncounter);
+		int? d_ = this.Measure_Observation_4(QualifyingEncounter);
+		int?[] e_ = new int?[]
 		{
 			a_,
 			b_,
 			c_,
 			d_,
 		};
-		var f_ = context.Operators.Sum((e_ as IEnumerable<int?>));
+		int? f_ = context.Operators.Sum((e_ as IEnumerable<int?>));
 
 		return f_;
 	}
@@ -1274,35 +1354,35 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		{
 			bool b_()
 			{
-				var d_ = this.Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral();
-				var e_ = context.Operators.Contains<Encounter>(d_, QualifyingEncounter);
-				var f_ = this.Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk();
-				var g_ = context.Operators.Contains<Encounter>(f_, QualifyingEncounter);
-				var h_ = context.Operators.And(e_, g_);
-				var i_ = this.Encounter_with_Hospital_Dietitian_Referral();
-				var j_ = context.Operators.Contains<Encounter>(i_, QualifyingEncounter);
-				var k_ = context.Operators.Not(j_);
-				var l_ = context.Operators.And(h_, k_);
+				IEnumerable<Encounter> d_ = this.Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral();
+				bool? e_ = context.Operators.Contains<Encounter>(d_, QualifyingEncounter);
+				IEnumerable<Encounter> f_ = this.Encounter_with_Malnutrition_Risk_Screening_Not_at_Risk();
+				bool? g_ = context.Operators.Contains<Encounter>(f_, QualifyingEncounter);
+				bool? h_ = context.Operators.And(e_, g_);
+				IEnumerable<Encounter> i_ = this.Encounter_with_Hospital_Dietitian_Referral();
+				bool? j_ = context.Operators.Contains<Encounter>(i_, QualifyingEncounter);
+				bool? k_ = context.Operators.Not(j_);
+				bool? l_ = context.Operators.And(h_, k_);
 
 				return (l_ ?? false);
 			};
 			bool c_()
 			{
-				var m_ = this.Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral();
-				var n_ = context.Operators.Contains<Encounter>(m_, QualifyingEncounter);
-				var o_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk();
-				var p_ = context.Operators.Contains<Encounter>(o_, QualifyingEncounter);
-				var q_ = context.Operators.And(n_, p_);
-				var r_ = this.Encounter_with_Hospital_Dietitian_Referral();
-				var s_ = context.Operators.Contains<Encounter>(r_, QualifyingEncounter);
-				var t_ = context.Operators.Or(q_, s_);
-				var u_ = this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished();
-				var v_ = context.Operators.Contains<Encounter>(u_, QualifyingEncounter);
-				var w_ = context.Operators.And(t_, v_);
-				var x_ = this.Encounter_with_Nutrition_Assessment_and_Identified_Status();
-				var y_ = context.Operators.Contains<Encounter>(x_, QualifyingEncounter);
-				var z_ = context.Operators.Not(y_);
-				var aa_ = context.Operators.Or(w_, z_);
+				IEnumerable<Encounter> m_ = this.Encounter_with_Malnutrition_Risk_Screening_or_with_Hospital_Dietitian_Referral();
+				bool? n_ = context.Operators.Contains<Encounter>(m_, QualifyingEncounter);
+				IEnumerable<Encounter> o_ = this.Encounter_with_Malnutrition_Risk_Screening_at_Risk();
+				bool? p_ = context.Operators.Contains<Encounter>(o_, QualifyingEncounter);
+				bool? q_ = context.Operators.And(n_, p_);
+				IEnumerable<Encounter> r_ = this.Encounter_with_Hospital_Dietitian_Referral();
+				bool? s_ = context.Operators.Contains<Encounter>(r_, QualifyingEncounter);
+				bool? t_ = context.Operators.Or(q_, s_);
+				IEnumerable<Encounter> u_ = this.Encounter_with_Nutrition_Assessment_Not_or_Mildly_Malnourished();
+				bool? v_ = context.Operators.Contains<Encounter>(u_, QualifyingEncounter);
+				bool? w_ = context.Operators.And(t_, v_);
+				IEnumerable<Encounter> x_ = this.Encounter_with_Nutrition_Assessment_and_Identified_Status();
+				bool? y_ = context.Operators.Contains<Encounter>(x_, QualifyingEncounter);
+				bool? z_ = context.Operators.Not(y_);
+				bool? aa_ = context.Operators.Or(w_, z_);
 
 				return (aa_ ?? false);
 			};
@@ -1326,13 +1406,13 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
     [CqlDeclaration("Measure Observation TotalMalnutritionCompositeScore as Percentage")]
 	public decimal? Measure_Observation_TotalMalnutritionCompositeScore_as_Percentage(Encounter QualifyingEncounter)
 	{
-		var a_ = context.Operators.ConvertIntegerToDecimal(100);
-		var b_ = this.Measure_Observation_TotalMalnutritionComponentsScore(QualifyingEncounter);
-		var c_ = context.Operators.ConvertIntegerToDecimal(b_);
-		var d_ = this.TotalMalnutritionCompositeScore_Eligible_Denominators(QualifyingEncounter);
-		var e_ = context.Operators.ConvertIntegerToDecimal(d_);
-		var f_ = context.Operators.Divide(c_, e_);
-		var g_ = context.Operators.Multiply(a_, f_);
+		decimal? a_ = context.Operators.ConvertIntegerToDecimal(100);
+		int? b_ = this.Measure_Observation_TotalMalnutritionComponentsScore(QualifyingEncounter);
+		decimal? c_ = context.Operators.ConvertIntegerToDecimal(b_);
+		int? d_ = this.TotalMalnutritionCompositeScore_Eligible_Denominators(QualifyingEncounter);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(d_);
+		decimal? f_ = context.Operators.Divide(c_, e_);
+		decimal? g_ = context.Operators.Multiply(a_, f_);
 
 		return g_;
 	}

--- a/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
@@ -124,128 +124,159 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
     #endregion
 
+    /// <seealso cref="Allergy_to_Beta_Blocker_Therapy"/>
 	private CqlValueSet Allergy_to_Beta_Blocker_Therapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", null);
 
+    /// <seealso cref="Allergy_to_Beta_Blocker_Therapy_Value"/>
     [CqlDeclaration("Allergy to Beta Blocker Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177")]
 	public CqlValueSet Allergy_to_Beta_Blocker_Therapy() => 
 		__Allergy_to_Beta_Blocker_Therapy.Value;
 
+    /// <seealso cref="Arrhythmia"/>
 	private CqlValueSet Arrhythmia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", null);
 
+    /// <seealso cref="Arrhythmia_Value"/>
     [CqlDeclaration("Arrhythmia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366")]
 	public CqlValueSet Arrhythmia() => 
 		__Arrhythmia.Value;
 
+    /// <seealso cref="Asthma"/>
 	private CqlValueSet Asthma_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", null);
 
+    /// <seealso cref="Asthma_Value"/>
     [CqlDeclaration("Asthma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362")]
 	public CqlValueSet Asthma() => 
 		__Asthma.Value;
 
+    /// <seealso cref="Atrioventricular_Block"/>
 	private CqlValueSet Atrioventricular_Block_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", null);
 
+    /// <seealso cref="Atrioventricular_Block_Value"/>
     [CqlDeclaration("Atrioventricular Block")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367")]
 	public CqlValueSet Atrioventricular_Block() => 
 		__Atrioventricular_Block.Value;
 
+    /// <seealso cref="Beta_Blocker_Therapy_for_LVSD"/>
 	private CqlValueSet Beta_Blocker_Therapy_for_LVSD_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", null);
 
+    /// <seealso cref="Beta_Blocker_Therapy_for_LVSD_Value"/>
     [CqlDeclaration("Beta Blocker Therapy for LVSD")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184")]
 	public CqlValueSet Beta_Blocker_Therapy_for_LVSD() => 
 		__Beta_Blocker_Therapy_for_LVSD.Value;
 
+    /// <seealso cref="Beta_Blocker_Therapy_Ingredient"/>
 	private CqlValueSet Beta_Blocker_Therapy_Ingredient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", null);
 
+    /// <seealso cref="Beta_Blocker_Therapy_Ingredient_Value"/>
     [CqlDeclaration("Beta Blocker Therapy Ingredient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493")]
 	public CqlValueSet Beta_Blocker_Therapy_Ingredient() => 
 		__Beta_Blocker_Therapy_Ingredient.Value;
 
+    /// <seealso cref="Bradycardia"/>
 	private CqlValueSet Bradycardia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", null);
 
+    /// <seealso cref="Bradycardia_Value"/>
     [CqlDeclaration("Bradycardia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412")]
 	public CqlValueSet Bradycardia() => 
 		__Bradycardia.Value;
 
+    /// <seealso cref="Cardiac_Pacer"/>
 	private CqlValueSet Cardiac_Pacer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", null);
 
+    /// <seealso cref="Cardiac_Pacer_Value"/>
     [CqlDeclaration("Cardiac Pacer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53")]
 	public CqlValueSet Cardiac_Pacer() => 
 		__Cardiac_Pacer.Value;
 
+    /// <seealso cref="Cardiac_Pacer_in_Situ"/>
 	private CqlValueSet Cardiac_Pacer_in_Situ_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", null);
 
+    /// <seealso cref="Cardiac_Pacer_in_Situ_Value"/>
     [CqlDeclaration("Cardiac Pacer in Situ")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368")]
 	public CqlValueSet Cardiac_Pacer_in_Situ() => 
 		__Cardiac_Pacer_in_Situ.Value;
 
+    /// <seealso cref="Hypotension"/>
 	private CqlValueSet Hypotension_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", null);
 
+    /// <seealso cref="Hypotension_Value"/>
     [CqlDeclaration("Hypotension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370")]
 	public CqlValueSet Hypotension() => 
 		__Hypotension.Value;
 
+    /// <seealso cref="Intolerance_to_Beta_Blocker_Therapy"/>
 	private CqlValueSet Intolerance_to_Beta_Blocker_Therapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", null);
 
+    /// <seealso cref="Intolerance_to_Beta_Blocker_Therapy_Value"/>
     [CqlDeclaration("Intolerance to Beta Blocker Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178")]
 	public CqlValueSet Intolerance_to_Beta_Blocker_Therapy() => 
 		__Intolerance_to_Beta_Blocker_Therapy.Value;
 
+    /// <seealso cref="Left_Ventricular_Assist_Device_Placement"/>
 	private CqlValueSet Left_Ventricular_Assist_Device_Placement_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", null);
 
+    /// <seealso cref="Left_Ventricular_Assist_Device_Placement_Value"/>
     [CqlDeclaration("Left Ventricular Assist Device Placement")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61")]
 	public CqlValueSet Left_Ventricular_Assist_Device_Placement() => 
 		__Left_Ventricular_Assist_Device_Placement.Value;
 
+    /// <seealso cref="Medical_Reason"/>
 	private CqlValueSet Medical_Reason_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
 
+    /// <seealso cref="Medical_Reason_Value"/>
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
 	public CqlValueSet Medical_Reason() => 
 		__Medical_Reason.Value;
 
+    /// <seealso cref="Patient_Reason"/>
 	private CqlValueSet Patient_Reason_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
 
+    /// <seealso cref="Patient_Reason_Value"/>
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
 	public CqlValueSet Patient_Reason() => 
 		__Patient_Reason.Value;
 
+    /// <seealso cref="Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_"/>
 	private CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance__Value() => 
 		new CqlCode("373254001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance__Value"/>
     [CqlDeclaration("Substance with beta adrenergic receptor antagonist mechanism of action (substance)")]
 	public CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_() => 
 		__Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("373254001", "http://snomed.info/sct", null, null),
 		};
@@ -253,114 +284,128 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("HFBetaBlockerTherapyforLVSDFHIR-1.3.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("HFBetaBlockerTherapyforLVSDFHIR-1.3.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 18);
-		var h_ = AHAOverall_2_6_000.Qualifying_Outpatient_Encounter_During_Measurement_Period();
-		var i_ = context.Operators.Count<Encounter>(h_);
-		var j_ = context.Operators.GreaterOrEqual(i_, 2);
-		var k_ = context.Operators.And(g_, j_);
-		var l_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter();
-		var m_ = context.Operators.Exists<Encounter>(l_);
-		var n_ = context.Operators.And(k_, m_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+		IEnumerable<Encounter> j_ = AHAOverall_2_6_000.Qualifying_Outpatient_Encounter_During_Measurement_Period();
+		int? k_ = context.Operators.Count<Encounter>(j_);
+		bool? l_ = context.Operators.GreaterOrEqual(k_, 2);
+		bool? m_ = context.Operators.And(i_, l_);
+		IEnumerable<Encounter> n_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter();
+		bool? o_ = context.Operators.Exists<Encounter>(n_);
+		bool? p_ = context.Operators.And(m_, o_);
 
-		return n_;
+		return p_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
-		var b_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
-		var c_ = context.Operators.Exists<Encounter>(b_);
-		var d_ = context.Operators.And(a_, c_);
+		bool? a_ = this.Initial_Population();
+		IEnumerable<Encounter> b_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+		bool? c_ = context.Operators.Exists<Encounter>(b_);
+		bool? d_ = context.Operators.And(a_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = AHAOverall_2_6_000.Has_Heart_Transplant();
-		var b_ = AHAOverall_2_6_000.Has_Heart_Transplant_Complications();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = AHAOverall_2_6_000.Has_Left_Ventricular_Assist_Device();
-		var e_ = context.Operators.Or(c_, d_);
-		var f_ = AHAOverall_2_6_000.Has_Left_Ventricular_Assist_Device_Complications();
-		var g_ = context.Operators.Or(e_, f_);
+		bool? a_ = AHAOverall_2_6_000.Has_Heart_Transplant();
+		bool? b_ = AHAOverall_2_6_000.Has_Heart_Transplant_Complications();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = AHAOverall_2_6_000.Has_Left_Ventricular_Assist_Device();
+		bool? e_ = context.Operators.Or(c_, d_);
+		bool? f_ = AHAOverall_2_6_000.Has_Left_Ventricular_Assist_Device_Complications();
+		bool? g_ = context.Operators.Or(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Has_Beta_Blocker_Therapy_for_LVSD_Ordered"/>
 	private bool? Has_Beta_Blocker_Therapy_for_LVSD_Ordered_Value()
 	{
-		var a_ = this.Beta_Blocker_Therapy_for_LVSD();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest BetaBlockerOrdered)
 		{
-			var i_ = AHAOverall_2_6_000.isOrderedDuringHeartFailureOutpatientEncounter(BetaBlockerOrdered);
-			var j_ = BetaBlockerOrdered?.StatusElement;
-			var k_ = j_?.Value;
-			var l_ = context.Operators.Convert<string>(k_);
-			var m_ = new string[]
+			bool? i_ = AHAOverall_2_6_000.isOrderedDuringHeartFailureOutpatientEncounter(BetaBlockerOrdered);
+			Code<MedicationRequest.MedicationrequestStatus> j_ = BetaBlockerOrdered?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? k_ = j_?.Value;
+			string l_ = context.Operators.Convert<string>(k_);
+			string[] m_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var n_ = context.Operators.In<string>(l_, (m_ as IEnumerable<string>));
-			var o_ = context.Operators.And(i_, n_);
-			var p_ = BetaBlockerOrdered?.IntentElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<string>(q_);
-			var s_ = new string[]
+			bool? n_ = context.Operators.In<string>(l_, (m_ as IEnumerable<string>));
+			bool? o_ = context.Operators.And(i_, n_);
+			Code<MedicationRequest.MedicationRequestIntent> p_ = BetaBlockerOrdered?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? q_ = p_?.Value;
+			string r_ = context.Operators.Convert<string>(q_);
+			string[] s_ = new string[]
 			{
 				"order",
 				"original-order",
@@ -368,64 +413,70 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 				"filler-order",
 				"instance-order",
 			};
-			var t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
-			var u_ = context.Operators.And(o_, t_);
+			bool? t_ = context.Operators.In<string>(r_, (s_ as IEnumerable<string>));
+			bool? u_ = context.Operators.And(o_, t_);
 
 			return u_;
 		};
-		var g_ = context.Operators.Where<MedicationRequest>(e_, f_);
-		var h_ = context.Operators.Exists<MedicationRequest>(g_);
+		IEnumerable<MedicationRequest> g_ = context.Operators.Where<MedicationRequest>(e_, f_);
+		bool? h_ = context.Operators.Exists<MedicationRequest>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Has_Beta_Blocker_Therapy_for_LVSD_Ordered_Value"/>
     [CqlDeclaration("Has Beta Blocker Therapy for LVSD Ordered")]
 	public bool? Has_Beta_Blocker_Therapy_for_LVSD_Ordered() => 
 		__Has_Beta_Blocker_Therapy_for_LVSD_Ordered.Value;
 
+    /// <seealso cref="Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD"/>
 	private bool? Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD_Value()
 	{
-		var a_ = this.Beta_Blocker_Therapy_for_LVSD();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest ActiveBetaBlocker)
 		{
-			var i_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((ActiveBetaBlocker as object));
+			bool? i_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((ActiveBetaBlocker as object));
 
 			return i_;
 		};
-		var g_ = context.Operators.Where<MedicationRequest>(e_, f_);
-		var h_ = context.Operators.Exists<MedicationRequest>(g_);
+		IEnumerable<MedicationRequest> g_ = context.Operators.Where<MedicationRequest>(e_, f_);
+		bool? h_ = context.Operators.Exists<MedicationRequest>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD_Value"/>
     [CqlDeclaration("Is Currently Taking Beta Blocker Therapy for LVSD")]
 	public bool? Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD() => 
 		__Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Has_Beta_Blocker_Therapy_for_LVSD_Ordered();
-		var b_ = this.Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD();
-		var c_ = context.Operators.Or(a_, b_);
+		bool? a_ = this.Has_Beta_Blocker_Therapy_for_LVSD_Ordered();
+		bool? b_ = this.Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD();
+		bool? c_ = context.Operators.Or(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Has_Consecutive_Heart_Rates_Less_than_50"/>
 	private bool? Has_Consecutive_Heart_Rates_Less_than_50_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
-		var b_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
-		var c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Encounter> b_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+		IEnumerable<ValueTuple<Observation, Encounter>> c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
 		Tuple_FUFPMQdRaTBgLhghDWfUUBaNF d_(ValueTuple<Observation, Encounter> _valueTuple)
 		{
-			var k_ = new Tuple_FUFPMQdRaTBgLhghDWfUUBaNF
+			Tuple_FUFPMQdRaTBgLhghDWfUUBaNF k_ = new Tuple_FUFPMQdRaTBgLhghDWfUUBaNF
 			{
 				HeartRate = _valueTuple.Item1,
 				ModerateOrSevereLVSDHFOutpatientEncounter = _valueTuple.Item2,
@@ -433,511 +484,544 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
 			return k_;
 		};
-		var e_ = context.Operators.Select<ValueTuple<Observation, Encounter>, Tuple_FUFPMQdRaTBgLhghDWfUUBaNF>(c_, d_);
+		IEnumerable<Tuple_FUFPMQdRaTBgLhghDWfUUBaNF> e_ = context.Operators.Select<ValueTuple<Observation, Encounter>, Tuple_FUFPMQdRaTBgLhghDWfUUBaNF>(c_, d_);
 		bool? f_(Tuple_FUFPMQdRaTBgLhghDWfUUBaNF tuple_fufpmqdratbglhghdwfuubanf)
 		{
-			var l_ = tuple_fufpmqdratbglhghdwfuubanf.ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = tuple_fufpmqdratbglhghdwfuubanf.HeartRate?.Effective;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = QICoreCommon_2_0_000.toInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
-			var r_ = tuple_fufpmqdratbglhghdwfuubanf.HeartRate?.StatusElement;
-			var s_ = r_?.Value;
-			var t_ = context.Operators.Convert<string>(s_);
-			var u_ = new string[]
+			Period l_ = tuple_fufpmqdratbglhghdwfuubanf.ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			DataType n_ = tuple_fufpmqdratbglhghdwfuubanf.HeartRate?.Effective;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
+			Code<ObservationStatus> r_ = tuple_fufpmqdratbglhghdwfuubanf.HeartRate?.StatusElement;
+			ObservationStatus? s_ = r_?.Value;
+			string t_ = context.Operators.Convert<string>(s_);
+			string[] u_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var v_ = context.Operators.In<string>(t_, (u_ as IEnumerable<string>));
-			var w_ = context.Operators.And(q_, v_);
-			var x_ = tuple_fufpmqdratbglhghdwfuubanf.HeartRate?.Value;
-			var y_ = context.Operators.Convert<Quantity>(x_);
-			var z_ = FHIRHelpers_4_3_000.ToQuantity(y_);
-			var aa_ = context.Operators.Quantity(50m, "/min");
-			var ab_ = context.Operators.Less(z_, aa_);
-			var ac_ = context.Operators.And(w_, ab_);
-			var ad_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			bool? v_ = context.Operators.In<string>(t_, (u_ as IEnumerable<string>));
+			bool? w_ = context.Operators.And(q_, v_);
+			DataType x_ = tuple_fufpmqdratbglhghdwfuubanf.HeartRate?.Value;
+			Quantity y_ = context.Operators.Convert<Quantity>(x_);
+			CqlQuantity z_ = FHIRHelpers_4_3_000.ToQuantity(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(50m, "/min");
+			bool? ab_ = context.Operators.Less(z_, aa_);
+			bool? ac_ = context.Operators.And(w_, ab_);
+			IEnumerable<Observation> ad_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? ae_(Observation MostRecentPriorHeartRate)
 			{
-				var ap_ = tuple_fufpmqdratbglhghdwfuubanf.ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-				var aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				var ar_ = MostRecentPriorHeartRate?.Effective;
-				var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
-				var at_ = QICoreCommon_2_0_000.toInterval(as_);
-				var au_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aq_, at_, null);
-				var aw_ = FHIRHelpers_4_3_000.ToValue(ar_);
-				var ax_ = QICoreCommon_2_0_000.toInterval(aw_);
-				var ay_ = tuple_fufpmqdratbglhghdwfuubanf.HeartRate?.Effective;
-				var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-				var ba_ = QICoreCommon_2_0_000.toInterval(az_);
-				var bb_ = context.Operators.Before(ax_, ba_, null);
-				var bc_ = context.Operators.And(au_, bb_);
+				Period ap_ = tuple_fufpmqdratbglhghdwfuubanf.ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
+				DataType ar_ = MostRecentPriorHeartRate?.Effective;
+				object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+				CqlInterval<CqlDateTime> at_ = QICoreCommon_2_0_000.toInterval(as_);
+				bool? au_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aq_, at_, null);
+				object aw_ = FHIRHelpers_4_3_000.ToValue(ar_);
+				CqlInterval<CqlDateTime> ax_ = QICoreCommon_2_0_000.toInterval(aw_);
+				DataType ay_ = tuple_fufpmqdratbglhghdwfuubanf.HeartRate?.Effective;
+				object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+				CqlInterval<CqlDateTime> ba_ = QICoreCommon_2_0_000.toInterval(az_);
+				bool? bb_ = context.Operators.Before(ax_, ba_, null);
+				bool? bc_ = context.Operators.And(au_, bb_);
 
 				return bc_;
 			};
-			var af_ = context.Operators.Where<Observation>(ad_, ae_);
+			IEnumerable<Observation> af_ = context.Operators.Where<Observation>(ad_, ae_);
 			object ag_(Observation @this)
 			{
-				var bd_ = @this?.Effective;
-				var be_ = FHIRHelpers_4_3_000.ToValue(bd_);
-				var bf_ = QICoreCommon_2_0_000.toInterval(be_);
-				var bg_ = context.Operators.Start(bf_);
+				DataType bd_ = @this?.Effective;
+				object be_ = FHIRHelpers_4_3_000.ToValue(bd_);
+				CqlInterval<CqlDateTime> bf_ = QICoreCommon_2_0_000.toInterval(be_);
+				CqlDateTime bg_ = context.Operators.Start(bf_);
 
 				return bg_;
 			};
-			var ah_ = context.Operators.SortBy<Observation>(af_, ag_, System.ComponentModel.ListSortDirection.Ascending);
-			var ai_ = context.Operators.Last<Observation>(ah_);
-			var aj_ = ai_?.Value;
-			var ak_ = context.Operators.Convert<Quantity>(aj_);
-			var al_ = FHIRHelpers_4_3_000.ToQuantity(ak_);
-			var an_ = context.Operators.Less(al_, aa_);
-			var ao_ = context.Operators.And(ac_, an_);
+			IEnumerable<Observation> ah_ = context.Operators.SortBy<Observation>(af_, ag_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation ai_ = context.Operators.Last<Observation>(ah_);
+			DataType aj_ = ai_?.Value;
+			Quantity ak_ = context.Operators.Convert<Quantity>(aj_);
+			CqlQuantity al_ = FHIRHelpers_4_3_000.ToQuantity(ak_);
+			bool? an_ = context.Operators.Less(al_, aa_);
+			bool? ao_ = context.Operators.And(ac_, an_);
 
 			return ao_;
 		};
-		var g_ = context.Operators.Where<Tuple_FUFPMQdRaTBgLhghDWfUUBaNF>(e_, f_);
+		IEnumerable<Tuple_FUFPMQdRaTBgLhghDWfUUBaNF> g_ = context.Operators.Where<Tuple_FUFPMQdRaTBgLhghDWfUUBaNF>(e_, f_);
 		Observation h_(Tuple_FUFPMQdRaTBgLhghDWfUUBaNF tuple_fufpmqdratbglhghdwfuubanf) => 
 			tuple_fufpmqdratbglhghdwfuubanf.HeartRate;
-		var i_ = context.Operators.Select<Tuple_FUFPMQdRaTBgLhghDWfUUBaNF, Observation>(g_, h_);
-		var j_ = context.Operators.Exists<Observation>(i_);
+		IEnumerable<Observation> i_ = context.Operators.Select<Tuple_FUFPMQdRaTBgLhghDWfUUBaNF, Observation>(g_, h_);
+		bool? j_ = context.Operators.Exists<Observation>(i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Has_Consecutive_Heart_Rates_Less_than_50_Value"/>
     [CqlDeclaration("Has Consecutive Heart Rates Less than 50")]
 	public bool? Has_Consecutive_Heart_Rates_Less_than_50() => 
 		__Has_Consecutive_Heart_Rates_Less_than_50.Value;
 
+    /// <seealso cref="Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD"/>
 	private bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<MedicationRequest>(null, null);
+		IEnumerable<MedicationRequest> a_ = context.Operators.RetrieveByValueSet<MedicationRequest>(null, null);
 		IEnumerable<MedicationRequest> b_(MedicationRequest NoBetaBlockerOrdered)
 		{
-			var g_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+			IEnumerable<Encounter> g_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 			bool? h_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
 			{
-				var l_ = NoBetaBlockerOrdered?.AuthoredOnElement;
-				var m_ = context.Operators.Convert<CqlDateTime>(l_);
-				var n_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-				var o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var p_ = context.Operators.In<CqlDateTime>(m_, o_, null);
+				FhirDateTime l_ = NoBetaBlockerOrdered?.AuthoredOnElement;
+				CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
+				Period n_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, null);
 
 				return p_;
 			};
-			var i_ = context.Operators.Where<Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
 			MedicationRequest j_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => 
 				NoBetaBlockerOrdered;
-			var k_ = context.Operators.Select<Encounter, MedicationRequest>(i_, j_);
+			IEnumerable<MedicationRequest> k_ = context.Operators.Select<Encounter, MedicationRequest>(i_, j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(a_, b_);
+		IEnumerable<MedicationRequest> c_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(a_, b_);
 		bool? d_(MedicationRequest NoBetaBlockerOrdered)
 		{
-			var q_ = NoBetaBlockerOrdered?.Medication;
-			var r_ = context.Operators.Convert<CodeableConcept>(q_);
-			var s_ = FHIRHelpers_4_3_000.ToConcept(r_);
-			var t_ = this.Beta_Blocker_Therapy_for_LVSD();
-			var u_ = context.Operators.ConceptInValueSet(s_, t_);
-			var v_ = NoBetaBlockerOrdered?.ReasonCode;
+			DataType q_ = NoBetaBlockerOrdered?.Medication;
+			CodeableConcept r_ = context.Operators.Convert<CodeableConcept>(q_);
+			CqlConcept s_ = FHIRHelpers_4_3_000.ToConcept(r_);
+			CqlValueSet t_ = this.Beta_Blocker_Therapy_for_LVSD();
+			bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+			List<CodeableConcept> v_ = NoBetaBlockerOrdered?.ReasonCode;
 			CqlConcept w_(CodeableConcept @this)
 			{
-				var ah_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept ah_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return ah_;
 			};
-			var x_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)v_, w_);
-			var y_ = this.Medical_Reason();
-			var z_ = context.Operators.ConceptsInValueSet(x_, y_);
+			IEnumerable<CqlConcept> x_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)v_, w_);
+			CqlValueSet y_ = this.Medical_Reason();
+			bool? z_ = context.Operators.ConceptsInValueSet(x_, y_);
 			CqlConcept ab_(CodeableConcept @this)
 			{
-				var ai_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept ai_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return ai_;
 			};
-			var ac_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)v_, ab_);
-			var ad_ = this.Patient_Reason();
-			var ae_ = context.Operators.ConceptsInValueSet(ac_, ad_);
-			var af_ = context.Operators.Or(z_, ae_);
-			var ag_ = context.Operators.And(u_, af_);
+			IEnumerable<CqlConcept> ac_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)v_, ab_);
+			CqlValueSet ad_ = this.Patient_Reason();
+			bool? ae_ = context.Operators.ConceptsInValueSet(ac_, ad_);
+			bool? af_ = context.Operators.Or(z_, ae_);
+			bool? ag_ = context.Operators.And(u_, af_);
 
 			return ag_;
 		};
-		var e_ = context.Operators.Where<MedicationRequest>(c_, d_);
-		var f_ = context.Operators.Exists<MedicationRequest>(e_);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Where<MedicationRequest>(c_, d_);
+		bool? f_ = context.Operators.Exists<MedicationRequest>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD_Value"/>
     [CqlDeclaration("Has Medical or Patient Reason for Not Ordering Beta Blocker for LVSD")]
 	public bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD() => 
 		__Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD.Value;
 
+    /// <seealso cref="Has_Arrhythmia_Diagnosis"/>
 	private bool? Has_Arrhythmia_Diagnosis_Value()
 	{
-		var a_ = this.Arrhythmia();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Arrhythmia();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition Arrhythmia)
 		{
-			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Arrhythmia);
-			var g_ = QICoreCommon_2_0_000.isActive(Arrhythmia);
-			var h_ = context.Operators.And(f_, g_);
-			var i_ = Arrhythmia?.VerificationStatus;
-			var j_ = FHIRHelpers_4_3_000.ToConcept(i_);
-			var k_ = QICoreCommon_2_0_000.confirmed();
-			var l_ = context.Operators.ConvertCodeToConcept(k_);
-			var m_ = context.Operators.Equivalent(j_, l_);
-			var n_ = context.Operators.And(h_, m_);
+			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Arrhythmia);
+			bool? g_ = QICoreCommon_2_0_000.isActive(Arrhythmia);
+			bool? h_ = context.Operators.And(f_, g_);
+			CodeableConcept i_ = Arrhythmia?.VerificationStatus;
+			CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
+			CqlCode k_ = QICoreCommon_2_0_000.confirmed();
+			CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+			bool? m_ = context.Operators.Equivalent(j_, l_);
+			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Arrhythmia_Diagnosis_Value"/>
     [CqlDeclaration("Has Arrhythmia Diagnosis")]
 	public bool? Has_Arrhythmia_Diagnosis() => 
 		__Has_Arrhythmia_Diagnosis.Value;
 
+    /// <seealso cref="Has_Hypotension_Diagnosis"/>
 	private bool? Has_Hypotension_Diagnosis_Value()
 	{
-		var a_ = this.Hypotension();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Hypotension();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition Hypotension)
 		{
-			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Hypotension);
-			var g_ = QICoreCommon_2_0_000.isActive(Hypotension);
-			var h_ = context.Operators.And(f_, g_);
-			var i_ = Hypotension?.VerificationStatus;
-			var j_ = FHIRHelpers_4_3_000.ToConcept(i_);
-			var k_ = QICoreCommon_2_0_000.confirmed();
-			var l_ = context.Operators.ConvertCodeToConcept(k_);
-			var m_ = context.Operators.Equivalent(j_, l_);
-			var n_ = context.Operators.And(h_, m_);
+			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Hypotension);
+			bool? g_ = QICoreCommon_2_0_000.isActive(Hypotension);
+			bool? h_ = context.Operators.And(f_, g_);
+			CodeableConcept i_ = Hypotension?.VerificationStatus;
+			CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
+			CqlCode k_ = QICoreCommon_2_0_000.confirmed();
+			CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+			bool? m_ = context.Operators.Equivalent(j_, l_);
+			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Hypotension_Diagnosis_Value"/>
     [CqlDeclaration("Has Hypotension Diagnosis")]
 	public bool? Has_Hypotension_Diagnosis() => 
 		__Has_Hypotension_Diagnosis.Value;
 
+    /// <seealso cref="Has_Asthma_Diagnosis"/>
 	private bool? Has_Asthma_Diagnosis_Value()
 	{
-		var a_ = this.Asthma();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Asthma();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition Asthma)
 		{
-			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Asthma);
-			var g_ = QICoreCommon_2_0_000.isActive(Asthma);
-			var h_ = context.Operators.And(f_, g_);
-			var i_ = Asthma?.VerificationStatus;
-			var j_ = FHIRHelpers_4_3_000.ToConcept(i_);
-			var k_ = QICoreCommon_2_0_000.confirmed();
-			var l_ = context.Operators.ConvertCodeToConcept(k_);
-			var m_ = context.Operators.Equivalent(j_, l_);
-			var n_ = context.Operators.And(h_, m_);
+			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Asthma);
+			bool? g_ = QICoreCommon_2_0_000.isActive(Asthma);
+			bool? h_ = context.Operators.And(f_, g_);
+			CodeableConcept i_ = Asthma?.VerificationStatus;
+			CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
+			CqlCode k_ = QICoreCommon_2_0_000.confirmed();
+			CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+			bool? m_ = context.Operators.Equivalent(j_, l_);
+			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Asthma_Diagnosis_Value"/>
     [CqlDeclaration("Has Asthma Diagnosis")]
 	public bool? Has_Asthma_Diagnosis() => 
 		__Has_Asthma_Diagnosis.Value;
 
+    /// <seealso cref="Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy"/>
 	private bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Value()
 	{
-		var a_ = this.Allergy_to_Beta_Blocker_Therapy();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Intolerance_to_Beta_Blocker_Therapy();
-		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
-		var e_ = context.Operators.Union<Condition>(b_, d_);
+		CqlValueSet a_ = this.Allergy_to_Beta_Blocker_Therapy();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet c_ = this.Intolerance_to_Beta_Blocker_Therapy();
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		bool? f_(Condition BetaBlockerAllergyOrIntoleranceDiagnosis)
 		{
-			var i_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((BetaBlockerAllergyOrIntoleranceDiagnosis as object));
-			var j_ = QICoreCommon_2_0_000.isActive(BetaBlockerAllergyOrIntoleranceDiagnosis);
-			var k_ = context.Operators.And(i_, j_);
-			var l_ = BetaBlockerAllergyOrIntoleranceDiagnosis?.VerificationStatus;
-			var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-			var n_ = QICoreCommon_2_0_000.confirmed();
-			var o_ = context.Operators.ConvertCodeToConcept(n_);
-			var p_ = context.Operators.Equivalent(m_, o_);
-			var q_ = context.Operators.And(k_, p_);
+			bool? i_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((BetaBlockerAllergyOrIntoleranceDiagnosis as object));
+			bool? j_ = QICoreCommon_2_0_000.isActive(BetaBlockerAllergyOrIntoleranceDiagnosis);
+			bool? k_ = context.Operators.And(i_, j_);
+			CodeableConcept l_ = BetaBlockerAllergyOrIntoleranceDiagnosis?.VerificationStatus;
+			CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+			CqlCode n_ = QICoreCommon_2_0_000.confirmed();
+			CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+			bool? p_ = context.Operators.Equivalent(m_, o_);
+			bool? q_ = context.Operators.And(k_, p_);
 
 			return q_;
 		};
-		var g_ = context.Operators.Where<Condition>(e_, f_);
-		var h_ = context.Operators.Exists<Condition>(g_);
+		IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+		bool? h_ = context.Operators.Exists<Condition>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Value"/>
     [CqlDeclaration("Has Diagnosis of Allergy or Intolerance to Beta Blocker Therapy")]
 	public bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy() => 
 		__Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy.Value;
 
+    /// <seealso cref="Has_Bradycardia_Diagnosis"/>
 	private bool? Has_Bradycardia_Diagnosis_Value()
 	{
-		var a_ = this.Bradycardia();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Bradycardia();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition Bradycardia)
 		{
-			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Bradycardia);
-			var g_ = QICoreCommon_2_0_000.isActive(Bradycardia);
-			var h_ = context.Operators.And(f_, g_);
-			var i_ = Bradycardia?.VerificationStatus;
-			var j_ = FHIRHelpers_4_3_000.ToConcept(i_);
-			var k_ = QICoreCommon_2_0_000.confirmed();
-			var l_ = context.Operators.ConvertCodeToConcept(k_);
-			var m_ = context.Operators.Equivalent(j_, l_);
-			var n_ = context.Operators.And(h_, m_);
+			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Bradycardia);
+			bool? g_ = QICoreCommon_2_0_000.isActive(Bradycardia);
+			bool? h_ = context.Operators.And(f_, g_);
+			CodeableConcept i_ = Bradycardia?.VerificationStatus;
+			CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
+			CqlCode k_ = QICoreCommon_2_0_000.confirmed();
+			CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+			bool? m_ = context.Operators.Equivalent(j_, l_);
+			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Bradycardia_Diagnosis_Value"/>
     [CqlDeclaration("Has Bradycardia Diagnosis")]
 	public bool? Has_Bradycardia_Diagnosis() => 
 		__Has_Bradycardia_Diagnosis.Value;
 
+    /// <seealso cref="Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient"/>
 	private bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_Value()
 	{
-		var a_ = this.Beta_Blocker_Therapy_Ingredient();
-		var b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, null);
-		var c_ = this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_();
-		var d_ = context.Operators.ToList<CqlCode>(c_);
-		var e_ = context.Operators.RetrieveByCodes<AllergyIntolerance>(d_, null);
-		var f_ = context.Operators.Union<AllergyIntolerance>(b_, e_);
+		CqlValueSet a_ = this.Beta_Blocker_Therapy_Ingredient();
+		IEnumerable<AllergyIntolerance> b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, null);
+		CqlCode c_ = this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_();
+		IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
+		IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByCodes<AllergyIntolerance>(d_, null);
+		IEnumerable<AllergyIntolerance> f_ = context.Operators.Union<AllergyIntolerance>(b_, e_);
 		bool? g_(AllergyIntolerance BetaBlockerAllergyIntolerance)
 		{
-			var j_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((BetaBlockerAllergyIntolerance as object));
-			var k_ = BetaBlockerAllergyIntolerance?.ClinicalStatus;
-			var l_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var n_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var o_ = QICoreCommon_2_0_000.allergy_active();
-			var p_ = context.Operators.ConvertCodeToConcept(o_);
-			var q_ = context.Operators.Equivalent(n_, p_);
-			var r_ = context.Operators.Or((bool?)(l_ is null), q_);
-			var s_ = context.Operators.And(j_, r_);
+			bool? j_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((BetaBlockerAllergyIntolerance as object));
+			CodeableConcept k_ = BetaBlockerAllergyIntolerance?.ClinicalStatus;
+			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlConcept n_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode o_ = QICoreCommon_2_0_000.allergy_active();
+			CqlConcept p_ = context.Operators.ConvertCodeToConcept(o_);
+			bool? q_ = context.Operators.Equivalent(n_, p_);
+			bool? r_ = context.Operators.Or((bool?)(l_ is null), q_);
+			bool? s_ = context.Operators.And(j_, r_);
 
 			return s_;
 		};
-		var h_ = context.Operators.Where<AllergyIntolerance>(f_, g_);
-		var i_ = context.Operators.Exists<AllergyIntolerance>(h_);
+		IEnumerable<AllergyIntolerance> h_ = context.Operators.Where<AllergyIntolerance>(f_, g_);
+		bool? i_ = context.Operators.Exists<AllergyIntolerance>(h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_Value"/>
     [CqlDeclaration("Has Allergy or Intolerance to Beta Blocker Therapy Ingredient")]
 	public bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient() => 
 		__Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient.Value;
 
+    /// <seealso cref="Has_Atrioventricular_Block_Diagnosis"/>
 	private bool? Has_Atrioventricular_Block_Diagnosis_Value()
 	{
-		var a_ = this.Atrioventricular_Block();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Atrioventricular_Block();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition AtrioventricularBlock)
 		{
-			var f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(AtrioventricularBlock);
-			var g_ = QICoreCommon_2_0_000.isActive(AtrioventricularBlock);
-			var h_ = context.Operators.And(f_, g_);
-			var i_ = AtrioventricularBlock?.VerificationStatus;
-			var j_ = FHIRHelpers_4_3_000.ToConcept(i_);
-			var k_ = QICoreCommon_2_0_000.confirmed();
-			var l_ = context.Operators.ConvertCodeToConcept(k_);
-			var m_ = context.Operators.Equivalent(j_, l_);
-			var n_ = context.Operators.And(h_, m_);
+			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(AtrioventricularBlock);
+			bool? g_ = QICoreCommon_2_0_000.isActive(AtrioventricularBlock);
+			bool? h_ = context.Operators.And(f_, g_);
+			CodeableConcept i_ = AtrioventricularBlock?.VerificationStatus;
+			CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
+			CqlCode k_ = QICoreCommon_2_0_000.confirmed();
+			CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+			bool? m_ = context.Operators.Equivalent(j_, l_);
+			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Atrioventricular_Block_Diagnosis_Value"/>
     [CqlDeclaration("Has Atrioventricular Block Diagnosis")]
 	public bool? Has_Atrioventricular_Block_Diagnosis() => 
 		__Has_Atrioventricular_Block_Diagnosis.Value;
 
+    /// <seealso cref="Has_Diagnosis_of_Cardiac_Pacer_in_Situ"/>
 	private bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ_Value()
 	{
-		var a_ = this.Cardiac_Pacer_in_Situ();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Cardiac_Pacer_in_Situ();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition CardiacPacerDiagnosis)
 		{
-			var f_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((CardiacPacerDiagnosis as object));
-			var g_ = QICoreCommon_2_0_000.isActive(CardiacPacerDiagnosis);
-			var h_ = context.Operators.And(f_, g_);
-			var i_ = CardiacPacerDiagnosis?.VerificationStatus;
-			var j_ = FHIRHelpers_4_3_000.ToConcept(i_);
-			var k_ = QICoreCommon_2_0_000.confirmed();
-			var l_ = context.Operators.ConvertCodeToConcept(k_);
-			var m_ = context.Operators.Equivalent(j_, l_);
-			var n_ = context.Operators.And(h_, m_);
+			bool? f_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((CardiacPacerDiagnosis as object));
+			bool? g_ = QICoreCommon_2_0_000.isActive(CardiacPacerDiagnosis);
+			bool? h_ = context.Operators.And(f_, g_);
+			CodeableConcept i_ = CardiacPacerDiagnosis?.VerificationStatus;
+			CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
+			CqlCode k_ = QICoreCommon_2_0_000.confirmed();
+			CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+			bool? m_ = context.Operators.Equivalent(j_, l_);
+			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Diagnosis_of_Cardiac_Pacer_in_Situ_Value"/>
     [CqlDeclaration("Has Diagnosis of Cardiac Pacer in Situ")]
 	public bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ() => 
 		__Has_Diagnosis_of_Cardiac_Pacer_in_Situ.Value;
 
+    /// <seealso cref="Has_Cardiac_Pacer_Device_Implanted"/>
 	private bool? Has_Cardiac_Pacer_Device_Implanted_Value()
 	{
-		var a_ = this.Cardiac_Pacer();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		CqlValueSet a_ = this.Cardiac_Pacer();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer)
 		{
-			var h_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
+			IEnumerable<Encounter> h_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 			bool? i_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter)
 			{
-				var m_ = ImplantedCardiacPacer?.Performed;
-				var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var o_ = QICoreCommon_2_0_000.toInterval(n_);
-				var p_ = context.Operators.Start(o_);
-				var q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
-				var r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				var s_ = context.Operators.End(r_);
-				var t_ = context.Operators.Before(p_, s_, null);
+				DataType m_ = ImplantedCardiacPacer?.Performed;
+				object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				Period q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
+				CqlDateTime s_ = context.Operators.End(r_);
+				bool? t_ = context.Operators.Before(p_, s_, null);
 
 				return t_;
 			};
-			var j_ = context.Operators.Where<Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
 			Procedure k_(Encounter ModerateOrSevereLVSDHFOutpatientEncounter) => 
 				ImplantedCardiacPacer;
-			var l_ = context.Operators.Select<Encounter, Procedure>(j_, k_);
+			IEnumerable<Procedure> l_ = context.Operators.Select<Encounter, Procedure>(j_, k_);
 
 			return l_;
 		};
-		var d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+		IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
 		bool? e_(Procedure ImplantedCardiacPacer)
 		{
-			var u_ = ImplantedCardiacPacer?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<string>(v_);
-			var x_ = context.Operators.Equal(w_, "completed");
+			Code<EventStatus> u_ = ImplantedCardiacPacer?.StatusElement;
+			EventStatus? v_ = u_?.Value;
+			string w_ = context.Operators.Convert<string>(v_);
+			bool? x_ = context.Operators.Equal(w_, "completed");
 
 			return x_;
 		};
-		var f_ = context.Operators.Where<Procedure>(d_, e_);
-		var g_ = context.Operators.Exists<Procedure>(f_);
+		IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);
+		bool? g_ = context.Operators.Exists<Procedure>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Has_Cardiac_Pacer_Device_Implanted_Value"/>
     [CqlDeclaration("Has Cardiac Pacer Device Implanted")]
 	public bool? Has_Cardiac_Pacer_Device_Implanted() => 
 		__Has_Cardiac_Pacer_Device_Implanted.Value;
 
+    /// <seealso cref="Atrioventricular_Block_without_Cardiac_Pacer"/>
 	private bool? Atrioventricular_Block_without_Cardiac_Pacer_Value()
 	{
-		var a_ = this.Has_Atrioventricular_Block_Diagnosis();
-		var b_ = this.Has_Diagnosis_of_Cardiac_Pacer_in_Situ();
-		var c_ = context.Operators.Not(b_);
-		var d_ = context.Operators.And(a_, c_);
-		var e_ = this.Has_Cardiac_Pacer_Device_Implanted();
-		var f_ = context.Operators.Not(e_);
-		var g_ = context.Operators.And(d_, f_);
+		bool? a_ = this.Has_Atrioventricular_Block_Diagnosis();
+		bool? b_ = this.Has_Diagnosis_of_Cardiac_Pacer_in_Situ();
+		bool? c_ = context.Operators.Not(b_);
+		bool? d_ = context.Operators.And(a_, c_);
+		bool? e_ = this.Has_Cardiac_Pacer_Device_Implanted();
+		bool? f_ = context.Operators.Not(e_);
+		bool? g_ = context.Operators.And(d_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Atrioventricular_Block_without_Cardiac_Pacer_Value"/>
     [CqlDeclaration("Atrioventricular Block without Cardiac Pacer")]
 	public bool? Atrioventricular_Block_without_Cardiac_Pacer() => 
 		__Atrioventricular_Block_without_Cardiac_Pacer.Value;
 
+    /// <seealso cref="Denominator_Exceptions"/>
 	private bool? Denominator_Exceptions_Value()
 	{
-		var a_ = this.Has_Consecutive_Heart_Rates_Less_than_50();
-		var b_ = this.Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_Arrhythmia_Diagnosis();
-		var e_ = context.Operators.Or(c_, d_);
-		var f_ = this.Has_Hypotension_Diagnosis();
-		var g_ = context.Operators.Or(e_, f_);
-		var h_ = this.Has_Asthma_Diagnosis();
-		var i_ = context.Operators.Or(g_, h_);
-		var j_ = this.Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy();
-		var k_ = context.Operators.Or(i_, j_);
-		var l_ = this.Has_Bradycardia_Diagnosis();
-		var m_ = context.Operators.Or(k_, l_);
-		var n_ = this.Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient();
-		var o_ = context.Operators.Or(m_, n_);
-		var p_ = this.Atrioventricular_Block_without_Cardiac_Pacer();
-		var q_ = context.Operators.Or(o_, p_);
+		bool? a_ = this.Has_Consecutive_Heart_Rates_Less_than_50();
+		bool? b_ = this.Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = this.Has_Arrhythmia_Diagnosis();
+		bool? e_ = context.Operators.Or(c_, d_);
+		bool? f_ = this.Has_Hypotension_Diagnosis();
+		bool? g_ = context.Operators.Or(e_, f_);
+		bool? h_ = this.Has_Asthma_Diagnosis();
+		bool? i_ = context.Operators.Or(g_, h_);
+		bool? j_ = this.Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy();
+		bool? k_ = context.Operators.Or(i_, j_);
+		bool? l_ = this.Has_Bradycardia_Diagnosis();
+		bool? m_ = context.Operators.Or(k_, l_);
+		bool? n_ = this.Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient();
+		bool? o_ = context.Operators.Or(m_, n_);
+		bool? p_ = this.Atrioventricular_Block_without_Cardiac_Pacer();
+		bool? q_ = context.Operators.Or(o_, p_);
 
 		return q_;
 	}
 
+    /// <seealso cref="Denominator_Exceptions_Value"/>
     [CqlDeclaration("Denominator Exceptions")]
 	public bool? Denominator_Exceptions() => 
 		__Denominator_Exceptions.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
@@ -102,173 +102,208 @@ public class HIVRetentionFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Annual_Wellness_Visit"/>
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
+    /// <seealso cref="Annual_Wellness_Visit_Value"/>
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
 	public CqlValueSet Annual_Wellness_Visit() => 
 		__Annual_Wellness_Visit.Value;
 
+    /// <seealso cref="Face_to_Face_Interaction"/>
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
 
+    /// <seealso cref="Face_to_Face_Interaction_Value"/>
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
 	public CqlValueSet Face_to_Face_Interaction() => 
 		__Face_to_Face_Interaction.Value;
 
+    /// <seealso cref="HIV"/>
 	private CqlValueSet HIV_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
 
+    /// <seealso cref="HIV_Value"/>
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
 	public CqlValueSet HIV() => 
 		__HIV.Value;
 
+    /// <seealso cref="HIV_Viral_Load"/>
 	private CqlValueSet HIV_Viral_Load_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", null);
 
+    /// <seealso cref="HIV_Viral_Load_Value"/>
     [CqlDeclaration("HIV Viral Load")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002")]
 	public CqlValueSet HIV_Viral_Load() => 
 		__HIV_Viral_Load.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
 	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
 	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Other"/>
 	private CqlValueSet Preventive_Care_Services_Other_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150", null);
 
+    /// <seealso cref="Preventive_Care_Services_Other_Value"/>
     [CqlDeclaration("Preventive Care Services Other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150")]
 	public CqlValueSet Preventive_Care_Services_Other() => 
 		__Preventive_Care_Services_Other.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("HIVRetentionFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("HIVRetentionFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
 		List<Extension> a_()
 		{
 			bool i_()
 			{
-				var j_ = this.Patient();
-				var k_ = j_ is DomainResource;
+				Patient j_ = this.Patient();
+				bool k_ = j_ is DomainResource;
 
 				return k_;
 			};
 			if (i_())
 			{
-				var l_ = this.Patient();
+				Patient l_ = this.Patient();
 
 				return (l_ as DomainResource).Extension;
 			}
@@ -279,16 +314,16 @@ public class HIVRetentionFHIR_0_1_000
 		};
 		bool? b_(Extension @this)
 		{
-			var m_ = @this?.Url;
-			var n_ = context.Operators.Convert<FhirUri>(m_);
-			var o_ = FHIRHelpers_4_3_000.ToString(n_);
-			var p_ = context.Operators.Equal(o_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
+			string m_ = @this?.Url;
+			FhirUri n_ = context.Operators.Convert<FhirUri>(m_);
+			string o_ = FHIRHelpers_4_3_000.ToString(n_);
+			bool? p_ = context.Operators.Equal(o_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
 
 			return p_;
 		};
-		var c_ = context.Operators.Where<Extension>((IEnumerable<Extension>)a_(), b_);
-		var d_ = context.Operators.SingletonFrom<Extension>(c_);
-		var e_ = new Extension[]
+		IEnumerable<Extension> c_ = context.Operators.Where<Extension>((IEnumerable<Extension>)a_(), b_);
+		Extension d_ = context.Operators.SingletonFrom<Extension>(c_);
+		Extension[] e_ = new Extension[]
 		{
 			d_,
 		};
@@ -296,80 +331,80 @@ public class HIVRetentionFHIR_0_1_000
 		{
 			bool? q_(Extension @this)
 			{
-				var am_ = @this?.Url;
-				var an_ = context.Operators.Convert<FhirUri>(am_);
-				var ao_ = FHIRHelpers_4_3_000.ToString(an_);
-				var ap_ = context.Operators.Equal(ao_, "ombCategory");
+				string am_ = @this?.Url;
+				FhirUri an_ = context.Operators.Convert<FhirUri>(am_);
+				string ao_ = FHIRHelpers_4_3_000.ToString(an_);
+				bool? ap_ = context.Operators.Equal(ao_, "ombCategory");
 
 				return ap_;
 			};
-			var r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
+			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
 					: null), q_);
 			DataType s_(Extension @this)
 			{
-				var aq_ = @this?.Value;
+				DataType aq_ = @this?.Value;
 
 				return aq_;
 			};
-			var t_ = context.Operators.Select<Extension, DataType>(r_, s_);
-			var u_ = context.Operators.SingletonFrom<DataType>(t_);
-			var v_ = context.Operators.Convert<Coding>(u_);
-			var w_ = FHIRHelpers_4_3_000.ToCode(v_);
-			var x_ = new CqlCode[]
+			IEnumerable<DataType> t_ = context.Operators.Select<Extension, DataType>(r_, s_);
+			DataType u_ = context.Operators.SingletonFrom<DataType>(t_);
+			Coding v_ = context.Operators.Convert<Coding>(u_);
+			CqlCode w_ = FHIRHelpers_4_3_000.ToCode(v_);
+			CqlCode[] x_ = new CqlCode[]
 			{
 				w_,
 			};
 			bool? y_(Extension @this)
 			{
-				var ar_ = @this?.Url;
-				var as_ = context.Operators.Convert<FhirUri>(ar_);
-				var at_ = FHIRHelpers_4_3_000.ToString(as_);
-				var au_ = context.Operators.Equal(at_, "detailed");
+				string ar_ = @this?.Url;
+				FhirUri as_ = context.Operators.Convert<FhirUri>(ar_);
+				string at_ = FHIRHelpers_4_3_000.ToString(as_);
+				bool? au_ = context.Operators.Equal(at_, "detailed");
 
 				return au_;
 			};
-			var z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
+			IEnumerable<Extension> z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
 					: null), y_);
 			DataType aa_(Extension @this)
 			{
-				var av_ = @this?.Value;
+				DataType av_ = @this?.Value;
 
 				return av_;
 			};
-			var ab_ = context.Operators.Select<Extension, DataType>(z_, aa_);
+			IEnumerable<DataType> ab_ = context.Operators.Select<Extension, DataType>(z_, aa_);
 			CqlCode ac_(DataType @this)
 			{
-				var aw_ = context.Operators.Convert<Coding>(@this);
-				var ax_ = FHIRHelpers_4_3_000.ToCode(aw_);
+				Coding aw_ = context.Operators.Convert<Coding>(@this);
+				CqlCode ax_ = FHIRHelpers_4_3_000.ToCode(aw_);
 
 				return ax_;
 			};
-			var ad_ = context.Operators.Select<DataType, CqlCode>(ab_, ac_);
-			var ae_ = context.Operators.Union<CqlCode>((x_ as IEnumerable<CqlCode>), ad_);
+			IEnumerable<CqlCode> ad_ = context.Operators.Select<DataType, CqlCode>(ab_, ac_);
+			IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>((x_ as IEnumerable<CqlCode>), ad_);
 			bool? af_(Extension @this)
 			{
-				var ay_ = @this?.Url;
-				var az_ = context.Operators.Convert<FhirUri>(ay_);
-				var ba_ = FHIRHelpers_4_3_000.ToString(az_);
-				var bb_ = context.Operators.Equal(ba_, "text");
+				string ay_ = @this?.Url;
+				FhirUri az_ = context.Operators.Convert<FhirUri>(ay_);
+				string ba_ = FHIRHelpers_4_3_000.ToString(az_);
+				bool? bb_ = context.Operators.Equal(ba_, "text");
 
 				return bb_;
 			};
-			var ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
+			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
 					: null), af_);
 			DataType ah_(Extension @this)
 			{
-				var bc_ = @this?.Value;
+				DataType bc_ = @this?.Value;
 
 				return bc_;
 			};
-			var ai_ = context.Operators.Select<Extension, DataType>(ag_, ah_);
-			var aj_ = context.Operators.SingletonFrom<DataType>(ai_);
-			var ak_ = context.Operators.Convert<string>(aj_);
-			var al_ = new Tuple_HPcCiDPXQfZTXIORThMLfTQDR
+			IEnumerable<DataType> ai_ = context.Operators.Select<Extension, DataType>(ag_, ah_);
+			DataType aj_ = context.Operators.SingletonFrom<DataType>(ai_);
+			string ak_ = context.Operators.Convert<string>(aj_);
+			Tuple_HPcCiDPXQfZTXIORThMLfTQDR al_ = new Tuple_HPcCiDPXQfZTXIORThMLfTQDR
 			{
 				codes = ae_,
 				display = ak_,
@@ -377,30 +412,32 @@ public class HIVRetentionFHIR_0_1_000
 
 			return al_;
 		};
-		var g_ = context.Operators.Select<Extension, Tuple_HPcCiDPXQfZTXIORThMLfTQDR>((IEnumerable<Extension>)e_, f_);
-		var h_ = context.Operators.SingletonFrom<Tuple_HPcCiDPXQfZTXIORThMLfTQDR>(g_);
+		IEnumerable<Tuple_HPcCiDPXQfZTXIORThMLfTQDR> g_ = context.Operators.Select<Extension, Tuple_HPcCiDPXQfZTXIORThMLfTQDR>((IEnumerable<Extension>)e_, f_);
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR h_ = context.Operators.SingletonFrom<Tuple_HPcCiDPXQfZTXIORThMLfTQDR>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
 		List<Extension> a_()
 		{
 			bool i_()
 			{
-				var j_ = this.Patient();
-				var k_ = j_ is DomainResource;
+				Patient j_ = this.Patient();
+				bool k_ = j_ is DomainResource;
 
 				return k_;
 			};
 			if (i_())
 			{
-				var l_ = this.Patient();
+				Patient l_ = this.Patient();
 
 				return (l_ as DomainResource).Extension;
 			}
@@ -411,16 +448,16 @@ public class HIVRetentionFHIR_0_1_000
 		};
 		bool? b_(Extension @this)
 		{
-			var m_ = @this?.Url;
-			var n_ = context.Operators.Convert<FhirUri>(m_);
-			var o_ = FHIRHelpers_4_3_000.ToString(n_);
-			var p_ = context.Operators.Equal(o_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race");
+			string m_ = @this?.Url;
+			FhirUri n_ = context.Operators.Convert<FhirUri>(m_);
+			string o_ = FHIRHelpers_4_3_000.ToString(n_);
+			bool? p_ = context.Operators.Equal(o_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race");
 
 			return p_;
 		};
-		var c_ = context.Operators.Where<Extension>((IEnumerable<Extension>)a_(), b_);
-		var d_ = context.Operators.SingletonFrom<Extension>(c_);
-		var e_ = new Extension[]
+		IEnumerable<Extension> c_ = context.Operators.Where<Extension>((IEnumerable<Extension>)a_(), b_);
+		Extension d_ = context.Operators.SingletonFrom<Extension>(c_);
+		Extension[] e_ = new Extension[]
 		{
 			d_,
 		};
@@ -428,81 +465,81 @@ public class HIVRetentionFHIR_0_1_000
 		{
 			bool? q_(Extension @this)
 			{
-				var ak_ = @this?.Url;
-				var al_ = context.Operators.Convert<FhirUri>(ak_);
-				var am_ = FHIRHelpers_4_3_000.ToString(al_);
-				var an_ = context.Operators.Equal(am_, "ombCategory");
+				string ak_ = @this?.Url;
+				FhirUri al_ = context.Operators.Convert<FhirUri>(ak_);
+				string am_ = FHIRHelpers_4_3_000.ToString(al_);
+				bool? an_ = context.Operators.Equal(am_, "ombCategory");
 
 				return an_;
 			};
-			var r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
+			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
 					: null), q_);
 			DataType s_(Extension @this)
 			{
-				var ao_ = @this?.Value;
+				DataType ao_ = @this?.Value;
 
 				return ao_;
 			};
-			var t_ = context.Operators.Select<Extension, DataType>(r_, s_);
+			IEnumerable<DataType> t_ = context.Operators.Select<Extension, DataType>(r_, s_);
 			CqlCode u_(DataType @this)
 			{
-				var ap_ = context.Operators.Convert<Coding>(@this);
-				var aq_ = FHIRHelpers_4_3_000.ToCode(ap_);
+				Coding ap_ = context.Operators.Convert<Coding>(@this);
+				CqlCode aq_ = FHIRHelpers_4_3_000.ToCode(ap_);
 
 				return aq_;
 			};
-			var v_ = context.Operators.Select<DataType, CqlCode>(t_, u_);
+			IEnumerable<CqlCode> v_ = context.Operators.Select<DataType, CqlCode>(t_, u_);
 			bool? w_(Extension @this)
 			{
-				var ar_ = @this?.Url;
-				var as_ = context.Operators.Convert<FhirUri>(ar_);
-				var at_ = FHIRHelpers_4_3_000.ToString(as_);
-				var au_ = context.Operators.Equal(at_, "detailed");
+				string ar_ = @this?.Url;
+				FhirUri as_ = context.Operators.Convert<FhirUri>(ar_);
+				string at_ = FHIRHelpers_4_3_000.ToString(as_);
+				bool? au_ = context.Operators.Equal(at_, "detailed");
 
 				return au_;
 			};
-			var x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
+			IEnumerable<Extension> x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
 					: null), w_);
 			DataType y_(Extension @this)
 			{
-				var av_ = @this?.Value;
+				DataType av_ = @this?.Value;
 
 				return av_;
 			};
-			var z_ = context.Operators.Select<Extension, DataType>(x_, y_);
+			IEnumerable<DataType> z_ = context.Operators.Select<Extension, DataType>(x_, y_);
 			CqlCode aa_(DataType @this)
 			{
-				var aw_ = context.Operators.Convert<Coding>(@this);
-				var ax_ = FHIRHelpers_4_3_000.ToCode(aw_);
+				Coding aw_ = context.Operators.Convert<Coding>(@this);
+				CqlCode ax_ = FHIRHelpers_4_3_000.ToCode(aw_);
 
 				return ax_;
 			};
-			var ab_ = context.Operators.Select<DataType, CqlCode>(z_, aa_);
-			var ac_ = context.Operators.Union<CqlCode>(v_, ab_);
+			IEnumerable<CqlCode> ab_ = context.Operators.Select<DataType, CqlCode>(z_, aa_);
+			IEnumerable<CqlCode> ac_ = context.Operators.Union<CqlCode>(v_, ab_);
 			bool? ad_(Extension @this)
 			{
-				var ay_ = @this?.Url;
-				var az_ = context.Operators.Convert<FhirUri>(ay_);
-				var ba_ = FHIRHelpers_4_3_000.ToString(az_);
-				var bb_ = context.Operators.Equal(ba_, "text");
+				string ay_ = @this?.Url;
+				FhirUri az_ = context.Operators.Convert<FhirUri>(ay_);
+				string ba_ = FHIRHelpers_4_3_000.ToString(az_);
+				bool? bb_ = context.Operators.Equal(ba_, "text");
 
 				return bb_;
 			};
-			var ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
+			IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
 					: null), ad_);
 			DataType af_(Extension @this)
 			{
-				var bc_ = @this?.Value;
+				DataType bc_ = @this?.Value;
 
 				return bc_;
 			};
-			var ag_ = context.Operators.Select<Extension, DataType>(ae_, af_);
-			var ah_ = context.Operators.SingletonFrom<DataType>(ag_);
-			var ai_ = context.Operators.Convert<string>(ah_);
-			var aj_ = new Tuple_HPcCiDPXQfZTXIORThMLfTQDR
+			IEnumerable<DataType> ag_ = context.Operators.Select<Extension, DataType>(ae_, af_);
+			DataType ah_ = context.Operators.SingletonFrom<DataType>(ag_);
+			string ai_ = context.Operators.Convert<string>(ah_);
+			Tuple_HPcCiDPXQfZTXIORThMLfTQDR aj_ = new Tuple_HPcCiDPXQfZTXIORThMLfTQDR
 			{
 				codes = ac_,
 				display = ai_,
@@ -510,189 +547,201 @@ public class HIVRetentionFHIR_0_1_000
 
 			return aj_;
 		};
-		var g_ = context.Operators.Select<Extension, Tuple_HPcCiDPXQfZTXIORThMLfTQDR>((IEnumerable<Extension>)e_, f_);
-		var h_ = context.Operators.SingletonFrom<Tuple_HPcCiDPXQfZTXIORThMLfTQDR>(g_);
+		IEnumerable<Tuple_HPcCiDPXQfZTXIORThMLfTQDR> g_ = context.Operators.Select<Extension, Tuple_HPcCiDPXQfZTXIORThMLfTQDR>((IEnumerable<Extension>)e_, f_);
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR h_ = context.Operators.SingletonFrom<Tuple_HPcCiDPXQfZTXIORThMLfTQDR>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period"/>
 	private bool? Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period_Value()
 	{
-		var a_ = this.HIV();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.HIV();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition HIVDx)
 		{
-			var f_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDx);
-			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.Start(h_);
-			var j_ = context.Operators.Quantity(240m, "days");
-			var k_ = context.Operators.Add(i_, j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.ConvertDateToDateTime(l_);
-			var n_ = context.Operators.SameOrBefore(g_, m_, null);
-			var o_ = QICoreCommon_2_0_000.isActive(HIVDx);
-			var p_ = context.Operators.And(n_, o_);
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDx);
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.Start(h_);
+			CqlQuantity j_ = context.Operators.Quantity(240m, "days");
+			CqlDateTime k_ = context.Operators.Add(i_, j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			CqlDateTime m_ = context.Operators.ConvertDateToDateTime(l_);
+			bool? n_ = context.Operators.SameOrBefore(g_, m_, null);
+			bool? o_ = QICoreCommon_2_0_000.isActive(HIVDx);
+			bool? p_ = context.Operators.And(n_, o_);
 
 			return p_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period_Value"/>
     [CqlDeclaration("Has Active HIV Diagnosis Starts On or Before First 240 Days of Measurement Period")]
 	public bool? Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period() => 
 		__Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period"/>
 	private bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Outpatient_Consultation();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Annual_Wellness_Visit();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Face_to_Face_Interaction();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Home_Healthcare_Services();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
-		var x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
-		var z_ = this.Telephone_Visits();
-		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
-		var ab_ = context.Operators.Union<Encounter>(y_, aa_);
-		var ac_ = context.Operators.Union<Encounter>(w_, ab_);
-		var ad_ = this.Preventive_Care_Services_Other();
-		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
-		var af_ = context.Operators.Union<Encounter>(ac_, ae_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Face_to_Face_Interaction();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
+		CqlValueSet x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		CqlValueSet z_ = this.Telephone_Visits();
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
+		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
+		CqlValueSet ad_ = this.Preventive_Care_Services_Other();
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 		bool? ag_(Encounter QualifyingEncounter)
 		{
-			var aj_ = this.Measurement_Period();
-			var ak_ = context.Operators.Start(aj_);
-			var am_ = context.Operators.Start(aj_);
-			var an_ = context.Operators.Quantity(240m, "days");
-			var ao_ = context.Operators.Add(am_, an_);
-			var ap_ = context.Operators.Interval(ak_, ao_, true, true);
-			var aq_ = QualifyingEncounter?.Period;
-			var ar_ = FHIRHelpers_4_3_000.ToInterval(aq_);
-			var as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, ar_, "day");
+			CqlInterval<CqlDateTime> aj_ = this.Measurement_Period();
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlDateTime am_ = context.Operators.Start(aj_);
+			CqlQuantity an_ = context.Operators.Quantity(240m, "days");
+			CqlDateTime ao_ = context.Operators.Add(am_, an_);
+			CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ak_, ao_, true, true);
+			Period aq_ = QualifyingEncounter?.Period;
+			CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_3_000.ToInterval(aq_);
+			bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, ar_, "day");
 
 			return as_;
 		};
-		var ah_ = context.Operators.Where<Encounter>(af_, ag_);
-		var ai_ = context.Operators.Exists<Encounter>(ah_);
+		IEnumerable<Encounter> ah_ = context.Operators.Where<Encounter>(af_, ag_);
+		bool? ai_ = context.Operators.Exists<Encounter>(ah_);
 
 		return ai_;
 	}
 
+    /// <seealso cref="Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value"/>
     [CqlDeclaration("Has Qualifying Encounter During First 240 Days of Measurement Period")]
 	public bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period() => 
 		__Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period();
-		var b_ = this.Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period();
-		var c_ = context.Operators.And(a_, b_);
+		bool? a_ = this.Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period();
+		bool? b_ = this.Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period();
+		bool? c_ = context.Operators.And(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Encounter_During_Measurement_Period_With_HIV"/>
 	private IEnumerable<Encounter> Encounter_During_Measurement_Period_With_HIV_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Outpatient_Consultation();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Annual_Wellness_Visit();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Face_to_Face_Interaction();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Home_Healthcare_Services();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
-		var x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
-		var z_ = this.Telephone_Visits();
-		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
-		var ab_ = context.Operators.Union<Encounter>(y_, aa_);
-		var ac_ = context.Operators.Union<Encounter>(w_, ab_);
-		var ad_ = this.Preventive_Care_Services_Other();
-		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
-		var af_ = context.Operators.Union<Encounter>(ac_, ae_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Face_to_Face_Interaction();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
+		CqlValueSet x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		CqlValueSet z_ = this.Telephone_Visits();
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
+		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
+		CqlValueSet ad_ = this.Preventive_Care_Services_Other();
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 		IEnumerable<Encounter> ag_(Encounter ValidEncounter)
 		{
-			var ai_ = this.HIV();
-			var aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, null);
+			CqlValueSet ai_ = this.HIV();
+			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, null);
 			bool? ak_(Condition HIVDiagnosis)
 			{
-				var ao_ = this.Measurement_Period();
-				var ap_ = ValidEncounter?.Period;
-				var aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				var ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, null);
+				CqlInterval<CqlDateTime> ao_ = this.Measurement_Period();
+				Period ap_ = ValidEncounter?.Period;
+				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
+				bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, null);
 				CqlInterval<CqlDateTime> as_()
 				{
 					bool az_()
 					{
-						var ba_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDiagnosis);
-						var bb_ = context.Operators.Start(ba_);
+						CqlInterval<CqlDateTime> ba_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDiagnosis);
+						CqlDateTime bb_ = context.Operators.Start(ba_);
 
 						return (bb_ is null);
 					};
@@ -702,163 +751,172 @@ public class HIVRetentionFHIR_0_1_000
 					}
 					else
 					{
-						var bc_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDiagnosis);
-						var bd_ = context.Operators.Start(bc_);
-						var bf_ = context.Operators.Start(bc_);
-						var bg_ = context.Operators.Interval(bd_, bf_, true, true);
+						CqlInterval<CqlDateTime> bc_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDiagnosis);
+						CqlDateTime bd_ = context.Operators.Start(bc_);
+						CqlDateTime bf_ = context.Operators.Start(bc_);
+						CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(bd_, bf_, true, true);
 
 						return bg_;
 					}
 				};
-				var au_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				var av_ = context.Operators.SameOrBefore(as_(), au_, "day");
-				var aw_ = context.Operators.And(ar_, av_);
-				var ax_ = QICoreCommon_2_0_000.isActive(HIVDiagnosis);
-				var ay_ = context.Operators.And(aw_, ax_);
+				CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_3_000.ToInterval(ap_);
+				bool? av_ = context.Operators.SameOrBefore(as_(), au_, "day");
+				bool? aw_ = context.Operators.And(ar_, av_);
+				bool? ax_ = QICoreCommon_2_0_000.isActive(HIVDiagnosis);
+				bool? ay_ = context.Operators.And(aw_, ax_);
 
 				return ay_;
 			};
-			var al_ = context.Operators.Where<Condition>(aj_, ak_);
+			IEnumerable<Condition> al_ = context.Operators.Where<Condition>(aj_, ak_);
 			Encounter am_(Condition HIVDiagnosis) => 
 				ValidEncounter;
-			var an_ = context.Operators.Select<Condition, Encounter>(al_, am_);
+			IEnumerable<Encounter> an_ = context.Operators.Select<Condition, Encounter>(al_, am_);
 
 			return an_;
 		};
-		var ah_ = context.Operators.SelectMany<Encounter, Encounter>(af_, ag_);
+		IEnumerable<Encounter> ah_ = context.Operators.SelectMany<Encounter, Encounter>(af_, ag_);
 
 		return ah_;
 	}
 
+    /// <seealso cref="Encounter_During_Measurement_Period_With_HIV_Value"/>
     [CqlDeclaration("Encounter During Measurement Period With HIV")]
 	public IEnumerable<Encounter> Encounter_During_Measurement_Period_With_HIV() => 
 		__Encounter_During_Measurement_Period_With_HIV.Value;
 
+    /// <seealso cref="Has_HIV_Viral_Load_Test_During_Measurement_Period"/>
 	private bool? Has_HIV_Viral_Load_Test_During_Measurement_Period_Value()
 	{
-		var a_ = this.HIV_Viral_Load();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.HIV_Viral_Load();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation ViralLoadTest)
 		{
-			var f_ = this.Measurement_Period();
-			var g_ = ViralLoadTest?.Effective;
-			var h_ = FHIRHelpers_4_3_000.ToValue(g_);
-			var i_ = QICoreCommon_2_0_000.ToInterval(h_);
-			var j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, "day");
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			DataType g_ = ViralLoadTest?.Effective;
+			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
+			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToInterval(h_);
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, "day");
 
 			return j_;
 		};
-		var d_ = context.Operators.Where<Observation>(b_, c_);
-		var e_ = context.Operators.Exists<Observation>(d_);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
+		bool? e_ = context.Operators.Exists<Observation>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_HIV_Viral_Load_Test_During_Measurement_Period_Value"/>
     [CqlDeclaration("Has HIV Viral Load Test During Measurement Period")]
 	public bool? Has_HIV_Viral_Load_Test_During_Measurement_Period() => 
 		__Has_HIV_Viral_Load_Test_During_Measurement_Period.Value;
 
+    /// <seealso cref="Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart"/>
 	private bool? Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart_Value()
 	{
-		var a_ = this.Encounter_During_Measurement_Period_With_HIV();
+		IEnumerable<Encounter> a_ = this.Encounter_During_Measurement_Period_With_HIV();
 		IEnumerable<Encounter> b_(Encounter EncounterWithHIV)
 		{
-			var e_ = this.HIV_Viral_Load();
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(e_, null);
+			CqlValueSet e_ = this.HIV_Viral_Load();
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(e_, null);
 			bool? g_(Observation ViralLoadTest)
 			{
-				var k_ = this.Measurement_Period();
-				var l_ = ViralLoadTest?.Effective;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = QICoreCommon_2_0_000.ToInterval(m_);
-				var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, null);
-				var q_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var r_ = QICoreCommon_2_0_000.ToInterval(q_);
-				var s_ = context.Operators.Start(r_);
-				var t_ = EncounterWithHIV?.Period;
-				var u_ = FHIRHelpers_4_3_000.ToInterval(t_);
-				var v_ = context.Operators.End(u_);
-				var w_ = context.Operators.Quantity(90m, "days");
-				var x_ = context.Operators.Add(v_, w_);
-				var y_ = context.Operators.SameOrAfter(s_, x_, "day");
-				var aa_ = FHIRHelpers_4_3_000.ToInterval(t_);
-				var ab_ = context.Operators.Start(aa_);
-				var ad_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
-				var af_ = context.Operators.End(ae_);
-				var ah_ = context.Operators.Add(af_, w_);
-				var ai_ = context.Operators.SameOrAfter(ab_, ah_, "day");
-				var aj_ = context.Operators.Or(y_, ai_);
-				var ak_ = context.Operators.And(o_, aj_);
+				CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
+				DataType l_ = ViralLoadTest?.Effective;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.ToInterval(m_);
+				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, null);
+				object q_ = FHIRHelpers_4_3_000.ToValue(l_);
+				CqlInterval<CqlDateTime> r_ = QICoreCommon_2_0_000.ToInterval(q_);
+				CqlDateTime s_ = context.Operators.Start(r_);
+				Period t_ = EncounterWithHIV?.Period;
+				CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(t_);
+				CqlDateTime v_ = context.Operators.End(u_);
+				CqlQuantity w_ = context.Operators.Quantity(90m, "days");
+				CqlDateTime x_ = context.Operators.Add(v_, w_);
+				bool? y_ = context.Operators.SameOrAfter(s_, x_, "day");
+				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(t_);
+				CqlDateTime ab_ = context.Operators.Start(aa_);
+				object ad_ = FHIRHelpers_4_3_000.ToValue(l_);
+				CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.End(ae_);
+				CqlDateTime ah_ = context.Operators.Add(af_, w_);
+				bool? ai_ = context.Operators.SameOrAfter(ab_, ah_, "day");
+				bool? aj_ = context.Operators.Or(y_, ai_);
+				bool? ak_ = context.Operators.And(o_, aj_);
 
 				return ak_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			Encounter i_(Observation ViralLoadTest) => 
 				EncounterWithHIV;
-			var j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
-		var d_ = context.Operators.Exists<Encounter>(c_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		bool? d_ = context.Operators.Exists<Encounter>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart_Value"/>
     [CqlDeclaration("Has One Encounter With HIV and One Viral Load Test At Least 90 Days Apart")]
 	public bool? Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart() => 
 		__Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart.Value;
 
+    /// <seealso cref="Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart"/>
 	private bool? Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart_Value()
 	{
-		var a_ = this.Encounter_During_Measurement_Period_With_HIV();
+		IEnumerable<Encounter> a_ = this.Encounter_During_Measurement_Period_With_HIV();
 		IEnumerable<Encounter> b_(Encounter EncounterWithHIV)
 		{
-			var e_ = this.Encounter_During_Measurement_Period_With_HIV();
+			IEnumerable<Encounter> e_ = this.Encounter_During_Measurement_Period_With_HIV();
 			bool? f_(Encounter AnotherEncounterWithHIV)
 			{
-				var j_ = context.Operators.Equivalent(EncounterWithHIV, AnotherEncounterWithHIV);
-				var k_ = context.Operators.Not(j_);
-				var l_ = AnotherEncounterWithHIV?.Period;
-				var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-				var n_ = context.Operators.Start(m_);
-				var o_ = EncounterWithHIV?.Period;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = context.Operators.End(p_);
-				var r_ = context.Operators.Quantity(90m, "days");
-				var s_ = context.Operators.Add(q_, r_);
-				var t_ = context.Operators.SameOrAfter(n_, s_, "day");
-				var u_ = context.Operators.And(k_, t_);
+				bool? j_ = context.Operators.Equivalent(EncounterWithHIV, AnotherEncounterWithHIV);
+				bool? k_ = context.Operators.Not(j_);
+				Period l_ = AnotherEncounterWithHIV?.Period;
+				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				Period o_ = EncounterWithHIV?.Period;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				CqlDateTime q_ = context.Operators.End(p_);
+				CqlQuantity r_ = context.Operators.Quantity(90m, "days");
+				CqlDateTime s_ = context.Operators.Add(q_, r_);
+				bool? t_ = context.Operators.SameOrAfter(n_, s_, "day");
+				bool? u_ = context.Operators.And(k_, t_);
 
 				return u_;
 			};
-			var g_ = context.Operators.Where<Encounter>(e_, f_);
+			IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
 			Encounter h_(Encounter AnotherEncounterWithHIV) => 
 				EncounterWithHIV;
-			var i_ = context.Operators.Select<Encounter, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Encounter, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
-		var d_ = context.Operators.Exists<Encounter>(c_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		bool? d_ = context.Operators.Exists<Encounter>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart_Value"/>
     [CqlDeclaration("Has Two Encounters With HIV At Least 90 Days Apart")]
 	public bool? Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart() => 
 		__Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart();
-		var b_ = this.Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart();
-		var c_ = context.Operators.Or(a_, b_);
+		bool? a_ = this.Has_One_Encounter_With_HIV_and_One_Viral_Load_Test_At_Least_90_Days_Apart();
+		bool? b_ = this.Has_Two_Encounters_With_HIV_At_Least_90_Days_Apart();
+		bool? c_ = context.Operators.Or(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
@@ -102,135 +102,168 @@ public class HIVViralSuppressionFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Annual_Wellness_Visit"/>
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
+    /// <seealso cref="Annual_Wellness_Visit_Value"/>
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
 	public CqlValueSet Annual_Wellness_Visit() => 
 		__Annual_Wellness_Visit.Value;
 
+    /// <seealso cref="Face_to_Face_Interaction"/>
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
 
+    /// <seealso cref="Face_to_Face_Interaction_Value"/>
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
 	public CqlValueSet Face_to_Face_Interaction() => 
 		__Face_to_Face_Interaction.Value;
 
+    /// <seealso cref="HIV"/>
 	private CqlValueSet HIV_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
 
+    /// <seealso cref="HIV_Value"/>
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
 	public CqlValueSet HIV() => 
 		__HIV.Value;
 
+    /// <seealso cref="HIV_Viral_Load"/>
 	private CqlValueSet HIV_Viral_Load_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", null);
 
+    /// <seealso cref="HIV_Viral_Load_Value"/>
     [CqlDeclaration("HIV Viral Load")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002")]
 	public CqlValueSet HIV_Viral_Load() => 
 		__HIV_Viral_Load.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Other"/>
 	private CqlValueSet Preventive_Care_Services_Other_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", null);
 
+    /// <seealso cref="Preventive_Care_Services_Other_Value"/>
     [CqlDeclaration("Preventive Care Services Other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030")]
 	public CqlValueSet Preventive_Care_Services_Other() => 
 		__Preventive_Care_Services_Other.Value;
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
 	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
 	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Telehealth_Services"/>
 	private CqlValueSet Telehealth_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", null);
 
+    /// <seealso cref="Telehealth_Services_Value"/>
     [CqlDeclaration("Telehealth Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031")]
 	public CqlValueSet Telehealth_Services() => 
 		__Telehealth_Services.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Below_threshold_level__qualifier_value_"/>
 	private CqlCode Below_threshold_level__qualifier_value__Value() => 
 		new CqlCode("260988000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Below_threshold_level__qualifier_value__Value"/>
     [CqlDeclaration("Below threshold level (qualifier value)")]
 	public CqlCode Below_threshold_level__qualifier_value_() => 
 		__Below_threshold_level__qualifier_value_.Value;
 
+    /// <seealso cref="Not_detected__qualifier_value_"/>
 	private CqlCode Not_detected__qualifier_value__Value() => 
 		new CqlCode("260415000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Not_detected__qualifier_value__Value"/>
     [CqlDeclaration("Not detected (qualifier value)")]
 	public CqlCode Not_detected__qualifier_value_() => 
 		__Not_detected__qualifier_value_.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("260988000", "http://snomed.info/sct", null, null),
 			new CqlCode("260415000", "http://snomed.info/sct", null, null),
@@ -239,250 +272,274 @@ public class HIVViralSuppressionFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("HIVViralSuppressionFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("HIVViralSuppressionFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period"/>
 	private bool? Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period_Value()
 	{
-		var a_ = this.HIV();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.HIV();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition HIVDx)
 		{
-			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HIVDx);
-			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.Start(h_);
-			var j_ = context.Operators.Quantity(90m, "days");
-			var k_ = context.Operators.Add(i_, j_);
-			var l_ = context.Operators.Before(g_, k_, "day");
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HIVDx);
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.Start(h_);
+			CqlQuantity j_ = context.Operators.Quantity(90m, "days");
+			CqlDateTime k_ = context.Operators.Add(i_, j_);
+			bool? l_ = context.Operators.Before(g_, k_, "day");
 
 			return l_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period_Value"/>
     [CqlDeclaration("Has Active HIV Diagnosis Before or in First 90 Days of Measurement Period")]
 	public bool? Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period() => 
 		__Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period"/>
 	private bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Outpatient_Consultation();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Annual_Wellness_Visit();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Face_to_Face_Interaction();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Home_Healthcare_Services();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
-		var x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
-		var z_ = this.Telephone_Visits();
-		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
-		var ab_ = context.Operators.Union<Encounter>(y_, aa_);
-		var ac_ = context.Operators.Union<Encounter>(w_, ab_);
-		var ad_ = this.Preventive_Care_Services_Other();
-		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
-		var af_ = context.Operators.Union<Encounter>(ac_, ae_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Face_to_Face_Interaction();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
+		CqlValueSet x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		CqlValueSet z_ = this.Telephone_Visits();
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
+		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
+		CqlValueSet ad_ = this.Preventive_Care_Services_Other();
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 		bool? ag_(Encounter QualifyingEncounter)
 		{
-			var aj_ = this.Measurement_Period();
-			var ak_ = context.Operators.Start(aj_);
-			var am_ = context.Operators.Start(aj_);
-			var an_ = context.Operators.Quantity(240m, "days");
-			var ao_ = context.Operators.Add(am_, an_);
-			var ap_ = context.Operators.Interval(ak_, ao_, true, true);
-			var aq_ = QualifyingEncounter?.Period;
-			var ar_ = FHIRHelpers_4_3_000.ToInterval(aq_);
-			var as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, ar_, "day");
+			CqlInterval<CqlDateTime> aj_ = this.Measurement_Period();
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlDateTime am_ = context.Operators.Start(aj_);
+			CqlQuantity an_ = context.Operators.Quantity(240m, "days");
+			CqlDateTime ao_ = context.Operators.Add(am_, an_);
+			CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ak_, ao_, true, true);
+			Period aq_ = QualifyingEncounter?.Period;
+			CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_3_000.ToInterval(aq_);
+			bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, ar_, "day");
 
 			return as_;
 		};
-		var ah_ = context.Operators.Where<Encounter>(af_, ag_);
-		var ai_ = context.Operators.Exists<Encounter>(ah_);
+		IEnumerable<Encounter> ah_ = context.Operators.Where<Encounter>(af_, ag_);
+		bool? ai_ = context.Operators.Exists<Encounter>(ah_);
 
 		return ai_;
 	}
 
+    /// <seealso cref="Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value"/>
     [CqlDeclaration("Has Qualifying Encounter During First 240 Days of Measurement Period")]
 	public bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period() => 
 		__Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period();
-		var b_ = this.Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period();
-		var c_ = context.Operators.And(a_, b_);
+		bool? a_ = this.Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period();
+		bool? b_ = this.Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period();
+		bool? c_ = context.Operators.And(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Most_Recent_Viral_Load_Test_During_Measurement_Period"/>
 	private Observation Most_Recent_Viral_Load_Test_During_Measurement_Period_Value()
 	{
-		var a_ = this.HIV_Viral_Load();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.HIV_Viral_Load();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation ViralLoad)
 		{
 			object h_()
 			{
 				bool l_()
 				{
-					var o_ = ViralLoad?.Effective;
-					var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-					var q_ = p_ is CqlDateTime;
+					DataType o_ = ViralLoad?.Effective;
+					object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+					bool q_ = p_ is CqlDateTime;
 
 					return q_;
 				};
 				bool m_()
 				{
-					var r_ = ViralLoad?.Effective;
-					var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-					var t_ = s_ is CqlInterval<CqlDateTime>;
+					DataType r_ = ViralLoad?.Effective;
+					object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+					bool t_ = s_ is CqlInterval<CqlDateTime>;
 
 					return t_;
 				};
 				bool n_()
 				{
-					var u_ = ViralLoad?.Effective;
-					var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-					var w_ = v_ is CqlDateTime;
+					DataType u_ = ViralLoad?.Effective;
+					object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+					bool w_ = v_ is CqlDateTime;
 
 					return w_;
 				};
 				if (l_())
 				{
-					var x_ = ViralLoad?.Effective;
-					var y_ = FHIRHelpers_4_3_000.ToValue(x_);
+					DataType x_ = ViralLoad?.Effective;
+					object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 
 					return ((y_ as CqlDateTime) as object);
 				}
 				else if (m_())
 				{
-					var z_ = ViralLoad?.Effective;
-					var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+					DataType z_ = ViralLoad?.Effective;
+					object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
 
 					return ((aa_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (n_())
 				{
-					var ab_ = ViralLoad?.Effective;
-					var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+					DataType ab_ = ViralLoad?.Effective;
+					object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 
 					return ((ac_ as CqlDateTime) as object);
 				}
@@ -491,52 +548,58 @@ public class HIVViralSuppressionFHIR_0_1_000
 					return null;
 				}
 			};
-			var i_ = QICoreCommon_2_0_000.Latest(h_());
-			var j_ = this.Measurement_Period();
-			var k_ = context.Operators.In<CqlDateTime>(i_, j_, "day");
+			CqlDateTime i_ = QICoreCommon_2_0_000.Latest(h_());
+			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
+			bool? k_ = context.Operators.In<CqlDateTime>(i_, j_, "day");
 
 			return k_;
 		};
-		var d_ = context.Operators.Where<Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		object e_(Observation @this)
 		{
-			var ad_ = @this?.Effective;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = QICoreCommon_2_0_000.ToInterval(ae_);
-			var ag_ = context.Operators.Start(af_);
+			DataType ad_ = @this?.Effective;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
+			CqlDateTime ag_ = context.Operators.Start(af_);
 
 			return ag_;
 		};
-		var f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-		var g_ = context.Operators.Last<Observation>(f_);
+		IEnumerable<Observation> f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation g_ = context.Operators.Last<Observation>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Most_Recent_Viral_Load_Test_During_Measurement_Period_Value"/>
     [CqlDeclaration("Most Recent Viral Load Test During Measurement Period")]
 	public Observation Most_Recent_Viral_Load_Test_During_Measurement_Period() => 
 		__Most_Recent_Viral_Load_Test_During_Measurement_Period.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Most_Recent_Viral_Load_Test_During_Measurement_Period();
-		var b_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
-		var c_ = context.Operators.Quantity(200m, "{copies}/mL");
-		var d_ = context.Operators.Less((b_ as CqlQuantity), c_);
-		var f_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
-		var g_ = this.Below_threshold_level__qualifier_value_();
-		var h_ = context.Operators.ConvertCodeToConcept(g_);
-		var i_ = context.Operators.Equivalent((f_ as CqlConcept), h_);
-		var j_ = context.Operators.Or(d_, i_);
-		var l_ = FHIRHelpers_4_3_000.ToValue(a_?.Value);
-		var m_ = this.Not_detected__qualifier_value_();
-		var n_ = context.Operators.ConvertCodeToConcept(m_);
-		var o_ = context.Operators.Equivalent((l_ as CqlConcept), n_);
-		var p_ = context.Operators.Or(j_, o_);
+		Observation a_ = this.Most_Recent_Viral_Load_Test_During_Measurement_Period();
+		DataType b_ = a_?.Value;
+		object c_ = FHIRHelpers_4_3_000.ToValue(b_);
+		CqlQuantity d_ = context.Operators.Quantity(200m, "{copies}/mL");
+		bool? e_ = context.Operators.Less((c_ as CqlQuantity), d_);
+		DataType g_ = a_?.Value;
+		object h_ = FHIRHelpers_4_3_000.ToValue(g_);
+		CqlCode i_ = this.Below_threshold_level__qualifier_value_();
+		CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+		bool? k_ = context.Operators.Equivalent((h_ as CqlConcept), j_);
+		bool? l_ = context.Operators.Or(e_, k_);
+		DataType n_ = a_?.Value;
+		object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+		CqlCode p_ = this.Not_detected__qualifier_value_();
+		CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+		bool? r_ = context.Operators.Equivalent((o_ as CqlConcept), q_);
+		bool? s_ = context.Operators.Or(l_, r_);
 
-		return p_;
+		return s_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
@@ -66,69 +66,86 @@ public class Hospice_6_9_000
 
     #endregion
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Hospice_Care_Ambulatory"/>
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", null);
 
+    /// <seealso cref="Hospice_Care_Ambulatory_Value"/>
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
 	public CqlValueSet Hospice_Care_Ambulatory() => 
 		__Hospice_Care_Ambulatory.Value;
 
+    /// <seealso cref="Hospice_Encounter"/>
 	private CqlValueSet Hospice_Encounter_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003", null);
 
+    /// <seealso cref="Hospice_Encounter_Value"/>
     [CqlDeclaration("Hospice Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003")]
 	public CqlValueSet Hospice_Encounter() => 
 		__Hospice_Encounter.Value;
 
+    /// <seealso cref="Hospice_Diagnosis"/>
 	private CqlValueSet Hospice_Diagnosis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165", null);
 
+    /// <seealso cref="Hospice_Diagnosis_Value"/>
     [CqlDeclaration("Hospice Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165")]
 	public CqlValueSet Hospice_Diagnosis() => 
 		__Hospice_Diagnosis.Value;
 
+    /// <seealso cref="Discharge_to_healthcare_facility_for_hospice_care__procedure_"/>
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
 		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Discharge_to_healthcare_facility_for_hospice_care__procedure__Value"/>
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
+    /// <seealso cref="Discharge_to_home_for_hospice_care__procedure_"/>
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
 		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Discharge_to_home_for_hospice_care__procedure__Value"/>
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
+    /// <seealso cref="Hospice_care__Minimum_Data_Set_"/>
 	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
 		new CqlCode("45755-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Hospice_care__Minimum_Data_Set__Value"/>
     [CqlDeclaration("Hospice care [Minimum Data Set]")]
 	public CqlCode Hospice_care__Minimum_Data_Set_() => 
 		__Hospice_care__Minimum_Data_Set_.Value;
 
+    /// <seealso cref="Yes__qualifier_value_"/>
 	private CqlCode Yes__qualifier_value__Value() => 
 		new CqlCode("373066001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Yes__qualifier_value__Value"/>
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
 		__Yes__qualifier_value_.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("45755-6", "http://loinc.org", null, null),
 		};
@@ -136,13 +153,15 @@ public class Hospice_6_9_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
 			new CqlCode("428361000124107", "http://snomed.info/sct", null, null),
@@ -152,154 +171,161 @@ public class Hospice_6_9_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("Hospice-6.9.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("Hospice-6.9.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Has_Hospice_Services"/>
 	private bool? Has_Hospice_Services_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = Status_1_6_000.isEncounterPerformed(b_);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter InpatientEncounter)
 		{
-			var ap_ = InpatientEncounter?.Hospitalization;
-			var aq_ = ap_?.DischargeDisposition;
-			var ar_ = FHIRHelpers_4_3_000.ToConcept(aq_);
-			var as_ = this.Discharge_to_home_for_hospice_care__procedure_();
-			var at_ = context.Operators.ConvertCodeToConcept(as_);
-			var au_ = context.Operators.Equivalent(ar_, at_);
-			var aw_ = ap_?.DischargeDisposition;
-			var ax_ = FHIRHelpers_4_3_000.ToConcept(aw_);
-			var ay_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_();
-			var az_ = context.Operators.ConvertCodeToConcept(ay_);
-			var ba_ = context.Operators.Equivalent(ax_, az_);
-			var bb_ = context.Operators.Or(au_, ba_);
-			var bc_ = InpatientEncounter?.Period;
-			var bd_ = FHIRHelpers_4_3_000.ToInterval(bc_);
-			var be_ = QICoreCommon_2_0_000.toInterval((bd_ as object));
-			var bf_ = context.Operators.End(be_);
-			var bg_ = this.Measurement_Period();
-			var bh_ = context.Operators.In<CqlDateTime>(bf_, bg_, "day");
-			var bi_ = context.Operators.And(bb_, bh_);
+			Encounter.HospitalizationComponent ap_ = InpatientEncounter?.Hospitalization;
+			CodeableConcept aq_ = ap_?.DischargeDisposition;
+			CqlConcept ar_ = FHIRHelpers_4_3_000.ToConcept(aq_);
+			CqlCode as_ = this.Discharge_to_home_for_hospice_care__procedure_();
+			CqlConcept at_ = context.Operators.ConvertCodeToConcept(as_);
+			bool? au_ = context.Operators.Equivalent(ar_, at_);
+			CodeableConcept aw_ = ap_?.DischargeDisposition;
+			CqlConcept ax_ = FHIRHelpers_4_3_000.ToConcept(aw_);
+			CqlCode ay_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_();
+			CqlConcept az_ = context.Operators.ConvertCodeToConcept(ay_);
+			bool? ba_ = context.Operators.Equivalent(ax_, az_);
+			bool? bb_ = context.Operators.Or(au_, ba_);
+			Period bc_ = InpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> bd_ = FHIRHelpers_4_3_000.ToInterval(bc_);
+			CqlInterval<CqlDateTime> be_ = QICoreCommon_2_0_000.toInterval((bd_ as object));
+			CqlDateTime bf_ = context.Operators.End(be_);
+			CqlInterval<CqlDateTime> bg_ = this.Measurement_Period();
+			bool? bh_ = context.Operators.In<CqlDateTime>(bf_, bg_, "day");
+			bool? bi_ = context.Operators.And(bb_, bh_);
 
 			return bi_;
 		};
-		var e_ = context.Operators.Where<Encounter>(c_, d_);
-		var f_ = context.Operators.Exists<Encounter>(e_);
-		var g_ = this.Hospice_Encounter();
-		var h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, null);
-		var i_ = Status_1_6_000.isEncounterPerformed(h_);
+		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
+		bool? f_ = context.Operators.Exists<Encounter>(e_);
+		CqlValueSet g_ = this.Hospice_Encounter();
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, null);
+		IEnumerable<Encounter> i_ = Status_1_6_000.isEncounterPerformed(h_);
 		bool? j_(Encounter HospiceEncounter)
 		{
-			var bj_ = HospiceEncounter?.Period;
-			var bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
-			var bl_ = QICoreCommon_2_0_000.toInterval((bk_ as object));
-			var bm_ = this.Measurement_Period();
-			var bn_ = context.Operators.Overlaps(bl_, bm_, "day");
+			Period bj_ = HospiceEncounter?.Period;
+			CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
+			CqlInterval<CqlDateTime> bl_ = QICoreCommon_2_0_000.toInterval((bk_ as object));
+			CqlInterval<CqlDateTime> bm_ = this.Measurement_Period();
+			bool? bn_ = context.Operators.Overlaps(bl_, bm_, "day");
 
 			return bn_;
 		};
-		var k_ = context.Operators.Where<Encounter>(i_, j_);
-		var l_ = context.Operators.Exists<Encounter>(k_);
-		var m_ = context.Operators.Or(f_, l_);
-		var n_ = this.Hospice_care__Minimum_Data_Set_();
-		var o_ = context.Operators.ToList<CqlCode>(n_);
-		var p_ = context.Operators.RetrieveByCodes<Observation>(o_, null);
-		var q_ = Status_1_6_000.isAssessmentPerformed(p_);
+		IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
+		bool? l_ = context.Operators.Exists<Encounter>(k_);
+		bool? m_ = context.Operators.Or(f_, l_);
+		CqlCode n_ = this.Hospice_care__Minimum_Data_Set_();
+		IEnumerable<CqlCode> o_ = context.Operators.ToList<CqlCode>(n_);
+		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, null);
+		IEnumerable<Observation> q_ = Status_1_6_000.isAssessmentPerformed(p_);
 		bool? r_(Observation HospiceAssessment)
 		{
-			var bo_ = HospiceAssessment?.Value;
-			var bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
-			var bq_ = this.Yes__qualifier_value_();
-			var br_ = context.Operators.ConvertCodeToConcept(bq_);
-			var bs_ = context.Operators.Equivalent((bp_ as CqlConcept), br_);
-			var bt_ = HospiceAssessment?.Effective;
-			var bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
-			var bv_ = QICoreCommon_2_0_000.toInterval(bu_);
-			var bw_ = this.Measurement_Period();
-			var bx_ = context.Operators.Overlaps(bv_, bw_, "day");
-			var by_ = context.Operators.And(bs_, bx_);
+			DataType bo_ = HospiceAssessment?.Value;
+			object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
+			CqlCode bq_ = this.Yes__qualifier_value_();
+			CqlConcept br_ = context.Operators.ConvertCodeToConcept(bq_);
+			bool? bs_ = context.Operators.Equivalent((bp_ as CqlConcept), br_);
+			DataType bt_ = HospiceAssessment?.Effective;
+			object bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
+			CqlInterval<CqlDateTime> bv_ = QICoreCommon_2_0_000.toInterval(bu_);
+			CqlInterval<CqlDateTime> bw_ = this.Measurement_Period();
+			bool? bx_ = context.Operators.Overlaps(bv_, bw_, "day");
+			bool? by_ = context.Operators.And(bs_, bx_);
 
 			return by_;
 		};
-		var s_ = context.Operators.Where<Observation>(q_, r_);
-		var t_ = context.Operators.Exists<Observation>(s_);
-		var u_ = context.Operators.Or(m_, t_);
-		var v_ = this.Hospice_Care_Ambulatory();
-		var w_ = context.Operators.RetrieveByValueSet<ServiceRequest>(v_, null);
-		var x_ = Status_1_6_000.isInterventionOrder(w_);
+		IEnumerable<Observation> s_ = context.Operators.Where<Observation>(q_, r_);
+		bool? t_ = context.Operators.Exists<Observation>(s_);
+		bool? u_ = context.Operators.Or(m_, t_);
+		CqlValueSet v_ = this.Hospice_Care_Ambulatory();
+		IEnumerable<ServiceRequest> w_ = context.Operators.RetrieveByValueSet<ServiceRequest>(v_, null);
+		IEnumerable<ServiceRequest> x_ = Status_1_6_000.isInterventionOrder(w_);
 		bool? y_(ServiceRequest HospiceOrder)
 		{
-			var bz_ = this.Measurement_Period();
-			var ca_ = HospiceOrder?.AuthoredOnElement;
-			var cb_ = context.Operators.Convert<CqlDateTime>(ca_);
-			var cc_ = QICoreCommon_2_0_000.toInterval((cb_ as object));
-			var cd_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bz_, cc_, "day");
+			CqlInterval<CqlDateTime> bz_ = this.Measurement_Period();
+			FhirDateTime ca_ = HospiceOrder?.AuthoredOnElement;
+			CqlDateTime cb_ = context.Operators.Convert<CqlDateTime>(ca_);
+			CqlInterval<CqlDateTime> cc_ = QICoreCommon_2_0_000.toInterval((cb_ as object));
+			bool? cd_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bz_, cc_, "day");
 
 			return cd_;
 		};
-		var z_ = context.Operators.Where<ServiceRequest>(x_, y_);
-		var aa_ = context.Operators.Exists<ServiceRequest>(z_);
-		var ab_ = context.Operators.Or(u_, aa_);
-		var ad_ = context.Operators.RetrieveByValueSet<Procedure>(v_, null);
-		var ae_ = Status_1_6_000.isInterventionPerformed(ad_);
+		IEnumerable<ServiceRequest> z_ = context.Operators.Where<ServiceRequest>(x_, y_);
+		bool? aa_ = context.Operators.Exists<ServiceRequest>(z_);
+		bool? ab_ = context.Operators.Or(u_, aa_);
+		IEnumerable<Procedure> ad_ = context.Operators.RetrieveByValueSet<Procedure>(v_, null);
+		IEnumerable<Procedure> ae_ = Status_1_6_000.isInterventionPerformed(ad_);
 		bool? af_(Procedure HospicePerformed)
 		{
-			var ce_ = HospicePerformed?.Performed;
-			var cf_ = FHIRHelpers_4_3_000.ToValue(ce_);
-			var cg_ = QICoreCommon_2_0_000.toInterval(cf_);
-			var ch_ = this.Measurement_Period();
-			var ci_ = context.Operators.Overlaps(cg_, ch_, "day");
+			DataType ce_ = HospicePerformed?.Performed;
+			object cf_ = FHIRHelpers_4_3_000.ToValue(ce_);
+			CqlInterval<CqlDateTime> cg_ = QICoreCommon_2_0_000.toInterval(cf_);
+			CqlInterval<CqlDateTime> ch_ = this.Measurement_Period();
+			bool? ci_ = context.Operators.Overlaps(cg_, ch_, "day");
 
 			return ci_;
 		};
-		var ag_ = context.Operators.Where<Procedure>(ae_, af_);
-		var ah_ = context.Operators.Exists<Procedure>(ag_);
-		var ai_ = context.Operators.Or(ab_, ah_);
-		var aj_ = this.Hospice_Diagnosis();
-		var ak_ = context.Operators.RetrieveByValueSet<Condition>(aj_, null);
+		IEnumerable<Procedure> ag_ = context.Operators.Where<Procedure>(ae_, af_);
+		bool? ah_ = context.Operators.Exists<Procedure>(ag_);
+		bool? ai_ = context.Operators.Or(ab_, ah_);
+		CqlValueSet aj_ = this.Hospice_Diagnosis();
+		IEnumerable<Condition> ak_ = context.Operators.RetrieveByValueSet<Condition>(aj_, null);
 		bool? al_(Condition HospiceCareDiagnosis)
 		{
-			var cj_ = QICoreCommon_2_0_000.prevalenceInterval(HospiceCareDiagnosis);
-			var ck_ = this.Measurement_Period();
-			var cl_ = context.Operators.Overlaps(cj_, ck_, "day");
+			CqlInterval<CqlDateTime> cj_ = QICoreCommon_2_0_000.prevalenceInterval(HospiceCareDiagnosis);
+			CqlInterval<CqlDateTime> ck_ = this.Measurement_Period();
+			bool? cl_ = context.Operators.Overlaps(cj_, ck_, "day");
 
 			return cl_;
 		};
-		var am_ = context.Operators.Where<Condition>(ak_, al_);
-		var an_ = context.Operators.Exists<Condition>(am_);
-		var ao_ = context.Operators.Or(ai_, an_);
+		IEnumerable<Condition> am_ = context.Operators.Where<Condition>(ak_, al_);
+		bool? an_ = context.Operators.Exists<Condition>(am_);
+		bool? ao_ = context.Operators.Or(ai_, an_);
 
 		return ao_;
 	}
 
+    /// <seealso cref="Has_Hospice_Services_Value"/>
     [CqlDeclaration("Has Hospice Services")]
 	public bool? Has_Hospice_Services() => 
 		__Has_Hospice_Services.Value;

--- a/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
@@ -90,72 +90,89 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Emergency_Department_Visit"/>
 	private CqlValueSet Emergency_Department_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
+    /// <seealso cref="Emergency_Department_Visit_Value"/>
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
 	public CqlValueSet Emergency_Department_Visit() => 
 		__Emergency_Department_Visit.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Observation_Services"/>
 	private CqlValueSet Observation_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
+    /// <seealso cref="Observation_Services_Value"/>
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
 	public CqlValueSet Observation_Services() => 
 		__Observation_Services.Value;
 
+    /// <seealso cref="Operating_Room_Suite"/>
 	private CqlValueSet Operating_Room_Suite_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141", null);
 
+    /// <seealso cref="Operating_Room_Suite_Value"/>
     [CqlDeclaration("Operating Room Suite")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141")]
 	public CqlValueSet Operating_Room_Suite() => 
 		__Operating_Room_Suite.Value;
 
+    /// <seealso cref="Opioid_Antagonist"/>
 	private CqlValueSet Opioid_Antagonist_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119", null);
 
+    /// <seealso cref="Opioid_Antagonist_Value"/>
     [CqlDeclaration("Opioid Antagonist")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119")]
 	public CqlValueSet Opioid_Antagonist() => 
 		__Opioid_Antagonist.Value;
 
+    /// <seealso cref="Opioids__All"/>
 	private CqlValueSet Opioids__All_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226", null);
 
+    /// <seealso cref="Opioids__All_Value"/>
     [CqlDeclaration("Opioids, All")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226")]
 	public CqlValueSet Opioids__All() => 
 		__Opioids__All.Value;
 
+    /// <seealso cref="Routes_of_Administration_for_Opioid_Antagonists"/>
 	private CqlValueSet Routes_of_Administration_for_Opioid_Antagonists_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187", null);
 
+    /// <seealso cref="Routes_of_Administration_for_Opioid_Antagonists_Value"/>
     [CqlDeclaration("Routes of Administration for Opioid Antagonists")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187")]
 	public CqlValueSet Routes_of_Administration_for_Opioid_Antagonists() => 
 		__Routes_of_Administration_for_Opioid_Antagonists.Value;
 
+    /// <seealso cref="Dead"/>
 	private CqlCode Dead_Value() => 
 		new CqlCode("419099009", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Dead_Value"/>
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
 		__Dead.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("419099009", "http://snomed.info/sct", null, null),
 		};
@@ -163,238 +180,258 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="HSLOC"/>
 	private CqlCode[] HSLOC_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="HSLOC_Value"/>
     [CqlDeclaration("HSLOC")]
 	public CqlCode[] HSLOC() => 
 		__HSLOC.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounter"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter InpatientEncounter)
 		{
-			var e_ = this.Patient();
-			var f_ = e_?.BirthDateElement;
-			var g_ = f_?.Value;
-			var h_ = context.Operators.Convert<CqlDate>(g_);
-			var i_ = InpatientEncounter?.Period;
-			var j_ = FHIRHelpers_4_3_000.ToInterval(i_);
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
-			var n_ = context.Operators.GreaterOrEqual(m_, 18);
-			var p_ = FHIRHelpers_4_3_000.ToInterval(i_);
-			var q_ = context.Operators.End(p_);
-			var r_ = this.Measurement_Period();
-			var s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
-			var t_ = context.Operators.And(n_, s_);
-			var u_ = InpatientEncounter?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
-			var x_ = context.Operators.Equal(w_, "finished");
-			var y_ = context.Operators.And(t_, x_);
+			Patient e_ = this.Patient();
+			Date f_ = e_?.BirthDateElement;
+			string g_ = f_?.Value;
+			CqlDate h_ = context.Operators.Convert<CqlDate>(g_);
+			Period i_ = InpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
+			bool? n_ = context.Operators.GreaterOrEqual(m_, 18);
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(i_);
+			CqlDateTime q_ = context.Operators.End(p_);
+			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
+			bool? t_ = context.Operators.And(n_, s_);
+			Code<Encounter.EncounterStatus> u_ = InpatientEncounter?.StatusElement;
+			Encounter.EncounterStatus? v_ = u_?.Value;
+			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+			bool? x_ = context.Operators.Equal(w_, "finished");
+			bool? y_ = context.Operators.And(t_, x_);
 
 			return y_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_Value"/>
     [CqlDeclaration("Qualifying Encounter")]
 	public IEnumerable<Encounter> Qualifying_Encounter() => 
 		__Qualifying_Encounter.Value;
 
+    /// <seealso cref="Opioid_Administration"/>
 	private IEnumerable<MedicationAdministration> Opioid_Administration_Value()
 	{
-		var a_ = this.Opioids__All();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
+		CqlValueSet a_ = this.Opioids__All();
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration Opioids)
 		{
-			var h_ = Opioids?.StatusElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(i_);
-			var k_ = context.Operators.Equal(j_, "completed");
-			var m_ = h_?.Value;
-			var n_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(m_);
-			var o_ = context.Operators.Equal(n_, "not-done");
-			var p_ = context.Operators.Not(o_);
-			var q_ = context.Operators.And(k_, p_);
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> h_ = Opioids?.StatusElement;
+			MedicationAdministration.MedicationAdministrationStatusCodes? i_ = h_?.Value;
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> j_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(i_);
+			bool? k_ = context.Operators.Equal(j_, "completed");
+			MedicationAdministration.MedicationAdministrationStatusCodes? m_ = h_?.Value;
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> n_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(m_);
+			bool? o_ = context.Operators.Equal(n_, "not-done");
+			bool? p_ = context.Operators.Not(o_);
+			bool? q_ = context.Operators.And(k_, p_);
 
 			return q_;
 		};
-		var g_ = context.Operators.Where<MedicationAdministration>(e_, f_);
+		IEnumerable<MedicationAdministration> g_ = context.Operators.Where<MedicationAdministration>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Opioid_Administration_Value"/>
     [CqlDeclaration("Opioid Administration")]
 	public IEnumerable<MedicationAdministration> Opioid_Administration() => 
 		__Opioid_Administration.Value;
 
+    /// <seealso cref="Encounter_with_Opioid_Administration_Outside_of_Operating_Room"/>
 	private IEnumerable<Encounter> Encounter_with_Opioid_Administration_Outside_of_Operating_Room_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		IEnumerable<Encounter> b_(Encounter InpatientEncounter)
 		{
-			var d_ = this.Opioid_Administration();
+			IEnumerable<MedicationAdministration> d_ = this.Opioid_Administration();
 			bool? e_(MedicationAdministration OpioidGiven)
 			{
-				var i_ = OpioidGiven?.Effective;
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = QICoreCommon_2_0_000.ToInterval(j_);
-				var l_ = context.Operators.Start(k_);
-				var m_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientEncounter);
-				var n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
-				var o_ = InpatientEncounter?.Location;
+				DataType i_ = OpioidGiven?.Effective;
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval(j_);
+				CqlDateTime l_ = context.Operators.Start(k_);
+				CqlInterval<CqlDateTime> m_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientEncounter);
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
+				List<Encounter.LocationComponent> o_ = InpatientEncounter?.Location;
 				bool? p_(Encounter.LocationComponent EncounterLocation)
 				{
-					var u_ = EncounterLocation?.Location;
-					var v_ = CQMCommon_2_0_000.GetLocation(u_);
-					var w_ = v_?.Type;
+					ResourceReference u_ = EncounterLocation?.Location;
+					Location v_ = CQMCommon_2_0_000.GetLocation(u_);
+					List<CodeableConcept> w_ = v_?.Type;
 					CqlConcept x_(CodeableConcept @this)
 					{
-						var aj_ = FHIRHelpers_4_3_000.ToConcept(@this);
+						CqlConcept aj_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 						return aj_;
 					};
-					var y_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)w_, x_);
-					var z_ = this.Operating_Room_Suite();
-					var aa_ = context.Operators.ConceptsInValueSet(y_, z_);
-					var ab_ = OpioidGiven?.Effective;
-					var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-					var ad_ = QICoreCommon_2_0_000.ToInterval(ac_);
-					var ae_ = context.Operators.Start(ad_);
-					var af_ = EncounterLocation?.Period;
-					var ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-					var ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, null);
-					var ai_ = context.Operators.And(aa_, ah_);
+					IEnumerable<CqlConcept> y_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)w_, x_);
+					CqlValueSet z_ = this.Operating_Room_Suite();
+					bool? aa_ = context.Operators.ConceptsInValueSet(y_, z_);
+					DataType ab_ = OpioidGiven?.Effective;
+					object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+					CqlInterval<CqlDateTime> ad_ = QICoreCommon_2_0_000.ToInterval(ac_);
+					CqlDateTime ae_ = context.Operators.Start(ad_);
+					Period af_ = EncounterLocation?.Period;
+					CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
+					bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, null);
+					bool? ai_ = context.Operators.And(aa_, ah_);
 
 					return ai_;
 				};
-				var q_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)o_, p_);
-				var r_ = context.Operators.Exists<Encounter.LocationComponent>(q_);
-				var s_ = context.Operators.Not(r_);
-				var t_ = context.Operators.And(n_, s_);
+				IEnumerable<Encounter.LocationComponent> q_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)o_, p_);
+				bool? r_ = context.Operators.Exists<Encounter.LocationComponent>(q_);
+				bool? s_ = context.Operators.Not(r_);
+				bool? t_ = context.Operators.And(n_, s_);
 
 				return t_;
 			};
-			var f_ = context.Operators.Where<MedicationAdministration>(d_, e_);
+			IEnumerable<MedicationAdministration> f_ = context.Operators.Where<MedicationAdministration>(d_, e_);
 			Encounter g_(MedicationAdministration OpioidGiven) => 
 				InpatientEncounter;
-			var h_ = context.Operators.Select<MedicationAdministration, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<MedicationAdministration, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Opioid_Administration_Outside_of_Operating_Room_Value"/>
     [CqlDeclaration("Encounter with Opioid Administration Outside of Operating Room")]
 	public IEnumerable<Encounter> Encounter_with_Opioid_Administration_Outside_of_Operating_Room() => 
 		__Encounter_with_Opioid_Administration_Outside_of_Operating_Room.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Encounter_with_Opioid_Administration_Outside_of_Operating_Room();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Opioid_Administration_Outside_of_Operating_Room();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Opioid_Antagonist_Administration"/>
 	private IEnumerable<MedicationAdministration> Opioid_Antagonist_Administration_Value()
 	{
-		var a_ = this.Opioid_Antagonist();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
+		CqlValueSet a_ = this.Opioid_Antagonist();
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration AntagonistGiven)
 		{
-			var h_ = AntagonistGiven?.StatusElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(i_);
-			var k_ = context.Operators.Equal(j_, "completed");
-			var m_ = h_?.Value;
-			var n_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(m_);
-			var o_ = context.Operators.Equal(n_, "not-done");
-			var p_ = context.Operators.Not(o_);
-			var q_ = context.Operators.And(k_, p_);
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> h_ = AntagonistGiven?.StatusElement;
+			MedicationAdministration.MedicationAdministrationStatusCodes? i_ = h_?.Value;
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> j_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(i_);
+			bool? k_ = context.Operators.Equal(j_, "completed");
+			MedicationAdministration.MedicationAdministrationStatusCodes? m_ = h_?.Value;
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> n_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(m_);
+			bool? o_ = context.Operators.Equal(n_, "not-done");
+			bool? p_ = context.Operators.Not(o_);
+			bool? q_ = context.Operators.And(k_, p_);
 
 			return q_;
 		};
-		var g_ = context.Operators.Where<MedicationAdministration>(e_, f_);
+		IEnumerable<MedicationAdministration> g_ = context.Operators.Where<MedicationAdministration>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Opioid_Antagonist_Administration_Value"/>
     [CqlDeclaration("Opioid Antagonist Administration")]
 	public IEnumerable<MedicationAdministration> Opioid_Antagonist_Administration() => 
 		__Opioid_Antagonist_Administration.Value;
 
+    /// <seealso cref="Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid"/>
 	private IEnumerable<Encounter> Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid_Value()
 	{
-		var a_ = this.Opioid_Antagonist_Administration();
-		var b_ = this.Opioid_Administration();
-		var c_ = this.Denominator();
-		var d_ = context.Operators.CrossJoin<MedicationAdministration, MedicationAdministration, Encounter>(a_, b_, c_);
+		IEnumerable<MedicationAdministration> a_ = this.Opioid_Antagonist_Administration();
+		IEnumerable<MedicationAdministration> b_ = this.Opioid_Administration();
+		IEnumerable<Encounter> c_ = this.Denominator();
+		IEnumerable<ValueTuple<MedicationAdministration, MedicationAdministration, Encounter>> d_ = context.Operators.CrossJoin<MedicationAdministration, MedicationAdministration, Encounter>(a_, b_, c_);
 		Tuple_DiOQPVXLKifMhgTIYEEjRUSaD e_(ValueTuple<MedicationAdministration, MedicationAdministration, Encounter> _valueTuple)
 		{
-			var k_ = new Tuple_DiOQPVXLKifMhgTIYEEjRUSaD
+			Tuple_DiOQPVXLKifMhgTIYEEjRUSaD k_ = new Tuple_DiOQPVXLKifMhgTIYEEjRUSaD
 			{
 				OpioidAntagonistGiven = _valueTuple.Item1,
 				OpioidGiven = _valueTuple.Item2,
@@ -403,142 +440,153 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 
 			return k_;
 		};
-		var f_ = context.Operators.Select<ValueTuple<MedicationAdministration, MedicationAdministration, Encounter>, Tuple_DiOQPVXLKifMhgTIYEEjRUSaD>(d_, e_);
+		IEnumerable<Tuple_DiOQPVXLKifMhgTIYEEjRUSaD> f_ = context.Operators.Select<ValueTuple<MedicationAdministration, MedicationAdministration, Encounter>, Tuple_DiOQPVXLKifMhgTIYEEjRUSaD>(d_, e_);
 		bool? g_(Tuple_DiOQPVXLKifMhgTIYEEjRUSaD tuple_dioqpvxlkifmhgtiyeejrusad)
 		{
-			var l_ = tuple_dioqpvxlkifmhgtiyeejrusad.EncounterWithQualifyingAge?.Location;
+			List<Encounter.LocationComponent> l_ = tuple_dioqpvxlkifmhgtiyeejrusad.EncounterWithQualifyingAge?.Location;
 			bool? m_(Encounter.LocationComponent EncounterLocation)
 			{
-				var bh_ = EncounterLocation?.Location;
-				var bi_ = CQMCommon_2_0_000.GetLocation(bh_);
-				var bj_ = bi_?.Type;
+				ResourceReference bh_ = EncounterLocation?.Location;
+				Location bi_ = CQMCommon_2_0_000.GetLocation(bh_);
+				List<CodeableConcept> bj_ = bi_?.Type;
 				CqlConcept bk_(CodeableConcept @this)
 				{
-					var bw_ = FHIRHelpers_4_3_000.ToConcept(@this);
+					CqlConcept bw_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 					return bw_;
 				};
-				var bl_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bj_, bk_);
-				var bm_ = this.Operating_Room_Suite();
-				var bn_ = context.Operators.ConceptsInValueSet(bl_, bm_);
-				var bo_ = tuple_dioqpvxlkifmhgtiyeejrusad.OpioidAntagonistGiven?.Effective;
-				var bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
-				var bq_ = QICoreCommon_2_0_000.ToInterval(bp_);
-				var br_ = context.Operators.Start(bq_);
-				var bs_ = EncounterLocation?.Period;
-				var bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
-				var bu_ = context.Operators.In<CqlDateTime>(br_, bt_, null);
-				var bv_ = context.Operators.And(bn_, bu_);
+				IEnumerable<CqlConcept> bl_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bj_, bk_);
+				CqlValueSet bm_ = this.Operating_Room_Suite();
+				bool? bn_ = context.Operators.ConceptsInValueSet(bl_, bm_);
+				DataType bo_ = tuple_dioqpvxlkifmhgtiyeejrusad.OpioidAntagonistGiven?.Effective;
+				object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
+				CqlInterval<CqlDateTime> bq_ = QICoreCommon_2_0_000.ToInterval(bp_);
+				CqlDateTime br_ = context.Operators.Start(bq_);
+				Period bs_ = EncounterLocation?.Period;
+				CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
+				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, null);
+				bool? bv_ = context.Operators.And(bn_, bu_);
 
 				return bv_;
 			};
-			var n_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)l_, m_);
-			var o_ = context.Operators.Exists<Encounter.LocationComponent>(n_);
-			var p_ = context.Operators.Not(o_);
-			var q_ = tuple_dioqpvxlkifmhgtiyeejrusad.OpioidAntagonistGiven?.Effective;
-			var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var s_ = QICoreCommon_2_0_000.ToInterval(r_);
-			var t_ = context.Operators.Start(s_);
-			var u_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_dioqpvxlkifmhgtiyeejrusad.EncounterWithQualifyingAge);
-			var v_ = context.Operators.In<CqlDateTime>(t_, u_, null);
-			var w_ = tuple_dioqpvxlkifmhgtiyeejrusad.OpioidGiven?.Effective;
-			var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-			var y_ = QICoreCommon_2_0_000.ToInterval(x_);
-			var z_ = context.Operators.Start(y_);
-			var ab_ = context.Operators.In<CqlDateTime>(z_, u_, null);
-			var ac_ = context.Operators.And(v_, ab_);
-			var ae_ = FHIRHelpers_4_3_000.ToValue(w_);
-			var af_ = QICoreCommon_2_0_000.ToInterval(ae_);
-			var ag_ = context.Operators.End(af_);
-			var ai_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var aj_ = QICoreCommon_2_0_000.ToInterval(ai_);
-			var ak_ = context.Operators.Start(aj_);
-			var al_ = context.Operators.Quantity(12m, "hours");
-			var am_ = context.Operators.Subtract(ak_, al_);
-			var ao_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var ap_ = QICoreCommon_2_0_000.ToInterval(ao_);
-			var aq_ = context.Operators.Start(ap_);
-			var ar_ = context.Operators.Interval(am_, aq_, true, false);
-			var as_ = context.Operators.In<CqlDateTime>(ag_, ar_, null);
-			var au_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var av_ = QICoreCommon_2_0_000.ToInterval(au_);
-			var aw_ = context.Operators.Start(av_);
-			var ax_ = context.Operators.Not((bool?)(aw_ is null));
-			var ay_ = context.Operators.And(as_, ax_);
-			var az_ = context.Operators.And(ac_, ay_);
-			var ba_ = tuple_dioqpvxlkifmhgtiyeejrusad.OpioidAntagonistGiven?.Dosage;
-			var bb_ = ba_?.Route;
-			var bc_ = FHIRHelpers_4_3_000.ToConcept(bb_);
-			var bd_ = this.Routes_of_Administration_for_Opioid_Antagonists();
-			var be_ = context.Operators.ConceptInValueSet(bc_, bd_);
-			var bf_ = context.Operators.And(az_, be_);
-			var bg_ = context.Operators.And(p_, bf_);
+			IEnumerable<Encounter.LocationComponent> n_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)l_, m_);
+			bool? o_ = context.Operators.Exists<Encounter.LocationComponent>(n_);
+			bool? p_ = context.Operators.Not(o_);
+			DataType q_ = tuple_dioqpvxlkifmhgtiyeejrusad.OpioidAntagonistGiven?.Effective;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
+			CqlDateTime t_ = context.Operators.Start(s_);
+			CqlInterval<CqlDateTime> u_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_dioqpvxlkifmhgtiyeejrusad.EncounterWithQualifyingAge);
+			bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, null);
+			DataType w_ = tuple_dioqpvxlkifmhgtiyeejrusad.OpioidGiven?.Effective;
+			object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval(x_);
+			CqlDateTime z_ = context.Operators.Start(y_);
+			bool? ab_ = context.Operators.In<CqlDateTime>(z_, u_, null);
+			bool? ac_ = context.Operators.And(v_, ab_);
+			object ae_ = FHIRHelpers_4_3_000.ToValue(w_);
+			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
+			CqlDateTime ag_ = context.Operators.End(af_);
+			object ai_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.ToInterval(ai_);
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlQuantity al_ = context.Operators.Quantity(12m, "hours");
+			CqlDateTime am_ = context.Operators.Subtract(ak_, al_);
+			object ao_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> ap_ = QICoreCommon_2_0_000.ToInterval(ao_);
+			CqlDateTime aq_ = context.Operators.Start(ap_);
+			CqlInterval<CqlDateTime> ar_ = context.Operators.Interval(am_, aq_, true, false);
+			bool? as_ = context.Operators.In<CqlDateTime>(ag_, ar_, null);
+			object au_ = FHIRHelpers_4_3_000.ToValue(q_);
+			CqlInterval<CqlDateTime> av_ = QICoreCommon_2_0_000.ToInterval(au_);
+			CqlDateTime aw_ = context.Operators.Start(av_);
+			bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+			bool? ay_ = context.Operators.And(as_, ax_);
+			bool? az_ = context.Operators.And(ac_, ay_);
+			MedicationAdministration.DosageComponent ba_ = tuple_dioqpvxlkifmhgtiyeejrusad.OpioidAntagonistGiven?.Dosage;
+			CodeableConcept bb_ = ba_?.Route;
+			CqlConcept bc_ = FHIRHelpers_4_3_000.ToConcept(bb_);
+			CqlValueSet bd_ = this.Routes_of_Administration_for_Opioid_Antagonists();
+			bool? be_ = context.Operators.ConceptInValueSet(bc_, bd_);
+			bool? bf_ = context.Operators.And(az_, be_);
+			bool? bg_ = context.Operators.And(p_, bf_);
 
 			return bg_;
 		};
-		var h_ = context.Operators.Where<Tuple_DiOQPVXLKifMhgTIYEEjRUSaD>(f_, g_);
+		IEnumerable<Tuple_DiOQPVXLKifMhgTIYEEjRUSaD> h_ = context.Operators.Where<Tuple_DiOQPVXLKifMhgTIYEEjRUSaD>(f_, g_);
 		Encounter i_(Tuple_DiOQPVXLKifMhgTIYEEjRUSaD tuple_dioqpvxlkifmhgtiyeejrusad) => 
 			tuple_dioqpvxlkifmhgtiyeejrusad.EncounterWithQualifyingAge;
-		var j_ = context.Operators.Select<Tuple_DiOQPVXLKifMhgTIYEEjRUSaD, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.Select<Tuple_DiOQPVXLKifMhgTIYEEjRUSaD, Encounter>(h_, i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid_Value"/>
     [CqlDeclaration("Encounter with Non Enteral Opioid Antagonist Administration Outside of Operating Room and within 12 Hrs After Opioid")]
 	public IEnumerable<Encounter> Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid() => 
 		__Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Non_Enteral_Opioid_Antagonist_Administration_Outside_of_Operating_Room_and_within_12_Hrs_After_Opioid();
 
 		return a_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
@@ -114,96 +114,119 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="COVID_19"/>
 	private CqlValueSet COVID_19_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140", null);
 
+    /// <seealso cref="COVID_19_Value"/>
     [CqlDeclaration("COVID 19")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140")]
 	public CqlValueSet COVID_19() => 
 		__COVID_19.Value;
 
+    /// <seealso cref="Emergency_Department_Visit"/>
 	private CqlValueSet Emergency_Department_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
+    /// <seealso cref="Emergency_Department_Visit_Value"/>
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
 	public CqlValueSet Emergency_Department_Visit() => 
 		__Emergency_Department_Visit.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine"/>
 	private CqlValueSet Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198", null);
 
+    /// <seealso cref="Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine_Value"/>
     [CqlDeclaration("Not Present On Admission or Documentation Insufficient to Determine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198")]
 	public CqlValueSet Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine() => 
 		__Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine.Value;
 
+    /// <seealso cref="Observation_Services"/>
 	private CqlValueSet Observation_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
+    /// <seealso cref="Observation_Services_Value"/>
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
 	public CqlValueSet Observation_Services() => 
 		__Observation_Services.Value;
 
+    /// <seealso cref="Present_on_Admission_or_Clinically_Undetermined"/>
 	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", null);
 
+    /// <seealso cref="Present_on_Admission_or_Clinically_Undetermined_Value"/>
     [CqlDeclaration("Present on Admission or Clinically Undetermined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
 	public CqlValueSet Present_on_Admission_or_Clinically_Undetermined() => 
 		__Present_on_Admission_or_Clinically_Undetermined.Value;
 
+    /// <seealso cref="Pressure_Injury_Deep_Tissue"/>
 	private CqlValueSet Pressure_Injury_Deep_Tissue_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112", null);
 
+    /// <seealso cref="Pressure_Injury_Deep_Tissue_Value"/>
     [CqlDeclaration("Pressure Injury Deep Tissue")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112")]
 	public CqlValueSet Pressure_Injury_Deep_Tissue() => 
 		__Pressure_Injury_Deep_Tissue.Value;
 
+    /// <seealso cref="Pressure_Injury_Deep_Tissue_Diagnoses"/>
 	private CqlValueSet Pressure_Injury_Deep_Tissue_Diagnoses_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194", null);
 
+    /// <seealso cref="Pressure_Injury_Deep_Tissue_Diagnoses_Value"/>
     [CqlDeclaration("Pressure Injury Deep Tissue Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194")]
 	public CqlValueSet Pressure_Injury_Deep_Tissue_Diagnoses() => 
 		__Pressure_Injury_Deep_Tissue_Diagnoses.Value;
 
+    /// <seealso cref="Pressure_Injury_Stage_2__3__4_or_Unstageable"/>
 	private CqlValueSet Pressure_Injury_Stage_2__3__4_or_Unstageable_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113", null);
 
+    /// <seealso cref="Pressure_Injury_Stage_2__3__4_or_Unstageable_Value"/>
     [CqlDeclaration("Pressure Injury Stage 2, 3, 4 or Unstageable")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113")]
 	public CqlValueSet Pressure_Injury_Stage_2__3__4_or_Unstageable() => 
 		__Pressure_Injury_Stage_2__3__4_or_Unstageable.Value;
 
+    /// <seealso cref="Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses"/>
 	private CqlValueSet Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196", null);
 
+    /// <seealso cref="Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses_Value"/>
     [CqlDeclaration("Pressure Injury Stage 2, 3, 4, or Unstageable Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196")]
 	public CqlValueSet Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses() => 
 		__Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses.Value;
 
+    /// <seealso cref="Physical_findings_of_Skin"/>
 	private CqlCode Physical_findings_of_Skin_Value() => 
 		new CqlCode("8709-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Physical_findings_of_Skin_Value"/>
     [CqlDeclaration("Physical findings of Skin")]
 	public CqlCode Physical_findings_of_Skin() => 
 		__Physical_findings_of_Skin.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("8709-8", "http://loinc.org", null, null),
 		};
@@ -211,737 +234,786 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("HospitalHarmPressureInjuryFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("HospitalHarmPressureInjuryFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Encounter_with_Age_18_and_Older"/>
 	private IEnumerable<Encounter> Encounter_with_Age_18_and_Older_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter InpatientEncounter)
 		{
-			var e_ = this.Patient();
-			var f_ = e_?.BirthDateElement;
-			var g_ = f_?.Value;
-			var h_ = context.Operators.Convert<CqlDate>(g_);
-			var i_ = InpatientEncounter?.Period;
-			var j_ = FHIRHelpers_4_3_000.ToInterval(i_);
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
-			var n_ = context.Operators.GreaterOrEqual(m_, 18);
-			var p_ = FHIRHelpers_4_3_000.ToInterval(i_);
-			var q_ = context.Operators.End(p_);
-			var r_ = this.Measurement_Period();
-			var s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
-			var t_ = context.Operators.And(n_, s_);
-			var u_ = InpatientEncounter?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
-			var x_ = context.Operators.Equal(w_, "finished");
-			var y_ = context.Operators.And(t_, x_);
+			Patient e_ = this.Patient();
+			Date f_ = e_?.BirthDateElement;
+			string g_ = f_?.Value;
+			CqlDate h_ = context.Operators.Convert<CqlDate>(g_);
+			Period i_ = InpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
+			bool? n_ = context.Operators.GreaterOrEqual(m_, 18);
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(i_);
+			CqlDateTime q_ = context.Operators.End(p_);
+			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
+			bool? t_ = context.Operators.And(n_, s_);
+			Code<Encounter.EncounterStatus> u_ = InpatientEncounter?.StatusElement;
+			Encounter.EncounterStatus? v_ = u_?.Value;
+			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+			bool? x_ = context.Operators.Equal(w_, "finished");
+			bool? y_ = context.Operators.And(t_, x_);
 
 			return y_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Encounter_with_Age_18_and_Older_Value"/>
     [CqlDeclaration("Encounter with Age 18 and Older")]
 	public IEnumerable<Encounter> Encounter_with_Age_18_and_Older() => 
 		__Encounter_with_Age_18_and_Older.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator"/>
 	private IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 		bool? b_(Encounter InpatientHospitalization)
 		{
-			var d_ = InpatientHospitalization?.Diagnosis;
+			List<Encounter.DiagnosisComponent> d_ = InpatientHospitalization?.Diagnosis;
 			bool? e_(Encounter.DiagnosisComponent EncounterDiag)
 			{
-				var h_ = EncounterDiag?.Condition;
-				var i_ = CQMCommon_2_0_000.getCondition(h_);
-				var j_ = i_?.Code;
-				var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
-				var l_ = this.Pressure_Injury_Deep_Tissue_Diagnoses();
-				var m_ = context.Operators.ConceptInValueSet(k_, l_);
+				ResourceReference h_ = EncounterDiag?.Condition;
+				Condition i_ = CQMCommon_2_0_000.getCondition(h_);
+				CodeableConcept j_ = i_?.Code;
+				CqlConcept k_ = FHIRHelpers_4_3_000.ToConcept(j_);
+				CqlValueSet l_ = this.Pressure_Injury_Deep_Tissue_Diagnoses();
+				bool? m_ = context.Operators.ConceptInValueSet(k_, l_);
 				bool? n_(Extension @this)
 				{
-					var x_ = @this?.Url;
-					var y_ = context.Operators.Convert<FhirUri>(x_);
-					var z_ = FHIRHelpers_4_3_000.ToString(y_);
-					var aa_ = context.Operators.Equal(z_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+					string x_ = @this?.Url;
+					FhirUri y_ = context.Operators.Convert<FhirUri>(x_);
+					string z_ = FHIRHelpers_4_3_000.ToString(y_);
+					bool? aa_ = context.Operators.Equal(z_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
 
 					return aa_;
 				};
-				var o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiag is Element)
+				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiag is Element)
 						? ((EncounterDiag as Element).Extension)
 						: null), n_);
 				DataType p_(Extension @this)
 				{
-					var ab_ = @this?.Value;
+					DataType ab_ = @this?.Value;
 
 					return ab_;
 				};
-				var q_ = context.Operators.Select<Extension, DataType>(o_, p_);
-				var r_ = context.Operators.SingletonFrom<DataType>(q_);
-				var s_ = context.Operators.Convert<CodeableConcept>(r_);
-				var t_ = FHIRHelpers_4_3_000.ToConcept(s_);
-				var u_ = this.Present_on_Admission_or_Clinically_Undetermined();
-				var v_ = context.Operators.ConceptInValueSet(t_, u_);
-				var w_ = context.Operators.And(m_, v_);
+				IEnumerable<DataType> q_ = context.Operators.Select<Extension, DataType>(o_, p_);
+				DataType r_ = context.Operators.SingletonFrom<DataType>(q_);
+				CodeableConcept s_ = context.Operators.Convert<CodeableConcept>(r_);
+				CqlConcept t_ = FHIRHelpers_4_3_000.ToConcept(s_);
+				CqlValueSet u_ = this.Present_on_Admission_or_Clinically_Undetermined();
+				bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
+				bool? w_ = context.Operators.And(m_, v_);
 
 				return w_;
 			};
-			var f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
-			var g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
+			IEnumerable<Encounter.DiagnosisComponent> f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
+			bool? g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
 
 			return g_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator_Value"/>
     [CqlDeclaration("Encounter with Deep Tissue Pressure Injury POA by Indicator")]
 	public IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator() => 
 		__Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator.Value;
 
+    /// <seealso cref="Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours"/>
 	private IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
 		{
-			var d_ = this.Physical_findings_of_Skin();
-			var e_ = context.Operators.ToList<CqlCode>(d_);
-			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			CqlCode d_ = this.Physical_findings_of_Skin();
+			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
 			bool? g_(Observation SkinExam)
 			{
-				var k_ = SkinExam?.Effective;
-				var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-				var m_ = QICoreCommon_2_0_000.ToInterval(l_);
-				var n_ = context.Operators.Start(m_);
-				var o_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
-				var p_ = context.Operators.Start(o_);
-				var r_ = context.Operators.Start(o_);
-				var s_ = context.Operators.Quantity(72m, "hours");
-				var t_ = context.Operators.Add(r_, s_);
-				var u_ = context.Operators.Interval(p_, t_, true, true);
-				var v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
-				var w_ = SkinExam?.StatusElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
-				var z_ = context.Operators.Convert<string>(y_);
-				var aa_ = new string[]
+				DataType k_ = SkinExam?.Effective;
+				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.ToInterval(l_);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlDateTime r_ = context.Operators.Start(o_);
+				CqlQuantity s_ = context.Operators.Quantity(72m, "hours");
+				CqlDateTime t_ = context.Operators.Add(r_, s_);
+				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
+				ObservationStatus? x_ = w_?.Value;
+				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
+				string z_ = context.Operators.Convert<string>(y_);
+				string[] aa_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
-				var ac_ = context.Operators.And(v_, ab_);
-				var ad_ = SkinExam?.Code;
-				var ae_ = FHIRHelpers_4_3_000.ToConcept(ad_);
-				var af_ = this.Pressure_Injury_Deep_Tissue();
-				var ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-				var ah_ = context.Operators.And(ac_, ag_);
+				bool? ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
+				bool? ac_ = context.Operators.And(v_, ab_);
+				CodeableConcept ad_ = SkinExam?.Code;
+				CqlConcept ae_ = FHIRHelpers_4_3_000.ToConcept(ad_);
+				CqlValueSet af_ = this.Pressure_Injury_Deep_Tissue();
+				bool? ag_ = context.Operators.ConceptInValueSet(ae_, af_);
+				bool? ah_ = context.Operators.And(ac_, ag_);
 
 				return ah_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			Encounter i_(Observation SkinExam) => 
 				InpatientHospitalization;
-			var j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours_Value"/>
     [CqlDeclaration("Encounter with Deep Tissue Pressure Injury POA by Skin Exam within First 72 Hours")]
 	public IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours() => 
 		__Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours.Value;
 
+    /// <seealso cref="Encounter_with_Deep_Tissue_Pressure_Injury_POA"/>
 	private IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA_Value()
 	{
-		var a_ = this.Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator();
-		var b_ = this.Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Indicator();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Deep_Tissue_Pressure_Injury_POA_by_Skin_Exam_within_First_72_Hours();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Deep_Tissue_Pressure_Injury_POA_Value"/>
     [CqlDeclaration("Encounter with Deep Tissue Pressure Injury POA")]
 	public IEnumerable<Encounter> Encounter_with_Deep_Tissue_Pressure_Injury_POA() => 
 		__Encounter_with_Deep_Tissue_Pressure_Injury_POA.Value;
 
+    /// <seealso cref="Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator"/>
 	private IEnumerable<Encounter> Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 		bool? b_(Encounter InpatientHospitalization)
 		{
-			var d_ = InpatientHospitalization?.Diagnosis;
+			List<Encounter.DiagnosisComponent> d_ = InpatientHospitalization?.Diagnosis;
 			bool? e_(Encounter.DiagnosisComponent Stage234UnstageablePressureInjury)
 			{
-				var h_ = Stage234UnstageablePressureInjury?.Condition;
-				var i_ = CQMCommon_2_0_000.getCondition(h_);
-				var j_ = i_?.Code;
-				var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
-				var l_ = this.Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses();
-				var m_ = context.Operators.ConceptInValueSet(k_, l_);
+				ResourceReference h_ = Stage234UnstageablePressureInjury?.Condition;
+				Condition i_ = CQMCommon_2_0_000.getCondition(h_);
+				CodeableConcept j_ = i_?.Code;
+				CqlConcept k_ = FHIRHelpers_4_3_000.ToConcept(j_);
+				CqlValueSet l_ = this.Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses();
+				bool? m_ = context.Operators.ConceptInValueSet(k_, l_);
 				bool? n_(Extension @this)
 				{
-					var x_ = @this?.Url;
-					var y_ = context.Operators.Convert<FhirUri>(x_);
-					var z_ = FHIRHelpers_4_3_000.ToString(y_);
-					var aa_ = context.Operators.Equal(z_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+					string x_ = @this?.Url;
+					FhirUri y_ = context.Operators.Convert<FhirUri>(x_);
+					string z_ = FHIRHelpers_4_3_000.ToString(y_);
+					bool? aa_ = context.Operators.Equal(z_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
 
 					return aa_;
 				};
-				var o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((Stage234UnstageablePressureInjury is Element)
+				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((Stage234UnstageablePressureInjury is Element)
 						? ((Stage234UnstageablePressureInjury as Element).Extension)
 						: null), n_);
 				DataType p_(Extension @this)
 				{
-					var ab_ = @this?.Value;
+					DataType ab_ = @this?.Value;
 
 					return ab_;
 				};
-				var q_ = context.Operators.Select<Extension, DataType>(o_, p_);
-				var r_ = context.Operators.SingletonFrom<DataType>(q_);
-				var s_ = context.Operators.Convert<CodeableConcept>(r_);
-				var t_ = FHIRHelpers_4_3_000.ToConcept(s_);
-				var u_ = this.Present_on_Admission_or_Clinically_Undetermined();
-				var v_ = context.Operators.ConceptInValueSet(t_, u_);
-				var w_ = context.Operators.And(m_, v_);
+				IEnumerable<DataType> q_ = context.Operators.Select<Extension, DataType>(o_, p_);
+				DataType r_ = context.Operators.SingletonFrom<DataType>(q_);
+				CodeableConcept s_ = context.Operators.Convert<CodeableConcept>(r_);
+				CqlConcept t_ = FHIRHelpers_4_3_000.ToConcept(s_);
+				CqlValueSet u_ = this.Present_on_Admission_or_Clinically_Undetermined();
+				bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
+				bool? w_ = context.Operators.And(m_, v_);
 
 				return w_;
 			};
-			var f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
-			var g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
+			IEnumerable<Encounter.DiagnosisComponent> f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
+			bool? g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
 
 			return g_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator_Value"/>
     [CqlDeclaration("Encounter with Stage 2, 3, 4, or Unstageable Pressure Injury Present on Admission by POA Indicator")]
 	public IEnumerable<Encounter> Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator() => 
 		__Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator.Value;
 
+    /// <seealso cref="Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours"/>
 	private IEnumerable<Encounter> Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
 		{
-			var d_ = this.Physical_findings_of_Skin();
-			var e_ = context.Operators.ToList<CqlCode>(d_);
-			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			CqlCode d_ = this.Physical_findings_of_Skin();
+			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
 			bool? g_(Observation SkinExam)
 			{
-				var k_ = SkinExam?.Effective;
-				var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-				var m_ = QICoreCommon_2_0_000.ToInterval(l_);
-				var n_ = context.Operators.Start(m_);
-				var o_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
-				var p_ = context.Operators.Start(o_);
-				var r_ = context.Operators.Start(o_);
-				var s_ = context.Operators.Quantity(24m, "hours");
-				var t_ = context.Operators.Add(r_, s_);
-				var u_ = context.Operators.Interval(p_, t_, true, true);
-				var v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
-				var w_ = SkinExam?.StatusElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
-				var z_ = context.Operators.Convert<string>(y_);
-				var aa_ = new string[]
+				DataType k_ = SkinExam?.Effective;
+				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.ToInterval(l_);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlDateTime r_ = context.Operators.Start(o_);
+				CqlQuantity s_ = context.Operators.Quantity(24m, "hours");
+				CqlDateTime t_ = context.Operators.Add(r_, s_);
+				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
+				ObservationStatus? x_ = w_?.Value;
+				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
+				string z_ = context.Operators.Convert<string>(y_);
+				string[] aa_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
-				var ac_ = context.Operators.And(v_, ab_);
-				var ad_ = SkinExam?.Code;
-				var ae_ = FHIRHelpers_4_3_000.ToConcept(ad_);
-				var af_ = this.Pressure_Injury_Stage_2__3__4_or_Unstageable();
-				var ag_ = context.Operators.ConceptInValueSet(ae_, af_);
-				var ah_ = context.Operators.And(ac_, ag_);
+				bool? ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
+				bool? ac_ = context.Operators.And(v_, ab_);
+				CodeableConcept ad_ = SkinExam?.Code;
+				CqlConcept ae_ = FHIRHelpers_4_3_000.ToConcept(ad_);
+				CqlValueSet af_ = this.Pressure_Injury_Stage_2__3__4_or_Unstageable();
+				bool? ag_ = context.Operators.ConceptInValueSet(ae_, af_);
+				bool? ah_ = context.Operators.And(ac_, ag_);
 
 				return ah_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			Encounter i_(Observation SkinExam) => 
 				InpatientHospitalization;
-			var j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours_Value"/>
     [CqlDeclaration("Encounter with Stage 2, 3, 4 or Unstageable Pressure Injury POA by Skin Exam within 24 Hours")]
 	public IEnumerable<Encounter> Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours() => 
 		__Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours.Value;
 
+    /// <seealso cref="Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA"/>
 	private IEnumerable<Encounter> Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_Value()
 	{
-		var a_ = this.Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator();
-		var b_ = this.Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_Stage_2__3__4__or_Unstageable_Pressure_Injury_Present_on_Admission_by_POA_Indicator();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_by_Skin_Exam_within_24_Hours();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA_Value"/>
     [CqlDeclaration("Encounter with Stage 2, 3, 4 or Unstageable Pressure Injury POA")]
 	public IEnumerable<Encounter> Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA() => 
 		__Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA.Value;
 
+    /// <seealso cref="Encounter_with_Diagnosis_of_COVID19_Infection"/>
 	private IEnumerable<Encounter> Encounter_with_Diagnosis_of_COVID19_Infection_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 		bool? b_(Encounter InpatientHospitalization)
 		{
-			var d_ = CQMCommon_2_0_000.EncounterDiagnosis(InpatientHospitalization);
+			IEnumerable<Condition> d_ = CQMCommon_2_0_000.EncounterDiagnosis(InpatientHospitalization);
 			bool? e_(Condition EncounterDiag)
 			{
-				var h_ = EncounterDiag?.Code;
-				var i_ = FHIRHelpers_4_3_000.ToConcept(h_);
-				var j_ = this.COVID_19();
-				var k_ = context.Operators.ConceptInValueSet(i_, j_);
+				CodeableConcept h_ = EncounterDiag?.Code;
+				CqlConcept i_ = FHIRHelpers_4_3_000.ToConcept(h_);
+				CqlValueSet j_ = this.COVID_19();
+				bool? k_ = context.Operators.ConceptInValueSet(i_, j_);
 
 				return k_;
 			};
-			var f_ = context.Operators.Where<Condition>(d_, e_);
-			var g_ = context.Operators.Exists<Condition>(f_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+			bool? g_ = context.Operators.Exists<Condition>(f_);
 
 			return g_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Diagnosis_of_COVID19_Infection_Value"/>
     [CqlDeclaration("Encounter with Diagnosis of COVID19 Infection")]
 	public IEnumerable<Encounter> Encounter_with_Diagnosis_of_COVID19_Infection() => 
 		__Encounter_with_Diagnosis_of_COVID19_Infection.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private IEnumerable<Encounter> Denominator_Exclusions_Value()
 	{
-		var a_ = this.Encounter_with_Deep_Tissue_Pressure_Injury_POA();
-		var b_ = this.Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
-		var d_ = this.Encounter_with_Diagnosis_of_COVID19_Infection();
-		var e_ = context.Operators.Union<Encounter>(c_, d_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_Deep_Tissue_Pressure_Injury_POA();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Stage_2__3__4_or_Unstageable_Pressure_Injury_POA();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.Encounter_with_Diagnosis_of_COVID19_Infection();
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public IEnumerable<Encounter> Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator"/>
 	private IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 		bool? b_(Encounter InpatientHospitalization)
 		{
-			var d_ = InpatientHospitalization?.Diagnosis;
+			List<Encounter.DiagnosisComponent> d_ = InpatientHospitalization?.Diagnosis;
 			bool? e_(Encounter.DiagnosisComponent EncounterDiag)
 			{
-				var h_ = EncounterDiag?.Condition;
-				var i_ = CQMCommon_2_0_000.getCondition(h_);
-				var j_ = i_?.Code;
-				var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
-				var l_ = this.Pressure_Injury_Deep_Tissue_Diagnoses();
-				var m_ = context.Operators.ConceptInValueSet(k_, l_);
+				ResourceReference h_ = EncounterDiag?.Condition;
+				Condition i_ = CQMCommon_2_0_000.getCondition(h_);
+				CodeableConcept j_ = i_?.Code;
+				CqlConcept k_ = FHIRHelpers_4_3_000.ToConcept(j_);
+				CqlValueSet l_ = this.Pressure_Injury_Deep_Tissue_Diagnoses();
+				bool? m_ = context.Operators.ConceptInValueSet(k_, l_);
 				bool? n_(Extension @this)
 				{
-					var x_ = @this?.Url;
-					var y_ = context.Operators.Convert<FhirUri>(x_);
-					var z_ = FHIRHelpers_4_3_000.ToString(y_);
-					var aa_ = context.Operators.Equal(z_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+					string x_ = @this?.Url;
+					FhirUri y_ = context.Operators.Convert<FhirUri>(x_);
+					string z_ = FHIRHelpers_4_3_000.ToString(y_);
+					bool? aa_ = context.Operators.Equal(z_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
 
 					return aa_;
 				};
-				var o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiag is Element)
+				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiag is Element)
 						? ((EncounterDiag as Element).Extension)
 						: null), n_);
 				DataType p_(Extension @this)
 				{
-					var ab_ = @this?.Value;
+					DataType ab_ = @this?.Value;
 
 					return ab_;
 				};
-				var q_ = context.Operators.Select<Extension, DataType>(o_, p_);
-				var r_ = context.Operators.SingletonFrom<DataType>(q_);
-				var s_ = context.Operators.Convert<CodeableConcept>(r_);
-				var t_ = FHIRHelpers_4_3_000.ToConcept(s_);
-				var u_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine();
-				var v_ = context.Operators.ConceptInValueSet(t_, u_);
-				var w_ = context.Operators.And(m_, v_);
+				IEnumerable<DataType> q_ = context.Operators.Select<Extension, DataType>(o_, p_);
+				DataType r_ = context.Operators.SingletonFrom<DataType>(q_);
+				CodeableConcept s_ = context.Operators.Convert<CodeableConcept>(r_);
+				CqlConcept t_ = FHIRHelpers_4_3_000.ToConcept(s_);
+				CqlValueSet u_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine();
+				bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
+				bool? w_ = context.Operators.And(m_, v_);
 
 				return w_;
 			};
-			var f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
-			var g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
+			IEnumerable<Encounter.DiagnosisComponent> f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
+			bool? g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
 
 			return g_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator_Value"/>
     [CqlDeclaration("Encounter with New Deep Tissue Pressure Injury Not POA by Indicator")]
 	public IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator() => 
 		__Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator.Value;
 
+    /// <seealso cref="Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours"/>
 	private IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
 		{
-			var d_ = this.Physical_findings_of_Skin();
-			var e_ = context.Operators.ToList<CqlCode>(d_);
-			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			CqlCode d_ = this.Physical_findings_of_Skin();
+			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
 			bool? g_(Observation SkinExam)
 			{
-				var k_ = SkinExam?.Effective;
-				var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-				var m_ = QICoreCommon_2_0_000.ToInterval(l_);
-				var n_ = context.Operators.Start(m_);
-				var o_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
-				var p_ = context.Operators.Start(o_);
-				var q_ = context.Operators.Quantity(72m, "hours");
-				var r_ = context.Operators.Add(p_, q_);
-				var t_ = context.Operators.End(o_);
-				var u_ = context.Operators.Interval(r_, t_, true, true);
-				var v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
-				var w_ = SkinExam?.StatusElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
-				var z_ = context.Operators.Convert<string>(y_);
-				var aa_ = new string[]
+				DataType k_ = SkinExam?.Effective;
+				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.ToInterval(l_);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlQuantity q_ = context.Operators.Quantity(72m, "hours");
+				CqlDateTime r_ = context.Operators.Add(p_, q_);
+				CqlDateTime t_ = context.Operators.End(o_);
+				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
+				ObservationStatus? x_ = w_?.Value;
+				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
+				string z_ = context.Operators.Convert<string>(y_);
+				string[] aa_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
-				var ac_ = context.Operators.And(v_, ab_);
-				var ad_ = SkinExam?.Value;
-				var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-				var af_ = this.Pressure_Injury_Deep_Tissue();
-				var ag_ = context.Operators.ConceptInValueSet((ae_ as CqlConcept), af_);
-				var ah_ = SkinExam?.Component;
+				bool? ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
+				bool? ac_ = context.Operators.And(v_, ab_);
+				DataType ad_ = SkinExam?.Value;
+				object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+				CqlValueSet af_ = this.Pressure_Injury_Deep_Tissue();
+				bool? ag_ = context.Operators.ConceptInValueSet((ae_ as CqlConcept), af_);
+				List<Observation.ComponentComponent> ah_ = SkinExam?.Component;
 				bool? ai_(Observation.ComponentComponent @this)
 				{
-					var aq_ = @this?.Code;
-					var ar_ = FHIRHelpers_4_3_000.ToConcept(aq_);
-					var as_ = context.Operators.Not((bool?)(ar_ is null));
+					CodeableConcept aq_ = @this?.Code;
+					CqlConcept ar_ = FHIRHelpers_4_3_000.ToConcept(aq_);
+					bool? as_ = context.Operators.Not((bool?)(ar_ is null));
 
 					return as_;
 				};
-				var aj_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ah_, ai_);
+				IEnumerable<Observation.ComponentComponent> aj_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ah_, ai_);
 				CqlConcept ak_(Observation.ComponentComponent @this)
 				{
-					var at_ = @this?.Code;
-					var au_ = FHIRHelpers_4_3_000.ToConcept(at_);
+					CodeableConcept at_ = @this?.Code;
+					CqlConcept au_ = FHIRHelpers_4_3_000.ToConcept(at_);
 
 					return au_;
 				};
-				var al_ = context.Operators.Select<Observation.ComponentComponent, CqlConcept>(aj_, ak_);
-				var an_ = context.Operators.ConceptsInValueSet(al_, af_);
-				var ao_ = context.Operators.Or(ag_, an_);
-				var ap_ = context.Operators.And(ac_, ao_);
+				IEnumerable<CqlConcept> al_ = context.Operators.Select<Observation.ComponentComponent, CqlConcept>(aj_, ak_);
+				bool? an_ = context.Operators.ConceptsInValueSet(al_, af_);
+				bool? ao_ = context.Operators.Or(ag_, an_);
+				bool? ap_ = context.Operators.And(ac_, ao_);
 
 				return ap_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			Encounter i_(Observation SkinExam) => 
 				InpatientHospitalization;
-			var j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours_Value"/>
     [CqlDeclaration("Encounter with New Deep Tissue Pressure Injury by Skin Exam after First 72 Hours")]
 	public IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours() => 
 		__Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours.Value;
 
+    /// <seealso cref="Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA"/>
 	private IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_Value()
 	{
-		var a_ = this.Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator();
-		var b_ = this.Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_by_Indicator();
+		IEnumerable<Encounter> b_ = this.Encounter_with_New_Deep_Tissue_Pressure_Injury_by_Skin_Exam_after_First_72_Hours();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA_Value"/>
     [CqlDeclaration("Encounter with New Deep Tissue Pressure Injury Not POA")]
 	public IEnumerable<Encounter> Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA() => 
 		__Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA.Value;
 
+    /// <seealso cref="Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator"/>
 	private IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 		bool? b_(Encounter InpatientHospitalization)
 		{
-			var d_ = InpatientHospitalization?.Diagnosis;
+			List<Encounter.DiagnosisComponent> d_ = InpatientHospitalization?.Diagnosis;
 			bool? e_(Encounter.DiagnosisComponent Stage234UnstageablePressureInjury)
 			{
-				var h_ = Stage234UnstageablePressureInjury?.Condition;
-				var i_ = CQMCommon_2_0_000.getCondition(h_);
-				var j_ = i_?.Code;
-				var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
-				var l_ = this.Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses();
-				var m_ = context.Operators.ConceptInValueSet(k_, l_);
+				ResourceReference h_ = Stage234UnstageablePressureInjury?.Condition;
+				Condition i_ = CQMCommon_2_0_000.getCondition(h_);
+				CodeableConcept j_ = i_?.Code;
+				CqlConcept k_ = FHIRHelpers_4_3_000.ToConcept(j_);
+				CqlValueSet l_ = this.Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses();
+				bool? m_ = context.Operators.ConceptInValueSet(k_, l_);
 				bool? n_(Extension @this)
 				{
-					var x_ = @this?.Url;
-					var y_ = context.Operators.Convert<FhirUri>(x_);
-					var z_ = FHIRHelpers_4_3_000.ToString(y_);
-					var aa_ = context.Operators.Equal(z_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+					string x_ = @this?.Url;
+					FhirUri y_ = context.Operators.Convert<FhirUri>(x_);
+					string z_ = FHIRHelpers_4_3_000.ToString(y_);
+					bool? aa_ = context.Operators.Equal(z_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
 
 					return aa_;
 				};
-				var o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((Stage234UnstageablePressureInjury is Element)
+				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((Stage234UnstageablePressureInjury is Element)
 						? ((Stage234UnstageablePressureInjury as Element).Extension)
 						: null), n_);
 				DataType p_(Extension @this)
 				{
-					var ab_ = @this?.Value;
+					DataType ab_ = @this?.Value;
 
 					return ab_;
 				};
-				var q_ = context.Operators.Select<Extension, DataType>(o_, p_);
-				var r_ = context.Operators.SingletonFrom<DataType>(q_);
-				var s_ = context.Operators.Convert<CodeableConcept>(r_);
-				var t_ = FHIRHelpers_4_3_000.ToConcept(s_);
-				var u_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine();
-				var v_ = context.Operators.ConceptInValueSet(t_, u_);
-				var w_ = context.Operators.And(m_, v_);
+				IEnumerable<DataType> q_ = context.Operators.Select<Extension, DataType>(o_, p_);
+				DataType r_ = context.Operators.SingletonFrom<DataType>(q_);
+				CodeableConcept s_ = context.Operators.Convert<CodeableConcept>(r_);
+				CqlConcept t_ = FHIRHelpers_4_3_000.ToConcept(s_);
+				CqlValueSet u_ = this.Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine();
+				bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
+				bool? w_ = context.Operators.And(m_, v_);
 
 				return w_;
 			};
-			var f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
-			var g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
+			IEnumerable<Encounter.DiagnosisComponent> f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
+			bool? g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
 
 			return g_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator_Value"/>
     [CqlDeclaration("Encounter with New Stage 2, 3, 4 or Unstageable Pressure Injury Not POA by Indicator")]
 	public IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator() => 
 		__Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator.Value;
 
+    /// <seealso cref="Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours"/>
 	private IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours_Value()
 	{
-		var a_ = this.Encounter_with_Age_18_and_Older();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Older();
 		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
 		{
-			var d_ = this.Physical_findings_of_Skin();
-			var e_ = context.Operators.ToList<CqlCode>(d_);
-			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			CqlCode d_ = this.Physical_findings_of_Skin();
+			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
 			bool? g_(Observation SkinExam)
 			{
-				var k_ = SkinExam?.Effective;
-				var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-				var m_ = QICoreCommon_2_0_000.ToInterval(l_);
-				var n_ = context.Operators.Start(m_);
-				var o_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
-				var p_ = context.Operators.Start(o_);
-				var q_ = context.Operators.Quantity(24m, "hours");
-				var r_ = context.Operators.Add(p_, q_);
-				var t_ = context.Operators.End(o_);
-				var u_ = context.Operators.Interval(r_, t_, true, true);
-				var v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
-				var w_ = SkinExam?.StatusElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
-				var z_ = context.Operators.Convert<string>(y_);
-				var aa_ = new string[]
+				DataType k_ = SkinExam?.Effective;
+				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.ToInterval(l_);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlQuantity q_ = context.Operators.Quantity(24m, "hours");
+				CqlDateTime r_ = context.Operators.Add(p_, q_);
+				CqlDateTime t_ = context.Operators.End(o_);
+				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
+				ObservationStatus? x_ = w_?.Value;
+				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
+				string z_ = context.Operators.Convert<string>(y_);
+				string[] aa_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
-				var ac_ = context.Operators.And(v_, ab_);
-				var ad_ = SkinExam?.Value;
-				var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-				var af_ = this.Pressure_Injury_Stage_2__3__4_or_Unstageable();
-				var ag_ = context.Operators.ConceptInValueSet((ae_ as CqlConcept), af_);
-				var ah_ = SkinExam?.Component;
+				bool? ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
+				bool? ac_ = context.Operators.And(v_, ab_);
+				DataType ad_ = SkinExam?.Value;
+				object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+				CqlValueSet af_ = this.Pressure_Injury_Stage_2__3__4_or_Unstageable();
+				bool? ag_ = context.Operators.ConceptInValueSet((ae_ as CqlConcept), af_);
+				List<Observation.ComponentComponent> ah_ = SkinExam?.Component;
 				bool? ai_(Observation.ComponentComponent @this)
 				{
-					var aq_ = @this?.Code;
-					var ar_ = FHIRHelpers_4_3_000.ToConcept(aq_);
-					var as_ = context.Operators.Not((bool?)(ar_ is null));
+					CodeableConcept aq_ = @this?.Code;
+					CqlConcept ar_ = FHIRHelpers_4_3_000.ToConcept(aq_);
+					bool? as_ = context.Operators.Not((bool?)(ar_ is null));
 
 					return as_;
 				};
-				var aj_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ah_, ai_);
+				IEnumerable<Observation.ComponentComponent> aj_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ah_, ai_);
 				CqlConcept ak_(Observation.ComponentComponent @this)
 				{
-					var at_ = @this?.Code;
-					var au_ = FHIRHelpers_4_3_000.ToConcept(at_);
+					CodeableConcept at_ = @this?.Code;
+					CqlConcept au_ = FHIRHelpers_4_3_000.ToConcept(at_);
 
 					return au_;
 				};
-				var al_ = context.Operators.Select<Observation.ComponentComponent, CqlConcept>(aj_, ak_);
-				var an_ = context.Operators.ConceptsInValueSet(al_, af_);
-				var ao_ = context.Operators.Or(ag_, an_);
-				var ap_ = context.Operators.And(ac_, ao_);
+				IEnumerable<CqlConcept> al_ = context.Operators.Select<Observation.ComponentComponent, CqlConcept>(aj_, ak_);
+				bool? an_ = context.Operators.ConceptsInValueSet(al_, af_);
+				bool? ao_ = context.Operators.Or(ag_, an_);
+				bool? ap_ = context.Operators.And(ac_, ao_);
 
 				return ap_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			Encounter i_(Observation SkinExam) => 
 				InpatientHospitalization;
-			var j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
+			IEnumerable<Encounter> j_ = context.Operators.Select<Observation, Encounter>(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours_Value"/>
     [CqlDeclaration("Encounter with New Stage 2, 3, 4 or Unstageable Pressure Injury by Skin Exam after First 24 Hours")]
 	public IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours() => 
 		__Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours.Value;
 
+    /// <seealso cref="Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA"/>
 	private IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_Value()
 	{
-		var a_ = this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator();
-		var b_ = this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_by_Indicator();
+		IEnumerable<Encounter> b_ = this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_by_Skin_Exam_after_First_24_Hours();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA_Value"/>
     [CqlDeclaration("Encounter with New Stage 2, 3, 4 or Unstageable Pressure Injury Not POA")]
 	public IEnumerable<Encounter> Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA() => 
 		__Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA();
-		var b_ = this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_New_Deep_Tissue_Pressure_Injury_Not_POA();
+		IEnumerable<Encounter> b_ = this.Encounter_with_New_Stage_2__3__4_or_Unstageable_Pressure_Injury_Not_POA();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
@@ -86,212 +86,239 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="birth_date"/>
 	private CqlValueSet birth_date_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
 
+    /// <seealso cref="birth_date_Value"/>
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
 	public CqlValueSet birth_date() => 
 		__birth_date.Value;
 
+    /// <seealso cref="Emergency_Department_Visit"/>
 	private CqlValueSet Emergency_Department_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
+    /// <seealso cref="Emergency_Department_Visit_Value"/>
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
 	public CqlValueSet Emergency_Department_Visit() => 
 		__Emergency_Department_Visit.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Glucose_Lab_Test_Mass_Per_Volume"/>
 	private CqlValueSet Glucose_Lab_Test_Mass_Per_Volume_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34", null);
 
+    /// <seealso cref="Glucose_Lab_Test_Mass_Per_Volume_Value"/>
     [CqlDeclaration("Glucose Lab Test Mass Per Volume")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34")]
 	public CqlValueSet Glucose_Lab_Test_Mass_Per_Volume() => 
 		__Glucose_Lab_Test_Mass_Per_Volume.Value;
 
+    /// <seealso cref="Hypoglycemics_Severe_Hypoglycemia"/>
 	private CqlValueSet Hypoglycemics_Severe_Hypoglycemia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", null);
 
+    /// <seealso cref="Hypoglycemics_Severe_Hypoglycemia_Value"/>
     [CqlDeclaration("Hypoglycemics Severe Hypoglycemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393")]
 	public CqlValueSet Hypoglycemics_Severe_Hypoglycemia() => 
 		__Hypoglycemics_Severe_Hypoglycemia.Value;
 
+    /// <seealso cref="Observation_Services"/>
 	private CqlValueSet Observation_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
+    /// <seealso cref="Observation_Services_Value"/>
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
 	public CqlValueSet Observation_Services() => 
 		__Observation_Services.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("HospitalHarmSevereHypoglycemiaFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("HospitalHarmSevereHypoglycemiaFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounter"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter InpatientEncounter)
 		{
-			var e_ = this.Patient();
-			var f_ = e_?.BirthDateElement;
-			var g_ = f_?.Value;
-			var h_ = context.Operators.Convert<CqlDate>(g_);
-			var i_ = InpatientEncounter?.Period;
-			var j_ = FHIRHelpers_4_3_000.ToInterval(i_);
-			var k_ = context.Operators.Start(j_);
-			var l_ = context.Operators.DateFrom(k_);
-			var m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
-			var n_ = context.Operators.GreaterOrEqual(m_, 18);
-			var p_ = FHIRHelpers_4_3_000.ToInterval(i_);
-			var q_ = context.Operators.End(p_);
-			var r_ = this.Measurement_Period();
-			var s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
-			var t_ = context.Operators.And(n_, s_);
-			var u_ = InpatientEncounter?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
-			var x_ = context.Operators.Equal(w_, "finished");
-			var y_ = context.Operators.And(t_, x_);
+			Patient e_ = this.Patient();
+			Date f_ = e_?.BirthDateElement;
+			string g_ = f_?.Value;
+			CqlDate h_ = context.Operators.Convert<CqlDate>(g_);
+			Period i_ = InpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
+			CqlDateTime k_ = context.Operators.Start(j_);
+			CqlDate l_ = context.Operators.DateFrom(k_);
+			int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
+			bool? n_ = context.Operators.GreaterOrEqual(m_, 18);
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(i_);
+			CqlDateTime q_ = context.Operators.End(p_);
+			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
+			bool? t_ = context.Operators.And(n_, s_);
+			Code<Encounter.EncounterStatus> u_ = InpatientEncounter?.StatusElement;
+			Encounter.EncounterStatus? v_ = u_?.Value;
+			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+			bool? x_ = context.Operators.Equal(w_, "finished");
+			bool? y_ = context.Operators.And(t_, x_);
 
 			return y_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_Value"/>
     [CqlDeclaration("Qualifying Encounter")]
 	public IEnumerable<Encounter> Qualifying_Encounter() => 
 		__Qualifying_Encounter.Value;
 
+    /// <seealso cref="Hypoglycemic_Medication_Administration"/>
 	private IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration_Value()
 	{
-		var a_ = this.Hypoglycemics_Severe_Hypoglycemia();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
+		CqlValueSet a_ = this.Hypoglycemics_Severe_Hypoglycemia();
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration HypoMedication)
 		{
-			var h_ = HypoMedication?.StatusElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(i_);
-			var k_ = context.Operators.Equal(j_, "completed");
-			var m_ = h_?.Value;
-			var n_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(m_);
-			var o_ = context.Operators.Equal(n_, "not-done");
-			var p_ = context.Operators.Not(o_);
-			var q_ = context.Operators.And(k_, p_);
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> h_ = HypoMedication?.StatusElement;
+			MedicationAdministration.MedicationAdministrationStatusCodes? i_ = h_?.Value;
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> j_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(i_);
+			bool? k_ = context.Operators.Equal(j_, "completed");
+			MedicationAdministration.MedicationAdministrationStatusCodes? m_ = h_?.Value;
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> n_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(m_);
+			bool? o_ = context.Operators.Equal(n_, "not-done");
+			bool? p_ = context.Operators.Not(o_);
+			bool? q_ = context.Operators.And(k_, p_);
 
 			return q_;
 		};
-		var g_ = context.Operators.Where<MedicationAdministration>(e_, f_);
+		IEnumerable<MedicationAdministration> g_ = context.Operators.Where<MedicationAdministration>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Hypoglycemic_Medication_Administration_Value"/>
     [CqlDeclaration("Hypoglycemic Medication Administration")]
 	public IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration() => 
 		__Hypoglycemic_Medication_Administration.Value;
 
+    /// <seealso cref="Encounter_with_Hypoglycemic_Medication_Administration"/>
 	private IEnumerable<Encounter> Encounter_with_Hypoglycemic_Medication_Administration_Value()
 	{
-		var a_ = this.Qualifying_Encounter();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		IEnumerable<Encounter> b_(Encounter InpatientHospitalization)
 		{
-			var d_ = this.Hypoglycemic_Medication_Administration();
+			IEnumerable<MedicationAdministration> d_ = this.Hypoglycemic_Medication_Administration();
 			bool? e_(MedicationAdministration HypoglycemicMedication)
 			{
-				var i_ = HypoglycemicMedication?.Effective;
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = QICoreCommon_2_0_000.ToInterval(j_);
-				var l_ = context.Operators.Start(k_);
-				var m_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
-				var n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
+				DataType i_ = HypoglycemicMedication?.Effective;
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval(j_);
+				CqlDateTime l_ = context.Operators.Start(k_);
+				CqlInterval<CqlDateTime> m_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
 
 				return n_;
 			};
-			var f_ = context.Operators.Where<MedicationAdministration>(d_, e_);
+			IEnumerable<MedicationAdministration> f_ = context.Operators.Where<MedicationAdministration>(d_, e_);
 			Encounter g_(MedicationAdministration HypoglycemicMedication) => 
 				InpatientHospitalization;
-			var h_ = context.Operators.Select<MedicationAdministration, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<MedicationAdministration, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Hypoglycemic_Medication_Administration_Value"/>
     [CqlDeclaration("Encounter with Hypoglycemic Medication Administration")]
 	public IEnumerable<Encounter> Encounter_with_Hypoglycemic_Medication_Administration() => 
 		__Encounter_with_Hypoglycemic_Medication_Administration.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Encounter_with_Hypoglycemic_Medication_Administration();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Hypoglycemic_Medication_Administration();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Glucose_Test_with_Result_Less_Than_40"/>
 	private IEnumerable<Observation> Glucose_Test_with_Result_Less_Than_40_Value()
 	{
-		var a_ = this.Denominator();
-		var b_ = this.Hypoglycemic_Medication_Administration();
-		var c_ = this.Glucose_Lab_Test_Mass_Per_Volume();
-		var d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
-		var e_ = context.Operators.CrossJoin<Encounter, MedicationAdministration, Observation>(a_, b_, d_);
+		IEnumerable<Encounter> a_ = this.Denominator();
+		IEnumerable<MedicationAdministration> b_ = this.Hypoglycemic_Medication_Administration();
+		CqlValueSet c_ = this.Glucose_Lab_Test_Mass_Per_Volume();
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		IEnumerable<ValueTuple<Encounter, MedicationAdministration, Observation>> e_ = context.Operators.CrossJoin<Encounter, MedicationAdministration, Observation>(a_, b_, d_);
 		Tuple_BTYMMDGaChdRaGRhOfgXBXGHO f_(ValueTuple<Encounter, MedicationAdministration, Observation> _valueTuple)
 		{
-			var l_ = new Tuple_BTYMMDGaChdRaGRhOfgXBXGHO
+			Tuple_BTYMMDGaChdRaGRhOfgXBXGHO l_ = new Tuple_BTYMMDGaChdRaGRhOfgXBXGHO
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				HypoglycemicMedication = _valueTuple.Item2,
@@ -300,53 +327,53 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 
 			return l_;
 		};
-		var g_ = context.Operators.Select<ValueTuple<Encounter, MedicationAdministration, Observation>, Tuple_BTYMMDGaChdRaGRhOfgXBXGHO>(e_, f_);
+		IEnumerable<Tuple_BTYMMDGaChdRaGRhOfgXBXGHO> g_ = context.Operators.Select<ValueTuple<Encounter, MedicationAdministration, Observation>, Tuple_BTYMMDGaChdRaGRhOfgXBXGHO>(e_, f_);
 		bool? h_(Tuple_BTYMMDGaChdRaGRhOfgXBXGHO tuple_btymmdgachdragrhofgxbxgho)
 		{
 			object m_()
 			{
 				bool at_()
 				{
-					var aw_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
-					var ay_ = ax_ is CqlDateTime;
+					DataType aw_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+					bool ay_ = ax_ is CqlDateTime;
 
 					return ay_;
 				};
 				bool au_()
 				{
-					var az_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var ba_ = FHIRHelpers_4_3_000.ToValue(az_);
-					var bb_ = ba_ is CqlInterval<CqlDateTime>;
+					DataType az_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object ba_ = FHIRHelpers_4_3_000.ToValue(az_);
+					bool bb_ = ba_ is CqlInterval<CqlDateTime>;
 
 					return bb_;
 				};
 				bool av_()
 				{
-					var bc_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
-					var be_ = bd_ is CqlDateTime;
+					DataType bc_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
+					bool be_ = bd_ is CqlDateTime;
 
 					return be_;
 				};
 				if (at_())
 				{
-					var bf_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var bg_ = FHIRHelpers_4_3_000.ToValue(bf_);
+					DataType bf_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object bg_ = FHIRHelpers_4_3_000.ToValue(bf_);
 
 					return ((bg_ as CqlDateTime) as object);
 				}
 				else if (au_())
 				{
-					var bh_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
+					DataType bh_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
 
 					return ((bi_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (av_())
 				{
-					var bj_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+					DataType bj_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
 
 					return ((bk_ as CqlDateTime) as object);
 				}
@@ -355,74 +382,74 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var n_ = QICoreCommon_2_0_000.Earliest(m_());
-			var o_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_btymmdgachdragrhofgxbxgho.QualifyingEncounter);
-			var p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
-			var q_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.StatusElement;
-			var r_ = q_?.Value;
-			var s_ = context.Operators.Convert<Code<ObservationStatus>>(r_);
-			var t_ = context.Operators.Convert<string>(s_);
-			var u_ = new string[]
+			CqlDateTime n_ = QICoreCommon_2_0_000.Earliest(m_());
+			CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_btymmdgachdragrhofgxbxgho.QualifyingEncounter);
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
+			Code<ObservationStatus> q_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.StatusElement;
+			ObservationStatus? r_ = q_?.Value;
+			Code<ObservationStatus> s_ = context.Operators.Convert<Code<ObservationStatus>>(r_);
+			string t_ = context.Operators.Convert<string>(s_);
+			string[] u_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var v_ = context.Operators.In<string>(t_, (u_ as IEnumerable<string>));
-			var w_ = context.Operators.And(p_, v_);
-			var x_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Value;
-			var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-			var z_ = context.Operators.Quantity(40m, "mg/dL");
-			var aa_ = context.Operators.Less((y_ as CqlQuantity), z_);
-			var ab_ = context.Operators.And(w_, aa_);
-			var ac_ = tuple_btymmdgachdragrhofgxbxgho.HypoglycemicMedication?.Effective;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
-			var af_ = context.Operators.Start(ae_);
+			bool? v_ = context.Operators.In<string>(t_, (u_ as IEnumerable<string>));
+			bool? w_ = context.Operators.And(p_, v_);
+			DataType x_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Value;
+			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+			CqlQuantity z_ = context.Operators.Quantity(40m, "mg/dL");
+			bool? aa_ = context.Operators.Less((y_ as CqlQuantity), z_);
+			bool? ab_ = context.Operators.And(w_, aa_);
+			DataType ac_ = tuple_btymmdgachdragrhofgxbxgho.HypoglycemicMedication?.Effective;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
+			CqlDateTime af_ = context.Operators.Start(ae_);
 			object ag_()
 			{
 				bool bl_()
 				{
-					var bo_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
-					var bq_ = bp_ is CqlDateTime;
+					DataType bo_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
+					bool bq_ = bp_ is CqlDateTime;
 
 					return bq_;
 				};
 				bool bm_()
 				{
-					var br_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var bs_ = FHIRHelpers_4_3_000.ToValue(br_);
-					var bt_ = bs_ is CqlInterval<CqlDateTime>;
+					DataType br_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object bs_ = FHIRHelpers_4_3_000.ToValue(br_);
+					bool bt_ = bs_ is CqlInterval<CqlDateTime>;
 
 					return bt_;
 				};
 				bool bn_()
 				{
-					var bu_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var bv_ = FHIRHelpers_4_3_000.ToValue(bu_);
-					var bw_ = bv_ is CqlDateTime;
+					DataType bu_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object bv_ = FHIRHelpers_4_3_000.ToValue(bu_);
+					bool bw_ = bv_ is CqlDateTime;
 
 					return bw_;
 				};
 				if (bl_())
 				{
-					var bx_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var by_ = FHIRHelpers_4_3_000.ToValue(bx_);
+					DataType bx_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object by_ = FHIRHelpers_4_3_000.ToValue(bx_);
 
 					return ((by_ as CqlDateTime) as object);
 				}
 				else if (bm_())
 				{
-					var bz_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+					DataType bz_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
 
 					return ((ca_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (bn_())
 				{
-					var cb_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+					DataType cb_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
 
 					return ((cc_ as CqlDateTime) as object);
 				}
@@ -431,53 +458,53 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var ah_ = QICoreCommon_2_0_000.Earliest(ag_());
-			var ai_ = context.Operators.Quantity(24m, "hours");
-			var aj_ = context.Operators.Subtract(ah_, ai_);
+			CqlDateTime ah_ = QICoreCommon_2_0_000.Earliest(ag_());
+			CqlQuantity ai_ = context.Operators.Quantity(24m, "hours");
+			CqlDateTime aj_ = context.Operators.Subtract(ah_, ai_);
 			object ak_()
 			{
 				bool cd_()
 				{
-					var cg_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var ch_ = FHIRHelpers_4_3_000.ToValue(cg_);
-					var ci_ = ch_ is CqlDateTime;
+					DataType cg_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object ch_ = FHIRHelpers_4_3_000.ToValue(cg_);
+					bool ci_ = ch_ is CqlDateTime;
 
 					return ci_;
 				};
 				bool ce_()
 				{
-					var cj_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
-					var cl_ = ck_ is CqlInterval<CqlDateTime>;
+					DataType cj_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
+					bool cl_ = ck_ is CqlInterval<CqlDateTime>;
 
 					return cl_;
 				};
 				bool cf_()
 				{
-					var cm_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var cn_ = FHIRHelpers_4_3_000.ToValue(cm_);
-					var co_ = cn_ is CqlDateTime;
+					DataType cm_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object cn_ = FHIRHelpers_4_3_000.ToValue(cm_);
+					bool co_ = cn_ is CqlDateTime;
 
 					return co_;
 				};
 				if (cd_())
 				{
-					var cp_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var cq_ = FHIRHelpers_4_3_000.ToValue(cp_);
+					DataType cp_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object cq_ = FHIRHelpers_4_3_000.ToValue(cp_);
 
 					return ((cq_ as CqlDateTime) as object);
 				}
 				else if (ce_())
 				{
-					var cr_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
+					DataType cr_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
 
 					return ((cs_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (cf_())
 				{
-					var ct_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
+					DataType ct_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
 
 					return ((cu_ as CqlDateTime) as object);
 				}
@@ -486,53 +513,53 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var al_ = QICoreCommon_2_0_000.Earliest(ak_());
-			var am_ = context.Operators.Interval(aj_, al_, true, true);
-			var an_ = context.Operators.In<CqlDateTime>(af_, am_, null);
+			CqlDateTime al_ = QICoreCommon_2_0_000.Earliest(ak_());
+			CqlInterval<CqlDateTime> am_ = context.Operators.Interval(aj_, al_, true, true);
+			bool? an_ = context.Operators.In<CqlDateTime>(af_, am_, null);
 			object ao_()
 			{
 				bool cv_()
 				{
-					var cy_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var cz_ = FHIRHelpers_4_3_000.ToValue(cy_);
-					var da_ = cz_ is CqlDateTime;
+					DataType cy_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object cz_ = FHIRHelpers_4_3_000.ToValue(cy_);
+					bool da_ = cz_ is CqlDateTime;
 
 					return da_;
 				};
 				bool cw_()
 				{
-					var db_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var dc_ = FHIRHelpers_4_3_000.ToValue(db_);
-					var dd_ = dc_ is CqlInterval<CqlDateTime>;
+					DataType db_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object dc_ = FHIRHelpers_4_3_000.ToValue(db_);
+					bool dd_ = dc_ is CqlInterval<CqlDateTime>;
 
 					return dd_;
 				};
 				bool cx_()
 				{
-					var de_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var df_ = FHIRHelpers_4_3_000.ToValue(de_);
-					var dg_ = df_ is CqlDateTime;
+					DataType de_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object df_ = FHIRHelpers_4_3_000.ToValue(de_);
+					bool dg_ = df_ is CqlDateTime;
 
 					return dg_;
 				};
 				if (cv_())
 				{
-					var dh_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var di_ = FHIRHelpers_4_3_000.ToValue(dh_);
+					DataType dh_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object di_ = FHIRHelpers_4_3_000.ToValue(dh_);
 
 					return ((di_ as CqlDateTime) as object);
 				}
 				else if (cw_())
 				{
-					var dj_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var dk_ = FHIRHelpers_4_3_000.ToValue(dj_);
+					DataType dj_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object dk_ = FHIRHelpers_4_3_000.ToValue(dj_);
 
 					return ((dk_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (cx_())
 				{
-					var dl_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
-					var dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
+					DataType dl_ = tuple_btymmdgachdragrhofgxbxgho.GlucoseTest?.Effective;
+					object dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
 
 					return ((dm_ as CqlDateTime) as object);
 				}
@@ -541,35 +568,37 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var ap_ = QICoreCommon_2_0_000.Earliest(ao_());
-			var aq_ = context.Operators.Not((bool?)(ap_ is null));
-			var ar_ = context.Operators.And(an_, aq_);
-			var as_ = context.Operators.And(ab_, ar_);
+			CqlDateTime ap_ = QICoreCommon_2_0_000.Earliest(ao_());
+			bool? aq_ = context.Operators.Not((bool?)(ap_ is null));
+			bool? ar_ = context.Operators.And(an_, aq_);
+			bool? as_ = context.Operators.And(ab_, ar_);
 
 			return as_;
 		};
-		var i_ = context.Operators.Where<Tuple_BTYMMDGaChdRaGRhOfgXBXGHO>(g_, h_);
+		IEnumerable<Tuple_BTYMMDGaChdRaGRhOfgXBXGHO> i_ = context.Operators.Where<Tuple_BTYMMDGaChdRaGRhOfgXBXGHO>(g_, h_);
 		Observation j_(Tuple_BTYMMDGaChdRaGRhOfgXBXGHO tuple_btymmdgachdragrhofgxbxgho) => 
 			tuple_btymmdgachdragrhofgxbxgho.GlucoseTest;
-		var k_ = context.Operators.Select<Tuple_BTYMMDGaChdRaGRhOfgXBXGHO, Observation>(i_, j_);
+		IEnumerable<Observation> k_ = context.Operators.Select<Tuple_BTYMMDGaChdRaGRhOfgXBXGHO, Observation>(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Glucose_Test_with_Result_Less_Than_40_Value"/>
     [CqlDeclaration("Glucose Test with Result Less Than 40")]
 	public IEnumerable<Observation> Glucose_Test_with_Result_Less_Than_40() => 
 		__Glucose_Test_with_Result_Less_Than_40.Value;
 
+    /// <seealso cref="Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80"/>
 	private IEnumerable<Observation> Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80_Value()
 	{
-		var a_ = this.Denominator();
-		var b_ = this.Glucose_Test_with_Result_Less_Than_40();
-		var c_ = this.Glucose_Lab_Test_Mass_Per_Volume();
-		var d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
-		var e_ = context.Operators.CrossJoin<Encounter, Observation, Observation>(a_, b_, d_);
+		IEnumerable<Encounter> a_ = this.Denominator();
+		IEnumerable<Observation> b_ = this.Glucose_Test_with_Result_Less_Than_40();
+		CqlValueSet c_ = this.Glucose_Lab_Test_Mass_Per_Volume();
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		IEnumerable<ValueTuple<Encounter, Observation, Observation>> e_ = context.Operators.CrossJoin<Encounter, Observation, Observation>(a_, b_, d_);
 		Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd f_(ValueTuple<Encounter, Observation, Observation> _valueTuple)
 		{
-			var l_ = new Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd
+			Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd l_ = new Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				LowGlucoseTest = _valueTuple.Item2,
@@ -578,53 +607,53 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 
 			return l_;
 		};
-		var g_ = context.Operators.Select<ValueTuple<Encounter, Observation, Observation>, Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd>(e_, f_);
+		IEnumerable<Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd> g_ = context.Operators.Select<ValueTuple<Encounter, Observation, Observation>, Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd>(e_, f_);
 		bool? h_(Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd tuple_clljqcgdejtdiiewkzyjpwapd)
 		{
 			object m_()
 			{
 				bool bd_()
 				{
-					var bg_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
-					var bi_ = bh_ is CqlDateTime;
+					DataType bg_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+					bool bi_ = bh_ is CqlDateTime;
 
 					return bi_;
 				};
 				bool be_()
 				{
-					var bj_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
-					var bl_ = bk_ is CqlInterval<CqlDateTime>;
+					DataType bj_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+					bool bl_ = bk_ is CqlInterval<CqlDateTime>;
 
 					return bl_;
 				};
 				bool bf_()
 				{
-					var bm_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
-					var bo_ = bn_ is CqlDateTime;
+					DataType bm_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
+					bool bo_ = bn_ is CqlDateTime;
 
 					return bo_;
 				};
 				if (bd_())
 				{
-					var bp_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var bq_ = FHIRHelpers_4_3_000.ToValue(bp_);
+					DataType bp_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object bq_ = FHIRHelpers_4_3_000.ToValue(bp_);
 
 					return ((bq_ as CqlDateTime) as object);
 				}
 				else if (be_())
 				{
-					var br_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var bs_ = FHIRHelpers_4_3_000.ToValue(br_);
+					DataType br_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object bs_ = FHIRHelpers_4_3_000.ToValue(br_);
 
 					return ((bs_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (bf_())
 				{
-					var bt_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
+					DataType bt_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
 
 					return ((bu_ as CqlDateTime) as object);
 				}
@@ -633,51 +662,51 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var n_ = QICoreCommon_2_0_000.Earliest(m_());
+			CqlDateTime n_ = QICoreCommon_2_0_000.Earliest(m_());
 			object o_()
 			{
 				bool bv_()
 				{
-					var by_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var bz_ = FHIRHelpers_4_3_000.ToValue(by_);
-					var ca_ = bz_ is CqlDateTime;
+					DataType by_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object bz_ = FHIRHelpers_4_3_000.ToValue(by_);
+					bool ca_ = bz_ is CqlDateTime;
 
 					return ca_;
 				};
 				bool bw_()
 				{
-					var cb_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
-					var cd_ = cc_ is CqlInterval<CqlDateTime>;
+					DataType cb_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+					bool cd_ = cc_ is CqlInterval<CqlDateTime>;
 
 					return cd_;
 				};
 				bool bx_()
 				{
-					var ce_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var cf_ = FHIRHelpers_4_3_000.ToValue(ce_);
-					var cg_ = cf_ is CqlDateTime;
+					DataType ce_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object cf_ = FHIRHelpers_4_3_000.ToValue(ce_);
+					bool cg_ = cf_ is CqlDateTime;
 
 					return cg_;
 				};
 				if (bv_())
 				{
-					var ch_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var ci_ = FHIRHelpers_4_3_000.ToValue(ch_);
+					DataType ch_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object ci_ = FHIRHelpers_4_3_000.ToValue(ch_);
 
 					return ((ci_ as CqlDateTime) as object);
 				}
 				else if (bw_())
 				{
-					var cj_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
+					DataType cj_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
 
 					return ((ck_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (bx_())
 				{
-					var cl_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var cm_ = FHIRHelpers_4_3_000.ToValue(cl_);
+					DataType cl_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object cm_ = FHIRHelpers_4_3_000.ToValue(cl_);
 
 					return ((cm_ as CqlDateTime) as object);
 				}
@@ -686,51 +715,51 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var p_ = QICoreCommon_2_0_000.Earliest(o_());
+			CqlDateTime p_ = QICoreCommon_2_0_000.Earliest(o_());
 			object q_()
 			{
 				bool cn_()
 				{
-					var cq_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var cr_ = FHIRHelpers_4_3_000.ToValue(cq_);
-					var cs_ = cr_ is CqlDateTime;
+					DataType cq_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object cr_ = FHIRHelpers_4_3_000.ToValue(cq_);
+					bool cs_ = cr_ is CqlDateTime;
 
 					return cs_;
 				};
 				bool co_()
 				{
-					var ct_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
-					var cv_ = cu_ is CqlInterval<CqlDateTime>;
+					DataType ct_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
+					bool cv_ = cu_ is CqlInterval<CqlDateTime>;
 
 					return cv_;
 				};
 				bool cp_()
 				{
-					var cw_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var cx_ = FHIRHelpers_4_3_000.ToValue(cw_);
-					var cy_ = cx_ is CqlDateTime;
+					DataType cw_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object cx_ = FHIRHelpers_4_3_000.ToValue(cw_);
+					bool cy_ = cx_ is CqlDateTime;
 
 					return cy_;
 				};
 				if (cn_())
 				{
-					var cz_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var da_ = FHIRHelpers_4_3_000.ToValue(cz_);
+					DataType cz_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object da_ = FHIRHelpers_4_3_000.ToValue(cz_);
 
 					return ((da_ as CqlDateTime) as object);
 				}
 				else if (co_())
 				{
-					var db_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var dc_ = FHIRHelpers_4_3_000.ToValue(db_);
+					DataType db_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object dc_ = FHIRHelpers_4_3_000.ToValue(db_);
 
 					return ((dc_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (cp_())
 				{
-					var dd_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var de_ = FHIRHelpers_4_3_000.ToValue(dd_);
+					DataType dd_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object de_ = FHIRHelpers_4_3_000.ToValue(dd_);
 
 					return ((de_ as CqlDateTime) as object);
 				}
@@ -739,55 +768,55 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var r_ = QICoreCommon_2_0_000.Earliest(q_());
-			var s_ = context.Operators.Quantity(5m, "minutes");
-			var t_ = context.Operators.Add(r_, s_);
-			var u_ = context.Operators.Interval(p_, t_, false, true);
-			var v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+			CqlDateTime r_ = QICoreCommon_2_0_000.Earliest(q_());
+			CqlQuantity s_ = context.Operators.Quantity(5m, "minutes");
+			CqlDateTime t_ = context.Operators.Add(r_, s_);
+			CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, false, true);
+			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
 			object w_()
 			{
 				bool df_()
 				{
-					var di_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var dj_ = FHIRHelpers_4_3_000.ToValue(di_);
-					var dk_ = dj_ is CqlDateTime;
+					DataType di_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object dj_ = FHIRHelpers_4_3_000.ToValue(di_);
+					bool dk_ = dj_ is CqlDateTime;
 
 					return dk_;
 				};
 				bool dg_()
 				{
-					var dl_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
-					var dn_ = dm_ is CqlInterval<CqlDateTime>;
+					DataType dl_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
+					bool dn_ = dm_ is CqlInterval<CqlDateTime>;
 
 					return dn_;
 				};
 				bool dh_()
 				{
-					var do_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var dp_ = FHIRHelpers_4_3_000.ToValue(do_);
-					var dq_ = dp_ is CqlDateTime;
+					DataType do_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object dp_ = FHIRHelpers_4_3_000.ToValue(do_);
+					bool dq_ = dp_ is CqlDateTime;
 
 					return dq_;
 				};
 				if (df_())
 				{
-					var dr_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var ds_ = FHIRHelpers_4_3_000.ToValue(dr_);
+					DataType dr_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object ds_ = FHIRHelpers_4_3_000.ToValue(dr_);
 
 					return ((ds_ as CqlDateTime) as object);
 				}
 				else if (dg_())
 				{
-					var dt_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var du_ = FHIRHelpers_4_3_000.ToValue(dt_);
+					DataType dt_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object du_ = FHIRHelpers_4_3_000.ToValue(dt_);
 
 					return ((du_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (dh_())
 				{
-					var dv_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var dw_ = FHIRHelpers_4_3_000.ToValue(dv_);
+					DataType dv_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object dw_ = FHIRHelpers_4_3_000.ToValue(dv_);
 
 					return ((dw_ as CqlDateTime) as object);
 				}
@@ -796,53 +825,53 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var x_ = QICoreCommon_2_0_000.Earliest(w_());
-			var y_ = context.Operators.Not((bool?)(x_ is null));
-			var z_ = context.Operators.And(v_, y_);
+			CqlDateTime x_ = QICoreCommon_2_0_000.Earliest(w_());
+			bool? y_ = context.Operators.Not((bool?)(x_ is null));
+			bool? z_ = context.Operators.And(v_, y_);
 			object aa_()
 			{
 				bool dx_()
 				{
-					var ea_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
-					var ec_ = eb_ is CqlDateTime;
+					DataType ea_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
+					bool ec_ = eb_ is CqlDateTime;
 
 					return ec_;
 				};
 				bool dy_()
 				{
-					var ed_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var ee_ = FHIRHelpers_4_3_000.ToValue(ed_);
-					var ef_ = ee_ is CqlInterval<CqlDateTime>;
+					DataType ed_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object ee_ = FHIRHelpers_4_3_000.ToValue(ed_);
+					bool ef_ = ee_ is CqlInterval<CqlDateTime>;
 
 					return ef_;
 				};
 				bool dz_()
 				{
-					var eg_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var eh_ = FHIRHelpers_4_3_000.ToValue(eg_);
-					var ei_ = eh_ is CqlDateTime;
+					DataType eg_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object eh_ = FHIRHelpers_4_3_000.ToValue(eg_);
+					bool ei_ = eh_ is CqlDateTime;
 
 					return ei_;
 				};
 				if (dx_())
 				{
-					var ej_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var ek_ = FHIRHelpers_4_3_000.ToValue(ej_);
+					DataType ej_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object ek_ = FHIRHelpers_4_3_000.ToValue(ej_);
 
 					return ((ek_ as CqlDateTime) as object);
 				}
 				else if (dy_())
 				{
-					var el_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var em_ = FHIRHelpers_4_3_000.ToValue(el_);
+					DataType el_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object em_ = FHIRHelpers_4_3_000.ToValue(el_);
 
 					return ((em_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (dz_())
 				{
-					var en_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
-					var eo_ = FHIRHelpers_4_3_000.ToValue(en_);
+					DataType en_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.Effective;
+					object eo_ = FHIRHelpers_4_3_000.ToValue(en_);
 
 					return ((eo_ as CqlDateTime) as object);
 				}
@@ -851,54 +880,54 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var ab_ = QICoreCommon_2_0_000.Earliest(aa_());
-			var ac_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_clljqcgdejtdiiewkzyjpwapd.QualifyingEncounter);
-			var ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, null);
-			var ae_ = context.Operators.And(z_, ad_);
+			CqlDateTime ab_ = QICoreCommon_2_0_000.Earliest(aa_());
+			CqlInterval<CqlDateTime> ac_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_clljqcgdejtdiiewkzyjpwapd.QualifyingEncounter);
+			bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, null);
+			bool? ae_ = context.Operators.And(z_, ad_);
 			object af_()
 			{
 				bool ep_()
 				{
-					var es_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var et_ = FHIRHelpers_4_3_000.ToValue(es_);
-					var eu_ = et_ is CqlDateTime;
+					DataType es_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object et_ = FHIRHelpers_4_3_000.ToValue(es_);
+					bool eu_ = et_ is CqlDateTime;
 
 					return eu_;
 				};
 				bool eq_()
 				{
-					var ev_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var ew_ = FHIRHelpers_4_3_000.ToValue(ev_);
-					var ex_ = ew_ is CqlInterval<CqlDateTime>;
+					DataType ev_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object ew_ = FHIRHelpers_4_3_000.ToValue(ev_);
+					bool ex_ = ew_ is CqlInterval<CqlDateTime>;
 
 					return ex_;
 				};
 				bool er_()
 				{
-					var ey_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var ez_ = FHIRHelpers_4_3_000.ToValue(ey_);
-					var fa_ = ez_ is CqlDateTime;
+					DataType ey_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object ez_ = FHIRHelpers_4_3_000.ToValue(ey_);
+					bool fa_ = ez_ is CqlDateTime;
 
 					return fa_;
 				};
 				if (ep_())
 				{
-					var fb_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var fc_ = FHIRHelpers_4_3_000.ToValue(fb_);
+					DataType fb_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object fc_ = FHIRHelpers_4_3_000.ToValue(fb_);
 
 					return ((fc_ as CqlDateTime) as object);
 				}
 				else if (eq_())
 				{
-					var fd_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var fe_ = FHIRHelpers_4_3_000.ToValue(fd_);
+					DataType fd_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object fe_ = FHIRHelpers_4_3_000.ToValue(fd_);
 
 					return ((fe_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (er_())
 				{
-					var ff_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
-					var fg_ = FHIRHelpers_4_3_000.ToValue(ff_);
+					DataType ff_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Effective;
+					object fg_ = FHIRHelpers_4_3_000.ToValue(ff_);
 
 					return ((fg_ as CqlDateTime) as object);
 				}
@@ -907,97 +936,101 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var ag_ = QICoreCommon_2_0_000.Earliest(af_());
-			var ai_ = context.Operators.In<CqlDateTime>(ag_, ac_, null);
-			var aj_ = context.Operators.And(ae_, ai_);
-			var ak_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.IdElement;
-			var al_ = ak_?.Value;
-			var am_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.IdElement;
-			var an_ = am_?.Value;
-			var ao_ = context.Operators.Equivalent(al_, an_);
-			var ap_ = context.Operators.Not(ao_);
-			var aq_ = context.Operators.And(aj_, ap_);
-			var ar_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.StatusElement;
-			var as_ = ar_?.Value;
-			var at_ = context.Operators.Convert<Code<ObservationStatus>>(as_);
-			var au_ = context.Operators.Convert<string>(at_);
-			var av_ = new string[]
+			CqlDateTime ag_ = QICoreCommon_2_0_000.Earliest(af_());
+			bool? ai_ = context.Operators.In<CqlDateTime>(ag_, ac_, null);
+			bool? aj_ = context.Operators.And(ae_, ai_);
+			Id ak_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.IdElement;
+			string al_ = ak_?.Value;
+			Id am_ = tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest?.IdElement;
+			string an_ = am_?.Value;
+			bool? ao_ = context.Operators.Equivalent(al_, an_);
+			bool? ap_ = context.Operators.Not(ao_);
+			bool? aq_ = context.Operators.And(aj_, ap_);
+			Code<ObservationStatus> ar_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.StatusElement;
+			ObservationStatus? as_ = ar_?.Value;
+			Code<ObservationStatus> at_ = context.Operators.Convert<Code<ObservationStatus>>(as_);
+			string au_ = context.Operators.Convert<string>(at_);
+			string[] av_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var aw_ = context.Operators.In<string>(au_, (av_ as IEnumerable<string>));
-			var ax_ = context.Operators.And(aq_, aw_);
-			var ay_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Value;
-			var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-			var ba_ = context.Operators.Quantity(80m, "mg/dL");
-			var bb_ = context.Operators.Greater((az_ as CqlQuantity), ba_);
-			var bc_ = context.Operators.And(ax_, bb_);
+			bool? aw_ = context.Operators.In<string>(au_, (av_ as IEnumerable<string>));
+			bool? ax_ = context.Operators.And(aq_, aw_);
+			DataType ay_ = tuple_clljqcgdejtdiiewkzyjpwapd.FollowupGlucoseTest?.Value;
+			object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+			CqlQuantity ba_ = context.Operators.Quantity(80m, "mg/dL");
+			bool? bb_ = context.Operators.Greater((az_ as CqlQuantity), ba_);
+			bool? bc_ = context.Operators.And(ax_, bb_);
 
 			return bc_;
 		};
-		var i_ = context.Operators.Where<Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd>(g_, h_);
+		IEnumerable<Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd> i_ = context.Operators.Where<Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd>(g_, h_);
 		Observation j_(Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd tuple_clljqcgdejtdiiewkzyjpwapd) => 
 			tuple_clljqcgdejtdiiewkzyjpwapd.LowGlucoseTest;
-		var k_ = context.Operators.Select<Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd, Observation>(i_, j_);
+		IEnumerable<Observation> k_ = context.Operators.Select<Tuple_CLLJQcGdEjTDiIeWKZYJPWaPd, Observation>(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80_Value"/>
     [CqlDeclaration("Low Glucose Test Followed By Glucose Test Result Greater Than 80")]
 	public IEnumerable<Observation> Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80() => 
 		__Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80.Value;
 
+    /// <seealso cref="Severe_Hypoglycemic_Harm_Event"/>
 	private IEnumerable<Observation> Severe_Hypoglycemic_Harm_Event_Value()
 	{
-		var a_ = this.Glucose_Test_with_Result_Less_Than_40();
+		IEnumerable<Observation> a_ = this.Glucose_Test_with_Result_Less_Than_40();
 		bool? b_(Observation LowGlucoseTest)
 		{
-			var d_ = LowGlucoseTest?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80();
+			Id d_ = LowGlucoseTest?.IdElement;
+			string e_ = d_?.Value;
+			IEnumerable<Observation> f_ = this.Low_Glucose_Test_Followed_By_Glucose_Test_Result_Greater_Than_80();
 			bool? g_(Observation @this)
 			{
-				var m_ = ((@this is Resource)
+				string m_ = ((@this is Resource)
 	? ((@this as Resource).IdElement)
 	: null)?.Value;
-				var n_ = context.Operators.Not((bool?)(m_ is null));
+				bool? n_ = context.Operators.Not((bool?)(m_ is null));
 
 				return n_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			string i_(Observation @this)
 			{
-				var o_ = ((@this is Resource)
+				string o_ = ((@this is Resource)
 	? ((@this as Resource).IdElement)
 	: null)?.Value;
 
 				return o_;
 			};
-			var j_ = context.Operators.Select<Observation, string>(h_, i_);
-			var k_ = context.Operators.In<string>(e_, j_);
-			var l_ = context.Operators.Not(k_);
+			IEnumerable<string> j_ = context.Operators.Select<Observation, string>(h_, i_);
+			bool? k_ = context.Operators.In<string>(e_, j_);
+			bool? l_ = context.Operators.Not(k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Severe_Hypoglycemic_Harm_Event_Value"/>
     [CqlDeclaration("Severe Hypoglycemic Harm Event")]
 	public IEnumerable<Observation> Severe_Hypoglycemic_Harm_Event() => 
 		__Severe_Hypoglycemic_Harm_Event.Value;
 
+    /// <seealso cref="Encounter_with_Severe_Hypoglycemic_Harm_Event"/>
 	private IEnumerable<Encounter> Encounter_with_Severe_Hypoglycemic_Harm_Event_Value()
 	{
-		var a_ = this.Denominator();
-		var b_ = this.Severe_Hypoglycemic_Harm_Event();
-		var c_ = context.Operators.CrossJoin<Encounter, Observation>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Denominator();
+		IEnumerable<Observation> b_ = this.Severe_Hypoglycemic_Harm_Event();
+		IEnumerable<ValueTuple<Encounter, Observation>> c_ = context.Operators.CrossJoin<Encounter, Observation>(a_, b_);
 		Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR d_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
-			var j_ = new Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR
+			Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR j_ = new Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR
 			{
 				QualifyingEncounter = _valueTuple.Item1,
 				HypoglycemicEvent = _valueTuple.Item2,
@@ -1005,53 +1038,53 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 
 			return j_;
 		};
-		var e_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR>(c_, d_);
+		IEnumerable<Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR> e_ = context.Operators.Select<ValueTuple<Encounter, Observation>, Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR>(c_, d_);
 		bool? f_(Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR tuple_hfnempjqliopfnrmypnydhffr)
 		{
 			object k_()
 			{
 				bool o_()
 				{
-					var r_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
-					var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-					var t_ = s_ is CqlDateTime;
+					DataType r_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
+					object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+					bool t_ = s_ is CqlDateTime;
 
 					return t_;
 				};
 				bool p_()
 				{
-					var u_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
-					var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-					var w_ = v_ is CqlInterval<CqlDateTime>;
+					DataType u_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
+					object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+					bool w_ = v_ is CqlInterval<CqlDateTime>;
 
 					return w_;
 				};
 				bool q_()
 				{
-					var x_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
-					var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-					var z_ = y_ is CqlDateTime;
+					DataType x_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
+					object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+					bool z_ = y_ is CqlDateTime;
 
 					return z_;
 				};
 				if (o_())
 				{
-					var aa_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
-					var ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
+					DataType aa_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
+					object ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
 
 					return ((ab_ as CqlDateTime) as object);
 				}
 				else if (p_())
 				{
-					var ac_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
-					var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+					DataType ac_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
+					object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
 
 					return ((ad_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (q_())
 				{
-					var ae_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
-					var af_ = FHIRHelpers_4_3_000.ToValue(ae_);
+					DataType ae_ = tuple_hfnempjqliopfnrmypnydhffr.HypoglycemicEvent?.Effective;
+					object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
 
 					return ((af_ as CqlDateTime) as object);
 				}
@@ -1060,75 +1093,86 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 					return null;
 				}
 			};
-			var l_ = QICoreCommon_2_0_000.Earliest(k_());
-			var m_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_hfnempjqliopfnrmypnydhffr.QualifyingEncounter);
-			var n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
+			CqlDateTime l_ = QICoreCommon_2_0_000.Earliest(k_());
+			CqlInterval<CqlDateTime> m_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_hfnempjqliopfnrmypnydhffr.QualifyingEncounter);
+			bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
 
 			return n_;
 		};
-		var g_ = context.Operators.Where<Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR>(e_, f_);
+		IEnumerable<Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR> g_ = context.Operators.Where<Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR>(e_, f_);
 		Encounter h_(Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR tuple_hfnempjqliopfnrmypnydhffr) => 
 			tuple_hfnempjqliopfnrmypnydhffr.QualifyingEncounter;
-		var i_ = context.Operators.Select<Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR, Encounter>(g_, h_);
+		IEnumerable<Encounter> i_ = context.Operators.Select<Tuple_HFNEMPjQLiOPFNRMYPNYDhFfR, Encounter>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Encounter_with_Severe_Hypoglycemic_Harm_Event_Value"/>
     [CqlDeclaration("Encounter with Severe Hypoglycemic Harm Event")]
 	public IEnumerable<Encounter> Encounter_with_Severe_Hypoglycemic_Harm_Event() => 
 		__Encounter_with_Severe_Hypoglycemic_Harm_Event.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Encounter_with_Severe_Hypoglycemic_Harm_Event();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Severe_Hypoglycemic_Harm_Event();
 
 		return a_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
@@ -112,110 +112,137 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
     #endregion
 
+    /// <seealso cref="Bicarbonate_lab_test"/>
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
 
+    /// <seealso cref="Bicarbonate_lab_test_Value"/>
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
 	public CqlValueSet Bicarbonate_lab_test() => 
 		__Bicarbonate_lab_test.Value;
 
+    /// <seealso cref="Creatinine_lab_test"/>
 	private CqlValueSet Creatinine_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
 
+    /// <seealso cref="Creatinine_lab_test_Value"/>
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
 	public CqlValueSet Creatinine_lab_test() => 
 		__Creatinine_lab_test.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Hematocrit_lab_test"/>
 	private CqlValueSet Hematocrit_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
 
+    /// <seealso cref="Hematocrit_lab_test_Value"/>
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
 	public CqlValueSet Hematocrit_lab_test() => 
 		__Hematocrit_lab_test.Value;
 
+    /// <seealso cref="Medicare_Advantage_payer"/>
 	private CqlValueSet Medicare_Advantage_payer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", null);
 
+    /// <seealso cref="Medicare_Advantage_payer_Value"/>
     [CqlDeclaration("Medicare Advantage payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12")]
 	public CqlValueSet Medicare_Advantage_payer() => 
 		__Medicare_Advantage_payer.Value;
 
+    /// <seealso cref="Medicare_FFS_payer"/>
 	private CqlValueSet Medicare_FFS_payer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
 
+    /// <seealso cref="Medicare_FFS_payer_Value"/>
     [CqlDeclaration("Medicare FFS payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
 	public CqlValueSet Medicare_FFS_payer() => 
 		__Medicare_FFS_payer.Value;
 
+    /// <seealso cref="Oxygen_Saturation_by_Pulse_Oximetry"/>
 	private CqlValueSet Oxygen_Saturation_by_Pulse_Oximetry_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", null);
 
+    /// <seealso cref="Oxygen_Saturation_by_Pulse_Oximetry_Value"/>
     [CqlDeclaration("Oxygen Saturation by Pulse Oximetry")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151")]
 	public CqlValueSet Oxygen_Saturation_by_Pulse_Oximetry() => 
 		__Oxygen_Saturation_by_Pulse_Oximetry.Value;
 
+    /// <seealso cref="Platelet_count_lab_test"/>
 	private CqlValueSet Platelet_count_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", null);
 
+    /// <seealso cref="Platelet_count_lab_test_Value"/>
     [CqlDeclaration("Platelet count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127")]
 	public CqlValueSet Platelet_count_lab_test() => 
 		__Platelet_count_lab_test.Value;
 
+    /// <seealso cref="Sodium_lab_test"/>
 	private CqlValueSet Sodium_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
 
+    /// <seealso cref="Sodium_lab_test_Value"/>
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
 	public CqlValueSet Sodium_lab_test() => 
 		__Sodium_lab_test.Value;
 
+    /// <seealso cref="White_blood_cells_count_lab_test"/>
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
 
+    /// <seealso cref="White_blood_cells_count_lab_test_Value"/>
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
 	public CqlValueSet White_blood_cells_count_lab_test() => 
 		__White_blood_cells_count_lab_test.Value;
 
+    /// <seealso cref="Oxygen_saturation_in_Arterial_blood"/>
 	private CqlCode Oxygen_saturation_in_Arterial_blood_Value() => 
 		new CqlCode("2708-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Oxygen_saturation_in_Arterial_blood_Value"/>
     [CqlDeclaration("Oxygen saturation in Arterial blood")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood() => 
 		__Oxygen_saturation_in_Arterial_blood.Value;
 
+    /// <seealso cref="Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry"/>
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
 		new CqlCode("59408-5", "http://loinc.org", null, null);
 
+    /// <seealso cref="Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value"/>
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
+    /// <seealso cref="Systolic_blood_pressure"/>
 	private CqlCode Systolic_blood_pressure_Value() => 
 		new CqlCode("8480-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Systolic_blood_pressure_Value"/>
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
 		__Systolic_blood_pressure.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("2708-6", "http://loinc.org", null, null),
 			new CqlCode("59408-5", "http://loinc.org", null, null),
@@ -225,235 +252,249 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="Source_of_Payment_Typology"/>
 	private CqlCode[] Source_of_Payment_Typology_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="Source_of_Payment_Typology_Value"/>
     [CqlDeclaration("Source of Payment Typology")]
 	public CqlCode[] Source_of_Payment_Typology() => 
 		__Source_of_Payment_Typology.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("HybridHospitalWideMortalityFHIR-0.0.001", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("HybridHospitalWideMortalityFHIR-0.0.001", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Inpatient_Encounters"/>
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		IEnumerable<Encounter> c_(Encounter InpatientEncounter)
 		{
-			var e_ = this.Medicare_FFS_payer();
-			var f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, null);
-			var g_ = this.Medicare_Advantage_payer();
-			var h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, null);
-			var i_ = context.Operators.Union<Coverage>(f_, h_);
+			CqlValueSet e_ = this.Medicare_FFS_payer();
+			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, null);
+			CqlValueSet g_ = this.Medicare_Advantage_payer();
+			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, null);
+			IEnumerable<Coverage> i_ = context.Operators.Union<Coverage>(f_, h_);
 			bool? j_(Coverage MedicarePayer)
 			{
-				var n_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(InpatientEncounter);
-				var o_ = CQMCommon_2_0_000.lengthInDays(n_);
-				var p_ = context.Operators.Less(o_, 365);
-				var q_ = InpatientEncounter?.StatusElement;
-				var r_ = q_?.Value;
-				var s_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(r_);
-				var t_ = context.Operators.Equal(s_, "finished");
-				var u_ = context.Operators.And(p_, t_);
-				var v_ = this.Patient();
-				var w_ = v_?.BirthDateElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Convert<CqlDate>(x_);
-				var z_ = InpatientEncounter?.Period;
-				var aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				var ab_ = context.Operators.Start(aa_);
-				var ac_ = context.Operators.DateFrom(ab_);
-				var ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
-				var ae_ = context.Operators.Interval(65, 94, true, true);
-				var af_ = context.Operators.In<int?>(ad_, ae_, null);
-				var ag_ = context.Operators.And(u_, af_);
-				var ai_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				var aj_ = context.Operators.End(ai_);
-				var ak_ = this.Measurement_Period();
-				var al_ = context.Operators.In<CqlDateTime>(aj_, ak_, "day");
-				var am_ = context.Operators.And(ag_, al_);
+				CqlInterval<CqlDateTime> n_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(InpatientEncounter);
+				int? o_ = CQMCommon_2_0_000.lengthInDays(n_);
+				bool? p_ = context.Operators.Less(o_, 365);
+				Code<Encounter.EncounterStatus> q_ = InpatientEncounter?.StatusElement;
+				Encounter.EncounterStatus? r_ = q_?.Value;
+				Code<Encounter.EncounterStatus> s_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(r_);
+				bool? t_ = context.Operators.Equal(s_, "finished");
+				bool? u_ = context.Operators.And(p_, t_);
+				Patient v_ = this.Patient();
+				Date w_ = v_?.BirthDateElement;
+				string x_ = w_?.Value;
+				CqlDate y_ = context.Operators.Convert<CqlDate>(x_);
+				Period z_ = InpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
+				CqlDateTime ab_ = context.Operators.Start(aa_);
+				CqlDate ac_ = context.Operators.DateFrom(ab_);
+				int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
+				CqlInterval<int?> ae_ = context.Operators.Interval(65, 94, true, true);
+				bool? af_ = context.Operators.In<int?>(ad_, ae_, null);
+				bool? ag_ = context.Operators.And(u_, af_);
+				CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_3_000.ToInterval(z_);
+				CqlDateTime aj_ = context.Operators.End(ai_);
+				CqlInterval<CqlDateTime> ak_ = this.Measurement_Period();
+				bool? al_ = context.Operators.In<CqlDateTime>(aj_, ak_, "day");
+				bool? am_ = context.Operators.And(ag_, al_);
 
 				return am_;
 			};
-			var k_ = context.Operators.Where<Coverage>(i_, j_);
+			IEnumerable<Coverage> k_ = context.Operators.Where<Coverage>(i_, j_);
 			Encounter l_(Coverage MedicarePayer) => 
 				InpatientEncounter;
-			var m_ = context.Operators.Select<Coverage, Encounter>(k_, l_);
+			IEnumerable<Encounter> m_ = context.Operators.Select<Coverage, Encounter>(k_, l_);
 
 			return m_;
 		};
-		var d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Inpatient_Encounters_Value"/>
     [CqlDeclaration("Inpatient Encounters")]
 	public IEnumerable<Encounter> Inpatient_Encounters() => 
 		__Inpatient_Encounters.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Encounter_with_First_Body_Temperature"/>
 	private IEnumerable<Tuple_GIbILVAdXLLNYBgcQIEiUiKaK> Encounter_with_First_Body_Temperature_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_GIbILVAdXLLNYBgcQIEiUiKaK b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? g_(Observation temperature)
 			{
-				var y_ = temperature?.Effective;
-				var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-				var aa_ = QICoreCommon_2_0_000.earliest(z_);
-				var ab_ = EncounterInpatient?.Period;
-				var ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ad_ = context.Operators.Start(ac_);
-				var ae_ = context.Operators.Quantity(1440m, "minutes");
-				var af_ = context.Operators.Subtract(ad_, ae_);
-				var ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ai_ = context.Operators.Start(ah_);
-				var aj_ = context.Operators.Quantity(120m, "minutes");
-				var ak_ = context.Operators.Add(ai_, aj_);
-				var al_ = context.Operators.Interval(af_, ak_, true, true);
-				var am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
-				var an_ = temperature?.StatusElement;
-				var ao_ = an_?.Value;
-				var ap_ = context.Operators.Convert<string>(ao_);
-				var aq_ = new string[]
+				DataType y_ = temperature?.Effective;
+				object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+				CqlDateTime aa_ = QICoreCommon_2_0_000.earliest(z_);
+				Period ab_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ad_ = context.Operators.Start(ac_);
+				CqlQuantity ae_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
+				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ai_ = context.Operators.Start(ah_);
+				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
+				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				Code<ObservationStatus> an_ = temperature?.StatusElement;
+				ObservationStatus? ao_ = an_?.Value;
+				string ap_ = context.Operators.Convert<string>(ao_);
+				string[] aq_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
-				var as_ = context.Operators.And(am_, ar_);
-				var at_ = temperature?.Value;
-				var au_ = context.Operators.Convert<Quantity>(at_);
-				var av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
-				var aw_ = context.Operators.Not((bool?)(av_ is null));
-				var ax_ = context.Operators.And(as_, aw_);
+				bool? ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
+				bool? as_ = context.Operators.And(am_, ar_);
+				DataType at_ = temperature?.Value;
+				Quantity au_ = context.Operators.Convert<Quantity>(at_);
+				CqlQuantity av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
+				bool? aw_ = context.Operators.Not((bool?)(av_ is null));
+				bool? ax_ = context.Operators.And(as_, aw_);
 
 				return ax_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			object i_(Observation @this)
 			{
-				var ay_ = @this?.Effective;
-				var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-				var ba_ = QICoreCommon_2_0_000.earliest(az_);
+				DataType ay_ = @this?.Effective;
+				object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+				CqlDateTime ba_ = QICoreCommon_2_0_000.earliest(az_);
 
 				return ba_;
 			};
-			var j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.First<Observation>(j_);
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<Quantity>(l_);
-			var n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
+			IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation k_ = context.Operators.First<Observation>(j_);
+			DataType l_ = k_?.Value;
+			Quantity m_ = context.Operators.Convert<Quantity>(l_);
+			CqlQuantity n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
 			bool? p_(Observation temperature)
 			{
-				var bb_ = temperature?.Effective;
-				var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
-				var bd_ = QICoreCommon_2_0_000.earliest(bc_);
-				var be_ = EncounterInpatient?.Period;
-				var bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bg_ = context.Operators.Start(bf_);
-				var bh_ = context.Operators.Quantity(1440m, "minutes");
-				var bi_ = context.Operators.Subtract(bg_, bh_);
-				var bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bl_ = context.Operators.Start(bk_);
-				var bm_ = context.Operators.Quantity(120m, "minutes");
-				var bn_ = context.Operators.Add(bl_, bm_);
-				var bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				var bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
-				var bq_ = temperature?.StatusElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.Convert<string>(br_);
-				var bt_ = new string[]
+				DataType bb_ = temperature?.Effective;
+				object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+				CqlDateTime bd_ = QICoreCommon_2_0_000.earliest(bc_);
+				Period be_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bg_ = context.Operators.Start(bf_);
+				CqlQuantity bh_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bi_ = context.Operators.Subtract(bg_, bh_);
+				CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bl_ = context.Operators.Start(bk_);
+				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
+				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				Code<ObservationStatus> bq_ = temperature?.StatusElement;
+				ObservationStatus? br_ = bq_?.Value;
+				string bs_ = context.Operators.Convert<string>(br_);
+				string[] bt_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
-				var bv_ = context.Operators.And(bp_, bu_);
-				var bw_ = temperature?.Value;
-				var bx_ = context.Operators.Convert<Quantity>(bw_);
-				var by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
-				var bz_ = context.Operators.Not((bool?)(by_ is null));
-				var ca_ = context.Operators.And(bv_, bz_);
+				bool? bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
+				bool? bv_ = context.Operators.And(bp_, bu_);
+				DataType bw_ = temperature?.Value;
+				Quantity bx_ = context.Operators.Convert<Quantity>(bw_);
+				CqlQuantity by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
+				bool? bz_ = context.Operators.Not((bool?)(by_ is null));
+				bool? ca_ = context.Operators.And(bv_, bz_);
 
 				return ca_;
 			};
-			var q_ = context.Operators.Where<Observation>(f_, p_);
+			IEnumerable<Observation> q_ = context.Operators.Where<Observation>(f_, p_);
 			object r_(Observation @this)
 			{
-				var cb_ = @this?.Effective;
-				var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
-				var cd_ = QICoreCommon_2_0_000.earliest(cc_);
+				DataType cb_ = @this?.Effective;
+				object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+				CqlDateTime cd_ = QICoreCommon_2_0_000.earliest(cc_);
 
 				return cd_;
 			};
-			var s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
-			var t_ = context.Operators.First<Observation>(s_);
-			var u_ = t_?.Effective;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = QICoreCommon_2_0_000.earliest(v_);
-			var x_ = new Tuple_GIbILVAdXLLNYBgcQIEiUiKaK
+			IEnumerable<Observation> s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation t_ = context.Operators.First<Observation>(s_);
+			DataType u_ = t_?.Effective;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			CqlDateTime w_ = QICoreCommon_2_0_000.earliest(v_);
+			Tuple_GIbILVAdXLLNYBgcQIEiUiKaK x_ = new Tuple_GIbILVAdXLLNYBgcQIEiUiKaK
 			{
 				EncounterId = e_,
 				FirstTemperatureResult = n_,
@@ -462,122 +503,124 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 			return x_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_GIbILVAdXLLNYBgcQIEiUiKaK>(a_, b_);
+		IEnumerable<Tuple_GIbILVAdXLLNYBgcQIEiUiKaK> c_ = context.Operators.Select<Encounter, Tuple_GIbILVAdXLLNYBgcQIEiUiKaK>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Body_Temperature_Value"/>
     [CqlDeclaration("Encounter with First Body Temperature")]
 	public IEnumerable<Tuple_GIbILVAdXLLNYBgcQIEiUiKaK> Encounter_with_First_Body_Temperature() => 
 		__Encounter_with_First_Body_Temperature.Value;
 
+    /// <seealso cref="Encounter_with_First_Heart_Rate"/>
 	private IEnumerable<Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ> Encounter_with_First_Heart_Rate_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? g_(Observation HeartRate)
 			{
-				var y_ = HeartRate?.Effective;
-				var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-				var aa_ = QICoreCommon_2_0_000.earliest(z_);
-				var ab_ = EncounterInpatient?.Period;
-				var ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ad_ = context.Operators.Start(ac_);
-				var ae_ = context.Operators.Quantity(1440m, "minutes");
-				var af_ = context.Operators.Subtract(ad_, ae_);
-				var ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ai_ = context.Operators.Start(ah_);
-				var aj_ = context.Operators.Quantity(120m, "minutes");
-				var ak_ = context.Operators.Add(ai_, aj_);
-				var al_ = context.Operators.Interval(af_, ak_, true, true);
-				var am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
-				var an_ = HeartRate?.StatusElement;
-				var ao_ = an_?.Value;
-				var ap_ = context.Operators.Convert<string>(ao_);
-				var aq_ = new string[]
+				DataType y_ = HeartRate?.Effective;
+				object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+				CqlDateTime aa_ = QICoreCommon_2_0_000.earliest(z_);
+				Period ab_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ad_ = context.Operators.Start(ac_);
+				CqlQuantity ae_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
+				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ai_ = context.Operators.Start(ah_);
+				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
+				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				Code<ObservationStatus> an_ = HeartRate?.StatusElement;
+				ObservationStatus? ao_ = an_?.Value;
+				string ap_ = context.Operators.Convert<string>(ao_);
+				string[] aq_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
-				var as_ = context.Operators.And(am_, ar_);
-				var at_ = HeartRate?.Value;
-				var au_ = context.Operators.Convert<Quantity>(at_);
-				var av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
-				var aw_ = context.Operators.Not((bool?)(av_ is null));
-				var ax_ = context.Operators.And(as_, aw_);
+				bool? ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
+				bool? as_ = context.Operators.And(am_, ar_);
+				DataType at_ = HeartRate?.Value;
+				Quantity au_ = context.Operators.Convert<Quantity>(at_);
+				CqlQuantity av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
+				bool? aw_ = context.Operators.Not((bool?)(av_ is null));
+				bool? ax_ = context.Operators.And(as_, aw_);
 
 				return ax_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			object i_(Observation @this)
 			{
-				var ay_ = @this?.Effective;
-				var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-				var ba_ = QICoreCommon_2_0_000.earliest(az_);
+				DataType ay_ = @this?.Effective;
+				object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+				CqlDateTime ba_ = QICoreCommon_2_0_000.earliest(az_);
 
 				return ba_;
 			};
-			var j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.First<Observation>(j_);
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<Quantity>(l_);
-			var n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
+			IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation k_ = context.Operators.First<Observation>(j_);
+			DataType l_ = k_?.Value;
+			Quantity m_ = context.Operators.Convert<Quantity>(l_);
+			CqlQuantity n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
 			bool? p_(Observation HeartRate)
 			{
-				var bb_ = HeartRate?.Effective;
-				var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
-				var bd_ = QICoreCommon_2_0_000.earliest(bc_);
-				var be_ = EncounterInpatient?.Period;
-				var bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bg_ = context.Operators.Start(bf_);
-				var bh_ = context.Operators.Quantity(1440m, "minutes");
-				var bi_ = context.Operators.Subtract(bg_, bh_);
-				var bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bl_ = context.Operators.Start(bk_);
-				var bm_ = context.Operators.Quantity(120m, "minutes");
-				var bn_ = context.Operators.Add(bl_, bm_);
-				var bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				var bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
-				var bq_ = HeartRate?.StatusElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.Convert<string>(br_);
-				var bt_ = new string[]
+				DataType bb_ = HeartRate?.Effective;
+				object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+				CqlDateTime bd_ = QICoreCommon_2_0_000.earliest(bc_);
+				Period be_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bg_ = context.Operators.Start(bf_);
+				CqlQuantity bh_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bi_ = context.Operators.Subtract(bg_, bh_);
+				CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bl_ = context.Operators.Start(bk_);
+				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
+				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				Code<ObservationStatus> bq_ = HeartRate?.StatusElement;
+				ObservationStatus? br_ = bq_?.Value;
+				string bs_ = context.Operators.Convert<string>(br_);
+				string[] bt_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
-				var bv_ = context.Operators.And(bp_, bu_);
-				var bw_ = HeartRate?.Value;
-				var bx_ = context.Operators.Convert<Quantity>(bw_);
-				var by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
-				var bz_ = context.Operators.Not((bool?)(by_ is null));
-				var ca_ = context.Operators.And(bv_, bz_);
+				bool? bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
+				bool? bv_ = context.Operators.And(bp_, bu_);
+				DataType bw_ = HeartRate?.Value;
+				Quantity bx_ = context.Operators.Convert<Quantity>(bw_);
+				CqlQuantity by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
+				bool? bz_ = context.Operators.Not((bool?)(by_ is null));
+				bool? ca_ = context.Operators.And(bv_, bz_);
 
 				return ca_;
 			};
-			var q_ = context.Operators.Where<Observation>(f_, p_);
+			IEnumerable<Observation> q_ = context.Operators.Where<Observation>(f_, p_);
 			object r_(Observation @this)
 			{
-				var cb_ = @this?.Effective;
-				var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
-				var cd_ = QICoreCommon_2_0_000.earliest(cc_);
+				DataType cb_ = @this?.Effective;
+				object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+				CqlDateTime cd_ = QICoreCommon_2_0_000.earliest(cc_);
 
 				return cd_;
 			};
-			var s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
-			var t_ = context.Operators.First<Observation>(s_);
-			var u_ = t_?.Effective;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = QICoreCommon_2_0_000.earliest(v_);
-			var x_ = new Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ
+			IEnumerable<Observation> s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation t_ = context.Operators.First<Observation>(s_);
+			DataType u_ = t_?.Effective;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			CqlDateTime w_ = QICoreCommon_2_0_000.earliest(v_);
+			Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ x_ = new Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ
 			{
 				EncounterId = e_,
 				FirstHeartRateResult = n_,
@@ -586,70 +629,72 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 			return x_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ>(a_, b_);
+		IEnumerable<Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ> c_ = context.Operators.Select<Encounter, Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Heart_Rate_Value"/>
     [CqlDeclaration("Encounter with First Heart Rate")]
 	public IEnumerable<Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ> Encounter_with_First_Heart_Rate() => 
 		__Encounter_with_First_Heart_Rate.Value;
 
+    /// <seealso cref="Encounter_with_First_Oxygen_Saturation"/>
 	private IEnumerable<Tuple_FdREYEdHOZIcMCNYCRFJYJReA> Encounter_with_First_Oxygen_Saturation_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_FdREYEdHOZIcMCNYCRFJYJReA b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation O2Saturation)
 			{
 				object r_()
 				{
 					bool aq_()
 					{
-						var at_ = O2Saturation?.Effective;
-						var au_ = FHIRHelpers_4_3_000.ToValue(at_);
-						var av_ = au_ is CqlDateTime;
+						DataType at_ = O2Saturation?.Effective;
+						object au_ = FHIRHelpers_4_3_000.ToValue(at_);
+						bool av_ = au_ is CqlDateTime;
 
 						return av_;
 					};
 					bool ar_()
 					{
-						var aw_ = O2Saturation?.Effective;
-						var ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
-						var ay_ = ax_ is CqlInterval<CqlDateTime>;
+						DataType aw_ = O2Saturation?.Effective;
+						object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+						bool ay_ = ax_ is CqlInterval<CqlDateTime>;
 
 						return ay_;
 					};
 					bool as_()
 					{
-						var az_ = O2Saturation?.Effective;
-						var ba_ = FHIRHelpers_4_3_000.ToValue(az_);
-						var bb_ = ba_ is CqlDateTime;
+						DataType az_ = O2Saturation?.Effective;
+						object ba_ = FHIRHelpers_4_3_000.ToValue(az_);
+						bool bb_ = ba_ is CqlDateTime;
 
 						return bb_;
 					};
 					if (aq_())
 					{
-						var bc_ = O2Saturation?.Effective;
-						var bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
+						DataType bc_ = O2Saturation?.Effective;
+						object bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
 
 						return ((bd_ as CqlDateTime) as object);
 					}
 					else if (ar_())
 					{
-						var be_ = O2Saturation?.Effective;
-						var bf_ = FHIRHelpers_4_3_000.ToValue(be_);
+						DataType be_ = O2Saturation?.Effective;
+						object bf_ = FHIRHelpers_4_3_000.ToValue(be_);
 
 						return ((bf_ as CqlInterval<CqlDateTime>) as object);
 					}
 					else if (as_())
 					{
-						var bg_ = O2Saturation?.Effective;
-						var bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+						DataType bg_ = O2Saturation?.Effective;
+						object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
 
 						return ((bh_ as CqlDateTime) as object);
 					}
@@ -658,84 +703,84 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						return null;
 					}
 				};
-				var s_ = QICoreCommon_2_0_000.earliest(r_());
-				var t_ = EncounterInpatient?.Period;
-				var u_ = FHIRHelpers_4_3_000.ToInterval(t_);
-				var v_ = context.Operators.Start(u_);
-				var w_ = context.Operators.Quantity(1440m, "minutes");
-				var x_ = context.Operators.Subtract(v_, w_);
-				var z_ = FHIRHelpers_4_3_000.ToInterval(t_);
-				var aa_ = context.Operators.Start(z_);
-				var ab_ = context.Operators.Quantity(120m, "minutes");
-				var ac_ = context.Operators.Add(aa_, ab_);
-				var ad_ = context.Operators.Interval(x_, ac_, true, true);
-				var ae_ = context.Operators.In<CqlDateTime>(s_, ad_, null);
-				var af_ = O2Saturation?.StatusElement;
-				var ag_ = af_?.Value;
-				var ah_ = context.Operators.Convert<Code<ObservationStatus>>(ag_);
-				var ai_ = context.Operators.Convert<string>(ah_);
-				var aj_ = new string[]
+				CqlDateTime s_ = QICoreCommon_2_0_000.earliest(r_());
+				Period t_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(t_);
+				CqlDateTime v_ = context.Operators.Start(u_);
+				CqlQuantity w_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime x_ = context.Operators.Subtract(v_, w_);
+				CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(t_);
+				CqlDateTime aa_ = context.Operators.Start(z_);
+				CqlQuantity ab_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
+				CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
+				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, null);
+				Code<ObservationStatus> af_ = O2Saturation?.StatusElement;
+				ObservationStatus? ag_ = af_?.Value;
+				Code<ObservationStatus> ah_ = context.Operators.Convert<Code<ObservationStatus>>(ag_);
+				string ai_ = context.Operators.Convert<string>(ah_);
+				string[] aj_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ak_ = context.Operators.In<string>(ai_, (aj_ as IEnumerable<string>));
-				var al_ = context.Operators.And(ae_, ak_);
-				var am_ = O2Saturation?.Value;
-				var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-				var ao_ = context.Operators.Not((bool?)(an_ is null));
-				var ap_ = context.Operators.And(al_, ao_);
+				bool? ak_ = context.Operators.In<string>(ai_, (aj_ as IEnumerable<string>));
+				bool? al_ = context.Operators.And(ae_, ak_);
+				DataType am_ = O2Saturation?.Value;
+				object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+				bool? ao_ = context.Operators.Not((bool?)(an_ is null));
+				bool? ap_ = context.Operators.And(al_, ao_);
 
 				return ap_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
 				object bi_()
 				{
 					bool bk_()
 					{
-						var bn_ = @this?.Effective;
-						var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
-						var bp_ = bo_ is CqlDateTime;
+						DataType bn_ = @this?.Effective;
+						object bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+						bool bp_ = bo_ is CqlDateTime;
 
 						return bp_;
 					};
 					bool bl_()
 					{
-						var bq_ = @this?.Effective;
-						var br_ = FHIRHelpers_4_3_000.ToValue(bq_);
-						var bs_ = br_ is CqlInterval<CqlDateTime>;
+						DataType bq_ = @this?.Effective;
+						object br_ = FHIRHelpers_4_3_000.ToValue(bq_);
+						bool bs_ = br_ is CqlInterval<CqlDateTime>;
 
 						return bs_;
 					};
 					bool bm_()
 					{
-						var bt_ = @this?.Effective;
-						var bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
-						var bv_ = bu_ is CqlDateTime;
+						DataType bt_ = @this?.Effective;
+						object bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
+						bool bv_ = bu_ is CqlDateTime;
 
 						return bv_;
 					};
 					if (bk_())
 					{
-						var bw_ = @this?.Effective;
-						var bx_ = FHIRHelpers_4_3_000.ToValue(bw_);
+						DataType bw_ = @this?.Effective;
+						object bx_ = FHIRHelpers_4_3_000.ToValue(bw_);
 
 						return ((bx_ as CqlDateTime) as object);
 					}
 					else if (bl_())
 					{
-						var by_ = @this?.Effective;
-						var bz_ = FHIRHelpers_4_3_000.ToValue(by_);
+						DataType by_ = @this?.Effective;
+						object bz_ = FHIRHelpers_4_3_000.ToValue(by_);
 
 						return ((bz_ as CqlInterval<CqlDateTime>) as object);
 					}
 					else if (bm_())
 					{
-						var ca_ = @this?.Effective;
-						var cb_ = FHIRHelpers_4_3_000.ToValue(ca_);
+						DataType ca_ = @this?.Effective;
+						object cb_ = FHIRHelpers_4_3_000.ToValue(ca_);
 
 						return ((cb_ as CqlDateTime) as object);
 					}
@@ -744,66 +789,66 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						return null;
 					}
 				};
-				var bj_ = QICoreCommon_2_0_000.earliest(bi_());
+				CqlDateTime bj_ = QICoreCommon_2_0_000.earliest(bi_());
 
 				return bj_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
 			object o_()
 			{
 				bool cc_()
 				{
-					var cf_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, null);
+					CqlValueSet cf_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, null);
 					bool? ch_(Observation O2Saturation)
 					{
 						object cp_()
 						{
 							bool do_()
 							{
-								var dr_ = O2Saturation?.Effective;
-								var ds_ = FHIRHelpers_4_3_000.ToValue(dr_);
-								var dt_ = ds_ is CqlDateTime;
+								DataType dr_ = O2Saturation?.Effective;
+								object ds_ = FHIRHelpers_4_3_000.ToValue(dr_);
+								bool dt_ = ds_ is CqlDateTime;
 
 								return dt_;
 							};
 							bool dp_()
 							{
-								var du_ = O2Saturation?.Effective;
-								var dv_ = FHIRHelpers_4_3_000.ToValue(du_);
-								var dw_ = dv_ is CqlInterval<CqlDateTime>;
+								DataType du_ = O2Saturation?.Effective;
+								object dv_ = FHIRHelpers_4_3_000.ToValue(du_);
+								bool dw_ = dv_ is CqlInterval<CqlDateTime>;
 
 								return dw_;
 							};
 							bool dq_()
 							{
-								var dx_ = O2Saturation?.Effective;
-								var dy_ = FHIRHelpers_4_3_000.ToValue(dx_);
-								var dz_ = dy_ is CqlDateTime;
+								DataType dx_ = O2Saturation?.Effective;
+								object dy_ = FHIRHelpers_4_3_000.ToValue(dx_);
+								bool dz_ = dy_ is CqlDateTime;
 
 								return dz_;
 							};
 							if (do_())
 							{
-								var ea_ = O2Saturation?.Effective;
-								var eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
+								DataType ea_ = O2Saturation?.Effective;
+								object eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
 
 								return ((eb_ as CqlDateTime) as object);
 							}
 							else if (dp_())
 							{
-								var ec_ = O2Saturation?.Effective;
-								var ed_ = FHIRHelpers_4_3_000.ToValue(ec_);
+								DataType ec_ = O2Saturation?.Effective;
+								object ed_ = FHIRHelpers_4_3_000.ToValue(ec_);
 
 								return ((ed_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (dq_())
 							{
-								var ee_ = O2Saturation?.Effective;
-								var ef_ = FHIRHelpers_4_3_000.ToValue(ee_);
+								DataType ee_ = O2Saturation?.Effective;
+								object ef_ = FHIRHelpers_4_3_000.ToValue(ee_);
 
 								return ((ef_ as CqlDateTime) as object);
 							}
@@ -812,84 +857,84 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var cq_ = QICoreCommon_2_0_000.earliest(cp_());
-						var cr_ = EncounterInpatient?.Period;
-						var cs_ = FHIRHelpers_4_3_000.ToInterval(cr_);
-						var ct_ = context.Operators.Start(cs_);
-						var cu_ = context.Operators.Quantity(1440m, "minutes");
-						var cv_ = context.Operators.Subtract(ct_, cu_);
-						var cx_ = FHIRHelpers_4_3_000.ToInterval(cr_);
-						var cy_ = context.Operators.Start(cx_);
-						var cz_ = context.Operators.Quantity(120m, "minutes");
-						var da_ = context.Operators.Add(cy_, cz_);
-						var db_ = context.Operators.Interval(cv_, da_, true, true);
-						var dc_ = context.Operators.In<CqlDateTime>(cq_, db_, null);
-						var dd_ = O2Saturation?.StatusElement;
-						var de_ = dd_?.Value;
-						var df_ = context.Operators.Convert<Code<ObservationStatus>>(de_);
-						var dg_ = context.Operators.Convert<string>(df_);
-						var dh_ = new string[]
+						CqlDateTime cq_ = QICoreCommon_2_0_000.earliest(cp_());
+						Period cr_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> cs_ = FHIRHelpers_4_3_000.ToInterval(cr_);
+						CqlDateTime ct_ = context.Operators.Start(cs_);
+						CqlQuantity cu_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime cv_ = context.Operators.Subtract(ct_, cu_);
+						CqlInterval<CqlDateTime> cx_ = FHIRHelpers_4_3_000.ToInterval(cr_);
+						CqlDateTime cy_ = context.Operators.Start(cx_);
+						CqlQuantity cz_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime da_ = context.Operators.Add(cy_, cz_);
+						CqlInterval<CqlDateTime> db_ = context.Operators.Interval(cv_, da_, true, true);
+						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, null);
+						Code<ObservationStatus> dd_ = O2Saturation?.StatusElement;
+						ObservationStatus? de_ = dd_?.Value;
+						Code<ObservationStatus> df_ = context.Operators.Convert<Code<ObservationStatus>>(de_);
+						string dg_ = context.Operators.Convert<string>(df_);
+						string[] dh_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var di_ = context.Operators.In<string>(dg_, (dh_ as IEnumerable<string>));
-						var dj_ = context.Operators.And(dc_, di_);
-						var dk_ = O2Saturation?.Value;
-						var dl_ = FHIRHelpers_4_3_000.ToValue(dk_);
-						var dm_ = context.Operators.Not((bool?)(dl_ is null));
-						var dn_ = context.Operators.And(dj_, dm_);
+						bool? di_ = context.Operators.In<string>(dg_, (dh_ as IEnumerable<string>));
+						bool? dj_ = context.Operators.And(dc_, di_);
+						DataType dk_ = O2Saturation?.Value;
+						object dl_ = FHIRHelpers_4_3_000.ToValue(dk_);
+						bool? dm_ = context.Operators.Not((bool?)(dl_ is null));
+						bool? dn_ = context.Operators.And(dj_, dm_);
 
 						return dn_;
 					};
-					var ci_ = context.Operators.Where<Observation>(cg_, ch_);
+					IEnumerable<Observation> ci_ = context.Operators.Where<Observation>(cg_, ch_);
 					object cj_(Observation @this)
 					{
 						object eg_()
 						{
 							bool ei_()
 							{
-								var el_ = @this?.Effective;
-								var em_ = FHIRHelpers_4_3_000.ToValue(el_);
-								var en_ = em_ is CqlDateTime;
+								DataType el_ = @this?.Effective;
+								object em_ = FHIRHelpers_4_3_000.ToValue(el_);
+								bool en_ = em_ is CqlDateTime;
 
 								return en_;
 							};
 							bool ej_()
 							{
-								var eo_ = @this?.Effective;
-								var ep_ = FHIRHelpers_4_3_000.ToValue(eo_);
-								var eq_ = ep_ is CqlInterval<CqlDateTime>;
+								DataType eo_ = @this?.Effective;
+								object ep_ = FHIRHelpers_4_3_000.ToValue(eo_);
+								bool eq_ = ep_ is CqlInterval<CqlDateTime>;
 
 								return eq_;
 							};
 							bool ek_()
 							{
-								var er_ = @this?.Effective;
-								var es_ = FHIRHelpers_4_3_000.ToValue(er_);
-								var et_ = es_ is CqlDateTime;
+								DataType er_ = @this?.Effective;
+								object es_ = FHIRHelpers_4_3_000.ToValue(er_);
+								bool et_ = es_ is CqlDateTime;
 
 								return et_;
 							};
 							if (ei_())
 							{
-								var eu_ = @this?.Effective;
-								var ev_ = FHIRHelpers_4_3_000.ToValue(eu_);
+								DataType eu_ = @this?.Effective;
+								object ev_ = FHIRHelpers_4_3_000.ToValue(eu_);
 
 								return ((ev_ as CqlDateTime) as object);
 							}
 							else if (ej_())
 							{
-								var ew_ = @this?.Effective;
-								var ex_ = FHIRHelpers_4_3_000.ToValue(ew_);
+								DataType ew_ = @this?.Effective;
+								object ex_ = FHIRHelpers_4_3_000.ToValue(ew_);
 
 								return ((ex_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ek_())
 							{
-								var ey_ = @this?.Effective;
-								var ez_ = FHIRHelpers_4_3_000.ToValue(ey_);
+								DataType ey_ = @this?.Effective;
+								object ez_ = FHIRHelpers_4_3_000.ToValue(ey_);
 
 								return ((ez_ as CqlDateTime) as object);
 							}
@@ -898,68 +943,68 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var eh_ = QICoreCommon_2_0_000.earliest(eg_());
+						CqlDateTime eh_ = QICoreCommon_2_0_000.earliest(eg_());
 
 						return eh_;
 					};
-					var ck_ = context.Operators.SortBy<Observation>(ci_, cj_, System.ComponentModel.ListSortDirection.Ascending);
-					var cl_ = context.Operators.First<Observation>(ck_);
-					var cm_ = cl_?.Effective;
-					var cn_ = FHIRHelpers_4_3_000.ToValue(cm_);
-					var co_ = cn_ is CqlDateTime;
+					IEnumerable<Observation> ck_ = context.Operators.SortBy<Observation>(ci_, cj_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation cl_ = context.Operators.First<Observation>(ck_);
+					DataType cm_ = cl_?.Effective;
+					object cn_ = FHIRHelpers_4_3_000.ToValue(cm_);
+					bool co_ = cn_ is CqlDateTime;
 
 					return co_;
 				};
 				bool cd_()
 				{
-					var fa_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, null);
+					CqlValueSet fa_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, null);
 					bool? fc_(Observation O2Saturation)
 					{
 						object fk_()
 						{
 							bool gj_()
 							{
-								var gm_ = O2Saturation?.Effective;
-								var gn_ = FHIRHelpers_4_3_000.ToValue(gm_);
-								var go_ = gn_ is CqlDateTime;
+								DataType gm_ = O2Saturation?.Effective;
+								object gn_ = FHIRHelpers_4_3_000.ToValue(gm_);
+								bool go_ = gn_ is CqlDateTime;
 
 								return go_;
 							};
 							bool gk_()
 							{
-								var gp_ = O2Saturation?.Effective;
-								var gq_ = FHIRHelpers_4_3_000.ToValue(gp_);
-								var gr_ = gq_ is CqlInterval<CqlDateTime>;
+								DataType gp_ = O2Saturation?.Effective;
+								object gq_ = FHIRHelpers_4_3_000.ToValue(gp_);
+								bool gr_ = gq_ is CqlInterval<CqlDateTime>;
 
 								return gr_;
 							};
 							bool gl_()
 							{
-								var gs_ = O2Saturation?.Effective;
-								var gt_ = FHIRHelpers_4_3_000.ToValue(gs_);
-								var gu_ = gt_ is CqlDateTime;
+								DataType gs_ = O2Saturation?.Effective;
+								object gt_ = FHIRHelpers_4_3_000.ToValue(gs_);
+								bool gu_ = gt_ is CqlDateTime;
 
 								return gu_;
 							};
 							if (gj_())
 							{
-								var gv_ = O2Saturation?.Effective;
-								var gw_ = FHIRHelpers_4_3_000.ToValue(gv_);
+								DataType gv_ = O2Saturation?.Effective;
+								object gw_ = FHIRHelpers_4_3_000.ToValue(gv_);
 
 								return ((gw_ as CqlDateTime) as object);
 							}
 							else if (gk_())
 							{
-								var gx_ = O2Saturation?.Effective;
-								var gy_ = FHIRHelpers_4_3_000.ToValue(gx_);
+								DataType gx_ = O2Saturation?.Effective;
+								object gy_ = FHIRHelpers_4_3_000.ToValue(gx_);
 
 								return ((gy_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (gl_())
 							{
-								var gz_ = O2Saturation?.Effective;
-								var ha_ = FHIRHelpers_4_3_000.ToValue(gz_);
+								DataType gz_ = O2Saturation?.Effective;
+								object ha_ = FHIRHelpers_4_3_000.ToValue(gz_);
 
 								return ((ha_ as CqlDateTime) as object);
 							}
@@ -968,84 +1013,84 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var fl_ = QICoreCommon_2_0_000.earliest(fk_());
-						var fm_ = EncounterInpatient?.Period;
-						var fn_ = FHIRHelpers_4_3_000.ToInterval(fm_);
-						var fo_ = context.Operators.Start(fn_);
-						var fp_ = context.Operators.Quantity(1440m, "minutes");
-						var fq_ = context.Operators.Subtract(fo_, fp_);
-						var fs_ = FHIRHelpers_4_3_000.ToInterval(fm_);
-						var ft_ = context.Operators.Start(fs_);
-						var fu_ = context.Operators.Quantity(120m, "minutes");
-						var fv_ = context.Operators.Add(ft_, fu_);
-						var fw_ = context.Operators.Interval(fq_, fv_, true, true);
-						var fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, null);
-						var fy_ = O2Saturation?.StatusElement;
-						var fz_ = fy_?.Value;
-						var ga_ = context.Operators.Convert<Code<ObservationStatus>>(fz_);
-						var gb_ = context.Operators.Convert<string>(ga_);
-						var gc_ = new string[]
+						CqlDateTime fl_ = QICoreCommon_2_0_000.earliest(fk_());
+						Period fm_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> fn_ = FHIRHelpers_4_3_000.ToInterval(fm_);
+						CqlDateTime fo_ = context.Operators.Start(fn_);
+						CqlQuantity fp_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime fq_ = context.Operators.Subtract(fo_, fp_);
+						CqlInterval<CqlDateTime> fs_ = FHIRHelpers_4_3_000.ToInterval(fm_);
+						CqlDateTime ft_ = context.Operators.Start(fs_);
+						CqlQuantity fu_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime fv_ = context.Operators.Add(ft_, fu_);
+						CqlInterval<CqlDateTime> fw_ = context.Operators.Interval(fq_, fv_, true, true);
+						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, null);
+						Code<ObservationStatus> fy_ = O2Saturation?.StatusElement;
+						ObservationStatus? fz_ = fy_?.Value;
+						Code<ObservationStatus> ga_ = context.Operators.Convert<Code<ObservationStatus>>(fz_);
+						string gb_ = context.Operators.Convert<string>(ga_);
+						string[] gc_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var gd_ = context.Operators.In<string>(gb_, (gc_ as IEnumerable<string>));
-						var ge_ = context.Operators.And(fx_, gd_);
-						var gf_ = O2Saturation?.Value;
-						var gg_ = FHIRHelpers_4_3_000.ToValue(gf_);
-						var gh_ = context.Operators.Not((bool?)(gg_ is null));
-						var gi_ = context.Operators.And(ge_, gh_);
+						bool? gd_ = context.Operators.In<string>(gb_, (gc_ as IEnumerable<string>));
+						bool? ge_ = context.Operators.And(fx_, gd_);
+						DataType gf_ = O2Saturation?.Value;
+						object gg_ = FHIRHelpers_4_3_000.ToValue(gf_);
+						bool? gh_ = context.Operators.Not((bool?)(gg_ is null));
+						bool? gi_ = context.Operators.And(ge_, gh_);
 
 						return gi_;
 					};
-					var fd_ = context.Operators.Where<Observation>(fb_, fc_);
+					IEnumerable<Observation> fd_ = context.Operators.Where<Observation>(fb_, fc_);
 					object fe_(Observation @this)
 					{
 						object hb_()
 						{
 							bool hd_()
 							{
-								var hg_ = @this?.Effective;
-								var hh_ = FHIRHelpers_4_3_000.ToValue(hg_);
-								var hi_ = hh_ is CqlDateTime;
+								DataType hg_ = @this?.Effective;
+								object hh_ = FHIRHelpers_4_3_000.ToValue(hg_);
+								bool hi_ = hh_ is CqlDateTime;
 
 								return hi_;
 							};
 							bool he_()
 							{
-								var hj_ = @this?.Effective;
-								var hk_ = FHIRHelpers_4_3_000.ToValue(hj_);
-								var hl_ = hk_ is CqlInterval<CqlDateTime>;
+								DataType hj_ = @this?.Effective;
+								object hk_ = FHIRHelpers_4_3_000.ToValue(hj_);
+								bool hl_ = hk_ is CqlInterval<CqlDateTime>;
 
 								return hl_;
 							};
 							bool hf_()
 							{
-								var hm_ = @this?.Effective;
-								var hn_ = FHIRHelpers_4_3_000.ToValue(hm_);
-								var ho_ = hn_ is CqlDateTime;
+								DataType hm_ = @this?.Effective;
+								object hn_ = FHIRHelpers_4_3_000.ToValue(hm_);
+								bool ho_ = hn_ is CqlDateTime;
 
 								return ho_;
 							};
 							if (hd_())
 							{
-								var hp_ = @this?.Effective;
-								var hq_ = FHIRHelpers_4_3_000.ToValue(hp_);
+								DataType hp_ = @this?.Effective;
+								object hq_ = FHIRHelpers_4_3_000.ToValue(hp_);
 
 								return ((hq_ as CqlDateTime) as object);
 							}
 							else if (he_())
 							{
-								var hr_ = @this?.Effective;
-								var hs_ = FHIRHelpers_4_3_000.ToValue(hr_);
+								DataType hr_ = @this?.Effective;
+								object hs_ = FHIRHelpers_4_3_000.ToValue(hr_);
 
 								return ((hs_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (hf_())
 							{
-								var ht_ = @this?.Effective;
-								var hu_ = FHIRHelpers_4_3_000.ToValue(ht_);
+								DataType ht_ = @this?.Effective;
+								object hu_ = FHIRHelpers_4_3_000.ToValue(ht_);
 
 								return ((hu_ as CqlDateTime) as object);
 							}
@@ -1054,68 +1099,68 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var hc_ = QICoreCommon_2_0_000.earliest(hb_());
+						CqlDateTime hc_ = QICoreCommon_2_0_000.earliest(hb_());
 
 						return hc_;
 					};
-					var ff_ = context.Operators.SortBy<Observation>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
-					var fg_ = context.Operators.First<Observation>(ff_);
-					var fh_ = fg_?.Effective;
-					var fi_ = FHIRHelpers_4_3_000.ToValue(fh_);
-					var fj_ = fi_ is CqlInterval<CqlDateTime>;
+					IEnumerable<Observation> ff_ = context.Operators.SortBy<Observation>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation fg_ = context.Operators.First<Observation>(ff_);
+					DataType fh_ = fg_?.Effective;
+					object fi_ = FHIRHelpers_4_3_000.ToValue(fh_);
+					bool fj_ = fi_ is CqlInterval<CqlDateTime>;
 
 					return fj_;
 				};
 				bool ce_()
 				{
-					var hv_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, null);
+					CqlValueSet hv_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, null);
 					bool? hx_(Observation O2Saturation)
 					{
 						object if_()
 						{
 							bool je_()
 							{
-								var jh_ = O2Saturation?.Effective;
-								var ji_ = FHIRHelpers_4_3_000.ToValue(jh_);
-								var jj_ = ji_ is CqlDateTime;
+								DataType jh_ = O2Saturation?.Effective;
+								object ji_ = FHIRHelpers_4_3_000.ToValue(jh_);
+								bool jj_ = ji_ is CqlDateTime;
 
 								return jj_;
 							};
 							bool jf_()
 							{
-								var jk_ = O2Saturation?.Effective;
-								var jl_ = FHIRHelpers_4_3_000.ToValue(jk_);
-								var jm_ = jl_ is CqlInterval<CqlDateTime>;
+								DataType jk_ = O2Saturation?.Effective;
+								object jl_ = FHIRHelpers_4_3_000.ToValue(jk_);
+								bool jm_ = jl_ is CqlInterval<CqlDateTime>;
 
 								return jm_;
 							};
 							bool jg_()
 							{
-								var jn_ = O2Saturation?.Effective;
-								var jo_ = FHIRHelpers_4_3_000.ToValue(jn_);
-								var jp_ = jo_ is CqlDateTime;
+								DataType jn_ = O2Saturation?.Effective;
+								object jo_ = FHIRHelpers_4_3_000.ToValue(jn_);
+								bool jp_ = jo_ is CqlDateTime;
 
 								return jp_;
 							};
 							if (je_())
 							{
-								var jq_ = O2Saturation?.Effective;
-								var jr_ = FHIRHelpers_4_3_000.ToValue(jq_);
+								DataType jq_ = O2Saturation?.Effective;
+								object jr_ = FHIRHelpers_4_3_000.ToValue(jq_);
 
 								return ((jr_ as CqlDateTime) as object);
 							}
 							else if (jf_())
 							{
-								var js_ = O2Saturation?.Effective;
-								var jt_ = FHIRHelpers_4_3_000.ToValue(js_);
+								DataType js_ = O2Saturation?.Effective;
+								object jt_ = FHIRHelpers_4_3_000.ToValue(js_);
 
 								return ((jt_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (jg_())
 							{
-								var ju_ = O2Saturation?.Effective;
-								var jv_ = FHIRHelpers_4_3_000.ToValue(ju_);
+								DataType ju_ = O2Saturation?.Effective;
+								object jv_ = FHIRHelpers_4_3_000.ToValue(ju_);
 
 								return ((jv_ as CqlDateTime) as object);
 							}
@@ -1124,84 +1169,84 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var ig_ = QICoreCommon_2_0_000.earliest(if_());
-						var ih_ = EncounterInpatient?.Period;
-						var ii_ = FHIRHelpers_4_3_000.ToInterval(ih_);
-						var ij_ = context.Operators.Start(ii_);
-						var ik_ = context.Operators.Quantity(1440m, "minutes");
-						var il_ = context.Operators.Subtract(ij_, ik_);
-						var in_ = FHIRHelpers_4_3_000.ToInterval(ih_);
-						var io_ = context.Operators.Start(in_);
-						var ip_ = context.Operators.Quantity(120m, "minutes");
-						var iq_ = context.Operators.Add(io_, ip_);
-						var ir_ = context.Operators.Interval(il_, iq_, true, true);
-						var is_ = context.Operators.In<CqlDateTime>(ig_, ir_, null);
-						var it_ = O2Saturation?.StatusElement;
-						var iu_ = it_?.Value;
-						var iv_ = context.Operators.Convert<Code<ObservationStatus>>(iu_);
-						var iw_ = context.Operators.Convert<string>(iv_);
-						var ix_ = new string[]
+						CqlDateTime ig_ = QICoreCommon_2_0_000.earliest(if_());
+						Period ih_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(ih_);
+						CqlDateTime ij_ = context.Operators.Start(ii_);
+						CqlQuantity ik_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime il_ = context.Operators.Subtract(ij_, ik_);
+						CqlInterval<CqlDateTime> in_ = FHIRHelpers_4_3_000.ToInterval(ih_);
+						CqlDateTime io_ = context.Operators.Start(in_);
+						CqlQuantity ip_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime iq_ = context.Operators.Add(io_, ip_);
+						CqlInterval<CqlDateTime> ir_ = context.Operators.Interval(il_, iq_, true, true);
+						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, null);
+						Code<ObservationStatus> it_ = O2Saturation?.StatusElement;
+						ObservationStatus? iu_ = it_?.Value;
+						Code<ObservationStatus> iv_ = context.Operators.Convert<Code<ObservationStatus>>(iu_);
+						string iw_ = context.Operators.Convert<string>(iv_);
+						string[] ix_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var iy_ = context.Operators.In<string>(iw_, (ix_ as IEnumerable<string>));
-						var iz_ = context.Operators.And(is_, iy_);
-						var ja_ = O2Saturation?.Value;
-						var jb_ = FHIRHelpers_4_3_000.ToValue(ja_);
-						var jc_ = context.Operators.Not((bool?)(jb_ is null));
-						var jd_ = context.Operators.And(iz_, jc_);
+						bool? iy_ = context.Operators.In<string>(iw_, (ix_ as IEnumerable<string>));
+						bool? iz_ = context.Operators.And(is_, iy_);
+						DataType ja_ = O2Saturation?.Value;
+						object jb_ = FHIRHelpers_4_3_000.ToValue(ja_);
+						bool? jc_ = context.Operators.Not((bool?)(jb_ is null));
+						bool? jd_ = context.Operators.And(iz_, jc_);
 
 						return jd_;
 					};
-					var hy_ = context.Operators.Where<Observation>(hw_, hx_);
+					IEnumerable<Observation> hy_ = context.Operators.Where<Observation>(hw_, hx_);
 					object hz_(Observation @this)
 					{
 						object jw_()
 						{
 							bool jy_()
 							{
-								var kb_ = @this?.Effective;
-								var kc_ = FHIRHelpers_4_3_000.ToValue(kb_);
-								var kd_ = kc_ is CqlDateTime;
+								DataType kb_ = @this?.Effective;
+								object kc_ = FHIRHelpers_4_3_000.ToValue(kb_);
+								bool kd_ = kc_ is CqlDateTime;
 
 								return kd_;
 							};
 							bool jz_()
 							{
-								var ke_ = @this?.Effective;
-								var kf_ = FHIRHelpers_4_3_000.ToValue(ke_);
-								var kg_ = kf_ is CqlInterval<CqlDateTime>;
+								DataType ke_ = @this?.Effective;
+								object kf_ = FHIRHelpers_4_3_000.ToValue(ke_);
+								bool kg_ = kf_ is CqlInterval<CqlDateTime>;
 
 								return kg_;
 							};
 							bool ka_()
 							{
-								var kh_ = @this?.Effective;
-								var ki_ = FHIRHelpers_4_3_000.ToValue(kh_);
-								var kj_ = ki_ is CqlDateTime;
+								DataType kh_ = @this?.Effective;
+								object ki_ = FHIRHelpers_4_3_000.ToValue(kh_);
+								bool kj_ = ki_ is CqlDateTime;
 
 								return kj_;
 							};
 							if (jy_())
 							{
-								var kk_ = @this?.Effective;
-								var kl_ = FHIRHelpers_4_3_000.ToValue(kk_);
+								DataType kk_ = @this?.Effective;
+								object kl_ = FHIRHelpers_4_3_000.ToValue(kk_);
 
 								return ((kl_ as CqlDateTime) as object);
 							}
 							else if (jz_())
 							{
-								var km_ = @this?.Effective;
-								var kn_ = FHIRHelpers_4_3_000.ToValue(km_);
+								DataType km_ = @this?.Effective;
+								object kn_ = FHIRHelpers_4_3_000.ToValue(km_);
 
 								return ((kn_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ka_())
 							{
-								var ko_ = @this?.Effective;
-								var kp_ = FHIRHelpers_4_3_000.ToValue(ko_);
+								DataType ko_ = @this?.Effective;
+								object kp_ = FHIRHelpers_4_3_000.ToValue(ko_);
 
 								return ((kp_ as CqlDateTime) as object);
 							}
@@ -1210,68 +1255,68 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var jx_ = QICoreCommon_2_0_000.earliest(jw_());
+						CqlDateTime jx_ = QICoreCommon_2_0_000.earliest(jw_());
 
 						return jx_;
 					};
-					var ia_ = context.Operators.SortBy<Observation>(hy_, hz_, System.ComponentModel.ListSortDirection.Ascending);
-					var ib_ = context.Operators.First<Observation>(ia_);
-					var ic_ = ib_?.Effective;
-					var id_ = FHIRHelpers_4_3_000.ToValue(ic_);
-					var ie_ = id_ is CqlDateTime;
+					IEnumerable<Observation> ia_ = context.Operators.SortBy<Observation>(hy_, hz_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation ib_ = context.Operators.First<Observation>(ia_);
+					DataType ic_ = ib_?.Effective;
+					object id_ = FHIRHelpers_4_3_000.ToValue(ic_);
+					bool ie_ = id_ is CqlDateTime;
 
 					return ie_;
 				};
 				if (cc_())
 				{
-					var kq_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, null);
+					CqlValueSet kq_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, null);
 					bool? ks_(Observation O2Saturation)
 					{
 						object kz_()
 						{
 							bool ly_()
 							{
-								var mb_ = O2Saturation?.Effective;
-								var mc_ = FHIRHelpers_4_3_000.ToValue(mb_);
-								var md_ = mc_ is CqlDateTime;
+								DataType mb_ = O2Saturation?.Effective;
+								object mc_ = FHIRHelpers_4_3_000.ToValue(mb_);
+								bool md_ = mc_ is CqlDateTime;
 
 								return md_;
 							};
 							bool lz_()
 							{
-								var me_ = O2Saturation?.Effective;
-								var mf_ = FHIRHelpers_4_3_000.ToValue(me_);
-								var mg_ = mf_ is CqlInterval<CqlDateTime>;
+								DataType me_ = O2Saturation?.Effective;
+								object mf_ = FHIRHelpers_4_3_000.ToValue(me_);
+								bool mg_ = mf_ is CqlInterval<CqlDateTime>;
 
 								return mg_;
 							};
 							bool ma_()
 							{
-								var mh_ = O2Saturation?.Effective;
-								var mi_ = FHIRHelpers_4_3_000.ToValue(mh_);
-								var mj_ = mi_ is CqlDateTime;
+								DataType mh_ = O2Saturation?.Effective;
+								object mi_ = FHIRHelpers_4_3_000.ToValue(mh_);
+								bool mj_ = mi_ is CqlDateTime;
 
 								return mj_;
 							};
 							if (ly_())
 							{
-								var mk_ = O2Saturation?.Effective;
-								var ml_ = FHIRHelpers_4_3_000.ToValue(mk_);
+								DataType mk_ = O2Saturation?.Effective;
+								object ml_ = FHIRHelpers_4_3_000.ToValue(mk_);
 
 								return ((ml_ as CqlDateTime) as object);
 							}
 							else if (lz_())
 							{
-								var mm_ = O2Saturation?.Effective;
-								var mn_ = FHIRHelpers_4_3_000.ToValue(mm_);
+								DataType mm_ = O2Saturation?.Effective;
+								object mn_ = FHIRHelpers_4_3_000.ToValue(mm_);
 
 								return ((mn_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ma_())
 							{
-								var mo_ = O2Saturation?.Effective;
-								var mp_ = FHIRHelpers_4_3_000.ToValue(mo_);
+								DataType mo_ = O2Saturation?.Effective;
+								object mp_ = FHIRHelpers_4_3_000.ToValue(mo_);
 
 								return ((mp_ as CqlDateTime) as object);
 							}
@@ -1280,84 +1325,84 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var la_ = QICoreCommon_2_0_000.earliest(kz_());
-						var lb_ = EncounterInpatient?.Period;
-						var lc_ = FHIRHelpers_4_3_000.ToInterval(lb_);
-						var ld_ = context.Operators.Start(lc_);
-						var le_ = context.Operators.Quantity(1440m, "minutes");
-						var lf_ = context.Operators.Subtract(ld_, le_);
-						var lh_ = FHIRHelpers_4_3_000.ToInterval(lb_);
-						var li_ = context.Operators.Start(lh_);
-						var lj_ = context.Operators.Quantity(120m, "minutes");
-						var lk_ = context.Operators.Add(li_, lj_);
-						var ll_ = context.Operators.Interval(lf_, lk_, true, true);
-						var lm_ = context.Operators.In<CqlDateTime>(la_, ll_, null);
-						var ln_ = O2Saturation?.StatusElement;
-						var lo_ = ln_?.Value;
-						var lp_ = context.Operators.Convert<Code<ObservationStatus>>(lo_);
-						var lq_ = context.Operators.Convert<string>(lp_);
-						var lr_ = new string[]
+						CqlDateTime la_ = QICoreCommon_2_0_000.earliest(kz_());
+						Period lb_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> lc_ = FHIRHelpers_4_3_000.ToInterval(lb_);
+						CqlDateTime ld_ = context.Operators.Start(lc_);
+						CqlQuantity le_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime lf_ = context.Operators.Subtract(ld_, le_);
+						CqlInterval<CqlDateTime> lh_ = FHIRHelpers_4_3_000.ToInterval(lb_);
+						CqlDateTime li_ = context.Operators.Start(lh_);
+						CqlQuantity lj_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime lk_ = context.Operators.Add(li_, lj_);
+						CqlInterval<CqlDateTime> ll_ = context.Operators.Interval(lf_, lk_, true, true);
+						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, null);
+						Code<ObservationStatus> ln_ = O2Saturation?.StatusElement;
+						ObservationStatus? lo_ = ln_?.Value;
+						Code<ObservationStatus> lp_ = context.Operators.Convert<Code<ObservationStatus>>(lo_);
+						string lq_ = context.Operators.Convert<string>(lp_);
+						string[] lr_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var ls_ = context.Operators.In<string>(lq_, (lr_ as IEnumerable<string>));
-						var lt_ = context.Operators.And(lm_, ls_);
-						var lu_ = O2Saturation?.Value;
-						var lv_ = FHIRHelpers_4_3_000.ToValue(lu_);
-						var lw_ = context.Operators.Not((bool?)(lv_ is null));
-						var lx_ = context.Operators.And(lt_, lw_);
+						bool? ls_ = context.Operators.In<string>(lq_, (lr_ as IEnumerable<string>));
+						bool? lt_ = context.Operators.And(lm_, ls_);
+						DataType lu_ = O2Saturation?.Value;
+						object lv_ = FHIRHelpers_4_3_000.ToValue(lu_);
+						bool? lw_ = context.Operators.Not((bool?)(lv_ is null));
+						bool? lx_ = context.Operators.And(lt_, lw_);
 
 						return lx_;
 					};
-					var kt_ = context.Operators.Where<Observation>(kr_, ks_);
+					IEnumerable<Observation> kt_ = context.Operators.Where<Observation>(kr_, ks_);
 					object ku_(Observation @this)
 					{
 						object mq_()
 						{
 							bool ms_()
 							{
-								var mv_ = @this?.Effective;
-								var mw_ = FHIRHelpers_4_3_000.ToValue(mv_);
-								var mx_ = mw_ is CqlDateTime;
+								DataType mv_ = @this?.Effective;
+								object mw_ = FHIRHelpers_4_3_000.ToValue(mv_);
+								bool mx_ = mw_ is CqlDateTime;
 
 								return mx_;
 							};
 							bool mt_()
 							{
-								var my_ = @this?.Effective;
-								var mz_ = FHIRHelpers_4_3_000.ToValue(my_);
-								var na_ = mz_ is CqlInterval<CqlDateTime>;
+								DataType my_ = @this?.Effective;
+								object mz_ = FHIRHelpers_4_3_000.ToValue(my_);
+								bool na_ = mz_ is CqlInterval<CqlDateTime>;
 
 								return na_;
 							};
 							bool mu_()
 							{
-								var nb_ = @this?.Effective;
-								var nc_ = FHIRHelpers_4_3_000.ToValue(nb_);
-								var nd_ = nc_ is CqlDateTime;
+								DataType nb_ = @this?.Effective;
+								object nc_ = FHIRHelpers_4_3_000.ToValue(nb_);
+								bool nd_ = nc_ is CqlDateTime;
 
 								return nd_;
 							};
 							if (ms_())
 							{
-								var ne_ = @this?.Effective;
-								var nf_ = FHIRHelpers_4_3_000.ToValue(ne_);
+								DataType ne_ = @this?.Effective;
+								object nf_ = FHIRHelpers_4_3_000.ToValue(ne_);
 
 								return ((nf_ as CqlDateTime) as object);
 							}
 							else if (mt_())
 							{
-								var ng_ = @this?.Effective;
-								var nh_ = FHIRHelpers_4_3_000.ToValue(ng_);
+								DataType ng_ = @this?.Effective;
+								object nh_ = FHIRHelpers_4_3_000.ToValue(ng_);
 
 								return ((nh_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (mu_())
 							{
-								var ni_ = @this?.Effective;
-								var nj_ = FHIRHelpers_4_3_000.ToValue(ni_);
+								DataType ni_ = @this?.Effective;
+								object nj_ = FHIRHelpers_4_3_000.ToValue(ni_);
 
 								return ((nj_ as CqlDateTime) as object);
 							}
@@ -1366,67 +1411,67 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var mr_ = QICoreCommon_2_0_000.earliest(mq_());
+						CqlDateTime mr_ = QICoreCommon_2_0_000.earliest(mq_());
 
 						return mr_;
 					};
-					var kv_ = context.Operators.SortBy<Observation>(kt_, ku_, System.ComponentModel.ListSortDirection.Ascending);
-					var kw_ = context.Operators.First<Observation>(kv_);
-					var kx_ = kw_?.Effective;
-					var ky_ = FHIRHelpers_4_3_000.ToValue(kx_);
+					IEnumerable<Observation> kv_ = context.Operators.SortBy<Observation>(kt_, ku_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation kw_ = context.Operators.First<Observation>(kv_);
+					DataType kx_ = kw_?.Effective;
+					object ky_ = FHIRHelpers_4_3_000.ToValue(kx_);
 
 					return ((ky_ as CqlDateTime) as object);
 				}
 				else if (cd_())
 				{
-					var nk_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, null);
+					CqlValueSet nk_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, null);
 					bool? nm_(Observation O2Saturation)
 					{
 						object nt_()
 						{
 							bool os_()
 							{
-								var ov_ = O2Saturation?.Effective;
-								var ow_ = FHIRHelpers_4_3_000.ToValue(ov_);
-								var ox_ = ow_ is CqlDateTime;
+								DataType ov_ = O2Saturation?.Effective;
+								object ow_ = FHIRHelpers_4_3_000.ToValue(ov_);
+								bool ox_ = ow_ is CqlDateTime;
 
 								return ox_;
 							};
 							bool ot_()
 							{
-								var oy_ = O2Saturation?.Effective;
-								var oz_ = FHIRHelpers_4_3_000.ToValue(oy_);
-								var pa_ = oz_ is CqlInterval<CqlDateTime>;
+								DataType oy_ = O2Saturation?.Effective;
+								object oz_ = FHIRHelpers_4_3_000.ToValue(oy_);
+								bool pa_ = oz_ is CqlInterval<CqlDateTime>;
 
 								return pa_;
 							};
 							bool ou_()
 							{
-								var pb_ = O2Saturation?.Effective;
-								var pc_ = FHIRHelpers_4_3_000.ToValue(pb_);
-								var pd_ = pc_ is CqlDateTime;
+								DataType pb_ = O2Saturation?.Effective;
+								object pc_ = FHIRHelpers_4_3_000.ToValue(pb_);
+								bool pd_ = pc_ is CqlDateTime;
 
 								return pd_;
 							};
 							if (os_())
 							{
-								var pe_ = O2Saturation?.Effective;
-								var pf_ = FHIRHelpers_4_3_000.ToValue(pe_);
+								DataType pe_ = O2Saturation?.Effective;
+								object pf_ = FHIRHelpers_4_3_000.ToValue(pe_);
 
 								return ((pf_ as CqlDateTime) as object);
 							}
 							else if (ot_())
 							{
-								var pg_ = O2Saturation?.Effective;
-								var ph_ = FHIRHelpers_4_3_000.ToValue(pg_);
+								DataType pg_ = O2Saturation?.Effective;
+								object ph_ = FHIRHelpers_4_3_000.ToValue(pg_);
 
 								return ((ph_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ou_())
 							{
-								var pi_ = O2Saturation?.Effective;
-								var pj_ = FHIRHelpers_4_3_000.ToValue(pi_);
+								DataType pi_ = O2Saturation?.Effective;
+								object pj_ = FHIRHelpers_4_3_000.ToValue(pi_);
 
 								return ((pj_ as CqlDateTime) as object);
 							}
@@ -1435,84 +1480,84 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var nu_ = QICoreCommon_2_0_000.earliest(nt_());
-						var nv_ = EncounterInpatient?.Period;
-						var nw_ = FHIRHelpers_4_3_000.ToInterval(nv_);
-						var nx_ = context.Operators.Start(nw_);
-						var ny_ = context.Operators.Quantity(1440m, "minutes");
-						var nz_ = context.Operators.Subtract(nx_, ny_);
-						var ob_ = FHIRHelpers_4_3_000.ToInterval(nv_);
-						var oc_ = context.Operators.Start(ob_);
-						var od_ = context.Operators.Quantity(120m, "minutes");
-						var oe_ = context.Operators.Add(oc_, od_);
-						var of_ = context.Operators.Interval(nz_, oe_, true, true);
-						var og_ = context.Operators.In<CqlDateTime>(nu_, of_, null);
-						var oh_ = O2Saturation?.StatusElement;
-						var oi_ = oh_?.Value;
-						var oj_ = context.Operators.Convert<Code<ObservationStatus>>(oi_);
-						var ok_ = context.Operators.Convert<string>(oj_);
-						var ol_ = new string[]
+						CqlDateTime nu_ = QICoreCommon_2_0_000.earliest(nt_());
+						Period nv_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> nw_ = FHIRHelpers_4_3_000.ToInterval(nv_);
+						CqlDateTime nx_ = context.Operators.Start(nw_);
+						CqlQuantity ny_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime nz_ = context.Operators.Subtract(nx_, ny_);
+						CqlInterval<CqlDateTime> ob_ = FHIRHelpers_4_3_000.ToInterval(nv_);
+						CqlDateTime oc_ = context.Operators.Start(ob_);
+						CqlQuantity od_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime oe_ = context.Operators.Add(oc_, od_);
+						CqlInterval<CqlDateTime> of_ = context.Operators.Interval(nz_, oe_, true, true);
+						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, null);
+						Code<ObservationStatus> oh_ = O2Saturation?.StatusElement;
+						ObservationStatus? oi_ = oh_?.Value;
+						Code<ObservationStatus> oj_ = context.Operators.Convert<Code<ObservationStatus>>(oi_);
+						string ok_ = context.Operators.Convert<string>(oj_);
+						string[] ol_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var om_ = context.Operators.In<string>(ok_, (ol_ as IEnumerable<string>));
-						var on_ = context.Operators.And(og_, om_);
-						var oo_ = O2Saturation?.Value;
-						var op_ = FHIRHelpers_4_3_000.ToValue(oo_);
-						var oq_ = context.Operators.Not((bool?)(op_ is null));
-						var or_ = context.Operators.And(on_, oq_);
+						bool? om_ = context.Operators.In<string>(ok_, (ol_ as IEnumerable<string>));
+						bool? on_ = context.Operators.And(og_, om_);
+						DataType oo_ = O2Saturation?.Value;
+						object op_ = FHIRHelpers_4_3_000.ToValue(oo_);
+						bool? oq_ = context.Operators.Not((bool?)(op_ is null));
+						bool? or_ = context.Operators.And(on_, oq_);
 
 						return or_;
 					};
-					var nn_ = context.Operators.Where<Observation>(nl_, nm_);
+					IEnumerable<Observation> nn_ = context.Operators.Where<Observation>(nl_, nm_);
 					object no_(Observation @this)
 					{
 						object pk_()
 						{
 							bool pm_()
 							{
-								var pp_ = @this?.Effective;
-								var pq_ = FHIRHelpers_4_3_000.ToValue(pp_);
-								var pr_ = pq_ is CqlDateTime;
+								DataType pp_ = @this?.Effective;
+								object pq_ = FHIRHelpers_4_3_000.ToValue(pp_);
+								bool pr_ = pq_ is CqlDateTime;
 
 								return pr_;
 							};
 							bool pn_()
 							{
-								var ps_ = @this?.Effective;
-								var pt_ = FHIRHelpers_4_3_000.ToValue(ps_);
-								var pu_ = pt_ is CqlInterval<CqlDateTime>;
+								DataType ps_ = @this?.Effective;
+								object pt_ = FHIRHelpers_4_3_000.ToValue(ps_);
+								bool pu_ = pt_ is CqlInterval<CqlDateTime>;
 
 								return pu_;
 							};
 							bool po_()
 							{
-								var pv_ = @this?.Effective;
-								var pw_ = FHIRHelpers_4_3_000.ToValue(pv_);
-								var px_ = pw_ is CqlDateTime;
+								DataType pv_ = @this?.Effective;
+								object pw_ = FHIRHelpers_4_3_000.ToValue(pv_);
+								bool px_ = pw_ is CqlDateTime;
 
 								return px_;
 							};
 							if (pm_())
 							{
-								var py_ = @this?.Effective;
-								var pz_ = FHIRHelpers_4_3_000.ToValue(py_);
+								DataType py_ = @this?.Effective;
+								object pz_ = FHIRHelpers_4_3_000.ToValue(py_);
 
 								return ((pz_ as CqlDateTime) as object);
 							}
 							else if (pn_())
 							{
-								var qa_ = @this?.Effective;
-								var qb_ = FHIRHelpers_4_3_000.ToValue(qa_);
+								DataType qa_ = @this?.Effective;
+								object qb_ = FHIRHelpers_4_3_000.ToValue(qa_);
 
 								return ((qb_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (po_())
 							{
-								var qc_ = @this?.Effective;
-								var qd_ = FHIRHelpers_4_3_000.ToValue(qc_);
+								DataType qc_ = @this?.Effective;
+								object qd_ = FHIRHelpers_4_3_000.ToValue(qc_);
 
 								return ((qd_ as CqlDateTime) as object);
 							}
@@ -1521,67 +1566,67 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var pl_ = QICoreCommon_2_0_000.earliest(pk_());
+						CqlDateTime pl_ = QICoreCommon_2_0_000.earliest(pk_());
 
 						return pl_;
 					};
-					var np_ = context.Operators.SortBy<Observation>(nn_, no_, System.ComponentModel.ListSortDirection.Ascending);
-					var nq_ = context.Operators.First<Observation>(np_);
-					var nr_ = nq_?.Effective;
-					var ns_ = FHIRHelpers_4_3_000.ToValue(nr_);
+					IEnumerable<Observation> np_ = context.Operators.SortBy<Observation>(nn_, no_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation nq_ = context.Operators.First<Observation>(np_);
+					DataType nr_ = nq_?.Effective;
+					object ns_ = FHIRHelpers_4_3_000.ToValue(nr_);
 
 					return ((ns_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (ce_())
 				{
-					var qe_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, null);
+					CqlValueSet qe_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, null);
 					bool? qg_(Observation O2Saturation)
 					{
 						object qn_()
 						{
 							bool rm_()
 							{
-								var rp_ = O2Saturation?.Effective;
-								var rq_ = FHIRHelpers_4_3_000.ToValue(rp_);
-								var rr_ = rq_ is CqlDateTime;
+								DataType rp_ = O2Saturation?.Effective;
+								object rq_ = FHIRHelpers_4_3_000.ToValue(rp_);
+								bool rr_ = rq_ is CqlDateTime;
 
 								return rr_;
 							};
 							bool rn_()
 							{
-								var rs_ = O2Saturation?.Effective;
-								var rt_ = FHIRHelpers_4_3_000.ToValue(rs_);
-								var ru_ = rt_ is CqlInterval<CqlDateTime>;
+								DataType rs_ = O2Saturation?.Effective;
+								object rt_ = FHIRHelpers_4_3_000.ToValue(rs_);
+								bool ru_ = rt_ is CqlInterval<CqlDateTime>;
 
 								return ru_;
 							};
 							bool ro_()
 							{
-								var rv_ = O2Saturation?.Effective;
-								var rw_ = FHIRHelpers_4_3_000.ToValue(rv_);
-								var rx_ = rw_ is CqlDateTime;
+								DataType rv_ = O2Saturation?.Effective;
+								object rw_ = FHIRHelpers_4_3_000.ToValue(rv_);
+								bool rx_ = rw_ is CqlDateTime;
 
 								return rx_;
 							};
 							if (rm_())
 							{
-								var ry_ = O2Saturation?.Effective;
-								var rz_ = FHIRHelpers_4_3_000.ToValue(ry_);
+								DataType ry_ = O2Saturation?.Effective;
+								object rz_ = FHIRHelpers_4_3_000.ToValue(ry_);
 
 								return ((rz_ as CqlDateTime) as object);
 							}
 							else if (rn_())
 							{
-								var sa_ = O2Saturation?.Effective;
-								var sb_ = FHIRHelpers_4_3_000.ToValue(sa_);
+								DataType sa_ = O2Saturation?.Effective;
+								object sb_ = FHIRHelpers_4_3_000.ToValue(sa_);
 
 								return ((sb_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ro_())
 							{
-								var sc_ = O2Saturation?.Effective;
-								var sd_ = FHIRHelpers_4_3_000.ToValue(sc_);
+								DataType sc_ = O2Saturation?.Effective;
+								object sd_ = FHIRHelpers_4_3_000.ToValue(sc_);
 
 								return ((sd_ as CqlDateTime) as object);
 							}
@@ -1590,84 +1635,84 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var qo_ = QICoreCommon_2_0_000.earliest(qn_());
-						var qp_ = EncounterInpatient?.Period;
-						var qq_ = FHIRHelpers_4_3_000.ToInterval(qp_);
-						var qr_ = context.Operators.Start(qq_);
-						var qs_ = context.Operators.Quantity(1440m, "minutes");
-						var qt_ = context.Operators.Subtract(qr_, qs_);
-						var qv_ = FHIRHelpers_4_3_000.ToInterval(qp_);
-						var qw_ = context.Operators.Start(qv_);
-						var qx_ = context.Operators.Quantity(120m, "minutes");
-						var qy_ = context.Operators.Add(qw_, qx_);
-						var qz_ = context.Operators.Interval(qt_, qy_, true, true);
-						var ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, null);
-						var rb_ = O2Saturation?.StatusElement;
-						var rc_ = rb_?.Value;
-						var rd_ = context.Operators.Convert<Code<ObservationStatus>>(rc_);
-						var re_ = context.Operators.Convert<string>(rd_);
-						var rf_ = new string[]
+						CqlDateTime qo_ = QICoreCommon_2_0_000.earliest(qn_());
+						Period qp_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> qq_ = FHIRHelpers_4_3_000.ToInterval(qp_);
+						CqlDateTime qr_ = context.Operators.Start(qq_);
+						CqlQuantity qs_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime qt_ = context.Operators.Subtract(qr_, qs_);
+						CqlInterval<CqlDateTime> qv_ = FHIRHelpers_4_3_000.ToInterval(qp_);
+						CqlDateTime qw_ = context.Operators.Start(qv_);
+						CqlQuantity qx_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime qy_ = context.Operators.Add(qw_, qx_);
+						CqlInterval<CqlDateTime> qz_ = context.Operators.Interval(qt_, qy_, true, true);
+						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, null);
+						Code<ObservationStatus> rb_ = O2Saturation?.StatusElement;
+						ObservationStatus? rc_ = rb_?.Value;
+						Code<ObservationStatus> rd_ = context.Operators.Convert<Code<ObservationStatus>>(rc_);
+						string re_ = context.Operators.Convert<string>(rd_);
+						string[] rf_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var rg_ = context.Operators.In<string>(re_, (rf_ as IEnumerable<string>));
-						var rh_ = context.Operators.And(ra_, rg_);
-						var ri_ = O2Saturation?.Value;
-						var rj_ = FHIRHelpers_4_3_000.ToValue(ri_);
-						var rk_ = context.Operators.Not((bool?)(rj_ is null));
-						var rl_ = context.Operators.And(rh_, rk_);
+						bool? rg_ = context.Operators.In<string>(re_, (rf_ as IEnumerable<string>));
+						bool? rh_ = context.Operators.And(ra_, rg_);
+						DataType ri_ = O2Saturation?.Value;
+						object rj_ = FHIRHelpers_4_3_000.ToValue(ri_);
+						bool? rk_ = context.Operators.Not((bool?)(rj_ is null));
+						bool? rl_ = context.Operators.And(rh_, rk_);
 
 						return rl_;
 					};
-					var qh_ = context.Operators.Where<Observation>(qf_, qg_);
+					IEnumerable<Observation> qh_ = context.Operators.Where<Observation>(qf_, qg_);
 					object qi_(Observation @this)
 					{
 						object se_()
 						{
 							bool sg_()
 							{
-								var sj_ = @this?.Effective;
-								var sk_ = FHIRHelpers_4_3_000.ToValue(sj_);
-								var sl_ = sk_ is CqlDateTime;
+								DataType sj_ = @this?.Effective;
+								object sk_ = FHIRHelpers_4_3_000.ToValue(sj_);
+								bool sl_ = sk_ is CqlDateTime;
 
 								return sl_;
 							};
 							bool sh_()
 							{
-								var sm_ = @this?.Effective;
-								var sn_ = FHIRHelpers_4_3_000.ToValue(sm_);
-								var so_ = sn_ is CqlInterval<CqlDateTime>;
+								DataType sm_ = @this?.Effective;
+								object sn_ = FHIRHelpers_4_3_000.ToValue(sm_);
+								bool so_ = sn_ is CqlInterval<CqlDateTime>;
 
 								return so_;
 							};
 							bool si_()
 							{
-								var sp_ = @this?.Effective;
-								var sq_ = FHIRHelpers_4_3_000.ToValue(sp_);
-								var sr_ = sq_ is CqlDateTime;
+								DataType sp_ = @this?.Effective;
+								object sq_ = FHIRHelpers_4_3_000.ToValue(sp_);
+								bool sr_ = sq_ is CqlDateTime;
 
 								return sr_;
 							};
 							if (sg_())
 							{
-								var ss_ = @this?.Effective;
-								var st_ = FHIRHelpers_4_3_000.ToValue(ss_);
+								DataType ss_ = @this?.Effective;
+								object st_ = FHIRHelpers_4_3_000.ToValue(ss_);
 
 								return ((st_ as CqlDateTime) as object);
 							}
 							else if (sh_())
 							{
-								var su_ = @this?.Effective;
-								var sv_ = FHIRHelpers_4_3_000.ToValue(su_);
+								DataType su_ = @this?.Effective;
+								object sv_ = FHIRHelpers_4_3_000.ToValue(su_);
 
 								return ((sv_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (si_())
 							{
-								var sw_ = @this?.Effective;
-								var sx_ = FHIRHelpers_4_3_000.ToValue(sw_);
+								DataType sw_ = @this?.Effective;
+								object sx_ = FHIRHelpers_4_3_000.ToValue(sw_);
 
 								return ((sx_ as CqlDateTime) as object);
 							}
@@ -1676,14 +1721,14 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 								return null;
 							}
 						};
-						var sf_ = QICoreCommon_2_0_000.earliest(se_());
+						CqlDateTime sf_ = QICoreCommon_2_0_000.earliest(se_());
 
 						return sf_;
 					};
-					var qj_ = context.Operators.SortBy<Observation>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
-					var qk_ = context.Operators.First<Observation>(qj_);
-					var ql_ = qk_?.Effective;
-					var qm_ = FHIRHelpers_4_3_000.ToValue(ql_);
+					IEnumerable<Observation> qj_ = context.Operators.SortBy<Observation>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation qk_ = context.Operators.First<Observation>(qj_);
+					DataType ql_ = qk_?.Effective;
+					object qm_ = FHIRHelpers_4_3_000.ToValue(ql_);
 
 					return ((qm_ as CqlDateTime) as object);
 				}
@@ -1692,8 +1737,8 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 					return null;
 				}
 			};
-			var p_ = QICoreCommon_2_0_000.earliest(o_());
-			var q_ = new Tuple_FdREYEdHOZIcMCNYCRFJYJReA
+			CqlDateTime p_ = QICoreCommon_2_0_000.earliest(o_());
+			Tuple_FdREYEdHOZIcMCNYCRFJYJReA q_ = new Tuple_FdREYEdHOZIcMCNYCRFJYJReA
 			{
 				EncounterId = e_,
 				FirstOxygenSatResult = (n_ as CqlQuantity),
@@ -1702,161 +1747,167 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 			return q_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_FdREYEdHOZIcMCNYCRFJYJReA>(a_, b_);
+		IEnumerable<Tuple_FdREYEdHOZIcMCNYCRFJYJReA> c_ = context.Operators.Select<Encounter, Tuple_FdREYEdHOZIcMCNYCRFJYJReA>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Oxygen_Saturation_Value"/>
     [CqlDeclaration("Encounter with First Oxygen Saturation")]
 	public IEnumerable<Tuple_FdREYEdHOZIcMCNYCRFJYJReA> Encounter_with_First_Oxygen_Saturation() => 
 		__Encounter_with_First_Oxygen_Saturation.Value;
 
+    /// <seealso cref="Blood_Pressure_Reading"/>
 	private IEnumerable<Observation> Blood_Pressure_Reading_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 		bool? b_(Observation BloodPressure)
 		{
-			var d_ = BloodPressure?.StatusElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> d_ = BloodPressure?.StatusElement;
+			ObservationStatus? e_ = d_?.Value;
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Blood_Pressure_Reading_Value"/>
     [CqlDeclaration("Blood Pressure Reading")]
 	public IEnumerable<Observation> Blood_Pressure_Reading() => 
 		__Blood_Pressure_Reading.Value;
 
+    /// <seealso cref="Encounter_with_First_Systolic_Blood_Pressure"/>
 	private IEnumerable<Encounter> Encounter_with_First_Systolic_Blood_Pressure_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 
 		return a_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Systolic_Blood_Pressure_Value"/>
     [CqlDeclaration("Encounter with First Systolic Blood Pressure")]
 	public IEnumerable<Encounter> Encounter_with_First_Systolic_Blood_Pressure() => 
 		__Encounter_with_First_Systolic_Blood_Pressure.Value;
 
+    /// <seealso cref="Encounter_with_First_Bicarbonate_Lab_Test"/>
 	private IEnumerable<Tuple_GbUHPXXHScejjXWhcHJFQQifQ> Encounter_with_First_Bicarbonate_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_GbUHPXXHScejjXWhcHJFQQifQ b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Bicarbonate_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Bicarbonate_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation BicarbonateLab)
 			{
-				var z_ = BicarbonateLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = BicarbonateLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = BicarbonateLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = BicarbonateLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = BicarbonateLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = BicarbonateLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation BicarbonateLab)
 			{
-				var bd_ = BicarbonateLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = BicarbonateLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = BicarbonateLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = BicarbonateLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = BicarbonateLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = BicarbonateLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_GbUHPXXHScejjXWhcHJFQQifQ
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_GbUHPXXHScejjXWhcHJFQQifQ y_ = new Tuple_GbUHPXXHScejjXWhcHJFQQifQ
 			{
 				EncounterId = e_,
 				FirstBicarbonateResult = (n_ as CqlQuantity),
@@ -1865,123 +1916,125 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_GbUHPXXHScejjXWhcHJFQQifQ>(a_, b_);
+		IEnumerable<Tuple_GbUHPXXHScejjXWhcHJFQQifQ> c_ = context.Operators.Select<Encounter, Tuple_GbUHPXXHScejjXWhcHJFQQifQ>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Bicarbonate_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Bicarbonate Lab Test")]
 	public IEnumerable<Tuple_GbUHPXXHScejjXWhcHJFQQifQ> Encounter_with_First_Bicarbonate_Lab_Test() => 
 		__Encounter_with_First_Bicarbonate_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Creatinine_Lab_Test"/>
 	private IEnumerable<Tuple_FETECNQPQREfGRgPYWhOWgeWA> Encounter_with_First_Creatinine_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_FETECNQPQREfGRgPYWhOWgeWA b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Creatinine_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Creatinine_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation CreatinineLab)
 			{
-				var z_ = CreatinineLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = CreatinineLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = CreatinineLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = CreatinineLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = CreatinineLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = CreatinineLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation CreatinineLab)
 			{
-				var bd_ = CreatinineLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = CreatinineLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = CreatinineLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = CreatinineLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = CreatinineLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = CreatinineLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_FETECNQPQREfGRgPYWhOWgeWA
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_FETECNQPQREfGRgPYWhOWgeWA y_ = new Tuple_FETECNQPQREfGRgPYWhOWgeWA
 			{
 				EncounterId = e_,
 				FirstCreatinineResult = (n_ as CqlQuantity),
@@ -1990,123 +2043,125 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_FETECNQPQREfGRgPYWhOWgeWA>(a_, b_);
+		IEnumerable<Tuple_FETECNQPQREfGRgPYWhOWgeWA> c_ = context.Operators.Select<Encounter, Tuple_FETECNQPQREfGRgPYWhOWgeWA>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Creatinine_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Creatinine Lab Test")]
 	public IEnumerable<Tuple_FETECNQPQREfGRgPYWhOWgeWA> Encounter_with_First_Creatinine_Lab_Test() => 
 		__Encounter_with_First_Creatinine_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Hematocrit_Lab_Test"/>
 	private IEnumerable<Tuple_DIHdhbAJeJTdiAVUAELUHRNdS> Encounter_with_First_Hematocrit_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_DIHdhbAJeJTdiAVUAELUHRNdS b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Hematocrit_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Hematocrit_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation HematocritLab)
 			{
-				var z_ = HematocritLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = HematocritLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = HematocritLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = HematocritLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = HematocritLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = HematocritLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation HematocritLab)
 			{
-				var bd_ = HematocritLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = HematocritLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = HematocritLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = HematocritLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = HematocritLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = HematocritLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_DIHdhbAJeJTdiAVUAELUHRNdS
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_DIHdhbAJeJTdiAVUAELUHRNdS y_ = new Tuple_DIHdhbAJeJTdiAVUAELUHRNdS
 			{
 				EncounterId = e_,
 				FirstHematocritResult = (n_ as CqlQuantity),
@@ -2115,123 +2170,125 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_DIHdhbAJeJTdiAVUAELUHRNdS>(a_, b_);
+		IEnumerable<Tuple_DIHdhbAJeJTdiAVUAELUHRNdS> c_ = context.Operators.Select<Encounter, Tuple_DIHdhbAJeJTdiAVUAELUHRNdS>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Hematocrit_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Hematocrit Lab Test")]
 	public IEnumerable<Tuple_DIHdhbAJeJTdiAVUAELUHRNdS> Encounter_with_First_Hematocrit_Lab_Test() => 
 		__Encounter_with_First_Hematocrit_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Platelet_Lab_Test"/>
 	private IEnumerable<Tuple_DAUcYHQZcDKbIfORJOEZBDgIh> Encounter_with_First_Platelet_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_DAUcYHQZcDKbIfORJOEZBDgIh b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Platelet_count_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Platelet_count_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation PlateletLab)
 			{
-				var z_ = PlateletLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = PlateletLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = PlateletLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = PlateletLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = PlateletLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = PlateletLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation PlateletLab)
 			{
-				var bd_ = PlateletLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = PlateletLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = PlateletLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = PlateletLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = PlateletLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = PlateletLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_DAUcYHQZcDKbIfORJOEZBDgIh
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_DAUcYHQZcDKbIfORJOEZBDgIh y_ = new Tuple_DAUcYHQZcDKbIfORJOEZBDgIh
 			{
 				EncounterId = e_,
 				FirstPlateletResult = (n_ as CqlQuantity),
@@ -2240,123 +2297,125 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_DAUcYHQZcDKbIfORJOEZBDgIh>(a_, b_);
+		IEnumerable<Tuple_DAUcYHQZcDKbIfORJOEZBDgIh> c_ = context.Operators.Select<Encounter, Tuple_DAUcYHQZcDKbIfORJOEZBDgIh>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Platelet_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Platelet Lab Test")]
 	public IEnumerable<Tuple_DAUcYHQZcDKbIfORJOEZBDgIh> Encounter_with_First_Platelet_Lab_Test() => 
 		__Encounter_with_First_Platelet_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Sodium_Lab_Test"/>
 	private IEnumerable<Tuple_GKGeLARADLGJcNcZaDhdCREMa> Encounter_with_First_Sodium_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_GKGeLARADLGJcNcZaDhdCREMa b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Sodium_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Sodium_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation SodiumLab)
 			{
-				var z_ = SodiumLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = SodiumLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = SodiumLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = SodiumLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = SodiumLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = SodiumLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation SodiumLab)
 			{
-				var bd_ = SodiumLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = SodiumLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = SodiumLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = SodiumLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = SodiumLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = SodiumLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_GKGeLARADLGJcNcZaDhdCREMa
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_GKGeLARADLGJcNcZaDhdCREMa y_ = new Tuple_GKGeLARADLGJcNcZaDhdCREMa
 			{
 				EncounterId = e_,
 				FirstSodiumResult = (n_ as CqlQuantity),
@@ -2365,123 +2424,125 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_GKGeLARADLGJcNcZaDhdCREMa>(a_, b_);
+		IEnumerable<Tuple_GKGeLARADLGJcNcZaDhdCREMa> c_ = context.Operators.Select<Encounter, Tuple_GKGeLARADLGJcNcZaDhdCREMa>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Sodium_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Sodium Lab Test")]
 	public IEnumerable<Tuple_GKGeLARADLGJcNcZaDhdCREMa> Encounter_with_First_Sodium_Lab_Test() => 
 		__Encounter_with_First_Sodium_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_White_Blood_Cells_Lab_Test"/>
 	private IEnumerable<Tuple_ChVYCdXDGgVcFTCCUefXMbCHX> Encounter_with_First_White_Blood_Cells_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_ChVYCdXDGgVcFTCCUefXMbCHX b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.White_blood_cells_count_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.White_blood_cells_count_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation WhiteBloodCellLab)
 			{
-				var z_ = WhiteBloodCellLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = WhiteBloodCellLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = WhiteBloodCellLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = WhiteBloodCellLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = WhiteBloodCellLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = WhiteBloodCellLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation WhiteBloodCellLab)
 			{
-				var bd_ = WhiteBloodCellLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = WhiteBloodCellLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = WhiteBloodCellLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = WhiteBloodCellLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = WhiteBloodCellLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = WhiteBloodCellLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_ChVYCdXDGgVcFTCCUefXMbCHX
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_ChVYCdXDGgVcFTCCUefXMbCHX y_ = new Tuple_ChVYCdXDGgVcFTCCUefXMbCHX
 			{
 				EncounterId = e_,
 				FirstWhiteBloodCellResult = (n_ as CqlQuantity),
@@ -2490,55 +2551,64 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_ChVYCdXDGgVcFTCCUefXMbCHX>(a_, b_);
+		IEnumerable<Tuple_ChVYCdXDGgVcFTCCUefXMbCHX> c_ = context.Operators.Select<Encounter, Tuple_ChVYCdXDGgVcFTCCUefXMbCHX>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_White_Blood_Cells_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First White Blood Cells Lab Test")]
 	public IEnumerable<Tuple_ChVYCdXDGgVcFTCCUefXMbCHX> Encounter_with_First_White_Blood_Cells_Lab_Test() => 
 		__Encounter_with_First_White_Blood_Cells_Lab_Test.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
@@ -120,118 +120,147 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
     #endregion
 
+    /// <seealso cref="Bicarbonate_lab_test"/>
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
 
+    /// <seealso cref="Bicarbonate_lab_test_Value"/>
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
 	public CqlValueSet Bicarbonate_lab_test() => 
 		__Bicarbonate_lab_test.Value;
 
+    /// <seealso cref="Creatinine_lab_test"/>
 	private CqlValueSet Creatinine_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
 
+    /// <seealso cref="Creatinine_lab_test_Value"/>
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
 	public CqlValueSet Creatinine_lab_test() => 
 		__Creatinine_lab_test.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Glucose_lab_test"/>
 	private CqlValueSet Glucose_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
 
+    /// <seealso cref="Glucose_lab_test_Value"/>
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
 	public CqlValueSet Glucose_lab_test() => 
 		__Glucose_lab_test.Value;
 
+    /// <seealso cref="Hematocrit_lab_test"/>
 	private CqlValueSet Hematocrit_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
 
+    /// <seealso cref="Hematocrit_lab_test_Value"/>
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
 	public CqlValueSet Hematocrit_lab_test() => 
 		__Hematocrit_lab_test.Value;
 
+    /// <seealso cref="Medicare_Advantage_payer"/>
 	private CqlValueSet Medicare_Advantage_payer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", null);
 
+    /// <seealso cref="Medicare_Advantage_payer_Value"/>
     [CqlDeclaration("Medicare Advantage payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12")]
 	public CqlValueSet Medicare_Advantage_payer() => 
 		__Medicare_Advantage_payer.Value;
 
+    /// <seealso cref="Medicare_FFS_payer"/>
 	private CqlValueSet Medicare_FFS_payer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
 
+    /// <seealso cref="Medicare_FFS_payer_Value"/>
     [CqlDeclaration("Medicare FFS payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
 	public CqlValueSet Medicare_FFS_payer() => 
 		__Medicare_FFS_payer.Value;
 
+    /// <seealso cref="Oxygen_Saturation_by_Pulse_Oximetry"/>
 	private CqlValueSet Oxygen_Saturation_by_Pulse_Oximetry_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", null);
 
+    /// <seealso cref="Oxygen_Saturation_by_Pulse_Oximetry_Value"/>
     [CqlDeclaration("Oxygen Saturation by Pulse Oximetry")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151")]
 	public CqlValueSet Oxygen_Saturation_by_Pulse_Oximetry() => 
 		__Oxygen_Saturation_by_Pulse_Oximetry.Value;
 
+    /// <seealso cref="Potassium_lab_test"/>
 	private CqlValueSet Potassium_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", null);
 
+    /// <seealso cref="Potassium_lab_test_Value"/>
     [CqlDeclaration("Potassium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117")]
 	public CqlValueSet Potassium_lab_test() => 
 		__Potassium_lab_test.Value;
 
+    /// <seealso cref="Sodium_lab_test"/>
 	private CqlValueSet Sodium_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
 
+    /// <seealso cref="Sodium_lab_test_Value"/>
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
 	public CqlValueSet Sodium_lab_test() => 
 		__Sodium_lab_test.Value;
 
+    /// <seealso cref="White_blood_cells_count_lab_test"/>
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
 
+    /// <seealso cref="White_blood_cells_count_lab_test_Value"/>
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
 	public CqlValueSet White_blood_cells_count_lab_test() => 
 		__White_blood_cells_count_lab_test.Value;
 
+    /// <seealso cref="Oxygen_saturation_in_Arterial_blood"/>
 	private CqlCode Oxygen_saturation_in_Arterial_blood_Value() => 
 		new CqlCode("2708-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Oxygen_saturation_in_Arterial_blood_Value"/>
     [CqlDeclaration("Oxygen saturation in Arterial blood")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood() => 
 		__Oxygen_saturation_in_Arterial_blood.Value;
 
+    /// <seealso cref="Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry"/>
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
 		new CqlCode("59408-5", "http://loinc.org", null, null);
 
+    /// <seealso cref="Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value"/>
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
+    /// <seealso cref="Systolic_blood_pressure"/>
 	private CqlCode Systolic_blood_pressure_Value() => 
 		new CqlCode("8480-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Systolic_blood_pressure_Value"/>
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
 		__Systolic_blood_pressure.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("2708-6", "http://loinc.org", null, null),
 			new CqlCode("59408-5", "http://loinc.org", null, null),
@@ -241,234 +270,248 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="Source_of_Payment_Typology"/>
 	private CqlCode[] Source_of_Payment_Typology_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="Source_of_Payment_Typology_Value"/>
     [CqlDeclaration("Source of Payment Typology")]
 	public CqlCode[] Source_of_Payment_Typology() => 
 		__Source_of_Payment_Typology.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("HybridHospitalWideReadmissionFHIR-0.0.001", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("HybridHospitalWideReadmissionFHIR-0.0.001", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Inpatient_Encounters"/>
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		IEnumerable<Encounter> c_(Encounter InpatientEncounter)
 		{
-			var e_ = this.Medicare_FFS_payer();
-			var f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, null);
-			var g_ = this.Medicare_Advantage_payer();
-			var h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, null);
-			var i_ = context.Operators.Union<Coverage>(f_, h_);
+			CqlValueSet e_ = this.Medicare_FFS_payer();
+			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, null);
+			CqlValueSet g_ = this.Medicare_Advantage_payer();
+			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, null);
+			IEnumerable<Coverage> i_ = context.Operators.Union<Coverage>(f_, h_);
 			bool? j_(Coverage MedicarePayer)
 			{
-				var n_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(InpatientEncounter);
-				var o_ = CQMCommon_2_0_000.lengthInDays(n_);
-				var p_ = context.Operators.Less(o_, 365);
-				var q_ = InpatientEncounter?.StatusElement;
-				var r_ = q_?.Value;
-				var s_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(r_);
-				var t_ = context.Operators.Equal(s_, "finished");
-				var u_ = context.Operators.And(p_, t_);
-				var v_ = this.Patient();
-				var w_ = v_?.BirthDateElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Convert<CqlDate>(x_);
-				var z_ = InpatientEncounter?.Period;
-				var aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				var ab_ = context.Operators.Start(aa_);
-				var ac_ = context.Operators.DateFrom(ab_);
-				var ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
-				var ae_ = context.Operators.GreaterOrEqual(ad_, 65);
-				var af_ = context.Operators.And(u_, ae_);
-				var ah_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				var ai_ = context.Operators.End(ah_);
-				var aj_ = this.Measurement_Period();
-				var ak_ = context.Operators.In<CqlDateTime>(ai_, aj_, "day");
-				var al_ = context.Operators.And(af_, ak_);
+				CqlInterval<CqlDateTime> n_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(InpatientEncounter);
+				int? o_ = CQMCommon_2_0_000.lengthInDays(n_);
+				bool? p_ = context.Operators.Less(o_, 365);
+				Code<Encounter.EncounterStatus> q_ = InpatientEncounter?.StatusElement;
+				Encounter.EncounterStatus? r_ = q_?.Value;
+				Code<Encounter.EncounterStatus> s_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(r_);
+				bool? t_ = context.Operators.Equal(s_, "finished");
+				bool? u_ = context.Operators.And(p_, t_);
+				Patient v_ = this.Patient();
+				Date w_ = v_?.BirthDateElement;
+				string x_ = w_?.Value;
+				CqlDate y_ = context.Operators.Convert<CqlDate>(x_);
+				Period z_ = InpatientEncounter?.Period;
+				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
+				CqlDateTime ab_ = context.Operators.Start(aa_);
+				CqlDate ac_ = context.Operators.DateFrom(ab_);
+				int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
+				bool? ae_ = context.Operators.GreaterOrEqual(ad_, 65);
+				bool? af_ = context.Operators.And(u_, ae_);
+				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(z_);
+				CqlDateTime ai_ = context.Operators.End(ah_);
+				CqlInterval<CqlDateTime> aj_ = this.Measurement_Period();
+				bool? ak_ = context.Operators.In<CqlDateTime>(ai_, aj_, "day");
+				bool? al_ = context.Operators.And(af_, ak_);
 
 				return al_;
 			};
-			var k_ = context.Operators.Where<Coverage>(i_, j_);
+			IEnumerable<Coverage> k_ = context.Operators.Where<Coverage>(i_, j_);
 			Encounter l_(Coverage MedicarePayer) => 
 				InpatientEncounter;
-			var m_ = context.Operators.Select<Coverage, Encounter>(k_, l_);
+			IEnumerable<Encounter> m_ = context.Operators.Select<Coverage, Encounter>(k_, l_);
 
 			return m_;
 		};
-		var d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.SelectMany<Encounter, Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Inpatient_Encounters_Value"/>
     [CqlDeclaration("Inpatient Encounters")]
 	public IEnumerable<Encounter> Inpatient_Encounters() => 
 		__Inpatient_Encounters.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Encounter_with_First_Body_Temperature"/>
 	private IEnumerable<Tuple_GIbILVAdXLLNYBgcQIEiUiKaK> Encounter_with_First_Body_Temperature_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_GIbILVAdXLLNYBgcQIEiUiKaK b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? g_(Observation temperature)
 			{
-				var y_ = temperature?.Effective;
-				var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-				var aa_ = QICoreCommon_2_0_000.earliest(z_);
-				var ab_ = EncounterInpatient?.Period;
-				var ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ad_ = context.Operators.Start(ac_);
-				var ae_ = context.Operators.Quantity(1440m, "minutes");
-				var af_ = context.Operators.Subtract(ad_, ae_);
-				var ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ai_ = context.Operators.Start(ah_);
-				var aj_ = context.Operators.Quantity(120m, "minutes");
-				var ak_ = context.Operators.Add(ai_, aj_);
-				var al_ = context.Operators.Interval(af_, ak_, true, true);
-				var am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
-				var an_ = temperature?.StatusElement;
-				var ao_ = an_?.Value;
-				var ap_ = context.Operators.Convert<string>(ao_);
-				var aq_ = new string[]
+				DataType y_ = temperature?.Effective;
+				object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+				CqlDateTime aa_ = QICoreCommon_2_0_000.earliest(z_);
+				Period ab_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ad_ = context.Operators.Start(ac_);
+				CqlQuantity ae_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
+				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ai_ = context.Operators.Start(ah_);
+				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
+				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				Code<ObservationStatus> an_ = temperature?.StatusElement;
+				ObservationStatus? ao_ = an_?.Value;
+				string ap_ = context.Operators.Convert<string>(ao_);
+				string[] aq_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
-				var as_ = context.Operators.And(am_, ar_);
-				var at_ = temperature?.Value;
-				var au_ = context.Operators.Convert<Quantity>(at_);
-				var av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
-				var aw_ = context.Operators.Not((bool?)(av_ is null));
-				var ax_ = context.Operators.And(as_, aw_);
+				bool? ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
+				bool? as_ = context.Operators.And(am_, ar_);
+				DataType at_ = temperature?.Value;
+				Quantity au_ = context.Operators.Convert<Quantity>(at_);
+				CqlQuantity av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
+				bool? aw_ = context.Operators.Not((bool?)(av_ is null));
+				bool? ax_ = context.Operators.And(as_, aw_);
 
 				return ax_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			object i_(Observation @this)
 			{
-				var ay_ = @this?.Effective;
-				var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-				var ba_ = QICoreCommon_2_0_000.earliest(az_);
+				DataType ay_ = @this?.Effective;
+				object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+				CqlDateTime ba_ = QICoreCommon_2_0_000.earliest(az_);
 
 				return ba_;
 			};
-			var j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.First<Observation>(j_);
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<Quantity>(l_);
-			var n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
+			IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation k_ = context.Operators.First<Observation>(j_);
+			DataType l_ = k_?.Value;
+			Quantity m_ = context.Operators.Convert<Quantity>(l_);
+			CqlQuantity n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
 			bool? p_(Observation temperature)
 			{
-				var bb_ = temperature?.Effective;
-				var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
-				var bd_ = QICoreCommon_2_0_000.earliest(bc_);
-				var be_ = EncounterInpatient?.Period;
-				var bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bg_ = context.Operators.Start(bf_);
-				var bh_ = context.Operators.Quantity(1440m, "minutes");
-				var bi_ = context.Operators.Subtract(bg_, bh_);
-				var bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bl_ = context.Operators.Start(bk_);
-				var bm_ = context.Operators.Quantity(120m, "minutes");
-				var bn_ = context.Operators.Add(bl_, bm_);
-				var bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				var bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
-				var bq_ = temperature?.StatusElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.Convert<string>(br_);
-				var bt_ = new string[]
+				DataType bb_ = temperature?.Effective;
+				object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+				CqlDateTime bd_ = QICoreCommon_2_0_000.earliest(bc_);
+				Period be_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bg_ = context.Operators.Start(bf_);
+				CqlQuantity bh_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bi_ = context.Operators.Subtract(bg_, bh_);
+				CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bl_ = context.Operators.Start(bk_);
+				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
+				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				Code<ObservationStatus> bq_ = temperature?.StatusElement;
+				ObservationStatus? br_ = bq_?.Value;
+				string bs_ = context.Operators.Convert<string>(br_);
+				string[] bt_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
-				var bv_ = context.Operators.And(bp_, bu_);
-				var bw_ = temperature?.Value;
-				var bx_ = context.Operators.Convert<Quantity>(bw_);
-				var by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
-				var bz_ = context.Operators.Not((bool?)(by_ is null));
-				var ca_ = context.Operators.And(bv_, bz_);
+				bool? bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
+				bool? bv_ = context.Operators.And(bp_, bu_);
+				DataType bw_ = temperature?.Value;
+				Quantity bx_ = context.Operators.Convert<Quantity>(bw_);
+				CqlQuantity by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
+				bool? bz_ = context.Operators.Not((bool?)(by_ is null));
+				bool? ca_ = context.Operators.And(bv_, bz_);
 
 				return ca_;
 			};
-			var q_ = context.Operators.Where<Observation>(f_, p_);
+			IEnumerable<Observation> q_ = context.Operators.Where<Observation>(f_, p_);
 			object r_(Observation @this)
 			{
-				var cb_ = @this?.Effective;
-				var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
-				var cd_ = QICoreCommon_2_0_000.earliest(cc_);
+				DataType cb_ = @this?.Effective;
+				object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+				CqlDateTime cd_ = QICoreCommon_2_0_000.earliest(cc_);
 
 				return cd_;
 			};
-			var s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
-			var t_ = context.Operators.First<Observation>(s_);
-			var u_ = t_?.Effective;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = QICoreCommon_2_0_000.earliest(v_);
-			var x_ = new Tuple_GIbILVAdXLLNYBgcQIEiUiKaK
+			IEnumerable<Observation> s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation t_ = context.Operators.First<Observation>(s_);
+			DataType u_ = t_?.Effective;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			CqlDateTime w_ = QICoreCommon_2_0_000.earliest(v_);
+			Tuple_GIbILVAdXLLNYBgcQIEiUiKaK x_ = new Tuple_GIbILVAdXLLNYBgcQIEiUiKaK
 			{
 				EncounterId = e_,
 				FirstTemperatureResult = n_,
@@ -477,122 +520,124 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return x_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_GIbILVAdXLLNYBgcQIEiUiKaK>(a_, b_);
+		IEnumerable<Tuple_GIbILVAdXLLNYBgcQIEiUiKaK> c_ = context.Operators.Select<Encounter, Tuple_GIbILVAdXLLNYBgcQIEiUiKaK>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Body_Temperature_Value"/>
     [CqlDeclaration("Encounter with First Body Temperature")]
 	public IEnumerable<Tuple_GIbILVAdXLLNYBgcQIEiUiKaK> Encounter_with_First_Body_Temperature() => 
 		__Encounter_with_First_Body_Temperature.Value;
 
+    /// <seealso cref="Encounter_with_First_Heart_Rate"/>
 	private IEnumerable<Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ> Encounter_with_First_Heart_Rate_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? g_(Observation HeartRate)
 			{
-				var y_ = HeartRate?.Effective;
-				var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-				var aa_ = QICoreCommon_2_0_000.earliest(z_);
-				var ab_ = EncounterInpatient?.Period;
-				var ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ad_ = context.Operators.Start(ac_);
-				var ae_ = context.Operators.Quantity(1440m, "minutes");
-				var af_ = context.Operators.Subtract(ad_, ae_);
-				var ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ai_ = context.Operators.Start(ah_);
-				var aj_ = context.Operators.Quantity(120m, "minutes");
-				var ak_ = context.Operators.Add(ai_, aj_);
-				var al_ = context.Operators.Interval(af_, ak_, true, true);
-				var am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
-				var an_ = HeartRate?.StatusElement;
-				var ao_ = an_?.Value;
-				var ap_ = context.Operators.Convert<string>(ao_);
-				var aq_ = new string[]
+				DataType y_ = HeartRate?.Effective;
+				object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+				CqlDateTime aa_ = QICoreCommon_2_0_000.earliest(z_);
+				Period ab_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ad_ = context.Operators.Start(ac_);
+				CqlQuantity ae_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
+				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ai_ = context.Operators.Start(ah_);
+				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
+				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				Code<ObservationStatus> an_ = HeartRate?.StatusElement;
+				ObservationStatus? ao_ = an_?.Value;
+				string ap_ = context.Operators.Convert<string>(ao_);
+				string[] aq_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
-				var as_ = context.Operators.And(am_, ar_);
-				var at_ = HeartRate?.Value;
-				var au_ = context.Operators.Convert<Quantity>(at_);
-				var av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
-				var aw_ = context.Operators.Not((bool?)(av_ is null));
-				var ax_ = context.Operators.And(as_, aw_);
+				bool? ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
+				bool? as_ = context.Operators.And(am_, ar_);
+				DataType at_ = HeartRate?.Value;
+				Quantity au_ = context.Operators.Convert<Quantity>(at_);
+				CqlQuantity av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
+				bool? aw_ = context.Operators.Not((bool?)(av_ is null));
+				bool? ax_ = context.Operators.And(as_, aw_);
 
 				return ax_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			object i_(Observation @this)
 			{
-				var ay_ = @this?.Effective;
-				var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-				var ba_ = QICoreCommon_2_0_000.earliest(az_);
+				DataType ay_ = @this?.Effective;
+				object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+				CqlDateTime ba_ = QICoreCommon_2_0_000.earliest(az_);
 
 				return ba_;
 			};
-			var j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.First<Observation>(j_);
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<Quantity>(l_);
-			var n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
+			IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation k_ = context.Operators.First<Observation>(j_);
+			DataType l_ = k_?.Value;
+			Quantity m_ = context.Operators.Convert<Quantity>(l_);
+			CqlQuantity n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
 			bool? p_(Observation HeartRate)
 			{
-				var bb_ = HeartRate?.Effective;
-				var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
-				var bd_ = QICoreCommon_2_0_000.earliest(bc_);
-				var be_ = EncounterInpatient?.Period;
-				var bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bg_ = context.Operators.Start(bf_);
-				var bh_ = context.Operators.Quantity(1440m, "minutes");
-				var bi_ = context.Operators.Subtract(bg_, bh_);
-				var bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bl_ = context.Operators.Start(bk_);
-				var bm_ = context.Operators.Quantity(120m, "minutes");
-				var bn_ = context.Operators.Add(bl_, bm_);
-				var bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				var bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
-				var bq_ = HeartRate?.StatusElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.Convert<string>(br_);
-				var bt_ = new string[]
+				DataType bb_ = HeartRate?.Effective;
+				object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+				CqlDateTime bd_ = QICoreCommon_2_0_000.earliest(bc_);
+				Period be_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bg_ = context.Operators.Start(bf_);
+				CqlQuantity bh_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bi_ = context.Operators.Subtract(bg_, bh_);
+				CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bl_ = context.Operators.Start(bk_);
+				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
+				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				Code<ObservationStatus> bq_ = HeartRate?.StatusElement;
+				ObservationStatus? br_ = bq_?.Value;
+				string bs_ = context.Operators.Convert<string>(br_);
+				string[] bt_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
-				var bv_ = context.Operators.And(bp_, bu_);
-				var bw_ = HeartRate?.Value;
-				var bx_ = context.Operators.Convert<Quantity>(bw_);
-				var by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
-				var bz_ = context.Operators.Not((bool?)(by_ is null));
-				var ca_ = context.Operators.And(bv_, bz_);
+				bool? bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
+				bool? bv_ = context.Operators.And(bp_, bu_);
+				DataType bw_ = HeartRate?.Value;
+				Quantity bx_ = context.Operators.Convert<Quantity>(bw_);
+				CqlQuantity by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
+				bool? bz_ = context.Operators.Not((bool?)(by_ is null));
+				bool? ca_ = context.Operators.And(bv_, bz_);
 
 				return ca_;
 			};
-			var q_ = context.Operators.Where<Observation>(f_, p_);
+			IEnumerable<Observation> q_ = context.Operators.Where<Observation>(f_, p_);
 			object r_(Observation @this)
 			{
-				var cb_ = @this?.Effective;
-				var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
-				var cd_ = QICoreCommon_2_0_000.earliest(cc_);
+				DataType cb_ = @this?.Effective;
+				object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+				CqlDateTime cd_ = QICoreCommon_2_0_000.earliest(cc_);
 
 				return cd_;
 			};
-			var s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
-			var t_ = context.Operators.First<Observation>(s_);
-			var u_ = t_?.Effective;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = QICoreCommon_2_0_000.earliest(v_);
-			var x_ = new Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ
+			IEnumerable<Observation> s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation t_ = context.Operators.First<Observation>(s_);
+			DataType u_ = t_?.Effective;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			CqlDateTime w_ = QICoreCommon_2_0_000.earliest(v_);
+			Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ x_ = new Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ
 			{
 				EncounterId = e_,
 				FirstHeartRateResult = n_,
@@ -601,70 +646,72 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return x_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ>(a_, b_);
+		IEnumerable<Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ> c_ = context.Operators.Select<Encounter, Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Heart_Rate_Value"/>
     [CqlDeclaration("Encounter with First Heart Rate")]
 	public IEnumerable<Tuple_DhbJAfCiKIAGYKTjJXYGSKECQ> Encounter_with_First_Heart_Rate() => 
 		__Encounter_with_First_Heart_Rate.Value;
 
+    /// <seealso cref="Encounter_with_First_Oxygen_Saturation"/>
 	private IEnumerable<Tuple_FdREYEdHOZIcMCNYCRFJYJReA> Encounter_with_First_Oxygen_Saturation_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_FdREYEdHOZIcMCNYCRFJYJReA b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation O2Saturation)
 			{
 				object r_()
 				{
 					bool aq_()
 					{
-						var at_ = O2Saturation?.Effective;
-						var au_ = FHIRHelpers_4_3_000.ToValue(at_);
-						var av_ = au_ is CqlDateTime;
+						DataType at_ = O2Saturation?.Effective;
+						object au_ = FHIRHelpers_4_3_000.ToValue(at_);
+						bool av_ = au_ is CqlDateTime;
 
 						return av_;
 					};
 					bool ar_()
 					{
-						var aw_ = O2Saturation?.Effective;
-						var ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
-						var ay_ = ax_ is CqlInterval<CqlDateTime>;
+						DataType aw_ = O2Saturation?.Effective;
+						object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+						bool ay_ = ax_ is CqlInterval<CqlDateTime>;
 
 						return ay_;
 					};
 					bool as_()
 					{
-						var az_ = O2Saturation?.Effective;
-						var ba_ = FHIRHelpers_4_3_000.ToValue(az_);
-						var bb_ = ba_ is CqlDateTime;
+						DataType az_ = O2Saturation?.Effective;
+						object ba_ = FHIRHelpers_4_3_000.ToValue(az_);
+						bool bb_ = ba_ is CqlDateTime;
 
 						return bb_;
 					};
 					if (aq_())
 					{
-						var bc_ = O2Saturation?.Effective;
-						var bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
+						DataType bc_ = O2Saturation?.Effective;
+						object bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
 
 						return ((bd_ as CqlDateTime) as object);
 					}
 					else if (ar_())
 					{
-						var be_ = O2Saturation?.Effective;
-						var bf_ = FHIRHelpers_4_3_000.ToValue(be_);
+						DataType be_ = O2Saturation?.Effective;
+						object bf_ = FHIRHelpers_4_3_000.ToValue(be_);
 
 						return ((bf_ as CqlInterval<CqlDateTime>) as object);
 					}
 					else if (as_())
 					{
-						var bg_ = O2Saturation?.Effective;
-						var bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+						DataType bg_ = O2Saturation?.Effective;
+						object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
 
 						return ((bh_ as CqlDateTime) as object);
 					}
@@ -673,84 +720,84 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						return null;
 					}
 				};
-				var s_ = QICoreCommon_2_0_000.earliest(r_());
-				var t_ = EncounterInpatient?.Period;
-				var u_ = FHIRHelpers_4_3_000.ToInterval(t_);
-				var v_ = context.Operators.Start(u_);
-				var w_ = context.Operators.Quantity(1440m, "minutes");
-				var x_ = context.Operators.Subtract(v_, w_);
-				var z_ = FHIRHelpers_4_3_000.ToInterval(t_);
-				var aa_ = context.Operators.Start(z_);
-				var ab_ = context.Operators.Quantity(120m, "minutes");
-				var ac_ = context.Operators.Add(aa_, ab_);
-				var ad_ = context.Operators.Interval(x_, ac_, true, true);
-				var ae_ = context.Operators.In<CqlDateTime>(s_, ad_, null);
-				var af_ = O2Saturation?.StatusElement;
-				var ag_ = af_?.Value;
-				var ah_ = context.Operators.Convert<Code<ObservationStatus>>(ag_);
-				var ai_ = context.Operators.Convert<string>(ah_);
-				var aj_ = new string[]
+				CqlDateTime s_ = QICoreCommon_2_0_000.earliest(r_());
+				Period t_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(t_);
+				CqlDateTime v_ = context.Operators.Start(u_);
+				CqlQuantity w_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime x_ = context.Operators.Subtract(v_, w_);
+				CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(t_);
+				CqlDateTime aa_ = context.Operators.Start(z_);
+				CqlQuantity ab_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
+				CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
+				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, null);
+				Code<ObservationStatus> af_ = O2Saturation?.StatusElement;
+				ObservationStatus? ag_ = af_?.Value;
+				Code<ObservationStatus> ah_ = context.Operators.Convert<Code<ObservationStatus>>(ag_);
+				string ai_ = context.Operators.Convert<string>(ah_);
+				string[] aj_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ak_ = context.Operators.In<string>(ai_, (aj_ as IEnumerable<string>));
-				var al_ = context.Operators.And(ae_, ak_);
-				var am_ = O2Saturation?.Value;
-				var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-				var ao_ = context.Operators.Not((bool?)(an_ is null));
-				var ap_ = context.Operators.And(al_, ao_);
+				bool? ak_ = context.Operators.In<string>(ai_, (aj_ as IEnumerable<string>));
+				bool? al_ = context.Operators.And(ae_, ak_);
+				DataType am_ = O2Saturation?.Value;
+				object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+				bool? ao_ = context.Operators.Not((bool?)(an_ is null));
+				bool? ap_ = context.Operators.And(al_, ao_);
 
 				return ap_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
 				object bi_()
 				{
 					bool bk_()
 					{
-						var bn_ = @this?.Effective;
-						var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
-						var bp_ = bo_ is CqlDateTime;
+						DataType bn_ = @this?.Effective;
+						object bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+						bool bp_ = bo_ is CqlDateTime;
 
 						return bp_;
 					};
 					bool bl_()
 					{
-						var bq_ = @this?.Effective;
-						var br_ = FHIRHelpers_4_3_000.ToValue(bq_);
-						var bs_ = br_ is CqlInterval<CqlDateTime>;
+						DataType bq_ = @this?.Effective;
+						object br_ = FHIRHelpers_4_3_000.ToValue(bq_);
+						bool bs_ = br_ is CqlInterval<CqlDateTime>;
 
 						return bs_;
 					};
 					bool bm_()
 					{
-						var bt_ = @this?.Effective;
-						var bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
-						var bv_ = bu_ is CqlDateTime;
+						DataType bt_ = @this?.Effective;
+						object bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
+						bool bv_ = bu_ is CqlDateTime;
 
 						return bv_;
 					};
 					if (bk_())
 					{
-						var bw_ = @this?.Effective;
-						var bx_ = FHIRHelpers_4_3_000.ToValue(bw_);
+						DataType bw_ = @this?.Effective;
+						object bx_ = FHIRHelpers_4_3_000.ToValue(bw_);
 
 						return ((bx_ as CqlDateTime) as object);
 					}
 					else if (bl_())
 					{
-						var by_ = @this?.Effective;
-						var bz_ = FHIRHelpers_4_3_000.ToValue(by_);
+						DataType by_ = @this?.Effective;
+						object bz_ = FHIRHelpers_4_3_000.ToValue(by_);
 
 						return ((bz_ as CqlInterval<CqlDateTime>) as object);
 					}
 					else if (bm_())
 					{
-						var ca_ = @this?.Effective;
-						var cb_ = FHIRHelpers_4_3_000.ToValue(ca_);
+						DataType ca_ = @this?.Effective;
+						object cb_ = FHIRHelpers_4_3_000.ToValue(ca_);
 
 						return ((cb_ as CqlDateTime) as object);
 					}
@@ -759,66 +806,66 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						return null;
 					}
 				};
-				var bj_ = QICoreCommon_2_0_000.earliest(bi_());
+				CqlDateTime bj_ = QICoreCommon_2_0_000.earliest(bi_());
 
 				return bj_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
 			object o_()
 			{
 				bool cc_()
 				{
-					var cf_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, null);
+					CqlValueSet cf_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, null);
 					bool? ch_(Observation O2Saturation)
 					{
 						object cp_()
 						{
 							bool do_()
 							{
-								var dr_ = O2Saturation?.Effective;
-								var ds_ = FHIRHelpers_4_3_000.ToValue(dr_);
-								var dt_ = ds_ is CqlDateTime;
+								DataType dr_ = O2Saturation?.Effective;
+								object ds_ = FHIRHelpers_4_3_000.ToValue(dr_);
+								bool dt_ = ds_ is CqlDateTime;
 
 								return dt_;
 							};
 							bool dp_()
 							{
-								var du_ = O2Saturation?.Effective;
-								var dv_ = FHIRHelpers_4_3_000.ToValue(du_);
-								var dw_ = dv_ is CqlInterval<CqlDateTime>;
+								DataType du_ = O2Saturation?.Effective;
+								object dv_ = FHIRHelpers_4_3_000.ToValue(du_);
+								bool dw_ = dv_ is CqlInterval<CqlDateTime>;
 
 								return dw_;
 							};
 							bool dq_()
 							{
-								var dx_ = O2Saturation?.Effective;
-								var dy_ = FHIRHelpers_4_3_000.ToValue(dx_);
-								var dz_ = dy_ is CqlDateTime;
+								DataType dx_ = O2Saturation?.Effective;
+								object dy_ = FHIRHelpers_4_3_000.ToValue(dx_);
+								bool dz_ = dy_ is CqlDateTime;
 
 								return dz_;
 							};
 							if (do_())
 							{
-								var ea_ = O2Saturation?.Effective;
-								var eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
+								DataType ea_ = O2Saturation?.Effective;
+								object eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
 
 								return ((eb_ as CqlDateTime) as object);
 							}
 							else if (dp_())
 							{
-								var ec_ = O2Saturation?.Effective;
-								var ed_ = FHIRHelpers_4_3_000.ToValue(ec_);
+								DataType ec_ = O2Saturation?.Effective;
+								object ed_ = FHIRHelpers_4_3_000.ToValue(ec_);
 
 								return ((ed_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (dq_())
 							{
-								var ee_ = O2Saturation?.Effective;
-								var ef_ = FHIRHelpers_4_3_000.ToValue(ee_);
+								DataType ee_ = O2Saturation?.Effective;
+								object ef_ = FHIRHelpers_4_3_000.ToValue(ee_);
 
 								return ((ef_ as CqlDateTime) as object);
 							}
@@ -827,84 +874,84 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var cq_ = QICoreCommon_2_0_000.earliest(cp_());
-						var cr_ = EncounterInpatient?.Period;
-						var cs_ = FHIRHelpers_4_3_000.ToInterval(cr_);
-						var ct_ = context.Operators.Start(cs_);
-						var cu_ = context.Operators.Quantity(1440m, "minutes");
-						var cv_ = context.Operators.Subtract(ct_, cu_);
-						var cx_ = FHIRHelpers_4_3_000.ToInterval(cr_);
-						var cy_ = context.Operators.Start(cx_);
-						var cz_ = context.Operators.Quantity(120m, "minutes");
-						var da_ = context.Operators.Add(cy_, cz_);
-						var db_ = context.Operators.Interval(cv_, da_, true, true);
-						var dc_ = context.Operators.In<CqlDateTime>(cq_, db_, null);
-						var dd_ = O2Saturation?.StatusElement;
-						var de_ = dd_?.Value;
-						var df_ = context.Operators.Convert<Code<ObservationStatus>>(de_);
-						var dg_ = context.Operators.Convert<string>(df_);
-						var dh_ = new string[]
+						CqlDateTime cq_ = QICoreCommon_2_0_000.earliest(cp_());
+						Period cr_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> cs_ = FHIRHelpers_4_3_000.ToInterval(cr_);
+						CqlDateTime ct_ = context.Operators.Start(cs_);
+						CqlQuantity cu_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime cv_ = context.Operators.Subtract(ct_, cu_);
+						CqlInterval<CqlDateTime> cx_ = FHIRHelpers_4_3_000.ToInterval(cr_);
+						CqlDateTime cy_ = context.Operators.Start(cx_);
+						CqlQuantity cz_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime da_ = context.Operators.Add(cy_, cz_);
+						CqlInterval<CqlDateTime> db_ = context.Operators.Interval(cv_, da_, true, true);
+						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, null);
+						Code<ObservationStatus> dd_ = O2Saturation?.StatusElement;
+						ObservationStatus? de_ = dd_?.Value;
+						Code<ObservationStatus> df_ = context.Operators.Convert<Code<ObservationStatus>>(de_);
+						string dg_ = context.Operators.Convert<string>(df_);
+						string[] dh_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var di_ = context.Operators.In<string>(dg_, (dh_ as IEnumerable<string>));
-						var dj_ = context.Operators.And(dc_, di_);
-						var dk_ = O2Saturation?.Value;
-						var dl_ = FHIRHelpers_4_3_000.ToValue(dk_);
-						var dm_ = context.Operators.Not((bool?)(dl_ is null));
-						var dn_ = context.Operators.And(dj_, dm_);
+						bool? di_ = context.Operators.In<string>(dg_, (dh_ as IEnumerable<string>));
+						bool? dj_ = context.Operators.And(dc_, di_);
+						DataType dk_ = O2Saturation?.Value;
+						object dl_ = FHIRHelpers_4_3_000.ToValue(dk_);
+						bool? dm_ = context.Operators.Not((bool?)(dl_ is null));
+						bool? dn_ = context.Operators.And(dj_, dm_);
 
 						return dn_;
 					};
-					var ci_ = context.Operators.Where<Observation>(cg_, ch_);
+					IEnumerable<Observation> ci_ = context.Operators.Where<Observation>(cg_, ch_);
 					object cj_(Observation @this)
 					{
 						object eg_()
 						{
 							bool ei_()
 							{
-								var el_ = @this?.Effective;
-								var em_ = FHIRHelpers_4_3_000.ToValue(el_);
-								var en_ = em_ is CqlDateTime;
+								DataType el_ = @this?.Effective;
+								object em_ = FHIRHelpers_4_3_000.ToValue(el_);
+								bool en_ = em_ is CqlDateTime;
 
 								return en_;
 							};
 							bool ej_()
 							{
-								var eo_ = @this?.Effective;
-								var ep_ = FHIRHelpers_4_3_000.ToValue(eo_);
-								var eq_ = ep_ is CqlInterval<CqlDateTime>;
+								DataType eo_ = @this?.Effective;
+								object ep_ = FHIRHelpers_4_3_000.ToValue(eo_);
+								bool eq_ = ep_ is CqlInterval<CqlDateTime>;
 
 								return eq_;
 							};
 							bool ek_()
 							{
-								var er_ = @this?.Effective;
-								var es_ = FHIRHelpers_4_3_000.ToValue(er_);
-								var et_ = es_ is CqlDateTime;
+								DataType er_ = @this?.Effective;
+								object es_ = FHIRHelpers_4_3_000.ToValue(er_);
+								bool et_ = es_ is CqlDateTime;
 
 								return et_;
 							};
 							if (ei_())
 							{
-								var eu_ = @this?.Effective;
-								var ev_ = FHIRHelpers_4_3_000.ToValue(eu_);
+								DataType eu_ = @this?.Effective;
+								object ev_ = FHIRHelpers_4_3_000.ToValue(eu_);
 
 								return ((ev_ as CqlDateTime) as object);
 							}
 							else if (ej_())
 							{
-								var ew_ = @this?.Effective;
-								var ex_ = FHIRHelpers_4_3_000.ToValue(ew_);
+								DataType ew_ = @this?.Effective;
+								object ex_ = FHIRHelpers_4_3_000.ToValue(ew_);
 
 								return ((ex_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ek_())
 							{
-								var ey_ = @this?.Effective;
-								var ez_ = FHIRHelpers_4_3_000.ToValue(ey_);
+								DataType ey_ = @this?.Effective;
+								object ez_ = FHIRHelpers_4_3_000.ToValue(ey_);
 
 								return ((ez_ as CqlDateTime) as object);
 							}
@@ -913,68 +960,68 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var eh_ = QICoreCommon_2_0_000.earliest(eg_());
+						CqlDateTime eh_ = QICoreCommon_2_0_000.earliest(eg_());
 
 						return eh_;
 					};
-					var ck_ = context.Operators.SortBy<Observation>(ci_, cj_, System.ComponentModel.ListSortDirection.Ascending);
-					var cl_ = context.Operators.First<Observation>(ck_);
-					var cm_ = cl_?.Effective;
-					var cn_ = FHIRHelpers_4_3_000.ToValue(cm_);
-					var co_ = cn_ is CqlDateTime;
+					IEnumerable<Observation> ck_ = context.Operators.SortBy<Observation>(ci_, cj_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation cl_ = context.Operators.First<Observation>(ck_);
+					DataType cm_ = cl_?.Effective;
+					object cn_ = FHIRHelpers_4_3_000.ToValue(cm_);
+					bool co_ = cn_ is CqlDateTime;
 
 					return co_;
 				};
 				bool cd_()
 				{
-					var fa_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, null);
+					CqlValueSet fa_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, null);
 					bool? fc_(Observation O2Saturation)
 					{
 						object fk_()
 						{
 							bool gj_()
 							{
-								var gm_ = O2Saturation?.Effective;
-								var gn_ = FHIRHelpers_4_3_000.ToValue(gm_);
-								var go_ = gn_ is CqlDateTime;
+								DataType gm_ = O2Saturation?.Effective;
+								object gn_ = FHIRHelpers_4_3_000.ToValue(gm_);
+								bool go_ = gn_ is CqlDateTime;
 
 								return go_;
 							};
 							bool gk_()
 							{
-								var gp_ = O2Saturation?.Effective;
-								var gq_ = FHIRHelpers_4_3_000.ToValue(gp_);
-								var gr_ = gq_ is CqlInterval<CqlDateTime>;
+								DataType gp_ = O2Saturation?.Effective;
+								object gq_ = FHIRHelpers_4_3_000.ToValue(gp_);
+								bool gr_ = gq_ is CqlInterval<CqlDateTime>;
 
 								return gr_;
 							};
 							bool gl_()
 							{
-								var gs_ = O2Saturation?.Effective;
-								var gt_ = FHIRHelpers_4_3_000.ToValue(gs_);
-								var gu_ = gt_ is CqlDateTime;
+								DataType gs_ = O2Saturation?.Effective;
+								object gt_ = FHIRHelpers_4_3_000.ToValue(gs_);
+								bool gu_ = gt_ is CqlDateTime;
 
 								return gu_;
 							};
 							if (gj_())
 							{
-								var gv_ = O2Saturation?.Effective;
-								var gw_ = FHIRHelpers_4_3_000.ToValue(gv_);
+								DataType gv_ = O2Saturation?.Effective;
+								object gw_ = FHIRHelpers_4_3_000.ToValue(gv_);
 
 								return ((gw_ as CqlDateTime) as object);
 							}
 							else if (gk_())
 							{
-								var gx_ = O2Saturation?.Effective;
-								var gy_ = FHIRHelpers_4_3_000.ToValue(gx_);
+								DataType gx_ = O2Saturation?.Effective;
+								object gy_ = FHIRHelpers_4_3_000.ToValue(gx_);
 
 								return ((gy_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (gl_())
 							{
-								var gz_ = O2Saturation?.Effective;
-								var ha_ = FHIRHelpers_4_3_000.ToValue(gz_);
+								DataType gz_ = O2Saturation?.Effective;
+								object ha_ = FHIRHelpers_4_3_000.ToValue(gz_);
 
 								return ((ha_ as CqlDateTime) as object);
 							}
@@ -983,84 +1030,84 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var fl_ = QICoreCommon_2_0_000.earliest(fk_());
-						var fm_ = EncounterInpatient?.Period;
-						var fn_ = FHIRHelpers_4_3_000.ToInterval(fm_);
-						var fo_ = context.Operators.Start(fn_);
-						var fp_ = context.Operators.Quantity(1440m, "minutes");
-						var fq_ = context.Operators.Subtract(fo_, fp_);
-						var fs_ = FHIRHelpers_4_3_000.ToInterval(fm_);
-						var ft_ = context.Operators.Start(fs_);
-						var fu_ = context.Operators.Quantity(120m, "minutes");
-						var fv_ = context.Operators.Add(ft_, fu_);
-						var fw_ = context.Operators.Interval(fq_, fv_, true, true);
-						var fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, null);
-						var fy_ = O2Saturation?.StatusElement;
-						var fz_ = fy_?.Value;
-						var ga_ = context.Operators.Convert<Code<ObservationStatus>>(fz_);
-						var gb_ = context.Operators.Convert<string>(ga_);
-						var gc_ = new string[]
+						CqlDateTime fl_ = QICoreCommon_2_0_000.earliest(fk_());
+						Period fm_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> fn_ = FHIRHelpers_4_3_000.ToInterval(fm_);
+						CqlDateTime fo_ = context.Operators.Start(fn_);
+						CqlQuantity fp_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime fq_ = context.Operators.Subtract(fo_, fp_);
+						CqlInterval<CqlDateTime> fs_ = FHIRHelpers_4_3_000.ToInterval(fm_);
+						CqlDateTime ft_ = context.Operators.Start(fs_);
+						CqlQuantity fu_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime fv_ = context.Operators.Add(ft_, fu_);
+						CqlInterval<CqlDateTime> fw_ = context.Operators.Interval(fq_, fv_, true, true);
+						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, null);
+						Code<ObservationStatus> fy_ = O2Saturation?.StatusElement;
+						ObservationStatus? fz_ = fy_?.Value;
+						Code<ObservationStatus> ga_ = context.Operators.Convert<Code<ObservationStatus>>(fz_);
+						string gb_ = context.Operators.Convert<string>(ga_);
+						string[] gc_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var gd_ = context.Operators.In<string>(gb_, (gc_ as IEnumerable<string>));
-						var ge_ = context.Operators.And(fx_, gd_);
-						var gf_ = O2Saturation?.Value;
-						var gg_ = FHIRHelpers_4_3_000.ToValue(gf_);
-						var gh_ = context.Operators.Not((bool?)(gg_ is null));
-						var gi_ = context.Operators.And(ge_, gh_);
+						bool? gd_ = context.Operators.In<string>(gb_, (gc_ as IEnumerable<string>));
+						bool? ge_ = context.Operators.And(fx_, gd_);
+						DataType gf_ = O2Saturation?.Value;
+						object gg_ = FHIRHelpers_4_3_000.ToValue(gf_);
+						bool? gh_ = context.Operators.Not((bool?)(gg_ is null));
+						bool? gi_ = context.Operators.And(ge_, gh_);
 
 						return gi_;
 					};
-					var fd_ = context.Operators.Where<Observation>(fb_, fc_);
+					IEnumerable<Observation> fd_ = context.Operators.Where<Observation>(fb_, fc_);
 					object fe_(Observation @this)
 					{
 						object hb_()
 						{
 							bool hd_()
 							{
-								var hg_ = @this?.Effective;
-								var hh_ = FHIRHelpers_4_3_000.ToValue(hg_);
-								var hi_ = hh_ is CqlDateTime;
+								DataType hg_ = @this?.Effective;
+								object hh_ = FHIRHelpers_4_3_000.ToValue(hg_);
+								bool hi_ = hh_ is CqlDateTime;
 
 								return hi_;
 							};
 							bool he_()
 							{
-								var hj_ = @this?.Effective;
-								var hk_ = FHIRHelpers_4_3_000.ToValue(hj_);
-								var hl_ = hk_ is CqlInterval<CqlDateTime>;
+								DataType hj_ = @this?.Effective;
+								object hk_ = FHIRHelpers_4_3_000.ToValue(hj_);
+								bool hl_ = hk_ is CqlInterval<CqlDateTime>;
 
 								return hl_;
 							};
 							bool hf_()
 							{
-								var hm_ = @this?.Effective;
-								var hn_ = FHIRHelpers_4_3_000.ToValue(hm_);
-								var ho_ = hn_ is CqlDateTime;
+								DataType hm_ = @this?.Effective;
+								object hn_ = FHIRHelpers_4_3_000.ToValue(hm_);
+								bool ho_ = hn_ is CqlDateTime;
 
 								return ho_;
 							};
 							if (hd_())
 							{
-								var hp_ = @this?.Effective;
-								var hq_ = FHIRHelpers_4_3_000.ToValue(hp_);
+								DataType hp_ = @this?.Effective;
+								object hq_ = FHIRHelpers_4_3_000.ToValue(hp_);
 
 								return ((hq_ as CqlDateTime) as object);
 							}
 							else if (he_())
 							{
-								var hr_ = @this?.Effective;
-								var hs_ = FHIRHelpers_4_3_000.ToValue(hr_);
+								DataType hr_ = @this?.Effective;
+								object hs_ = FHIRHelpers_4_3_000.ToValue(hr_);
 
 								return ((hs_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (hf_())
 							{
-								var ht_ = @this?.Effective;
-								var hu_ = FHIRHelpers_4_3_000.ToValue(ht_);
+								DataType ht_ = @this?.Effective;
+								object hu_ = FHIRHelpers_4_3_000.ToValue(ht_);
 
 								return ((hu_ as CqlDateTime) as object);
 							}
@@ -1069,68 +1116,68 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var hc_ = QICoreCommon_2_0_000.earliest(hb_());
+						CqlDateTime hc_ = QICoreCommon_2_0_000.earliest(hb_());
 
 						return hc_;
 					};
-					var ff_ = context.Operators.SortBy<Observation>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
-					var fg_ = context.Operators.First<Observation>(ff_);
-					var fh_ = fg_?.Effective;
-					var fi_ = FHIRHelpers_4_3_000.ToValue(fh_);
-					var fj_ = fi_ is CqlInterval<CqlDateTime>;
+					IEnumerable<Observation> ff_ = context.Operators.SortBy<Observation>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation fg_ = context.Operators.First<Observation>(ff_);
+					DataType fh_ = fg_?.Effective;
+					object fi_ = FHIRHelpers_4_3_000.ToValue(fh_);
+					bool fj_ = fi_ is CqlInterval<CqlDateTime>;
 
 					return fj_;
 				};
 				bool ce_()
 				{
-					var hv_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, null);
+					CqlValueSet hv_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, null);
 					bool? hx_(Observation O2Saturation)
 					{
 						object if_()
 						{
 							bool je_()
 							{
-								var jh_ = O2Saturation?.Effective;
-								var ji_ = FHIRHelpers_4_3_000.ToValue(jh_);
-								var jj_ = ji_ is CqlDateTime;
+								DataType jh_ = O2Saturation?.Effective;
+								object ji_ = FHIRHelpers_4_3_000.ToValue(jh_);
+								bool jj_ = ji_ is CqlDateTime;
 
 								return jj_;
 							};
 							bool jf_()
 							{
-								var jk_ = O2Saturation?.Effective;
-								var jl_ = FHIRHelpers_4_3_000.ToValue(jk_);
-								var jm_ = jl_ is CqlInterval<CqlDateTime>;
+								DataType jk_ = O2Saturation?.Effective;
+								object jl_ = FHIRHelpers_4_3_000.ToValue(jk_);
+								bool jm_ = jl_ is CqlInterval<CqlDateTime>;
 
 								return jm_;
 							};
 							bool jg_()
 							{
-								var jn_ = O2Saturation?.Effective;
-								var jo_ = FHIRHelpers_4_3_000.ToValue(jn_);
-								var jp_ = jo_ is CqlDateTime;
+								DataType jn_ = O2Saturation?.Effective;
+								object jo_ = FHIRHelpers_4_3_000.ToValue(jn_);
+								bool jp_ = jo_ is CqlDateTime;
 
 								return jp_;
 							};
 							if (je_())
 							{
-								var jq_ = O2Saturation?.Effective;
-								var jr_ = FHIRHelpers_4_3_000.ToValue(jq_);
+								DataType jq_ = O2Saturation?.Effective;
+								object jr_ = FHIRHelpers_4_3_000.ToValue(jq_);
 
 								return ((jr_ as CqlDateTime) as object);
 							}
 							else if (jf_())
 							{
-								var js_ = O2Saturation?.Effective;
-								var jt_ = FHIRHelpers_4_3_000.ToValue(js_);
+								DataType js_ = O2Saturation?.Effective;
+								object jt_ = FHIRHelpers_4_3_000.ToValue(js_);
 
 								return ((jt_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (jg_())
 							{
-								var ju_ = O2Saturation?.Effective;
-								var jv_ = FHIRHelpers_4_3_000.ToValue(ju_);
+								DataType ju_ = O2Saturation?.Effective;
+								object jv_ = FHIRHelpers_4_3_000.ToValue(ju_);
 
 								return ((jv_ as CqlDateTime) as object);
 							}
@@ -1139,84 +1186,84 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var ig_ = QICoreCommon_2_0_000.earliest(if_());
-						var ih_ = EncounterInpatient?.Period;
-						var ii_ = FHIRHelpers_4_3_000.ToInterval(ih_);
-						var ij_ = context.Operators.Start(ii_);
-						var ik_ = context.Operators.Quantity(1440m, "minutes");
-						var il_ = context.Operators.Subtract(ij_, ik_);
-						var in_ = FHIRHelpers_4_3_000.ToInterval(ih_);
-						var io_ = context.Operators.Start(in_);
-						var ip_ = context.Operators.Quantity(120m, "minutes");
-						var iq_ = context.Operators.Add(io_, ip_);
-						var ir_ = context.Operators.Interval(il_, iq_, true, true);
-						var is_ = context.Operators.In<CqlDateTime>(ig_, ir_, null);
-						var it_ = O2Saturation?.StatusElement;
-						var iu_ = it_?.Value;
-						var iv_ = context.Operators.Convert<Code<ObservationStatus>>(iu_);
-						var iw_ = context.Operators.Convert<string>(iv_);
-						var ix_ = new string[]
+						CqlDateTime ig_ = QICoreCommon_2_0_000.earliest(if_());
+						Period ih_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(ih_);
+						CqlDateTime ij_ = context.Operators.Start(ii_);
+						CqlQuantity ik_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime il_ = context.Operators.Subtract(ij_, ik_);
+						CqlInterval<CqlDateTime> in_ = FHIRHelpers_4_3_000.ToInterval(ih_);
+						CqlDateTime io_ = context.Operators.Start(in_);
+						CqlQuantity ip_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime iq_ = context.Operators.Add(io_, ip_);
+						CqlInterval<CqlDateTime> ir_ = context.Operators.Interval(il_, iq_, true, true);
+						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, null);
+						Code<ObservationStatus> it_ = O2Saturation?.StatusElement;
+						ObservationStatus? iu_ = it_?.Value;
+						Code<ObservationStatus> iv_ = context.Operators.Convert<Code<ObservationStatus>>(iu_);
+						string iw_ = context.Operators.Convert<string>(iv_);
+						string[] ix_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var iy_ = context.Operators.In<string>(iw_, (ix_ as IEnumerable<string>));
-						var iz_ = context.Operators.And(is_, iy_);
-						var ja_ = O2Saturation?.Value;
-						var jb_ = FHIRHelpers_4_3_000.ToValue(ja_);
-						var jc_ = context.Operators.Not((bool?)(jb_ is null));
-						var jd_ = context.Operators.And(iz_, jc_);
+						bool? iy_ = context.Operators.In<string>(iw_, (ix_ as IEnumerable<string>));
+						bool? iz_ = context.Operators.And(is_, iy_);
+						DataType ja_ = O2Saturation?.Value;
+						object jb_ = FHIRHelpers_4_3_000.ToValue(ja_);
+						bool? jc_ = context.Operators.Not((bool?)(jb_ is null));
+						bool? jd_ = context.Operators.And(iz_, jc_);
 
 						return jd_;
 					};
-					var hy_ = context.Operators.Where<Observation>(hw_, hx_);
+					IEnumerable<Observation> hy_ = context.Operators.Where<Observation>(hw_, hx_);
 					object hz_(Observation @this)
 					{
 						object jw_()
 						{
 							bool jy_()
 							{
-								var kb_ = @this?.Effective;
-								var kc_ = FHIRHelpers_4_3_000.ToValue(kb_);
-								var kd_ = kc_ is CqlDateTime;
+								DataType kb_ = @this?.Effective;
+								object kc_ = FHIRHelpers_4_3_000.ToValue(kb_);
+								bool kd_ = kc_ is CqlDateTime;
 
 								return kd_;
 							};
 							bool jz_()
 							{
-								var ke_ = @this?.Effective;
-								var kf_ = FHIRHelpers_4_3_000.ToValue(ke_);
-								var kg_ = kf_ is CqlInterval<CqlDateTime>;
+								DataType ke_ = @this?.Effective;
+								object kf_ = FHIRHelpers_4_3_000.ToValue(ke_);
+								bool kg_ = kf_ is CqlInterval<CqlDateTime>;
 
 								return kg_;
 							};
 							bool ka_()
 							{
-								var kh_ = @this?.Effective;
-								var ki_ = FHIRHelpers_4_3_000.ToValue(kh_);
-								var kj_ = ki_ is CqlDateTime;
+								DataType kh_ = @this?.Effective;
+								object ki_ = FHIRHelpers_4_3_000.ToValue(kh_);
+								bool kj_ = ki_ is CqlDateTime;
 
 								return kj_;
 							};
 							if (jy_())
 							{
-								var kk_ = @this?.Effective;
-								var kl_ = FHIRHelpers_4_3_000.ToValue(kk_);
+								DataType kk_ = @this?.Effective;
+								object kl_ = FHIRHelpers_4_3_000.ToValue(kk_);
 
 								return ((kl_ as CqlDateTime) as object);
 							}
 							else if (jz_())
 							{
-								var km_ = @this?.Effective;
-								var kn_ = FHIRHelpers_4_3_000.ToValue(km_);
+								DataType km_ = @this?.Effective;
+								object kn_ = FHIRHelpers_4_3_000.ToValue(km_);
 
 								return ((kn_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ka_())
 							{
-								var ko_ = @this?.Effective;
-								var kp_ = FHIRHelpers_4_3_000.ToValue(ko_);
+								DataType ko_ = @this?.Effective;
+								object kp_ = FHIRHelpers_4_3_000.ToValue(ko_);
 
 								return ((kp_ as CqlDateTime) as object);
 							}
@@ -1225,68 +1272,68 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var jx_ = QICoreCommon_2_0_000.earliest(jw_());
+						CqlDateTime jx_ = QICoreCommon_2_0_000.earliest(jw_());
 
 						return jx_;
 					};
-					var ia_ = context.Operators.SortBy<Observation>(hy_, hz_, System.ComponentModel.ListSortDirection.Ascending);
-					var ib_ = context.Operators.First<Observation>(ia_);
-					var ic_ = ib_?.Effective;
-					var id_ = FHIRHelpers_4_3_000.ToValue(ic_);
-					var ie_ = id_ is CqlDateTime;
+					IEnumerable<Observation> ia_ = context.Operators.SortBy<Observation>(hy_, hz_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation ib_ = context.Operators.First<Observation>(ia_);
+					DataType ic_ = ib_?.Effective;
+					object id_ = FHIRHelpers_4_3_000.ToValue(ic_);
+					bool ie_ = id_ is CqlDateTime;
 
 					return ie_;
 				};
 				if (cc_())
 				{
-					var kq_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, null);
+					CqlValueSet kq_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, null);
 					bool? ks_(Observation O2Saturation)
 					{
 						object kz_()
 						{
 							bool ly_()
 							{
-								var mb_ = O2Saturation?.Effective;
-								var mc_ = FHIRHelpers_4_3_000.ToValue(mb_);
-								var md_ = mc_ is CqlDateTime;
+								DataType mb_ = O2Saturation?.Effective;
+								object mc_ = FHIRHelpers_4_3_000.ToValue(mb_);
+								bool md_ = mc_ is CqlDateTime;
 
 								return md_;
 							};
 							bool lz_()
 							{
-								var me_ = O2Saturation?.Effective;
-								var mf_ = FHIRHelpers_4_3_000.ToValue(me_);
-								var mg_ = mf_ is CqlInterval<CqlDateTime>;
+								DataType me_ = O2Saturation?.Effective;
+								object mf_ = FHIRHelpers_4_3_000.ToValue(me_);
+								bool mg_ = mf_ is CqlInterval<CqlDateTime>;
 
 								return mg_;
 							};
 							bool ma_()
 							{
-								var mh_ = O2Saturation?.Effective;
-								var mi_ = FHIRHelpers_4_3_000.ToValue(mh_);
-								var mj_ = mi_ is CqlDateTime;
+								DataType mh_ = O2Saturation?.Effective;
+								object mi_ = FHIRHelpers_4_3_000.ToValue(mh_);
+								bool mj_ = mi_ is CqlDateTime;
 
 								return mj_;
 							};
 							if (ly_())
 							{
-								var mk_ = O2Saturation?.Effective;
-								var ml_ = FHIRHelpers_4_3_000.ToValue(mk_);
+								DataType mk_ = O2Saturation?.Effective;
+								object ml_ = FHIRHelpers_4_3_000.ToValue(mk_);
 
 								return ((ml_ as CqlDateTime) as object);
 							}
 							else if (lz_())
 							{
-								var mm_ = O2Saturation?.Effective;
-								var mn_ = FHIRHelpers_4_3_000.ToValue(mm_);
+								DataType mm_ = O2Saturation?.Effective;
+								object mn_ = FHIRHelpers_4_3_000.ToValue(mm_);
 
 								return ((mn_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ma_())
 							{
-								var mo_ = O2Saturation?.Effective;
-								var mp_ = FHIRHelpers_4_3_000.ToValue(mo_);
+								DataType mo_ = O2Saturation?.Effective;
+								object mp_ = FHIRHelpers_4_3_000.ToValue(mo_);
 
 								return ((mp_ as CqlDateTime) as object);
 							}
@@ -1295,84 +1342,84 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var la_ = QICoreCommon_2_0_000.earliest(kz_());
-						var lb_ = EncounterInpatient?.Period;
-						var lc_ = FHIRHelpers_4_3_000.ToInterval(lb_);
-						var ld_ = context.Operators.Start(lc_);
-						var le_ = context.Operators.Quantity(1440m, "minutes");
-						var lf_ = context.Operators.Subtract(ld_, le_);
-						var lh_ = FHIRHelpers_4_3_000.ToInterval(lb_);
-						var li_ = context.Operators.Start(lh_);
-						var lj_ = context.Operators.Quantity(120m, "minutes");
-						var lk_ = context.Operators.Add(li_, lj_);
-						var ll_ = context.Operators.Interval(lf_, lk_, true, true);
-						var lm_ = context.Operators.In<CqlDateTime>(la_, ll_, null);
-						var ln_ = O2Saturation?.StatusElement;
-						var lo_ = ln_?.Value;
-						var lp_ = context.Operators.Convert<Code<ObservationStatus>>(lo_);
-						var lq_ = context.Operators.Convert<string>(lp_);
-						var lr_ = new string[]
+						CqlDateTime la_ = QICoreCommon_2_0_000.earliest(kz_());
+						Period lb_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> lc_ = FHIRHelpers_4_3_000.ToInterval(lb_);
+						CqlDateTime ld_ = context.Operators.Start(lc_);
+						CqlQuantity le_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime lf_ = context.Operators.Subtract(ld_, le_);
+						CqlInterval<CqlDateTime> lh_ = FHIRHelpers_4_3_000.ToInterval(lb_);
+						CqlDateTime li_ = context.Operators.Start(lh_);
+						CqlQuantity lj_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime lk_ = context.Operators.Add(li_, lj_);
+						CqlInterval<CqlDateTime> ll_ = context.Operators.Interval(lf_, lk_, true, true);
+						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, null);
+						Code<ObservationStatus> ln_ = O2Saturation?.StatusElement;
+						ObservationStatus? lo_ = ln_?.Value;
+						Code<ObservationStatus> lp_ = context.Operators.Convert<Code<ObservationStatus>>(lo_);
+						string lq_ = context.Operators.Convert<string>(lp_);
+						string[] lr_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var ls_ = context.Operators.In<string>(lq_, (lr_ as IEnumerable<string>));
-						var lt_ = context.Operators.And(lm_, ls_);
-						var lu_ = O2Saturation?.Value;
-						var lv_ = FHIRHelpers_4_3_000.ToValue(lu_);
-						var lw_ = context.Operators.Not((bool?)(lv_ is null));
-						var lx_ = context.Operators.And(lt_, lw_);
+						bool? ls_ = context.Operators.In<string>(lq_, (lr_ as IEnumerable<string>));
+						bool? lt_ = context.Operators.And(lm_, ls_);
+						DataType lu_ = O2Saturation?.Value;
+						object lv_ = FHIRHelpers_4_3_000.ToValue(lu_);
+						bool? lw_ = context.Operators.Not((bool?)(lv_ is null));
+						bool? lx_ = context.Operators.And(lt_, lw_);
 
 						return lx_;
 					};
-					var kt_ = context.Operators.Where<Observation>(kr_, ks_);
+					IEnumerable<Observation> kt_ = context.Operators.Where<Observation>(kr_, ks_);
 					object ku_(Observation @this)
 					{
 						object mq_()
 						{
 							bool ms_()
 							{
-								var mv_ = @this?.Effective;
-								var mw_ = FHIRHelpers_4_3_000.ToValue(mv_);
-								var mx_ = mw_ is CqlDateTime;
+								DataType mv_ = @this?.Effective;
+								object mw_ = FHIRHelpers_4_3_000.ToValue(mv_);
+								bool mx_ = mw_ is CqlDateTime;
 
 								return mx_;
 							};
 							bool mt_()
 							{
-								var my_ = @this?.Effective;
-								var mz_ = FHIRHelpers_4_3_000.ToValue(my_);
-								var na_ = mz_ is CqlInterval<CqlDateTime>;
+								DataType my_ = @this?.Effective;
+								object mz_ = FHIRHelpers_4_3_000.ToValue(my_);
+								bool na_ = mz_ is CqlInterval<CqlDateTime>;
 
 								return na_;
 							};
 							bool mu_()
 							{
-								var nb_ = @this?.Effective;
-								var nc_ = FHIRHelpers_4_3_000.ToValue(nb_);
-								var nd_ = nc_ is CqlDateTime;
+								DataType nb_ = @this?.Effective;
+								object nc_ = FHIRHelpers_4_3_000.ToValue(nb_);
+								bool nd_ = nc_ is CqlDateTime;
 
 								return nd_;
 							};
 							if (ms_())
 							{
-								var ne_ = @this?.Effective;
-								var nf_ = FHIRHelpers_4_3_000.ToValue(ne_);
+								DataType ne_ = @this?.Effective;
+								object nf_ = FHIRHelpers_4_3_000.ToValue(ne_);
 
 								return ((nf_ as CqlDateTime) as object);
 							}
 							else if (mt_())
 							{
-								var ng_ = @this?.Effective;
-								var nh_ = FHIRHelpers_4_3_000.ToValue(ng_);
+								DataType ng_ = @this?.Effective;
+								object nh_ = FHIRHelpers_4_3_000.ToValue(ng_);
 
 								return ((nh_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (mu_())
 							{
-								var ni_ = @this?.Effective;
-								var nj_ = FHIRHelpers_4_3_000.ToValue(ni_);
+								DataType ni_ = @this?.Effective;
+								object nj_ = FHIRHelpers_4_3_000.ToValue(ni_);
 
 								return ((nj_ as CqlDateTime) as object);
 							}
@@ -1381,67 +1428,67 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var mr_ = QICoreCommon_2_0_000.earliest(mq_());
+						CqlDateTime mr_ = QICoreCommon_2_0_000.earliest(mq_());
 
 						return mr_;
 					};
-					var kv_ = context.Operators.SortBy<Observation>(kt_, ku_, System.ComponentModel.ListSortDirection.Ascending);
-					var kw_ = context.Operators.First<Observation>(kv_);
-					var kx_ = kw_?.Effective;
-					var ky_ = FHIRHelpers_4_3_000.ToValue(kx_);
+					IEnumerable<Observation> kv_ = context.Operators.SortBy<Observation>(kt_, ku_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation kw_ = context.Operators.First<Observation>(kv_);
+					DataType kx_ = kw_?.Effective;
+					object ky_ = FHIRHelpers_4_3_000.ToValue(kx_);
 
 					return ((ky_ as CqlDateTime) as object);
 				}
 				else if (cd_())
 				{
-					var nk_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, null);
+					CqlValueSet nk_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, null);
 					bool? nm_(Observation O2Saturation)
 					{
 						object nt_()
 						{
 							bool os_()
 							{
-								var ov_ = O2Saturation?.Effective;
-								var ow_ = FHIRHelpers_4_3_000.ToValue(ov_);
-								var ox_ = ow_ is CqlDateTime;
+								DataType ov_ = O2Saturation?.Effective;
+								object ow_ = FHIRHelpers_4_3_000.ToValue(ov_);
+								bool ox_ = ow_ is CqlDateTime;
 
 								return ox_;
 							};
 							bool ot_()
 							{
-								var oy_ = O2Saturation?.Effective;
-								var oz_ = FHIRHelpers_4_3_000.ToValue(oy_);
-								var pa_ = oz_ is CqlInterval<CqlDateTime>;
+								DataType oy_ = O2Saturation?.Effective;
+								object oz_ = FHIRHelpers_4_3_000.ToValue(oy_);
+								bool pa_ = oz_ is CqlInterval<CqlDateTime>;
 
 								return pa_;
 							};
 							bool ou_()
 							{
-								var pb_ = O2Saturation?.Effective;
-								var pc_ = FHIRHelpers_4_3_000.ToValue(pb_);
-								var pd_ = pc_ is CqlDateTime;
+								DataType pb_ = O2Saturation?.Effective;
+								object pc_ = FHIRHelpers_4_3_000.ToValue(pb_);
+								bool pd_ = pc_ is CqlDateTime;
 
 								return pd_;
 							};
 							if (os_())
 							{
-								var pe_ = O2Saturation?.Effective;
-								var pf_ = FHIRHelpers_4_3_000.ToValue(pe_);
+								DataType pe_ = O2Saturation?.Effective;
+								object pf_ = FHIRHelpers_4_3_000.ToValue(pe_);
 
 								return ((pf_ as CqlDateTime) as object);
 							}
 							else if (ot_())
 							{
-								var pg_ = O2Saturation?.Effective;
-								var ph_ = FHIRHelpers_4_3_000.ToValue(pg_);
+								DataType pg_ = O2Saturation?.Effective;
+								object ph_ = FHIRHelpers_4_3_000.ToValue(pg_);
 
 								return ((ph_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ou_())
 							{
-								var pi_ = O2Saturation?.Effective;
-								var pj_ = FHIRHelpers_4_3_000.ToValue(pi_);
+								DataType pi_ = O2Saturation?.Effective;
+								object pj_ = FHIRHelpers_4_3_000.ToValue(pi_);
 
 								return ((pj_ as CqlDateTime) as object);
 							}
@@ -1450,84 +1497,84 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var nu_ = QICoreCommon_2_0_000.earliest(nt_());
-						var nv_ = EncounterInpatient?.Period;
-						var nw_ = FHIRHelpers_4_3_000.ToInterval(nv_);
-						var nx_ = context.Operators.Start(nw_);
-						var ny_ = context.Operators.Quantity(1440m, "minutes");
-						var nz_ = context.Operators.Subtract(nx_, ny_);
-						var ob_ = FHIRHelpers_4_3_000.ToInterval(nv_);
-						var oc_ = context.Operators.Start(ob_);
-						var od_ = context.Operators.Quantity(120m, "minutes");
-						var oe_ = context.Operators.Add(oc_, od_);
-						var of_ = context.Operators.Interval(nz_, oe_, true, true);
-						var og_ = context.Operators.In<CqlDateTime>(nu_, of_, null);
-						var oh_ = O2Saturation?.StatusElement;
-						var oi_ = oh_?.Value;
-						var oj_ = context.Operators.Convert<Code<ObservationStatus>>(oi_);
-						var ok_ = context.Operators.Convert<string>(oj_);
-						var ol_ = new string[]
+						CqlDateTime nu_ = QICoreCommon_2_0_000.earliest(nt_());
+						Period nv_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> nw_ = FHIRHelpers_4_3_000.ToInterval(nv_);
+						CqlDateTime nx_ = context.Operators.Start(nw_);
+						CqlQuantity ny_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime nz_ = context.Operators.Subtract(nx_, ny_);
+						CqlInterval<CqlDateTime> ob_ = FHIRHelpers_4_3_000.ToInterval(nv_);
+						CqlDateTime oc_ = context.Operators.Start(ob_);
+						CqlQuantity od_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime oe_ = context.Operators.Add(oc_, od_);
+						CqlInterval<CqlDateTime> of_ = context.Operators.Interval(nz_, oe_, true, true);
+						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, null);
+						Code<ObservationStatus> oh_ = O2Saturation?.StatusElement;
+						ObservationStatus? oi_ = oh_?.Value;
+						Code<ObservationStatus> oj_ = context.Operators.Convert<Code<ObservationStatus>>(oi_);
+						string ok_ = context.Operators.Convert<string>(oj_);
+						string[] ol_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var om_ = context.Operators.In<string>(ok_, (ol_ as IEnumerable<string>));
-						var on_ = context.Operators.And(og_, om_);
-						var oo_ = O2Saturation?.Value;
-						var op_ = FHIRHelpers_4_3_000.ToValue(oo_);
-						var oq_ = context.Operators.Not((bool?)(op_ is null));
-						var or_ = context.Operators.And(on_, oq_);
+						bool? om_ = context.Operators.In<string>(ok_, (ol_ as IEnumerable<string>));
+						bool? on_ = context.Operators.And(og_, om_);
+						DataType oo_ = O2Saturation?.Value;
+						object op_ = FHIRHelpers_4_3_000.ToValue(oo_);
+						bool? oq_ = context.Operators.Not((bool?)(op_ is null));
+						bool? or_ = context.Operators.And(on_, oq_);
 
 						return or_;
 					};
-					var nn_ = context.Operators.Where<Observation>(nl_, nm_);
+					IEnumerable<Observation> nn_ = context.Operators.Where<Observation>(nl_, nm_);
 					object no_(Observation @this)
 					{
 						object pk_()
 						{
 							bool pm_()
 							{
-								var pp_ = @this?.Effective;
-								var pq_ = FHIRHelpers_4_3_000.ToValue(pp_);
-								var pr_ = pq_ is CqlDateTime;
+								DataType pp_ = @this?.Effective;
+								object pq_ = FHIRHelpers_4_3_000.ToValue(pp_);
+								bool pr_ = pq_ is CqlDateTime;
 
 								return pr_;
 							};
 							bool pn_()
 							{
-								var ps_ = @this?.Effective;
-								var pt_ = FHIRHelpers_4_3_000.ToValue(ps_);
-								var pu_ = pt_ is CqlInterval<CqlDateTime>;
+								DataType ps_ = @this?.Effective;
+								object pt_ = FHIRHelpers_4_3_000.ToValue(ps_);
+								bool pu_ = pt_ is CqlInterval<CqlDateTime>;
 
 								return pu_;
 							};
 							bool po_()
 							{
-								var pv_ = @this?.Effective;
-								var pw_ = FHIRHelpers_4_3_000.ToValue(pv_);
-								var px_ = pw_ is CqlDateTime;
+								DataType pv_ = @this?.Effective;
+								object pw_ = FHIRHelpers_4_3_000.ToValue(pv_);
+								bool px_ = pw_ is CqlDateTime;
 
 								return px_;
 							};
 							if (pm_())
 							{
-								var py_ = @this?.Effective;
-								var pz_ = FHIRHelpers_4_3_000.ToValue(py_);
+								DataType py_ = @this?.Effective;
+								object pz_ = FHIRHelpers_4_3_000.ToValue(py_);
 
 								return ((pz_ as CqlDateTime) as object);
 							}
 							else if (pn_())
 							{
-								var qa_ = @this?.Effective;
-								var qb_ = FHIRHelpers_4_3_000.ToValue(qa_);
+								DataType qa_ = @this?.Effective;
+								object qb_ = FHIRHelpers_4_3_000.ToValue(qa_);
 
 								return ((qb_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (po_())
 							{
-								var qc_ = @this?.Effective;
-								var qd_ = FHIRHelpers_4_3_000.ToValue(qc_);
+								DataType qc_ = @this?.Effective;
+								object qd_ = FHIRHelpers_4_3_000.ToValue(qc_);
 
 								return ((qd_ as CqlDateTime) as object);
 							}
@@ -1536,67 +1583,67 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var pl_ = QICoreCommon_2_0_000.earliest(pk_());
+						CqlDateTime pl_ = QICoreCommon_2_0_000.earliest(pk_());
 
 						return pl_;
 					};
-					var np_ = context.Operators.SortBy<Observation>(nn_, no_, System.ComponentModel.ListSortDirection.Ascending);
-					var nq_ = context.Operators.First<Observation>(np_);
-					var nr_ = nq_?.Effective;
-					var ns_ = FHIRHelpers_4_3_000.ToValue(nr_);
+					IEnumerable<Observation> np_ = context.Operators.SortBy<Observation>(nn_, no_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation nq_ = context.Operators.First<Observation>(np_);
+					DataType nr_ = nq_?.Effective;
+					object ns_ = FHIRHelpers_4_3_000.ToValue(nr_);
 
 					return ((ns_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (ce_())
 				{
-					var qe_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					var qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, null);
+					CqlValueSet qe_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
+					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, null);
 					bool? qg_(Observation O2Saturation)
 					{
 						object qn_()
 						{
 							bool rm_()
 							{
-								var rp_ = O2Saturation?.Effective;
-								var rq_ = FHIRHelpers_4_3_000.ToValue(rp_);
-								var rr_ = rq_ is CqlDateTime;
+								DataType rp_ = O2Saturation?.Effective;
+								object rq_ = FHIRHelpers_4_3_000.ToValue(rp_);
+								bool rr_ = rq_ is CqlDateTime;
 
 								return rr_;
 							};
 							bool rn_()
 							{
-								var rs_ = O2Saturation?.Effective;
-								var rt_ = FHIRHelpers_4_3_000.ToValue(rs_);
-								var ru_ = rt_ is CqlInterval<CqlDateTime>;
+								DataType rs_ = O2Saturation?.Effective;
+								object rt_ = FHIRHelpers_4_3_000.ToValue(rs_);
+								bool ru_ = rt_ is CqlInterval<CqlDateTime>;
 
 								return ru_;
 							};
 							bool ro_()
 							{
-								var rv_ = O2Saturation?.Effective;
-								var rw_ = FHIRHelpers_4_3_000.ToValue(rv_);
-								var rx_ = rw_ is CqlDateTime;
+								DataType rv_ = O2Saturation?.Effective;
+								object rw_ = FHIRHelpers_4_3_000.ToValue(rv_);
+								bool rx_ = rw_ is CqlDateTime;
 
 								return rx_;
 							};
 							if (rm_())
 							{
-								var ry_ = O2Saturation?.Effective;
-								var rz_ = FHIRHelpers_4_3_000.ToValue(ry_);
+								DataType ry_ = O2Saturation?.Effective;
+								object rz_ = FHIRHelpers_4_3_000.ToValue(ry_);
 
 								return ((rz_ as CqlDateTime) as object);
 							}
 							else if (rn_())
 							{
-								var sa_ = O2Saturation?.Effective;
-								var sb_ = FHIRHelpers_4_3_000.ToValue(sa_);
+								DataType sa_ = O2Saturation?.Effective;
+								object sb_ = FHIRHelpers_4_3_000.ToValue(sa_);
 
 								return ((sb_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (ro_())
 							{
-								var sc_ = O2Saturation?.Effective;
-								var sd_ = FHIRHelpers_4_3_000.ToValue(sc_);
+								DataType sc_ = O2Saturation?.Effective;
+								object sd_ = FHIRHelpers_4_3_000.ToValue(sc_);
 
 								return ((sd_ as CqlDateTime) as object);
 							}
@@ -1605,84 +1652,84 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var qo_ = QICoreCommon_2_0_000.earliest(qn_());
-						var qp_ = EncounterInpatient?.Period;
-						var qq_ = FHIRHelpers_4_3_000.ToInterval(qp_);
-						var qr_ = context.Operators.Start(qq_);
-						var qs_ = context.Operators.Quantity(1440m, "minutes");
-						var qt_ = context.Operators.Subtract(qr_, qs_);
-						var qv_ = FHIRHelpers_4_3_000.ToInterval(qp_);
-						var qw_ = context.Operators.Start(qv_);
-						var qx_ = context.Operators.Quantity(120m, "minutes");
-						var qy_ = context.Operators.Add(qw_, qx_);
-						var qz_ = context.Operators.Interval(qt_, qy_, true, true);
-						var ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, null);
-						var rb_ = O2Saturation?.StatusElement;
-						var rc_ = rb_?.Value;
-						var rd_ = context.Operators.Convert<Code<ObservationStatus>>(rc_);
-						var re_ = context.Operators.Convert<string>(rd_);
-						var rf_ = new string[]
+						CqlDateTime qo_ = QICoreCommon_2_0_000.earliest(qn_());
+						Period qp_ = EncounterInpatient?.Period;
+						CqlInterval<CqlDateTime> qq_ = FHIRHelpers_4_3_000.ToInterval(qp_);
+						CqlDateTime qr_ = context.Operators.Start(qq_);
+						CqlQuantity qs_ = context.Operators.Quantity(1440m, "minutes");
+						CqlDateTime qt_ = context.Operators.Subtract(qr_, qs_);
+						CqlInterval<CqlDateTime> qv_ = FHIRHelpers_4_3_000.ToInterval(qp_);
+						CqlDateTime qw_ = context.Operators.Start(qv_);
+						CqlQuantity qx_ = context.Operators.Quantity(120m, "minutes");
+						CqlDateTime qy_ = context.Operators.Add(qw_, qx_);
+						CqlInterval<CqlDateTime> qz_ = context.Operators.Interval(qt_, qy_, true, true);
+						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, null);
+						Code<ObservationStatus> rb_ = O2Saturation?.StatusElement;
+						ObservationStatus? rc_ = rb_?.Value;
+						Code<ObservationStatus> rd_ = context.Operators.Convert<Code<ObservationStatus>>(rc_);
+						string re_ = context.Operators.Convert<string>(rd_);
+						string[] rf_ = new string[]
 						{
 							"final",
 							"amended",
 							"corrected",
 						};
-						var rg_ = context.Operators.In<string>(re_, (rf_ as IEnumerable<string>));
-						var rh_ = context.Operators.And(ra_, rg_);
-						var ri_ = O2Saturation?.Value;
-						var rj_ = FHIRHelpers_4_3_000.ToValue(ri_);
-						var rk_ = context.Operators.Not((bool?)(rj_ is null));
-						var rl_ = context.Operators.And(rh_, rk_);
+						bool? rg_ = context.Operators.In<string>(re_, (rf_ as IEnumerable<string>));
+						bool? rh_ = context.Operators.And(ra_, rg_);
+						DataType ri_ = O2Saturation?.Value;
+						object rj_ = FHIRHelpers_4_3_000.ToValue(ri_);
+						bool? rk_ = context.Operators.Not((bool?)(rj_ is null));
+						bool? rl_ = context.Operators.And(rh_, rk_);
 
 						return rl_;
 					};
-					var qh_ = context.Operators.Where<Observation>(qf_, qg_);
+					IEnumerable<Observation> qh_ = context.Operators.Where<Observation>(qf_, qg_);
 					object qi_(Observation @this)
 					{
 						object se_()
 						{
 							bool sg_()
 							{
-								var sj_ = @this?.Effective;
-								var sk_ = FHIRHelpers_4_3_000.ToValue(sj_);
-								var sl_ = sk_ is CqlDateTime;
+								DataType sj_ = @this?.Effective;
+								object sk_ = FHIRHelpers_4_3_000.ToValue(sj_);
+								bool sl_ = sk_ is CqlDateTime;
 
 								return sl_;
 							};
 							bool sh_()
 							{
-								var sm_ = @this?.Effective;
-								var sn_ = FHIRHelpers_4_3_000.ToValue(sm_);
-								var so_ = sn_ is CqlInterval<CqlDateTime>;
+								DataType sm_ = @this?.Effective;
+								object sn_ = FHIRHelpers_4_3_000.ToValue(sm_);
+								bool so_ = sn_ is CqlInterval<CqlDateTime>;
 
 								return so_;
 							};
 							bool si_()
 							{
-								var sp_ = @this?.Effective;
-								var sq_ = FHIRHelpers_4_3_000.ToValue(sp_);
-								var sr_ = sq_ is CqlDateTime;
+								DataType sp_ = @this?.Effective;
+								object sq_ = FHIRHelpers_4_3_000.ToValue(sp_);
+								bool sr_ = sq_ is CqlDateTime;
 
 								return sr_;
 							};
 							if (sg_())
 							{
-								var ss_ = @this?.Effective;
-								var st_ = FHIRHelpers_4_3_000.ToValue(ss_);
+								DataType ss_ = @this?.Effective;
+								object st_ = FHIRHelpers_4_3_000.ToValue(ss_);
 
 								return ((st_ as CqlDateTime) as object);
 							}
 							else if (sh_())
 							{
-								var su_ = @this?.Effective;
-								var sv_ = FHIRHelpers_4_3_000.ToValue(su_);
+								DataType su_ = @this?.Effective;
+								object sv_ = FHIRHelpers_4_3_000.ToValue(su_);
 
 								return ((sv_ as CqlInterval<CqlDateTime>) as object);
 							}
 							else if (si_())
 							{
-								var sw_ = @this?.Effective;
-								var sx_ = FHIRHelpers_4_3_000.ToValue(sw_);
+								DataType sw_ = @this?.Effective;
+								object sx_ = FHIRHelpers_4_3_000.ToValue(sw_);
 
 								return ((sx_ as CqlDateTime) as object);
 							}
@@ -1691,14 +1738,14 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 								return null;
 							}
 						};
-						var sf_ = QICoreCommon_2_0_000.earliest(se_());
+						CqlDateTime sf_ = QICoreCommon_2_0_000.earliest(se_());
 
 						return sf_;
 					};
-					var qj_ = context.Operators.SortBy<Observation>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
-					var qk_ = context.Operators.First<Observation>(qj_);
-					var ql_ = qk_?.Effective;
-					var qm_ = FHIRHelpers_4_3_000.ToValue(ql_);
+					IEnumerable<Observation> qj_ = context.Operators.SortBy<Observation>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
+					Observation qk_ = context.Operators.First<Observation>(qj_);
+					DataType ql_ = qk_?.Effective;
+					object qm_ = FHIRHelpers_4_3_000.ToValue(ql_);
 
 					return ((qm_ as CqlDateTime) as object);
 				}
@@ -1707,8 +1754,8 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 					return null;
 				}
 			};
-			var p_ = QICoreCommon_2_0_000.earliest(o_());
-			var q_ = new Tuple_FdREYEdHOZIcMCNYCRFJYJReA
+			CqlDateTime p_ = QICoreCommon_2_0_000.earliest(o_());
+			Tuple_FdREYEdHOZIcMCNYCRFJYJReA q_ = new Tuple_FdREYEdHOZIcMCNYCRFJYJReA
 			{
 				EncounterId = e_,
 				FirstOxygenSatResult = (n_ as CqlQuantity),
@@ -1717,122 +1764,124 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return q_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_FdREYEdHOZIcMCNYCRFJYJReA>(a_, b_);
+		IEnumerable<Tuple_FdREYEdHOZIcMCNYCRFJYJReA> c_ = context.Operators.Select<Encounter, Tuple_FdREYEdHOZIcMCNYCRFJYJReA>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Oxygen_Saturation_Value"/>
     [CqlDeclaration("Encounter with First Oxygen Saturation")]
 	public IEnumerable<Tuple_FdREYEdHOZIcMCNYCRFJYJReA> Encounter_with_First_Oxygen_Saturation() => 
 		__Encounter_with_First_Oxygen_Saturation.Value;
 
+    /// <seealso cref="Encounter_with_First_Respiratory_Rate"/>
 	private IEnumerable<Tuple_CYbMQaXdPgTVSLXJSHHNTbhVM> Encounter_with_First_Respiratory_Rate_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_CYbMQaXdPgTVSLXJSHHNTbhVM b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? g_(Observation RespRate)
 			{
-				var y_ = RespRate?.Effective;
-				var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-				var aa_ = QICoreCommon_2_0_000.earliest(z_);
-				var ab_ = EncounterInpatient?.Period;
-				var ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ad_ = context.Operators.Start(ac_);
-				var ae_ = context.Operators.Quantity(1440m, "minutes");
-				var af_ = context.Operators.Subtract(ad_, ae_);
-				var ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				var ai_ = context.Operators.Start(ah_);
-				var aj_ = context.Operators.Quantity(120m, "minutes");
-				var ak_ = context.Operators.Add(ai_, aj_);
-				var al_ = context.Operators.Interval(af_, ak_, true, true);
-				var am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
-				var an_ = RespRate?.StatusElement;
-				var ao_ = an_?.Value;
-				var ap_ = context.Operators.Convert<string>(ao_);
-				var aq_ = new string[]
+				DataType y_ = RespRate?.Effective;
+				object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+				CqlDateTime aa_ = QICoreCommon_2_0_000.earliest(z_);
+				Period ab_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ad_ = context.Operators.Start(ac_);
+				CqlQuantity ae_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
+				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
+				CqlDateTime ai_ = context.Operators.Start(ah_);
+				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
+				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				Code<ObservationStatus> an_ = RespRate?.StatusElement;
+				ObservationStatus? ao_ = an_?.Value;
+				string ap_ = context.Operators.Convert<string>(ao_);
+				string[] aq_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
-				var as_ = context.Operators.And(am_, ar_);
-				var at_ = RespRate?.Value;
-				var au_ = context.Operators.Convert<Quantity>(at_);
-				var av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
-				var aw_ = context.Operators.Not((bool?)(av_ is null));
-				var ax_ = context.Operators.And(as_, aw_);
+				bool? ar_ = context.Operators.In<string>(ap_, (aq_ as IEnumerable<string>));
+				bool? as_ = context.Operators.And(am_, ar_);
+				DataType at_ = RespRate?.Value;
+				Quantity au_ = context.Operators.Convert<Quantity>(at_);
+				CqlQuantity av_ = FHIRHelpers_4_3_000.ToQuantity(au_);
+				bool? aw_ = context.Operators.Not((bool?)(av_ is null));
+				bool? ax_ = context.Operators.And(as_, aw_);
 
 				return ax_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			object i_(Observation @this)
 			{
-				var ay_ = @this?.Effective;
-				var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-				var ba_ = QICoreCommon_2_0_000.earliest(az_);
+				DataType ay_ = @this?.Effective;
+				object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+				CqlDateTime ba_ = QICoreCommon_2_0_000.earliest(az_);
 
 				return ba_;
 			};
-			var j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.First<Observation>(j_);
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<Quantity>(l_);
-			var n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
+			IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation k_ = context.Operators.First<Observation>(j_);
+			DataType l_ = k_?.Value;
+			Quantity m_ = context.Operators.Convert<Quantity>(l_);
+			CqlQuantity n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
 			bool? p_(Observation RespRate)
 			{
-				var bb_ = RespRate?.Effective;
-				var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
-				var bd_ = QICoreCommon_2_0_000.earliest(bc_);
-				var be_ = EncounterInpatient?.Period;
-				var bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bg_ = context.Operators.Start(bf_);
-				var bh_ = context.Operators.Quantity(1440m, "minutes");
-				var bi_ = context.Operators.Subtract(bg_, bh_);
-				var bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bl_ = context.Operators.Start(bk_);
-				var bm_ = context.Operators.Quantity(120m, "minutes");
-				var bn_ = context.Operators.Add(bl_, bm_);
-				var bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				var bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
-				var bq_ = RespRate?.StatusElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.Convert<string>(br_);
-				var bt_ = new string[]
+				DataType bb_ = RespRate?.Effective;
+				object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+				CqlDateTime bd_ = QICoreCommon_2_0_000.earliest(bc_);
+				Period be_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bg_ = context.Operators.Start(bf_);
+				CqlQuantity bh_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bi_ = context.Operators.Subtract(bg_, bh_);
+				CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bl_ = context.Operators.Start(bk_);
+				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
+				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
+				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				Code<ObservationStatus> bq_ = RespRate?.StatusElement;
+				ObservationStatus? br_ = bq_?.Value;
+				string bs_ = context.Operators.Convert<string>(br_);
+				string[] bt_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
-				var bv_ = context.Operators.And(bp_, bu_);
-				var bw_ = RespRate?.Value;
-				var bx_ = context.Operators.Convert<Quantity>(bw_);
-				var by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
-				var bz_ = context.Operators.Not((bool?)(by_ is null));
-				var ca_ = context.Operators.And(bv_, bz_);
+				bool? bu_ = context.Operators.In<string>(bs_, (bt_ as IEnumerable<string>));
+				bool? bv_ = context.Operators.And(bp_, bu_);
+				DataType bw_ = RespRate?.Value;
+				Quantity bx_ = context.Operators.Convert<Quantity>(bw_);
+				CqlQuantity by_ = FHIRHelpers_4_3_000.ToQuantity(bx_);
+				bool? bz_ = context.Operators.Not((bool?)(by_ is null));
+				bool? ca_ = context.Operators.And(bv_, bz_);
 
 				return ca_;
 			};
-			var q_ = context.Operators.Where<Observation>(f_, p_);
+			IEnumerable<Observation> q_ = context.Operators.Where<Observation>(f_, p_);
 			object r_(Observation @this)
 			{
-				var cb_ = @this?.Effective;
-				var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
-				var cd_ = QICoreCommon_2_0_000.earliest(cc_);
+				DataType cb_ = @this?.Effective;
+				object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+				CqlDateTime cd_ = QICoreCommon_2_0_000.earliest(cc_);
 
 				return cd_;
 			};
-			var s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
-			var t_ = context.Operators.First<Observation>(s_);
-			var u_ = t_?.Effective;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = QICoreCommon_2_0_000.earliest(v_);
-			var x_ = new Tuple_CYbMQaXdPgTVSLXJSHHNTbhVM
+			IEnumerable<Observation> s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation t_ = context.Operators.First<Observation>(s_);
+			DataType u_ = t_?.Effective;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			CqlDateTime w_ = QICoreCommon_2_0_000.earliest(v_);
+			Tuple_CYbMQaXdPgTVSLXJSHHNTbhVM x_ = new Tuple_CYbMQaXdPgTVSLXJSHHNTbhVM
 			{
 				EncounterId = e_,
 				FirstRespRateResult = n_,
@@ -1841,169 +1890,175 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return x_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_CYbMQaXdPgTVSLXJSHHNTbhVM>(a_, b_);
+		IEnumerable<Tuple_CYbMQaXdPgTVSLXJSHHNTbhVM> c_ = context.Operators.Select<Encounter, Tuple_CYbMQaXdPgTVSLXJSHHNTbhVM>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Respiratory_Rate_Value"/>
     [CqlDeclaration("Encounter with First Respiratory Rate")]
 	public IEnumerable<Tuple_CYbMQaXdPgTVSLXJSHHNTbhVM> Encounter_with_First_Respiratory_Rate() => 
 		__Encounter_with_First_Respiratory_Rate.Value;
 
+    /// <seealso cref="Blood_Pressure_Reading"/>
 	private IEnumerable<Observation> Blood_Pressure_Reading_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 		bool? b_(Observation BloodPressure)
 		{
-			var d_ = BloodPressure?.StatusElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> d_ = BloodPressure?.StatusElement;
+			ObservationStatus? e_ = d_?.Value;
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Blood_Pressure_Reading_Value"/>
     [CqlDeclaration("Blood Pressure Reading")]
 	public IEnumerable<Observation> Blood_Pressure_Reading() => 
 		__Blood_Pressure_Reading.Value;
 
+    /// <seealso cref="Encounter_with_First_Systolic_Blood_Pressure"/>
 	private IEnumerable<string> Encounter_with_First_Systolic_Blood_Pressure_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		string b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
 
 			return e_;
 		};
-		var c_ = context.Operators.Select<Encounter, string>(a_, b_);
+		IEnumerable<string> c_ = context.Operators.Select<Encounter, string>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Systolic_Blood_Pressure_Value"/>
     [CqlDeclaration("Encounter with First Systolic Blood Pressure")]
 	public IEnumerable<string> Encounter_with_First_Systolic_Blood_Pressure() => 
 		__Encounter_with_First_Systolic_Blood_Pressure.Value;
 
+    /// <seealso cref="Encounter_with_First_Bicarbonate_Lab_Test"/>
 	private IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Bicarbonate_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Bicarbonate_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Bicarbonate_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation bicarbonatelab)
 			{
-				var z_ = bicarbonatelab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = bicarbonatelab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = bicarbonatelab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = bicarbonatelab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = bicarbonatelab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = bicarbonatelab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation bicarbonatelab)
 			{
-				var bd_ = bicarbonatelab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = bicarbonatelab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = bicarbonatelab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = bicarbonatelab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = bicarbonatelab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = bicarbonatelab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
 			{
 				EncounterId = e_,
 				FirstResult = (n_ as CqlQuantity),
@@ -2012,123 +2067,125 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
+		IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Bicarbonate_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Bicarbonate Lab Test")]
 	public IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Bicarbonate_Lab_Test() => 
 		__Encounter_with_First_Bicarbonate_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Creatinine_Lab_Test"/>
 	private IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Creatinine_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Creatinine_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Creatinine_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation CreatinineLab)
 			{
-				var z_ = CreatinineLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = CreatinineLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = CreatinineLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = CreatinineLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = CreatinineLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = CreatinineLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation CreatinineLab)
 			{
-				var bd_ = CreatinineLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = CreatinineLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = CreatinineLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = CreatinineLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = CreatinineLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = CreatinineLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
 			{
 				EncounterId = e_,
 				FirstResult = (n_ as CqlQuantity),
@@ -2137,123 +2194,125 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
+		IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Creatinine_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Creatinine Lab Test")]
 	public IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Creatinine_Lab_Test() => 
 		__Encounter_with_First_Creatinine_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Glucose_Lab_Test"/>
 	private IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Glucose_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Glucose_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Glucose_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation GlucoseLab)
 			{
-				var z_ = GlucoseLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = GlucoseLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = GlucoseLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = GlucoseLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = GlucoseLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = GlucoseLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation GlucoseLab)
 			{
-				var bd_ = GlucoseLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = GlucoseLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = GlucoseLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = GlucoseLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = GlucoseLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = GlucoseLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
 			{
 				EncounterId = e_,
 				FirstResult = (n_ as CqlQuantity),
@@ -2262,123 +2321,125 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
+		IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Glucose_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Glucose Lab Test")]
 	public IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Glucose_Lab_Test() => 
 		__Encounter_with_First_Glucose_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Hematocrit_Lab_Test"/>
 	private IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Hematocrit_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Hematocrit_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Hematocrit_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation HematocritLab)
 			{
-				var z_ = HematocritLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = HematocritLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = HematocritLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = HematocritLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = HematocritLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = HematocritLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation HematocritLab)
 			{
-				var bd_ = HematocritLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = HematocritLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = HematocritLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = HematocritLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = HematocritLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = HematocritLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
 			{
 				EncounterId = e_,
 				FirstResult = (n_ as CqlQuantity),
@@ -2387,123 +2448,125 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
+		IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Hematocrit_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Hematocrit Lab Test")]
 	public IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Hematocrit_Lab_Test() => 
 		__Encounter_with_First_Hematocrit_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Potassium_Lab_Test"/>
 	private IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Potassium_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Potassium_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Potassium_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation PotassiumLab)
 			{
-				var z_ = PotassiumLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = PotassiumLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = PotassiumLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = PotassiumLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = PotassiumLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = PotassiumLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation PotassiumLab)
 			{
-				var bd_ = PotassiumLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = PotassiumLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = PotassiumLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = PotassiumLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = PotassiumLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = PotassiumLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
 			{
 				EncounterId = e_,
 				FirstResult = (n_ as CqlQuantity),
@@ -2512,123 +2575,125 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
+		IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Potassium_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Potassium Lab Test")]
 	public IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Potassium_Lab_Test() => 
 		__Encounter_with_First_Potassium_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Sodium_Lab_Test"/>
 	private IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Sodium_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Sodium_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Sodium_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation SodiumLab)
 			{
-				var z_ = SodiumLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = SodiumLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = SodiumLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = SodiumLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = SodiumLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = SodiumLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation SodiumLab)
 			{
-				var bd_ = SodiumLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = SodiumLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = SodiumLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = SodiumLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = SodiumLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = SodiumLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
 			{
 				EncounterId = e_,
 				FirstResult = (n_ as CqlQuantity),
@@ -2637,123 +2702,125 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
+		IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Sodium_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First Sodium Lab Test")]
 	public IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Sodium_Lab_Test() => 
 		__Encounter_with_First_Sodium_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_White_Blood_Cells_Lab_Test"/>
 	private IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_White_Blood_Cells_Lab_Test_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.White_blood_cells_count_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.White_blood_cells_count_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation WhiteBloodCellLab)
 			{
-				var z_ = WhiteBloodCellLab?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
-				var ad_ = EncounterInpatient?.Period;
-				var ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Quantity(1440m, "minutes");
-				var ah_ = context.Operators.Subtract(af_, ag_);
-				var aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-				var ak_ = context.Operators.Start(aj_);
-				var am_ = context.Operators.Add(ak_, ag_);
-				var an_ = context.Operators.Interval(ah_, am_, true, true);
-				var ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
-				var ap_ = WhiteBloodCellLab?.StatusElement;
-				var aq_ = ap_?.Value;
-				var ar_ = context.Operators.Convert<string>(aq_);
-				var as_ = new string[]
+				Instant z_ = WhiteBloodCellLab?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest((ab_ as object));
+				Period ad_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				CqlQuantity ag_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ah_ = context.Operators.Subtract(af_, ag_);
+				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ad_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
+				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				Code<ObservationStatus> ap_ = WhiteBloodCellLab?.StatusElement;
+				ObservationStatus? aq_ = ap_?.Value;
+				string ar_ = context.Operators.Convert<string>(aq_);
+				string[] as_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
-				var au_ = context.Operators.And(ao_, at_);
-				var av_ = WhiteBloodCellLab?.Value;
-				var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-				var ax_ = context.Operators.Not((bool?)(aw_ is null));
-				var ay_ = context.Operators.And(au_, ax_);
+				bool? at_ = context.Operators.In<string>(ar_, (as_ as IEnumerable<string>));
+				bool? au_ = context.Operators.And(ao_, at_);
+				DataType av_ = WhiteBloodCellLab?.Value;
+				object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+				bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+				bool? ay_ = context.Operators.And(au_, ax_);
 
 				return ay_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var az_ = @this?.IssuedElement;
-				var ba_ = az_?.Value;
-				var bb_ = context.Operators.Convert<CqlDateTime>(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
+				Instant az_ = @this?.IssuedElement;
+				DateTimeOffset? ba_ = az_?.Value;
+				CqlDateTime bb_ = context.Operators.Convert<CqlDateTime>(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest((bb_ as object));
 
 				return bc_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation WhiteBloodCellLab)
 			{
-				var bd_ = WhiteBloodCellLab?.IssuedElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<CqlDateTime>(be_);
-				var bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
-				var bh_ = EncounterInpatient?.Period;
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Quantity(1440m, "minutes");
-				var bl_ = context.Operators.Subtract(bj_, bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
-				var bo_ = context.Operators.Start(bn_);
-				var bq_ = context.Operators.Add(bo_, bk_);
-				var br_ = context.Operators.Interval(bl_, bq_, true, true);
-				var bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
-				var bt_ = WhiteBloodCellLab?.StatusElement;
-				var bu_ = bt_?.Value;
-				var bv_ = context.Operators.Convert<string>(bu_);
-				var bw_ = new string[]
+				Instant bd_ = WhiteBloodCellLab?.IssuedElement;
+				DateTimeOffset? be_ = bd_?.Value;
+				CqlDateTime bf_ = context.Operators.Convert<CqlDateTime>(be_);
+				CqlDateTime bg_ = QICoreCommon_2_0_000.earliest((bf_ as object));
+				Period bh_ = EncounterInpatient?.Period;
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlQuantity bk_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bl_ = context.Operators.Subtract(bj_, bk_);
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bh_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
+				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				Code<ObservationStatus> bt_ = WhiteBloodCellLab?.StatusElement;
+				ObservationStatus? bu_ = bt_?.Value;
+				string bv_ = context.Operators.Convert<string>(bu_);
+				string[] bw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
-				var by_ = context.Operators.And(bs_, bx_);
-				var bz_ = WhiteBloodCellLab?.Value;
-				var ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(by_, cb_);
+				bool? bx_ = context.Operators.In<string>(bv_, (bw_ as IEnumerable<string>));
+				bool? by_ = context.Operators.And(bs_, bx_);
+				DataType bz_ = WhiteBloodCellLab?.Value;
+				object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(by_, cb_);
 
 				return cc_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var cd_ = @this?.IssuedElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<CqlDateTime>(ce_);
-				var cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
+				Instant cd_ = @this?.IssuedElement;
+				DateTimeOffset? ce_ = cd_?.Value;
+				CqlDateTime cf_ = context.Operators.Convert<CqlDateTime>(ce_);
+				CqlDateTime cg_ = QICoreCommon_2_0_000.earliest((cf_ as object));
 
 				return cg_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd y_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
 			{
 				EncounterId = e_,
 				FirstResult = (n_ as CqlQuantity),
@@ -2762,104 +2829,106 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
+		IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_White_Blood_Cells_Lab_Test_Value"/>
     [CqlDeclaration("Encounter with First White Blood Cells Lab Test")]
 	public IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_White_Blood_Cells_Lab_Test() => 
 		__Encounter_with_First_White_Blood_Cells_Lab_Test.Value;
 
+    /// <seealso cref="Encounter_with_First_Weight_Recorded_During_Stay"/>
 	private IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Weight_Recorded_During_Stay_Value()
 	{
-		var a_ = this.Inpatient_Encounters();
+		IEnumerable<Encounter> a_ = this.Inpatient_Encounters();
 		Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd b_(Encounter EncounterInpatient)
 		{
-			var d_ = EncounterInpatient?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			Id d_ = EncounterInpatient?.IdElement;
+			string e_ = d_?.Value;
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? g_(Observation WeightExam)
 			{
-				var y_ = WeightExam?.Effective;
-				var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-				var aa_ = QICoreCommon_2_0_000.earliest(z_);
-				var ab_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(EncounterInpatient);
-				var ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, null);
-				var ad_ = WeightExam?.StatusElement;
-				var ae_ = ad_?.Value;
-				var af_ = context.Operators.Convert<string>(ae_);
-				var ag_ = new string[]
+				DataType y_ = WeightExam?.Effective;
+				object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+				CqlDateTime aa_ = QICoreCommon_2_0_000.earliest(z_);
+				CqlInterval<CqlDateTime> ab_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(EncounterInpatient);
+				bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, null);
+				Code<ObservationStatus> ad_ = WeightExam?.StatusElement;
+				ObservationStatus? ae_ = ad_?.Value;
+				string af_ = context.Operators.Convert<string>(ae_);
+				string[] ag_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ah_ = context.Operators.In<string>(af_, (ag_ as IEnumerable<string>));
-				var ai_ = context.Operators.And(ac_, ah_);
-				var aj_ = WeightExam?.Value;
-				var ak_ = context.Operators.Convert<Quantity>(aj_);
-				var al_ = FHIRHelpers_4_3_000.ToQuantity(ak_);
-				var am_ = context.Operators.Not((bool?)(al_ is null));
-				var an_ = context.Operators.And(ai_, am_);
+				bool? ah_ = context.Operators.In<string>(af_, (ag_ as IEnumerable<string>));
+				bool? ai_ = context.Operators.And(ac_, ah_);
+				DataType aj_ = WeightExam?.Value;
+				Quantity ak_ = context.Operators.Convert<Quantity>(aj_);
+				CqlQuantity al_ = FHIRHelpers_4_3_000.ToQuantity(ak_);
+				bool? am_ = context.Operators.Not((bool?)(al_ is null));
+				bool? an_ = context.Operators.And(ai_, am_);
 
 				return an_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			object i_(Observation @this)
 			{
-				var ao_ = @this?.Effective;
-				var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-				var aq_ = QICoreCommon_2_0_000.earliest(ap_);
+				DataType ao_ = @this?.Effective;
+				object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+				CqlDateTime aq_ = QICoreCommon_2_0_000.earliest(ap_);
 
 				return aq_;
 			};
-			var j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.First<Observation>(j_);
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<Quantity>(l_);
-			var n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
+			IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation k_ = context.Operators.First<Observation>(j_);
+			DataType l_ = k_?.Value;
+			Quantity m_ = context.Operators.Convert<Quantity>(l_);
+			CqlQuantity n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
 			bool? p_(Observation WeightExam)
 			{
-				var ar_ = WeightExam?.Effective;
-				var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
-				var at_ = QICoreCommon_2_0_000.earliest(as_);
-				var au_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(EncounterInpatient);
-				var av_ = context.Operators.In<CqlDateTime>(at_, au_, null);
-				var aw_ = WeightExam?.StatusElement;
-				var ax_ = aw_?.Value;
-				var ay_ = context.Operators.Convert<string>(ax_);
-				var az_ = new string[]
+				DataType ar_ = WeightExam?.Effective;
+				object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+				CqlDateTime at_ = QICoreCommon_2_0_000.earliest(as_);
+				CqlInterval<CqlDateTime> au_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(EncounterInpatient);
+				bool? av_ = context.Operators.In<CqlDateTime>(at_, au_, null);
+				Code<ObservationStatus> aw_ = WeightExam?.StatusElement;
+				ObservationStatus? ax_ = aw_?.Value;
+				string ay_ = context.Operators.Convert<string>(ax_);
+				string[] az_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ba_ = context.Operators.In<string>(ay_, (az_ as IEnumerable<string>));
-				var bb_ = context.Operators.And(av_, ba_);
-				var bc_ = WeightExam?.Value;
-				var bd_ = context.Operators.Convert<Quantity>(bc_);
-				var be_ = FHIRHelpers_4_3_000.ToQuantity(bd_);
-				var bf_ = context.Operators.Not((bool?)(be_ is null));
-				var bg_ = context.Operators.And(bb_, bf_);
+				bool? ba_ = context.Operators.In<string>(ay_, (az_ as IEnumerable<string>));
+				bool? bb_ = context.Operators.And(av_, ba_);
+				DataType bc_ = WeightExam?.Value;
+				Quantity bd_ = context.Operators.Convert<Quantity>(bc_);
+				CqlQuantity be_ = FHIRHelpers_4_3_000.ToQuantity(bd_);
+				bool? bf_ = context.Operators.Not((bool?)(be_ is null));
+				bool? bg_ = context.Operators.And(bb_, bf_);
 
 				return bg_;
 			};
-			var q_ = context.Operators.Where<Observation>(f_, p_);
+			IEnumerable<Observation> q_ = context.Operators.Where<Observation>(f_, p_);
 			object r_(Observation @this)
 			{
-				var bh_ = @this?.Effective;
-				var bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
-				var bj_ = QICoreCommon_2_0_000.earliest(bi_);
+				DataType bh_ = @this?.Effective;
+				object bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
+				CqlDateTime bj_ = QICoreCommon_2_0_000.earliest(bi_);
 
 				return bj_;
 			};
-			var s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
-			var t_ = context.Operators.First<Observation>(s_);
-			var u_ = t_?.Effective;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = QICoreCommon_2_0_000.earliest(v_);
-			var x_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
+			IEnumerable<Observation> s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation t_ = context.Operators.First<Observation>(s_);
+			DataType u_ = t_?.Effective;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			CqlDateTime w_ = QICoreCommon_2_0_000.earliest(v_);
+			Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd x_ = new Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd
 			{
 				EncounterId = e_,
 				FirstResult = n_,
@@ -2868,55 +2937,64 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 			return x_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
+		IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> c_ = context.Operators.Select<Encounter, Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Weight_Recorded_During_Stay_Value"/>
     [CqlDeclaration("Encounter with First Weight Recorded During Stay")]
 	public IEnumerable<Tuple_HDVhZFAYAdGHPZJWcDFSNFGPd> Encounter_with_First_Weight_Recorded_During_Stay() => 
 		__Encounter_with_First_Weight_Recorded_During_Stay.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
@@ -142,160 +142,201 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 
     #endregion
 
+    /// <seealso cref="Active_Tuberculosis_for_Urology_Care"/>
 	private CqlValueSet Active_Tuberculosis_for_Urology_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56", null);
 
+    /// <seealso cref="Active_Tuberculosis_for_Urology_Care_Value"/>
     [CqlDeclaration("Active Tuberculosis for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56")]
 	public CqlValueSet Active_Tuberculosis_for_Urology_Care() => 
 		__Active_Tuberculosis_for_Urology_Care.Value;
 
+    /// <seealso cref="BCG_Bacillus_Calmette_Guerin_for_Urology_Care"/>
 	private CqlValueSet BCG_Bacillus_Calmette_Guerin_for_Urology_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52", null);
 
+    /// <seealso cref="BCG_Bacillus_Calmette_Guerin_for_Urology_Care_Value"/>
     [CqlDeclaration("BCG Bacillus Calmette Guerin for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52")]
 	public CqlValueSet BCG_Bacillus_Calmette_Guerin_for_Urology_Care() => 
 		__BCG_Bacillus_Calmette_Guerin_for_Urology_Care.Value;
 
+    /// <seealso cref="Bladder_Cancer_for_Urology_Care"/>
 	private CqlValueSet Bladder_Cancer_for_Urology_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45", null);
 
+    /// <seealso cref="Bladder_Cancer_for_Urology_Care_Value"/>
     [CqlDeclaration("Bladder Cancer for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45")]
 	public CqlValueSet Bladder_Cancer_for_Urology_Care() => 
 		__Bladder_Cancer_for_Urology_Care.Value;
 
+    /// <seealso cref="Chemotherapy_Agents_for_Advanced_Cancer"/>
 	private CqlValueSet Chemotherapy_Agents_for_Advanced_Cancer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60", null);
 
+    /// <seealso cref="Chemotherapy_Agents_for_Advanced_Cancer_Value"/>
     [CqlDeclaration("Chemotherapy Agents for Advanced Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60")]
 	public CqlValueSet Chemotherapy_Agents_for_Advanced_Cancer() => 
 		__Chemotherapy_Agents_for_Advanced_Cancer.Value;
 
+    /// <seealso cref="Cystectomy_for_Urology_Care"/>
 	private CqlValueSet Cystectomy_for_Urology_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55", null);
 
+    /// <seealso cref="Cystectomy_for_Urology_Care_Value"/>
     [CqlDeclaration("Cystectomy for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55")]
 	public CqlValueSet Cystectomy_for_Urology_Care() => 
 		__Cystectomy_for_Urology_Care.Value;
 
+    /// <seealso cref="HIV"/>
 	private CqlValueSet HIV_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
 
+    /// <seealso cref="HIV_Value"/>
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
 	public CqlValueSet HIV() => 
 		__HIV.Value;
 
+    /// <seealso cref="Immunocompromised_Conditions"/>
 	private CqlValueSet Immunocompromised_Conditions_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940", null);
 
+    /// <seealso cref="Immunocompromised_Conditions_Value"/>
     [CqlDeclaration("Immunocompromised Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940")]
 	public CqlValueSet Immunocompromised_Conditions() => 
 		__Immunocompromised_Conditions.Value;
 
+    /// <seealso cref="Immunosuppressive_Drugs_for_Urology_Care"/>
 	private CqlValueSet Immunosuppressive_Drugs_for_Urology_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32", null);
 
+    /// <seealso cref="Immunosuppressive_Drugs_for_Urology_Care_Value"/>
     [CqlDeclaration("Immunosuppressive Drugs for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32")]
 	public CqlValueSet Immunosuppressive_Drugs_for_Urology_Care() => 
 		__Immunosuppressive_Drugs_for_Urology_Care.Value;
 
+    /// <seealso cref="Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care"/>
 	private CqlValueSet Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39", null);
 
+    /// <seealso cref="Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care_Value"/>
     [CqlDeclaration("Mixed histology urothelial cell carcinoma for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39")]
 	public CqlValueSet Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care() => 
 		__Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care"/>
 	private CqlValueSet Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44", null);
 
+    /// <seealso cref="Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care_Value"/>
     [CqlDeclaration("Unavailability of Bacillus Calmette Guerin for urology care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44")]
 	public CqlValueSet Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care() => 
 		__Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care.Value;
 
+    /// <seealso cref="Carcinoma_in_situ_of_bladder"/>
 	private CqlCode Carcinoma_in_situ_of_bladder_Value() => 
 		new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
 
+    /// <seealso cref="Carcinoma_in_situ_of_bladder_Value"/>
     [CqlDeclaration("Carcinoma in situ of bladder")]
 	public CqlCode Carcinoma_in_situ_of_bladder() => 
 		__Carcinoma_in_situ_of_bladder.Value;
 
+    /// <seealso cref="Combined_radiotherapy__procedure_"/>
 	private CqlCode Combined_radiotherapy__procedure__Value() => 
 		new CqlCode("169331000", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Combined_radiotherapy__procedure__Value"/>
     [CqlDeclaration("Combined radiotherapy (procedure)")]
 	public CqlCode Combined_radiotherapy__procedure_() => 
 		__Combined_radiotherapy__procedure_.Value;
 
+    /// <seealso cref="T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_"/>
 	private CqlCode T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding__Value() => 
 		new CqlCode("369935001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding__Value"/>
     [CqlDeclaration("T1: Urinary tract tumor invades subepithelial connective tissue (finding)")]
 	public CqlCode T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_() => 
 		__T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_.Value;
 
+    /// <seealso cref="Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_"/>
 	private CqlCode Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding__Value() => 
 		new CqlCode("369949005", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding__Value"/>
     [CqlDeclaration("Ta: Noninvasive papillary carcinoma (urinary tract) (finding)")]
 	public CqlCode Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_() => 
 		__Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_.Value;
 
+    /// <seealso cref="Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_"/>
 	private CqlCode Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding__Value() => 
 		new CqlCode("369934002", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding__Value"/>
     [CqlDeclaration("Tis: Carcinoma in situ (flat tumor of urinary bladder) (finding)")]
 	public CqlCode Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_() => 
 		__Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_.Value;
 
+    /// <seealso cref="Tumor_staging__tumor_staging_"/>
 	private CqlCode Tumor_staging__tumor_staging__Value() => 
 		new CqlCode("254292007", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Tumor_staging__tumor_staging__Value"/>
     [CqlDeclaration("Tumor staging (tumor staging)")]
 	public CqlCode Tumor_staging__tumor_staging_() => 
 		__Tumor_staging__tumor_staging_.Value;
 
+    /// <seealso cref="Dead__finding_"/>
 	private CqlCode Dead__finding__Value() => 
 		new CqlCode("419099009", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Dead__finding__Value"/>
     [CqlDeclaration("Dead (finding)")]
 	public CqlCode Dead__finding_() => 
 		__Dead__finding_.Value;
 
+    /// <seealso cref="@virtual"/>
 	private CqlCode @virtual_Value() => 
 		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="@virtual_Value"/>
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
+    /// <seealso cref="Stage_group_pathology_Cancer"/>
 	private CqlCode Stage_group_pathology_Cancer_Value() => 
 		new CqlCode("21902-2", "http://loinc.org", null, null);
 
+    /// <seealso cref="Stage_group_pathology_Cancer_Value"/>
     [CqlDeclaration("Stage group.pathology Cancer")]
 	public CqlCode Stage_group_pathology_Cancer() => 
 		__Stage_group_pathology_Cancer.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("169331000", "http://snomed.info/sct", null, null),
 			new CqlCode("369935001", "http://snomed.info/sct", null, null),
@@ -308,13 +349,15 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="ICD10CM"/>
 	private CqlCode[] ICD10CM_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
 		};
@@ -322,13 +365,15 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		return a_;
 	}
 
+    /// <seealso cref="ICD10CM_Value"/>
     [CqlDeclaration("ICD10CM")]
 	public CqlCode[] ICD10CM() => 
 		__ICD10CM.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("21902-2", "http://loinc.org", null, null),
 		};
@@ -336,13 +381,15 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 		};
@@ -350,32 +397,37 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
@@ -383,215 +435,227 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
     [CqlDeclaration("isConfirmedActiveDiagnosis")]
 	public bool? isConfirmedActiveDiagnosis(Condition Condition)
 	{
-		var a_ = new Condition[]
+		Condition[] a_ = new Condition[]
 		{
 			Condition,
 		};
 		bool? b_(Condition Diagnosis)
 		{
-			var f_ = Diagnosis?.ClinicalStatus;
-			var g_ = FHIRHelpers_4_3_000.ToConcept(f_);
-			var h_ = QICoreCommon_2_0_000.active();
-			var i_ = context.Operators.ConvertCodeToConcept(h_);
-			var j_ = context.Operators.Equivalent(g_, i_);
-			var k_ = Diagnosis?.VerificationStatus;
-			var l_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var m_ = QICoreCommon_2_0_000.unconfirmed();
-			var n_ = context.Operators.ConvertCodeToConcept(m_);
-			var o_ = context.Operators.Equivalent(l_, n_);
-			var q_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var r_ = QICoreCommon_2_0_000.refuted();
-			var s_ = context.Operators.ConvertCodeToConcept(r_);
-			var t_ = context.Operators.Equivalent(q_, s_);
-			var u_ = context.Operators.Or(o_, t_);
-			var w_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var x_ = QICoreCommon_2_0_000.entered_in_error();
-			var y_ = context.Operators.ConvertCodeToConcept(x_);
-			var z_ = context.Operators.Equivalent(w_, y_);
-			var aa_ = context.Operators.Or(u_, z_);
-			var ab_ = context.Operators.Not(aa_);
-			var ac_ = context.Operators.And(j_, ab_);
+			CodeableConcept f_ = Diagnosis?.ClinicalStatus;
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(f_);
+			CqlCode h_ = QICoreCommon_2_0_000.active();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(g_, i_);
+			CodeableConcept k_ = Diagnosis?.VerificationStatus;
+			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode m_ = QICoreCommon_2_0_000.unconfirmed();
+			CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
+			bool? o_ = context.Operators.Equivalent(l_, n_);
+			CqlConcept q_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode r_ = QICoreCommon_2_0_000.refuted();
+			CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+			bool? t_ = context.Operators.Equivalent(q_, s_);
+			bool? u_ = context.Operators.Or(o_, t_);
+			CqlConcept w_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode x_ = QICoreCommon_2_0_000.entered_in_error();
+			CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
+			bool? z_ = context.Operators.Equivalent(w_, y_);
+			bool? aa_ = context.Operators.Or(u_, z_);
+			bool? ab_ = context.Operators.Not(aa_);
+			bool? ac_ = context.Operators.And(j_, ab_);
 
 			return ac_;
 		};
-		var c_ = context.Operators.Where<Condition>((IEnumerable<Condition>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<Condition>(c_);
-		var e_ = context.Operators.Not((bool?)(d_ is null));
+		IEnumerable<Condition> c_ = context.Operators.Where<Condition>((IEnumerable<Condition>)a_, b_);
+		Condition d_ = context.Operators.SingletonFrom<Condition>(c_);
+		bool? e_ = context.Operators.Not((bool?)(d_ is null));
 
 		return e_;
 	}
 
+    /// <seealso cref="Bladder_Cancer_Diagnosis"/>
 	private IEnumerable<Condition> Bladder_Cancer_Diagnosis_Value()
 	{
-		var a_ = this.Bladder_Cancer_for_Urology_Care();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Bladder_Cancer_for_Urology_Care();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition BladderCancer)
 		{
-			var e_ = QICoreCommon_2_0_000.prevalenceInterval(BladderCancer);
-			var f_ = context.Operators.Start(e_);
-			var g_ = this.Measurement_Period();
-			var h_ = context.Operators.End(g_);
-			var i_ = context.Operators.Before(f_, h_, null);
-			var j_ = this.isConfirmedActiveDiagnosis(BladderCancer);
-			var k_ = context.Operators.And(i_, j_);
+			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.prevalenceInterval(BladderCancer);
+			CqlDateTime f_ = context.Operators.Start(e_);
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			CqlDateTime h_ = context.Operators.End(g_);
+			bool? i_ = context.Operators.Before(f_, h_, null);
+			bool? j_ = this.isConfirmedActiveDiagnosis(BladderCancer);
+			bool? k_ = context.Operators.And(i_, j_);
 
 			return k_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Bladder_Cancer_Diagnosis_Value"/>
     [CqlDeclaration("Bladder Cancer Diagnosis")]
 	public IEnumerable<Condition> Bladder_Cancer_Diagnosis() => 
 		__Bladder_Cancer_Diagnosis.Value;
 
+    /// <seealso cref="First_Bladder_Cancer_Staging_Procedure"/>
 	private Procedure First_Bladder_Cancer_Staging_Procedure_Value()
 	{
-		var a_ = this.Tumor_staging__tumor_staging_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Procedure>(b_, null);
+		CqlCode a_ = this.Tumor_staging__tumor_staging_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, null);
 		IEnumerable<Procedure> d_(Procedure BladderCancerStaging)
 		{
-			var k_ = this.Bladder_Cancer_Diagnosis();
+			IEnumerable<Condition> k_ = this.Bladder_Cancer_Diagnosis();
 			bool? l_(Condition BladderCancer)
 			{
-				var p_ = BladderCancerStaging?.Performed;
-				var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-				var r_ = QICoreCommon_2_0_000.toInterval(q_);
-				var s_ = context.Operators.Start(r_);
-				var t_ = QICoreCommon_2_0_000.prevalenceInterval(BladderCancer);
-				var u_ = context.Operators.Start(t_);
-				var v_ = context.Operators.SameOrBefore(s_, u_, "day");
-				var x_ = FHIRHelpers_4_3_000.ToValue(p_);
-				var y_ = QICoreCommon_2_0_000.toInterval(x_);
-				var aa_ = context.Operators.Overlaps(y_, t_, "day");
-				var ab_ = context.Operators.And(v_, aa_);
+				DataType p_ = BladderCancerStaging?.Performed;
+				object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+				CqlInterval<CqlDateTime> r_ = QICoreCommon_2_0_000.toInterval(q_);
+				CqlDateTime s_ = context.Operators.Start(r_);
+				CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.prevalenceInterval(BladderCancer);
+				CqlDateTime u_ = context.Operators.Start(t_);
+				bool? v_ = context.Operators.SameOrBefore(s_, u_, "day");
+				object x_ = FHIRHelpers_4_3_000.ToValue(p_);
+				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
+				bool? aa_ = context.Operators.Overlaps(y_, t_, "day");
+				bool? ab_ = context.Operators.And(v_, aa_);
 
 				return ab_;
 			};
-			var m_ = context.Operators.Where<Condition>(k_, l_);
+			IEnumerable<Condition> m_ = context.Operators.Where<Condition>(k_, l_);
 			Procedure n_(Condition BladderCancer) => 
 				BladderCancerStaging;
-			var o_ = context.Operators.Select<Condition, Procedure>(m_, n_);
+			IEnumerable<Procedure> o_ = context.Operators.Select<Condition, Procedure>(m_, n_);
 
 			return o_;
 		};
-		var e_ = context.Operators.SelectMany<Procedure, Procedure>(c_, d_);
+		IEnumerable<Procedure> e_ = context.Operators.SelectMany<Procedure, Procedure>(c_, d_);
 		bool? f_(Procedure BladderCancerStaging)
 		{
-			var ac_ = BladderCancerStaging?.StatusElement;
-			var ad_ = ac_?.Value;
-			var ae_ = context.Operators.Convert<string>(ad_);
-			var af_ = context.Operators.Equal(ae_, "completed");
+			Code<EventStatus> ac_ = BladderCancerStaging?.StatusElement;
+			EventStatus? ad_ = ac_?.Value;
+			string ae_ = context.Operators.Convert<string>(ad_);
+			bool? af_ = context.Operators.Equal(ae_, "completed");
 
 			return af_;
 		};
-		var g_ = context.Operators.Where<Procedure>(e_, f_);
+		IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
 		object h_(Procedure @this)
 		{
-			var ag_ = @this?.Performed;
-			var ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
-			var ai_ = QICoreCommon_2_0_000.toInterval(ah_);
-			var aj_ = context.Operators.Start(ai_);
+			DataType ag_ = @this?.Performed;
+			object ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
+			CqlInterval<CqlDateTime> ai_ = QICoreCommon_2_0_000.toInterval(ah_);
+			CqlDateTime aj_ = context.Operators.Start(ai_);
 
 			return aj_;
 		};
-		var i_ = context.Operators.SortBy<Procedure>(g_, h_, System.ComponentModel.ListSortDirection.Ascending);
-		var j_ = context.Operators.First<Procedure>(i_);
+		IEnumerable<Procedure> i_ = context.Operators.SortBy<Procedure>(g_, h_, System.ComponentModel.ListSortDirection.Ascending);
+		Procedure j_ = context.Operators.First<Procedure>(i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="First_Bladder_Cancer_Staging_Procedure_Value"/>
     [CqlDeclaration("First Bladder Cancer Staging Procedure")]
 	public Procedure First_Bladder_Cancer_Staging_Procedure() => 
 		__First_Bladder_Cancer_Staging_Procedure.Value;
 
+    /// <seealso cref="July_1_of_Year_Prior_to_the_Measurement_Period"/>
 	private CqlDateTime July_1_of_Year_Prior_to_the_Measurement_Period_Value()
 	{
-		var a_ = this.Measurement_Period();
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateTimeComponentFrom(b_, "year");
-		var d_ = context.Operators.Subtract(c_, 1);
-		var e_ = context.Operators.ConvertIntegerToDecimal(0);
-		var f_ = context.Operators.DateTime(d_, 7, 1, 0, 0, 0, 0, e_);
+		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
+		CqlDateTime b_ = context.Operators.Start(a_);
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? d_ = context.Operators.Subtract(c_, 1);
+		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
+		CqlDateTime f_ = context.Operators.DateTime(d_, 7, 1, 0, 0, 0, 0, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="July_1_of_Year_Prior_to_the_Measurement_Period_Value"/>
     [CqlDeclaration("July 1 of Year Prior to the Measurement Period")]
 	public CqlDateTime July_1_of_Year_Prior_to_the_Measurement_Period() => 
 		__July_1_of_Year_Prior_to_the_Measurement_Period.Value;
 
+    /// <seealso cref="June_30_of_the_Measurement_Period"/>
 	private CqlDateTime June_30_of_the_Measurement_Period_Value()
 	{
-		var a_ = this.Measurement_Period();
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateTimeComponentFrom(b_, "year");
-		var d_ = context.Operators.ConvertIntegerToDecimal(0);
-		var e_ = context.Operators.DateTime(c_, 6, 30, 23, 59, 59, 0, d_);
+		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
+		CqlDateTime b_ = context.Operators.Start(a_);
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		decimal? d_ = context.Operators.ConvertIntegerToDecimal(0);
+		CqlDateTime e_ = context.Operators.DateTime(c_, 6, 30, 23, 59, 59, 0, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="June_30_of_the_Measurement_Period_Value"/>
     [CqlDeclaration("June 30 of the Measurement Period")]
 	public CqlDateTime June_30_of_the_Measurement_Period() => 
 		__June_30_of_the_Measurement_Period.Value;
 
+    /// <seealso cref="First_Qualifying_Bladder_Cancer_Staging_Procedure"/>
 	private Procedure First_Qualifying_Bladder_Cancer_Staging_Procedure_Value()
 	{
-		var a_ = this.First_Bladder_Cancer_Staging_Procedure();
-		var b_ = new Procedure[]
+		Procedure a_ = this.First_Bladder_Cancer_Staging_Procedure();
+		Procedure[] b_ = new Procedure[]
 		{
 			a_,
 		};
 		bool? c_(Procedure FirstBladderCancerStaging)
 		{
-			var f_ = this.July_1_of_Year_Prior_to_the_Measurement_Period();
-			var g_ = this.June_30_of_the_Measurement_Period();
-			var h_ = context.Operators.Interval(f_, g_, true, true);
-			var i_ = FirstBladderCancerStaging?.Performed;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = QICoreCommon_2_0_000.toInterval(j_);
-			var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, "day");
+			CqlDateTime f_ = this.July_1_of_Year_Prior_to_the_Measurement_Period();
+			CqlDateTime g_ = this.June_30_of_the_Measurement_Period();
+			CqlInterval<CqlDateTime> h_ = context.Operators.Interval(f_, g_, true, true);
+			DataType i_ = FirstBladderCancerStaging?.Performed;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, "day");
 
 			return l_;
 		};
-		var d_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<Procedure>(d_);
+		IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)b_, c_);
+		Procedure e_ = context.Operators.SingletonFrom<Procedure>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="First_Qualifying_Bladder_Cancer_Staging_Procedure_Value"/>
     [CqlDeclaration("First Qualifying Bladder Cancer Staging Procedure")]
 	public Procedure First_Qualifying_Bladder_Cancer_Staging_Procedure() => 
 		__First_Qualifying_Bladder_Cancer_Staging_Procedure.Value;
 
+    /// <seealso cref="First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period"/>
 	private Procedure First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period_Value()
 	{
-		var a_ = this.First_Bladder_Cancer_Staging_Procedure();
-		var b_ = new Procedure[]
+		Procedure a_ = this.First_Bladder_Cancer_Staging_Procedure();
+		Procedure[] b_ = new Procedure[]
 		{
 			a_,
 		};
 		bool? c_(Procedure FirstBladderCancerStaging)
 		{
-			var f_ = this.July_1_of_Year_Prior_to_the_Measurement_Period();
-			var g_ = this.June_30_of_the_Measurement_Period();
-			var h_ = context.Operators.Interval(f_, g_, true, true);
-			var i_ = FirstBladderCancerStaging?.Performed;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = QICoreCommon_2_0_000.toInterval(j_);
-			var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, "day");
+			CqlDateTime f_ = this.July_1_of_Year_Prior_to_the_Measurement_Period();
+			CqlDateTime g_ = this.June_30_of_the_Measurement_Period();
+			CqlInterval<CqlDateTime> h_ = context.Operators.Interval(f_, g_, true, true);
+			DataType i_ = FirstBladderCancerStaging?.Performed;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, "day");
 
 			return l_;
 		};
-		var d_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<Procedure>(d_);
+		IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)b_, c_);
+		Procedure e_ = context.Operators.SingletonFrom<Procedure>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period_Value"/>
     [CqlDeclaration("First Bladder Cancer Staging Procedure during 6 Months Prior to Measurement Period through the First 6 Months of Measurement Period")]
 	public Procedure First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period() => 
 		__First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period.Value;
@@ -599,160 +663,170 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
     [CqlDeclaration("getStagingProcedure")]
 	public IEnumerable<Procedure> getStagingProcedure(Observation StagingObservation)
 	{
-		Procedure a_(ResourceReference StagingReference)
+		List<ResourceReference> a_ = StagingObservation?.PartOf;
+		Procedure b_(ResourceReference StagingReference)
 		{
-			var c_ = this.First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period();
-			var d_ = new Procedure[]
+			Procedure d_ = this.First_Bladder_Cancer_Staging_Procedure_during_6_Months_Prior_to_Measurement_Period_through_the_First_6_Months_of_Measurement_Period();
+			Procedure[] e_ = new Procedure[]
 			{
-				c_,
+				d_,
 			};
-			bool? e_(Procedure FirstBladderCancerStagingMP)
+			bool? f_(Procedure FirstBladderCancerStagingMP)
 			{
-				var h_ = FirstBladderCancerStagingMP?.IdElement;
-				var i_ = h_?.Value;
-				var j_ = StagingReference?.ReferenceElement;
-				var k_ = j_?.Value;
-				var l_ = QICoreCommon_2_0_000.getId(k_);
-				var m_ = context.Operators.Equal(i_, l_);
+				Id i_ = FirstBladderCancerStagingMP?.IdElement;
+				string j_ = i_?.Value;
+				FhirString k_ = StagingReference?.ReferenceElement;
+				string l_ = k_?.Value;
+				string m_ = QICoreCommon_2_0_000.getId(l_);
+				bool? n_ = context.Operators.Equal(j_, m_);
 
-				return m_;
+				return n_;
 			};
-			var f_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)d_, e_);
-			var g_ = context.Operators.SingletonFrom<Procedure>(f_);
+			IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)e_, f_);
+			Procedure h_ = context.Operators.SingletonFrom<Procedure>(g_);
 
-			return g_;
+			return h_;
 		};
-		var b_ = context.Operators.Select<ResourceReference, Procedure>((IEnumerable<ResourceReference>)StagingObservation?.PartOf, a_);
+		IEnumerable<Procedure> c_ = context.Operators.Select<ResourceReference, Procedure>((IEnumerable<ResourceReference>)a_, b_);
 
-		return b_;
+		return c_;
 	}
 
+    /// <seealso cref="Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1"/>
 	private bool? Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1_Value()
 	{
-		var a_ = this.Stage_group_pathology_Cancer();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.Stage_group_pathology_Cancer();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation StagingObservation)
 		{
-			var g_ = this.getStagingProcedure(StagingObservation);
-			var h_ = context.Operators.Not((bool?)(g_ is null));
-			var i_ = StagingObservation?.Value;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var k_ = this.T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_();
-			var l_ = context.Operators.ConvertCodeToConcept(k_);
-			var m_ = context.Operators.Equivalent((j_ as CqlConcept), l_);
-			var o_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var p_ = this.Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_();
-			var q_ = context.Operators.ConvertCodeToConcept(p_);
-			var r_ = context.Operators.Equivalent((o_ as CqlConcept), q_);
-			var s_ = context.Operators.Or(m_, r_);
-			var u_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var v_ = this.Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_();
-			var w_ = context.Operators.ConvertCodeToConcept(v_);
-			var x_ = context.Operators.Equivalent((u_ as CqlConcept), w_);
-			var y_ = context.Operators.Or(s_, x_);
-			var aa_ = FHIRHelpers_4_3_000.ToValue(i_);
-			var ab_ = this.Carcinoma_in_situ_of_bladder();
-			var ac_ = context.Operators.ConvertCodeToConcept(ab_);
-			var ad_ = context.Operators.Equivalent((aa_ as CqlConcept), ac_);
-			var ae_ = context.Operators.Or(y_, ad_);
-			var af_ = context.Operators.And(h_, ae_);
-			var ag_ = StagingObservation?.StatusElement;
-			var ah_ = ag_?.Value;
-			var ai_ = context.Operators.Convert<Code<ObservationStatus>>(ah_);
-			var aj_ = context.Operators.Convert<string>(ai_);
-			var ak_ = new string[]
+			IEnumerable<Procedure> g_ = this.getStagingProcedure(StagingObservation);
+			bool? h_ = context.Operators.Not((bool?)(g_ is null));
+			DataType i_ = StagingObservation?.Value;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlCode k_ = this.T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_();
+			CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+			bool? m_ = context.Operators.Equivalent((j_ as CqlConcept), l_);
+			object o_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlCode p_ = this.Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_();
+			CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+			bool? r_ = context.Operators.Equivalent((o_ as CqlConcept), q_);
+			bool? s_ = context.Operators.Or(m_, r_);
+			object u_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlCode v_ = this.Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_();
+			CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
+			bool? x_ = context.Operators.Equivalent((u_ as CqlConcept), w_);
+			bool? y_ = context.Operators.Or(s_, x_);
+			object aa_ = FHIRHelpers_4_3_000.ToValue(i_);
+			CqlCode ab_ = this.Carcinoma_in_situ_of_bladder();
+			CqlConcept ac_ = context.Operators.ConvertCodeToConcept(ab_);
+			bool? ad_ = context.Operators.Equivalent((aa_ as CqlConcept), ac_);
+			bool? ae_ = context.Operators.Or(y_, ad_);
+			bool? af_ = context.Operators.And(h_, ae_);
+			Code<ObservationStatus> ag_ = StagingObservation?.StatusElement;
+			ObservationStatus? ah_ = ag_?.Value;
+			Code<ObservationStatus> ai_ = context.Operators.Convert<Code<ObservationStatus>>(ah_);
+			string aj_ = context.Operators.Convert<string>(ai_);
+			string[] ak_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var al_ = context.Operators.In<string>(aj_, (ak_ as IEnumerable<string>));
-			var am_ = context.Operators.And(af_, al_);
+			bool? al_ = context.Operators.In<string>(aj_, (ak_ as IEnumerable<string>));
+			bool? am_ = context.Operators.And(af_, al_);
 
 			return am_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
-		var f_ = context.Operators.Exists<Observation>(e_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
+		bool? f_ = context.Operators.Exists<Observation>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1_Value"/>
     [CqlDeclaration("Has Most Recent Bladder Cancer Tumor Staging is Ta HG, Tis, T1")]
 	public bool? Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1() => 
 		__Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1.Value;
 
+    /// <seealso cref="Has_Qualifying_Encounter"/>
 	private bool? Has_Qualifying_Encounter_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter ValidEncounter)
 		{
-			var f_ = this.Measurement_Period();
-			var g_ = ValidEncounter?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, null);
-			var j_ = ValidEncounter?.Class;
-			var k_ = FHIRHelpers_4_3_000.ToCode(j_);
-			var l_ = this.@virtual();
-			var m_ = context.Operators.Equivalent(k_, l_);
-			var n_ = context.Operators.Not(m_);
-			var o_ = context.Operators.And(i_, n_);
-			var p_ = ValidEncounter?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
-			var s_ = context.Operators.Equal(r_, "finished");
-			var t_ = context.Operators.And(o_, s_);
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			Period g_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, null);
+			Coding j_ = ValidEncounter?.Class;
+			CqlCode k_ = FHIRHelpers_4_3_000.ToCode(j_);
+			CqlCode l_ = this.@virtual();
+			bool? m_ = context.Operators.Equivalent(k_, l_);
+			bool? n_ = context.Operators.Not(m_);
+			bool? o_ = context.Operators.And(i_, n_);
+			Code<Encounter.EncounterStatus> p_ = ValidEncounter?.StatusElement;
+			Encounter.EncounterStatus? q_ = p_?.Value;
+			Code<Encounter.EncounterStatus> r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
+			bool? s_ = context.Operators.Equal(r_, "finished");
+			bool? t_ = context.Operators.And(o_, s_);
 
 			return t_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
-		var e_ = context.Operators.Exists<Encounter>(d_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
+		bool? e_ = context.Operators.Exists<Encounter>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Qualifying_Encounter_Value"/>
     [CqlDeclaration("Has Qualifying Encounter")]
 	public bool? Has_Qualifying_Encounter() => 
 		__Has_Qualifying_Encounter.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.First_Qualifying_Bladder_Cancer_Staging_Procedure();
-		var b_ = context.Operators.Not((bool?)(a_ is null));
-		var c_ = this.Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1();
-		var d_ = context.Operators.And(b_, c_);
-		var e_ = this.Has_Qualifying_Encounter();
-		var f_ = context.Operators.And(d_, e_);
+		Procedure a_ = this.First_Qualifying_Bladder_Cancer_Staging_Procedure();
+		bool? b_ = context.Operators.Not((bool?)(a_ is null));
+		bool? c_ = this.Has_Most_Recent_Bladder_Cancer_Tumor_Staging_is_Ta_HG__Tis__T1();
+		bool? d_ = context.Operators.And(b_, c_);
+		bool? e_ = this.Has_Qualifying_Encounter();
+		bool? f_ = context.Operators.And(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging"/>
 	private IEnumerable<MedicationAdministration> BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging_Value()
 	{
-		var a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
+		CqlValueSet a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		IEnumerable<MedicationAdministration> f_(MedicationAdministration BCGNotGiven)
 		{
-			var j_ = this.First_Bladder_Cancer_Staging_Procedure();
-			var k_ = new Procedure[]
+			Procedure j_ = this.First_Bladder_Cancer_Staging_Procedure();
+			Procedure[] k_ = new Procedure[]
 			{
 				j_,
 			};
@@ -760,607 +834,634 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 			{
 				bool? p_(Extension @this)
 				{
-					var aw_ = @this?.Url;
-					var ax_ = context.Operators.Convert<FhirUri>(aw_);
-					var ay_ = FHIRHelpers_4_3_000.ToString(ax_);
-					var az_ = context.Operators.Equal(ay_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+					string aw_ = @this?.Url;
+					FhirUri ax_ = context.Operators.Convert<FhirUri>(aw_);
+					string ay_ = FHIRHelpers_4_3_000.ToString(ax_);
+					bool? az_ = context.Operators.Equal(ay_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
 
 					return az_;
 				};
-				var q_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((BCGNotGiven is DomainResource)
+				IEnumerable<Extension> q_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((BCGNotGiven is DomainResource)
 						? ((BCGNotGiven as DomainResource).Extension)
 						: null), p_);
 				DataType r_(Extension @this)
 				{
-					var ba_ = @this?.Value;
+					DataType ba_ = @this?.Value;
 
 					return ba_;
 				};
-				var s_ = context.Operators.Select<Extension, DataType>(q_, r_);
-				var t_ = context.Operators.SingletonFrom<DataType>(s_);
-				var u_ = context.Operators.Convert<CqlDateTime>(t_);
-				var v_ = FirstBladderCancerStaging?.Performed;
-				var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-				var x_ = QICoreCommon_2_0_000.toInterval(w_);
-				var y_ = context.Operators.Start(x_);
-				var aa_ = FHIRHelpers_4_3_000.ToValue(v_);
-				var ab_ = QICoreCommon_2_0_000.toInterval(aa_);
-				var ac_ = context.Operators.Start(ab_);
-				var ad_ = context.Operators.Quantity(6m, "months");
-				var ae_ = context.Operators.Add(ac_, ad_);
-				var af_ = context.Operators.Interval(y_, ae_, false, true);
-				var ag_ = context.Operators.In<CqlDateTime>(u_, af_, null);
-				var ai_ = FHIRHelpers_4_3_000.ToValue(v_);
-				var aj_ = QICoreCommon_2_0_000.toInterval(ai_);
-				var ak_ = context.Operators.Start(aj_);
-				var al_ = context.Operators.Not((bool?)(ak_ is null));
-				var am_ = context.Operators.And(ag_, al_);
+				IEnumerable<DataType> s_ = context.Operators.Select<Extension, DataType>(q_, r_);
+				DataType t_ = context.Operators.SingletonFrom<DataType>(s_);
+				CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(t_);
+				DataType v_ = FirstBladderCancerStaging?.Performed;
+				object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+				CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.toInterval(w_);
+				CqlDateTime y_ = context.Operators.Start(x_);
+				object aa_ = FHIRHelpers_4_3_000.ToValue(v_);
+				CqlInterval<CqlDateTime> ab_ = QICoreCommon_2_0_000.toInterval(aa_);
+				CqlDateTime ac_ = context.Operators.Start(ab_);
+				CqlQuantity ad_ = context.Operators.Quantity(6m, "months");
+				CqlDateTime ae_ = context.Operators.Add(ac_, ad_);
+				CqlInterval<CqlDateTime> af_ = context.Operators.Interval(y_, ae_, false, true);
+				bool? ag_ = context.Operators.In<CqlDateTime>(u_, af_, null);
+				object ai_ = FHIRHelpers_4_3_000.ToValue(v_);
+				CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				bool? al_ = context.Operators.Not((bool?)(ak_ is null));
+				bool? am_ = context.Operators.And(ag_, al_);
 				bool? an_(Extension @this)
 				{
-					var bb_ = @this?.Url;
-					var bc_ = context.Operators.Convert<FhirUri>(bb_);
-					var bd_ = FHIRHelpers_4_3_000.ToString(bc_);
-					var be_ = context.Operators.Equal(bd_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
+					string bb_ = @this?.Url;
+					FhirUri bc_ = context.Operators.Convert<FhirUri>(bb_);
+					string bd_ = FHIRHelpers_4_3_000.ToString(bc_);
+					bool? be_ = context.Operators.Equal(bd_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded");
 
 					return be_;
 				};
-				var ao_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((BCGNotGiven is DomainResource)
+				IEnumerable<Extension> ao_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((BCGNotGiven is DomainResource)
 						? ((BCGNotGiven as DomainResource).Extension)
 						: null), an_);
 				DataType ap_(Extension @this)
 				{
-					var bf_ = @this?.Value;
+					DataType bf_ = @this?.Value;
 
 					return bf_;
 				};
-				var aq_ = context.Operators.Select<Extension, DataType>(ao_, ap_);
-				var ar_ = context.Operators.SingletonFrom<DataType>(aq_);
-				var as_ = context.Operators.Convert<CqlDateTime>(ar_);
-				var at_ = this.Measurement_Period();
-				var au_ = context.Operators.In<CqlDateTime>(as_, at_, null);
-				var av_ = context.Operators.And(am_, au_);
+				IEnumerable<DataType> aq_ = context.Operators.Select<Extension, DataType>(ao_, ap_);
+				DataType ar_ = context.Operators.SingletonFrom<DataType>(aq_);
+				CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(ar_);
+				CqlInterval<CqlDateTime> at_ = this.Measurement_Period();
+				bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, null);
+				bool? av_ = context.Operators.And(am_, au_);
 
 				return av_;
 			};
-			var m_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)k_, l_);
+			IEnumerable<Procedure> m_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)k_, l_);
 			MedicationAdministration n_(Procedure FirstBladderCancerStaging) => 
 				BCGNotGiven;
-			var o_ = context.Operators.Select<Procedure, MedicationAdministration>(m_, n_);
+			IEnumerable<MedicationAdministration> o_ = context.Operators.Select<Procedure, MedicationAdministration>(m_, n_);
 
 			return o_;
 		};
-		var g_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(e_, f_);
+		IEnumerable<MedicationAdministration> g_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(e_, f_);
 		bool? h_(MedicationAdministration BCGNotGiven)
 		{
-			var bg_ = BCGNotGiven?.StatusReason;
+			List<CodeableConcept> bg_ = BCGNotGiven?.StatusReason;
 			CqlConcept bh_(CodeableConcept @this)
 			{
-				var bl_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept bl_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return bl_;
 			};
-			var bi_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bg_, bh_);
-			var bj_ = this.Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care();
-			var bk_ = context.Operators.ConceptsInValueSet(bi_, bj_);
+			IEnumerable<CqlConcept> bi_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bg_, bh_);
+			CqlValueSet bj_ = this.Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care();
+			bool? bk_ = context.Operators.ConceptsInValueSet(bi_, bj_);
 
 			return bk_;
 		};
-		var i_ = context.Operators.Where<MedicationAdministration>(g_, h_);
+		IEnumerable<MedicationAdministration> i_ = context.Operators.Where<MedicationAdministration>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging_Value"/>
     [CqlDeclaration("BCG Not Available Within 6 Months After Bladder Cancer Staging")]
 	public IEnumerable<MedicationAdministration> BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging() => 
 		__BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging.Value;
 
+    /// <seealso cref="Denominator_Exception"/>
 	private bool? Denominator_Exception_Value()
 	{
-		var a_ = this.BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging();
-		var b_ = context.Operators.Exists<MedicationAdministration>(a_);
+		IEnumerable<MedicationAdministration> a_ = this.BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging();
+		bool? b_ = context.Operators.Exists<MedicationAdministration>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Denominator_Exception_Value"/>
     [CqlDeclaration("Denominator Exception")]
 	public bool? Denominator_Exception() => 
 		__Denominator_Exception.Value;
 
+    /// <seealso cref="First_BCG_Administered"/>
 	private MedicationAdministration First_BCG_Administered_Value()
 	{
-		var a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		var e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
+		CqlValueSet a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		IEnumerable<MedicationAdministration> f_(MedicationAdministration BCG)
 		{
-			var m_ = this.First_Bladder_Cancer_Staging_Procedure();
-			var n_ = new Procedure[]
+			Procedure m_ = this.First_Bladder_Cancer_Staging_Procedure();
+			Procedure[] n_ = new Procedure[]
 			{
 				m_,
 			};
 			bool? o_(Procedure FirstBladderCancerStaging)
 			{
-				var s_ = BCG?.Effective;
-				var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-				var u_ = QICoreCommon_2_0_000.toInterval(t_);
-				var v_ = context.Operators.Start(u_);
-				var w_ = FirstBladderCancerStaging?.Performed;
-				var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-				var y_ = QICoreCommon_2_0_000.toInterval(x_);
-				var z_ = context.Operators.Start(y_);
-				var ab_ = FHIRHelpers_4_3_000.ToValue(w_);
-				var ac_ = QICoreCommon_2_0_000.toInterval(ab_);
-				var ad_ = context.Operators.Start(ac_);
-				var ae_ = context.Operators.Quantity(6m, "months");
-				var af_ = context.Operators.Add(ad_, ae_);
-				var ag_ = context.Operators.Interval(z_, af_, false, true);
-				var ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
-				var aj_ = FHIRHelpers_4_3_000.ToValue(w_);
-				var ak_ = QICoreCommon_2_0_000.toInterval(aj_);
-				var al_ = context.Operators.Start(ak_);
-				var am_ = context.Operators.Not((bool?)(al_ is null));
-				var an_ = context.Operators.And(ah_, am_);
-				var ap_ = FHIRHelpers_4_3_000.ToValue(s_);
-				var aq_ = QICoreCommon_2_0_000.toInterval(ap_);
-				var ar_ = context.Operators.Start(aq_);
-				var as_ = this.Measurement_Period();
-				var at_ = context.Operators.In<CqlDateTime>(ar_, as_, null);
-				var au_ = context.Operators.And(an_, at_);
+				DataType s_ = BCG?.Effective;
+				object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
+				CqlDateTime v_ = context.Operators.Start(u_);
+				DataType w_ = FirstBladderCancerStaging?.Performed;
+				object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
+				CqlDateTime z_ = context.Operators.Start(y_);
+				object ab_ = FHIRHelpers_4_3_000.ToValue(w_);
+				CqlInterval<CqlDateTime> ac_ = QICoreCommon_2_0_000.toInterval(ab_);
+				CqlDateTime ad_ = context.Operators.Start(ac_);
+				CqlQuantity ae_ = context.Operators.Quantity(6m, "months");
+				CqlDateTime af_ = context.Operators.Add(ad_, ae_);
+				CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(z_, af_, false, true);
+				bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
+				object aj_ = FHIRHelpers_4_3_000.ToValue(w_);
+				CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.toInterval(aj_);
+				CqlDateTime al_ = context.Operators.Start(ak_);
+				bool? am_ = context.Operators.Not((bool?)(al_ is null));
+				bool? an_ = context.Operators.And(ah_, am_);
+				object ap_ = FHIRHelpers_4_3_000.ToValue(s_);
+				CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.toInterval(ap_);
+				CqlDateTime ar_ = context.Operators.Start(aq_);
+				CqlInterval<CqlDateTime> as_ = this.Measurement_Period();
+				bool? at_ = context.Operators.In<CqlDateTime>(ar_, as_, null);
+				bool? au_ = context.Operators.And(an_, at_);
 
 				return au_;
 			};
-			var p_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)n_, o_);
+			IEnumerable<Procedure> p_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)n_, o_);
 			MedicationAdministration q_(Procedure FirstBladderCancerStaging) => 
 				BCG;
-			var r_ = context.Operators.Select<Procedure, MedicationAdministration>(p_, q_);
+			IEnumerable<MedicationAdministration> r_ = context.Operators.Select<Procedure, MedicationAdministration>(p_, q_);
 
 			return r_;
 		};
-		var g_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(e_, f_);
+		IEnumerable<MedicationAdministration> g_ = context.Operators.SelectMany<MedicationAdministration, MedicationAdministration>(e_, f_);
 		bool? h_(MedicationAdministration BCG)
 		{
-			var av_ = BCG?.StatusElement;
-			var aw_ = av_?.Value;
-			var ax_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(aw_);
-			var ay_ = context.Operators.Convert<string>(ax_);
-			var az_ = new string[]
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> av_ = BCG?.StatusElement;
+			MedicationAdministration.MedicationAdministrationStatusCodes? aw_ = av_?.Value;
+			Code<MedicationAdministration.MedicationAdministrationStatusCodes> ax_ = context.Operators.Convert<Code<MedicationAdministration.MedicationAdministrationStatusCodes>>(aw_);
+			string ay_ = context.Operators.Convert<string>(ax_);
+			string[] az_ = new string[]
 			{
 				"in-progress",
 				"completed",
 			};
-			var ba_ = context.Operators.In<string>(ay_, (az_ as IEnumerable<string>));
+			bool? ba_ = context.Operators.In<string>(ay_, (az_ as IEnumerable<string>));
 
 			return ba_;
 		};
-		var i_ = context.Operators.Where<MedicationAdministration>(g_, h_);
+		IEnumerable<MedicationAdministration> i_ = context.Operators.Where<MedicationAdministration>(g_, h_);
 		object j_(MedicationAdministration @this)
 		{
-			var bb_ = @this?.Effective;
-			var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
-			var bd_ = QICoreCommon_2_0_000.toInterval(bc_);
-			var be_ = context.Operators.Start(bd_);
+			DataType bb_ = @this?.Effective;
+			object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+			CqlInterval<CqlDateTime> bd_ = QICoreCommon_2_0_000.toInterval(bc_);
+			CqlDateTime be_ = context.Operators.Start(bd_);
 
 			return be_;
 		};
-		var k_ = context.Operators.SortBy<MedicationAdministration>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-		var l_ = context.Operators.First<MedicationAdministration>(k_);
+		IEnumerable<MedicationAdministration> k_ = context.Operators.SortBy<MedicationAdministration>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+		MedicationAdministration l_ = context.Operators.First<MedicationAdministration>(k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="First_BCG_Administered_Value"/>
     [CqlDeclaration("First BCG Administered")]
 	public MedicationAdministration First_BCG_Administered() => 
 		__First_BCG_Administered.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.First_BCG_Administered();
-		var b_ = context.Operators.Not((bool?)(a_ is null));
+		MedicationAdministration a_ = this.First_BCG_Administered();
+		bool? b_ = context.Operators.Not((bool?)(a_ is null));
 
 		return b_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Acute_Tuberculosis_Diagnosis"/>
 	private IEnumerable<Condition> Acute_Tuberculosis_Diagnosis_Value()
 	{
-		var a_ = this.Active_Tuberculosis_for_Urology_Care();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Active_Tuberculosis_for_Urology_Care();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		IEnumerable<Condition> c_(Condition ActiveTuberculosis)
 		{
-			var g_ = this.First_Bladder_Cancer_Staging_Procedure();
-			var h_ = new Procedure[]
+			Procedure g_ = this.First_Bladder_Cancer_Staging_Procedure();
+			Procedure[] h_ = new Procedure[]
 			{
 				g_,
 			};
 			bool? i_(Procedure FirstBladderCancerStaging)
 			{
-				var m_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveTuberculosis);
-				var n_ = FirstBladderCancerStaging?.Performed;
-				var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-				var p_ = QICoreCommon_2_0_000.toInterval(o_);
-				var q_ = context.Operators.OverlapsAfter(m_, p_, null);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveTuberculosis);
+				DataType n_ = FirstBladderCancerStaging?.Performed;
+				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+				bool? q_ = context.Operators.OverlapsAfter(m_, p_, null);
 
 				return q_;
 			};
-			var j_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)h_, i_);
+			IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)h_, i_);
 			Condition k_(Procedure FirstBladderCancerStaging) => 
 				ActiveTuberculosis;
-			var l_ = context.Operators.Select<Procedure, Condition>(j_, k_);
+			IEnumerable<Condition> l_ = context.Operators.Select<Procedure, Condition>(j_, k_);
 
 			return l_;
 		};
-		var d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+		IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
 		bool? e_(Condition ActiveTuberculosis)
 		{
-			var r_ = this.isConfirmedActiveDiagnosis(ActiveTuberculosis);
+			bool? r_ = this.isConfirmedActiveDiagnosis(ActiveTuberculosis);
 
 			return r_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Acute_Tuberculosis_Diagnosis_Value"/>
     [CqlDeclaration("Acute Tuberculosis Diagnosis")]
 	public IEnumerable<Condition> Acute_Tuberculosis_Diagnosis() => 
 		__Acute_Tuberculosis_Diagnosis.Value;
 
+    /// <seealso cref="Immunosuppressive_Drugs"/>
 	private IEnumerable<MedicationRequest> Immunosuppressive_Drugs_Value()
 	{
-		var a_ = this.Immunosuppressive_Drugs_for_Urology_Care();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet a_ = this.Immunosuppressive_Drugs_for_Urology_Care();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_(MedicationRequest ImmunosuppressiveDrugs)
 		{
-			var h_ = this.First_Bladder_Cancer_Staging_Procedure();
-			var i_ = new Procedure[]
+			Procedure h_ = this.First_Bladder_Cancer_Staging_Procedure();
+			Procedure[] i_ = new Procedure[]
 			{
 				h_,
 			};
 			bool? j_(Procedure FirstBladderCancerStaging)
 			{
-				var n_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ImmunosuppressiveDrugs);
-				var o_ = context.Operators.Start(n_);
-				var p_ = context.Operators.ConvertDateToDateTime(o_);
-				var q_ = FirstBladderCancerStaging?.Performed;
-				var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-				var s_ = QICoreCommon_2_0_000.toInterval(r_);
-				var t_ = context.Operators.Start(s_);
-				var u_ = context.Operators.SameOrBefore(p_, t_, null);
+				CqlInterval<CqlDate> n_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ImmunosuppressiveDrugs);
+				CqlDate o_ = context.Operators.Start(n_);
+				CqlDateTime p_ = context.Operators.ConvertDateToDateTime(o_);
+				DataType q_ = FirstBladderCancerStaging?.Performed;
+				object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+				CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.toInterval(r_);
+				CqlDateTime t_ = context.Operators.Start(s_);
+				bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 
 				return u_;
 			};
-			var k_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)i_, j_);
+			IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)i_, j_);
 			MedicationRequest l_(Procedure FirstBladderCancerStaging) => 
 				ImmunosuppressiveDrugs;
-			var m_ = context.Operators.Select<Procedure, MedicationRequest>(k_, l_);
+			IEnumerable<MedicationRequest> m_ = context.Operators.Select<Procedure, MedicationRequest>(k_, l_);
 
 			return m_;
 		};
-		var g_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(e_, f_);
+		IEnumerable<MedicationRequest> g_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Immunosuppressive_Drugs_Value"/>
     [CqlDeclaration("Immunosuppressive Drugs")]
 	public IEnumerable<MedicationRequest> Immunosuppressive_Drugs() => 
 		__Immunosuppressive_Drugs.Value;
 
+    /// <seealso cref="Cystectomy_Done"/>
 	private IEnumerable<Procedure> Cystectomy_Done_Value()
 	{
-		var a_ = this.Cystectomy_for_Urology_Care();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		CqlValueSet a_ = this.Cystectomy_for_Urology_Care();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		IEnumerable<Procedure> c_(Procedure Cystectomy)
 		{
-			var g_ = this.First_Bladder_Cancer_Staging_Procedure();
-			var h_ = new Procedure[]
+			Procedure g_ = this.First_Bladder_Cancer_Staging_Procedure();
+			Procedure[] h_ = new Procedure[]
 			{
 				g_,
 			};
 			bool? i_(Procedure FirstBladderCancerStaging)
 			{
-				var m_ = Cystectomy?.Performed;
-				var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-				var o_ = QICoreCommon_2_0_000.toInterval(n_);
-				var p_ = context.Operators.End(o_);
-				var q_ = FirstBladderCancerStaging?.Performed;
-				var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-				var s_ = QICoreCommon_2_0_000.toInterval(r_);
-				var t_ = context.Operators.Start(s_);
-				var u_ = context.Operators.Quantity(6m, "months");
-				var v_ = context.Operators.Subtract(t_, u_);
-				var x_ = FHIRHelpers_4_3_000.ToValue(q_);
-				var y_ = QICoreCommon_2_0_000.toInterval(x_);
-				var z_ = context.Operators.Start(y_);
-				var aa_ = context.Operators.Interval(v_, z_, true, false);
-				var ab_ = context.Operators.In<CqlDateTime>(p_, aa_, null);
-				var ad_ = FHIRHelpers_4_3_000.ToValue(q_);
-				var ae_ = QICoreCommon_2_0_000.toInterval(ad_);
-				var af_ = context.Operators.Start(ae_);
-				var ag_ = context.Operators.Not((bool?)(af_ is null));
-				var ah_ = context.Operators.And(ab_, ag_);
+				DataType m_ = Cystectomy?.Performed;
+				object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
+				CqlDateTime p_ = context.Operators.End(o_);
+				DataType q_ = FirstBladderCancerStaging?.Performed;
+				object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+				CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.toInterval(r_);
+				CqlDateTime t_ = context.Operators.Start(s_);
+				CqlQuantity u_ = context.Operators.Quantity(6m, "months");
+				CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+				object x_ = FHIRHelpers_4_3_000.ToValue(q_);
+				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
+				CqlDateTime z_ = context.Operators.Start(y_);
+				CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(v_, z_, true, false);
+				bool? ab_ = context.Operators.In<CqlDateTime>(p_, aa_, null);
+				object ad_ = FHIRHelpers_4_3_000.ToValue(q_);
+				CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.toInterval(ad_);
+				CqlDateTime af_ = context.Operators.Start(ae_);
+				bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+				bool? ah_ = context.Operators.And(ab_, ag_);
 
 				return ah_;
 			};
-			var j_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)h_, i_);
+			IEnumerable<Procedure> j_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)h_, i_);
 			Procedure k_(Procedure FirstBladderCancerStaging) => 
 				Cystectomy;
-			var l_ = context.Operators.Select<Procedure, Procedure>(j_, k_);
+			IEnumerable<Procedure> l_ = context.Operators.Select<Procedure, Procedure>(j_, k_);
 
 			return l_;
 		};
-		var d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+		IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
 		bool? e_(Procedure Cystectomy)
 		{
-			var ai_ = Cystectomy?.StatusElement;
-			var aj_ = ai_?.Value;
-			var ak_ = context.Operators.Convert<string>(aj_);
-			var al_ = context.Operators.Equal(ak_, "completed");
+			Code<EventStatus> ai_ = Cystectomy?.StatusElement;
+			EventStatus? aj_ = ai_?.Value;
+			string ak_ = context.Operators.Convert<string>(aj_);
+			bool? al_ = context.Operators.Equal(ak_, "completed");
 
 			return al_;
 		};
-		var f_ = context.Operators.Where<Procedure>(d_, e_);
+		IEnumerable<Procedure> f_ = context.Operators.Where<Procedure>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Cystectomy_Done_Value"/>
     [CqlDeclaration("Cystectomy Done")]
 	public IEnumerable<Procedure> Cystectomy_Done() => 
 		__Cystectomy_Done.Value;
 
+    /// <seealso cref="Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging"/>
 	private bool? Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging_Value()
 	{
-		var a_ = this.HIV();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Immunocompromised_Conditions();
-		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
-		var e_ = context.Operators.Union<Condition>(b_, d_);
-		var f_ = this.Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care();
-		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
-		var h_ = context.Operators.Union<Condition>(e_, g_);
+		CqlValueSet a_ = this.HIV();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet c_ = this.Immunocompromised_Conditions();
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
+		CqlValueSet f_ = this.Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care();
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		IEnumerable<Condition> i_(Condition ExclusionDiagnosis)
 		{
-			var n_ = this.First_Bladder_Cancer_Staging_Procedure();
-			var o_ = new Procedure[]
+			Procedure n_ = this.First_Bladder_Cancer_Staging_Procedure();
+			Procedure[] o_ = new Procedure[]
 			{
 				n_,
 			};
 			bool? p_(Procedure FirstBladderCancerStaging)
 			{
-				var t_ = QICoreCommon_2_0_000.prevalenceInterval(ExclusionDiagnosis);
-				var u_ = context.Operators.Start(t_);
-				var v_ = FirstBladderCancerStaging?.Performed;
-				var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-				var x_ = QICoreCommon_2_0_000.toInterval(w_);
-				var y_ = context.Operators.Start(x_);
-				var z_ = context.Operators.SameOrBefore(u_, y_, null);
+				CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.prevalenceInterval(ExclusionDiagnosis);
+				CqlDateTime u_ = context.Operators.Start(t_);
+				DataType v_ = FirstBladderCancerStaging?.Performed;
+				object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+				CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.toInterval(w_);
+				CqlDateTime y_ = context.Operators.Start(x_);
+				bool? z_ = context.Operators.SameOrBefore(u_, y_, null);
 
 				return z_;
 			};
-			var q_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)o_, p_);
+			IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)o_, p_);
 			Condition r_(Procedure FirstBladderCancerStaging) => 
 				ExclusionDiagnosis;
-			var s_ = context.Operators.Select<Procedure, Condition>(q_, r_);
+			IEnumerable<Condition> s_ = context.Operators.Select<Procedure, Condition>(q_, r_);
 
 			return s_;
 		};
-		var j_ = context.Operators.SelectMany<Condition, Condition>(h_, i_);
+		IEnumerable<Condition> j_ = context.Operators.SelectMany<Condition, Condition>(h_, i_);
 		bool? k_(Condition ExclusionDiagnosis)
 		{
-			var aa_ = this.isConfirmedActiveDiagnosis(ExclusionDiagnosis);
+			bool? aa_ = this.isConfirmedActiveDiagnosis(ExclusionDiagnosis);
 
 			return aa_;
 		};
-		var l_ = context.Operators.Where<Condition>(j_, k_);
-		var m_ = context.Operators.Exists<Condition>(l_);
+		IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
+		bool? m_ = context.Operators.Exists<Condition>(l_);
 
 		return m_;
 	}
 
+    /// <seealso cref="Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging_Value"/>
     [CqlDeclaration("Has Excluding  HIV, Immunocompromised Conditions or Mixed Histology Before Staging")]
 	public bool? Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging() => 
 		__Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging.Value;
 
+    /// <seealso cref="Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging"/>
 	private bool? Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging_Value()
 	{
-		var a_ = this.Chemotherapy_Agents_for_Advanced_Cancer();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet a_ = this.Chemotherapy_Agents_for_Advanced_Cancer();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_(MedicationRequest ExclusionMed)
 		{
-			var s_ = this.First_Bladder_Cancer_Staging_Procedure();
-			var t_ = new Procedure[]
+			Procedure s_ = this.First_Bladder_Cancer_Staging_Procedure();
+			Procedure[] t_ = new Procedure[]
 			{
 				s_,
 			};
 			bool? u_(Procedure FirstBladderCancerStaging)
 			{
-				var y_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ExclusionMed);
-				var z_ = context.Operators.Start(y_);
-				var aa_ = context.Operators.ConvertDateToDateTime(z_);
-				var ab_ = FirstBladderCancerStaging?.Performed;
-				var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-				var ad_ = QICoreCommon_2_0_000.toInterval(ac_);
-				var ae_ = context.Operators.Start(ad_);
-				var af_ = context.Operators.Quantity(6m, "months");
-				var ag_ = context.Operators.Subtract(ae_, af_);
-				var ai_ = FHIRHelpers_4_3_000.ToValue(ab_);
-				var aj_ = QICoreCommon_2_0_000.toInterval(ai_);
-				var ak_ = context.Operators.Start(aj_);
-				var al_ = context.Operators.Interval(ag_, ak_, true, false);
-				var am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
-				var ao_ = FHIRHelpers_4_3_000.ToValue(ab_);
-				var ap_ = QICoreCommon_2_0_000.toInterval(ao_);
-				var aq_ = context.Operators.Start(ap_);
-				var ar_ = context.Operators.Not((bool?)(aq_ is null));
-				var as_ = context.Operators.And(am_, ar_);
+				CqlInterval<CqlDate> y_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(ExclusionMed);
+				CqlDate z_ = context.Operators.Start(y_);
+				CqlDateTime aa_ = context.Operators.ConvertDateToDateTime(z_);
+				DataType ab_ = FirstBladderCancerStaging?.Performed;
+				object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+				CqlInterval<CqlDateTime> ad_ = QICoreCommon_2_0_000.toInterval(ac_);
+				CqlDateTime ae_ = context.Operators.Start(ad_);
+				CqlQuantity af_ = context.Operators.Quantity(6m, "months");
+				CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
+				object ai_ = FHIRHelpers_4_3_000.ToValue(ab_);
+				CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
+				CqlDateTime ak_ = context.Operators.Start(aj_);
+				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ag_, ak_, true, false);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				object ao_ = FHIRHelpers_4_3_000.ToValue(ab_);
+				CqlInterval<CqlDateTime> ap_ = QICoreCommon_2_0_000.toInterval(ao_);
+				CqlDateTime aq_ = context.Operators.Start(ap_);
+				bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
+				bool? as_ = context.Operators.And(am_, ar_);
 
 				return as_;
 			};
-			var v_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)t_, u_);
+			IEnumerable<Procedure> v_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)t_, u_);
 			MedicationRequest w_(Procedure FirstBladderCancerStaging) => 
 				ExclusionMed;
-			var x_ = context.Operators.Select<Procedure, MedicationRequest>(v_, w_);
+			IEnumerable<MedicationRequest> x_ = context.Operators.Select<Procedure, MedicationRequest>(v_, w_);
 
 			return x_;
 		};
-		var g_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(e_, f_);
+		IEnumerable<MedicationRequest> g_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(e_, f_);
 		bool? h_(MedicationRequest ExclusionMed)
 		{
-			var at_ = ExclusionMed?.StatusElement;
-			var au_ = at_?.Value;
-			var av_ = context.Operators.Convert<string>(au_);
-			var aw_ = new string[]
+			Code<MedicationRequest.MedicationrequestStatus> at_ = ExclusionMed?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? au_ = at_?.Value;
+			string av_ = context.Operators.Convert<string>(au_);
+			string[] aw_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var ax_ = context.Operators.In<string>(av_, (aw_ as IEnumerable<string>));
-			var ay_ = ExclusionMed?.IntentElement;
-			var az_ = ay_?.Value;
-			var ba_ = context.Operators.Convert<string>(az_);
-			var bb_ = context.Operators.Equal(ba_, "order");
-			var bc_ = context.Operators.And(ax_, bb_);
-			var bd_ = ExclusionMed?.DoNotPerformElement;
-			var be_ = bd_?.Value;
-			var bf_ = context.Operators.IsTrue(be_);
-			var bg_ = context.Operators.Not(bf_);
-			var bh_ = context.Operators.And(bc_, bg_);
+			bool? ax_ = context.Operators.In<string>(av_, (aw_ as IEnumerable<string>));
+			Code<MedicationRequest.MedicationRequestIntent> ay_ = ExclusionMed?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? az_ = ay_?.Value;
+			string ba_ = context.Operators.Convert<string>(az_);
+			bool? bb_ = context.Operators.Equal(ba_, "order");
+			bool? bc_ = context.Operators.And(ax_, bb_);
+			FhirBoolean bd_ = ExclusionMed?.DoNotPerformElement;
+			bool? be_ = bd_?.Value;
+			bool? bf_ = context.Operators.IsTrue(be_);
+			bool? bg_ = context.Operators.Not(bf_);
+			bool? bh_ = context.Operators.And(bc_, bg_);
 
 			return bh_;
 		};
-		var i_ = context.Operators.Where<MedicationRequest>(g_, h_);
-		var j_ = this.Combined_radiotherapy__procedure_();
-		var k_ = context.Operators.ToList<CqlCode>(j_);
-		var l_ = context.Operators.RetrieveByCodes<Procedure>(k_, null);
+		IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
+		CqlCode j_ = this.Combined_radiotherapy__procedure_();
+		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
+		IEnumerable<Procedure> l_ = context.Operators.RetrieveByCodes<Procedure>(k_, null);
 		IEnumerable<Procedure> m_(Procedure ExclusionProcedure)
 		{
-			var bi_ = this.First_Bladder_Cancer_Staging_Procedure();
-			var bj_ = new Procedure[]
+			Procedure bi_ = this.First_Bladder_Cancer_Staging_Procedure();
+			Procedure[] bj_ = new Procedure[]
 			{
 				bi_,
 			};
 			bool? bk_(Procedure FirstBladderCancerStaging)
 			{
-				var bo_ = ExclusionProcedure?.Performed;
-				var bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
-				var bq_ = QICoreCommon_2_0_000.toInterval(bp_);
-				var br_ = context.Operators.Start(bq_);
-				var bs_ = FirstBladderCancerStaging?.Performed;
-				var bt_ = FHIRHelpers_4_3_000.ToValue(bs_);
-				var bu_ = QICoreCommon_2_0_000.toInterval(bt_);
-				var bv_ = context.Operators.Start(bu_);
-				var bw_ = context.Operators.Quantity(6m, "months");
-				var bx_ = context.Operators.Subtract(bv_, bw_);
-				var bz_ = FHIRHelpers_4_3_000.ToValue(bs_);
-				var ca_ = QICoreCommon_2_0_000.toInterval(bz_);
-				var cb_ = context.Operators.Start(ca_);
-				var cc_ = context.Operators.Interval(bx_, cb_, true, false);
-				var cd_ = context.Operators.In<CqlDateTime>(br_, cc_, null);
-				var cf_ = FHIRHelpers_4_3_000.ToValue(bs_);
-				var cg_ = QICoreCommon_2_0_000.toInterval(cf_);
-				var ch_ = context.Operators.Start(cg_);
-				var ci_ = context.Operators.Not((bool?)(ch_ is null));
-				var cj_ = context.Operators.And(cd_, ci_);
+				DataType bo_ = ExclusionProcedure?.Performed;
+				object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
+				CqlInterval<CqlDateTime> bq_ = QICoreCommon_2_0_000.toInterval(bp_);
+				CqlDateTime br_ = context.Operators.Start(bq_);
+				DataType bs_ = FirstBladderCancerStaging?.Performed;
+				object bt_ = FHIRHelpers_4_3_000.ToValue(bs_);
+				CqlInterval<CqlDateTime> bu_ = QICoreCommon_2_0_000.toInterval(bt_);
+				CqlDateTime bv_ = context.Operators.Start(bu_);
+				CqlQuantity bw_ = context.Operators.Quantity(6m, "months");
+				CqlDateTime bx_ = context.Operators.Subtract(bv_, bw_);
+				object bz_ = FHIRHelpers_4_3_000.ToValue(bs_);
+				CqlInterval<CqlDateTime> ca_ = QICoreCommon_2_0_000.toInterval(bz_);
+				CqlDateTime cb_ = context.Operators.Start(ca_);
+				CqlInterval<CqlDateTime> cc_ = context.Operators.Interval(bx_, cb_, true, false);
+				bool? cd_ = context.Operators.In<CqlDateTime>(br_, cc_, null);
+				object cf_ = FHIRHelpers_4_3_000.ToValue(bs_);
+				CqlInterval<CqlDateTime> cg_ = QICoreCommon_2_0_000.toInterval(cf_);
+				CqlDateTime ch_ = context.Operators.Start(cg_);
+				bool? ci_ = context.Operators.Not((bool?)(ch_ is null));
+				bool? cj_ = context.Operators.And(cd_, ci_);
 
 				return cj_;
 			};
-			var bl_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)bj_, bk_);
+			IEnumerable<Procedure> bl_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)bj_, bk_);
 			Procedure bm_(Procedure FirstBladderCancerStaging) => 
 				ExclusionProcedure;
-			var bn_ = context.Operators.Select<Procedure, Procedure>(bl_, bm_);
+			IEnumerable<Procedure> bn_ = context.Operators.Select<Procedure, Procedure>(bl_, bm_);
 
 			return bn_;
 		};
-		var n_ = context.Operators.SelectMany<Procedure, Procedure>(l_, m_);
+		IEnumerable<Procedure> n_ = context.Operators.SelectMany<Procedure, Procedure>(l_, m_);
 		bool? o_(Procedure ExclusionProcedure)
 		{
-			var ck_ = ExclusionProcedure?.StatusElement;
-			var cl_ = ck_?.Value;
-			var cm_ = context.Operators.Convert<string>(cl_);
-			var cn_ = context.Operators.Equal(cm_, "completed");
+			Code<EventStatus> ck_ = ExclusionProcedure?.StatusElement;
+			EventStatus? cl_ = ck_?.Value;
+			string cm_ = context.Operators.Convert<string>(cl_);
+			bool? cn_ = context.Operators.Equal(cm_, "completed");
 
 			return cn_;
 		};
-		var p_ = context.Operators.Where<Procedure>(n_, o_);
-		var q_ = context.Operators.Union<object>((i_ as IEnumerable<object>), (p_ as IEnumerable<object>));
-		var r_ = context.Operators.Exists<object>(q_);
+		IEnumerable<Procedure> p_ = context.Operators.Where<Procedure>(n_, o_);
+		IEnumerable<object> q_ = context.Operators.Union<object>((i_ as IEnumerable<object>), (p_ as IEnumerable<object>));
+		bool? r_ = context.Operators.Exists<object>(q_);
 
 		return r_;
 	}
 
+    /// <seealso cref="Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging_Value"/>
     [CqlDeclaration("Has Excluding Chemotherapy or Radiotherapy Procedure Before Staging")]
 	public bool? Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging() => 
 		__Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging.Value;
 
+    /// <seealso cref="Denominator_Exclusion"/>
 	private bool? Denominator_Exclusion_Value()
 	{
-		var a_ = this.Acute_Tuberculosis_Diagnosis();
-		var b_ = context.Operators.Exists<Condition>(a_);
-		var c_ = this.Immunosuppressive_Drugs();
-		var d_ = context.Operators.Exists<MedicationRequest>(c_);
-		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Cystectomy_Done();
-		var g_ = context.Operators.Exists<Procedure>(f_);
-		var h_ = context.Operators.Or(e_, g_);
-		var i_ = this.Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging();
-		var j_ = context.Operators.Or(h_, i_);
-		var k_ = this.Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging();
-		var l_ = context.Operators.Or(j_, k_);
+		IEnumerable<Condition> a_ = this.Acute_Tuberculosis_Diagnosis();
+		bool? b_ = context.Operators.Exists<Condition>(a_);
+		IEnumerable<MedicationRequest> c_ = this.Immunosuppressive_Drugs();
+		bool? d_ = context.Operators.Exists<MedicationRequest>(c_);
+		bool? e_ = context.Operators.Or(b_, d_);
+		IEnumerable<Procedure> f_ = this.Cystectomy_Done();
+		bool? g_ = context.Operators.Exists<Procedure>(f_);
+		bool? h_ = context.Operators.Or(e_, g_);
+		bool? i_ = this.Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging();
+		bool? j_ = context.Operators.Or(h_, i_);
+		bool? k_ = this.Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging();
+		bool? l_ = context.Operators.Or(j_, k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Denominator_Exclusion_Value"/>
     [CqlDeclaration("Denominator Exclusion")]
 	public bool? Denominator_Exclusion() => 
 		__Denominator_Exclusion.Value;
@@ -1372,7 +1473,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		{
 			if ((context.Operators.Not((bool?)(pointInTime is null)) ?? false))
 			{
-				var b_ = context.Operators.Interval(pointInTime, pointInTime, true, true);
+				CqlInterval<CqlDateTime> b_ = context.Operators.Interval(pointInTime, pointInTime, true, true);
 
 				return b_;
 			}

--- a/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
@@ -120,165 +120,206 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Acute_Inpatient"/>
 	private CqlValueSet Acute_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
 
+    /// <seealso cref="Acute_Inpatient_Value"/>
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
 	public CqlValueSet Acute_Inpatient() => 
 		__Acute_Inpatient.Value;
 
+    /// <seealso cref="Annual_Wellness_Visit"/>
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
+    /// <seealso cref="Annual_Wellness_Visit_Value"/>
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
 	public CqlValueSet Annual_Wellness_Visit() => 
 		__Annual_Wellness_Visit.Value;
 
+    /// <seealso cref="Chronic_Kidney_Disease__Stage_5"/>
 	private CqlValueSet Chronic_Kidney_Disease__Stage_5_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002", null);
 
+    /// <seealso cref="Chronic_Kidney_Disease__Stage_5_Value"/>
     [CqlDeclaration("Chronic Kidney Disease, Stage 5")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002")]
 	public CqlValueSet Chronic_Kidney_Disease__Stage_5() => 
 		__Chronic_Kidney_Disease__Stage_5.Value;
 
+    /// <seealso cref="Diabetes"/>
 	private CqlValueSet Diabetes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
 
+    /// <seealso cref="Diabetes_Value"/>
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
 	public CqlValueSet Diabetes() => 
 		__Diabetes.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="End_Stage_Renal_Disease"/>
 	private CqlValueSet End_Stage_Renal_Disease_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", null);
 
+    /// <seealso cref="End_Stage_Renal_Disease_Value"/>
     [CqlDeclaration("End Stage Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
 	public CqlValueSet End_Stage_Renal_Disease() => 
 		__End_Stage_Renal_Disease.Value;
 
+    /// <seealso cref="Estimated_Glomerular_Filtration_Rate"/>
 	private CqlValueSet Estimated_Glomerular_Filtration_Rate_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000", null);
 
+    /// <seealso cref="Estimated_Glomerular_Filtration_Rate_Value"/>
     [CqlDeclaration("Estimated Glomerular Filtration Rate")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000")]
 	public CqlValueSet Estimated_Glomerular_Filtration_Rate() => 
 		__Estimated_Glomerular_Filtration_Rate.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Hospice_Care_Ambulatory"/>
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", null);
 
+    /// <seealso cref="Hospice_Care_Ambulatory_Value"/>
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
 	public CqlValueSet Hospice_Care_Ambulatory() => 
 		__Hospice_Care_Ambulatory.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Palliative_or_Hospice_Care"/>
 	private CqlValueSet Palliative_or_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", null);
 
+    /// <seealso cref="Palliative_or_Hospice_Care_Value"/>
     [CqlDeclaration("Palliative or Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
 	public CqlValueSet Palliative_or_Hospice_Care() => 
 		__Palliative_or_Hospice_Care.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Urine_Albumin_Creatinine_Ratio"/>
 	private CqlValueSet Urine_Albumin_Creatinine_Ratio_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007", null);
 
+    /// <seealso cref="Urine_Albumin_Creatinine_Ratio_Value"/>
     [CqlDeclaration("Urine Albumin Creatinine Ratio")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007")]
 	public CqlValueSet Urine_Albumin_Creatinine_Ratio() => 
 		__Urine_Albumin_Creatinine_Ratio.Value;
 
+    /// <seealso cref="Discharge_to_healthcare_facility_for_hospice_care__procedure_"/>
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
 		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Discharge_to_healthcare_facility_for_hospice_care__procedure__Value"/>
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
+    /// <seealso cref="Discharge_to_home_for_hospice_care__procedure_"/>
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
 		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Discharge_to_home_for_hospice_care__procedure__Value"/>
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
+    /// <seealso cref="AMB"/>
 	private CqlCode AMB_Value() => 
 		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="AMB_Value"/>
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
 		__AMB.Value;
 
+    /// <seealso cref="active"/>
 	private CqlCode active_Value() => 
 		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
+    /// <seealso cref="active_Value"/>
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
 			new CqlCode("428361000124107", "http://snomed.info/sct", null, null),
@@ -287,13 +328,15 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 		};
@@ -301,13 +344,15 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="ConditionClinicalStatusCodes"/>
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
 		};
@@ -315,311 +360,342 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="ConditionClinicalStatusCodes_Value"/>
     [CqlDeclaration("ConditionClinicalStatusCodes")]
 	public CqlCode[] ConditionClinicalStatusCodes() => 
 		__ConditionClinicalStatusCodes.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("KidneyHealthEvaluationFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("KidneyHealthEvaluationFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Has_Active_Diabetes_Overlaps_Measurement_Period"/>
 	private bool? Has_Active_Diabetes_Overlaps_Measurement_Period_Value()
 	{
-		var a_ = this.Diabetes();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Diabetes();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition Diabetes)
 		{
-			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
-			var g_ = this.Measurement_Period();
-			var h_ = context.Operators.Overlaps(f_, g_, null);
-			var i_ = Diabetes?.ClinicalStatus;
-			var j_ = FHIRHelpers_4_3_000.ToConcept(i_);
-			var k_ = this.active();
-			var l_ = context.Operators.ConvertCodeToConcept(k_);
-			var m_ = context.Operators.Equivalent(j_, l_);
-			var n_ = context.Operators.And(h_, m_);
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			bool? h_ = context.Operators.Overlaps(f_, g_, null);
+			CodeableConcept i_ = Diabetes?.ClinicalStatus;
+			CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
+			CqlCode k_ = this.active();
+			CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+			bool? m_ = context.Operators.Equivalent(j_, l_);
+			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Active_Diabetes_Overlaps_Measurement_Period_Value"/>
     [CqlDeclaration("Has Active Diabetes Overlaps Measurement Period")]
 	public bool? Has_Active_Diabetes_Overlaps_Measurement_Period() => 
 		__Has_Active_Diabetes_Overlaps_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Outpatient_Visit_During_Measurement_Period"/>
 	private bool? Has_Outpatient_Visit_During_Measurement_Period_Value()
 	{
-		var a_ = this.Annual_Wellness_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Home_Healthcare_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Office_Visit();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Outpatient_Consultation();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Telephone_Visits();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = context.Operators.Union<Encounter>(q_, s_);
+		CqlValueSet a_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Office_Visit();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Telephone_Visits();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
 		bool? u_(Encounter ValidEncounter)
 		{
-			var x_ = this.Measurement_Period();
-			var y_ = ValidEncounter?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, null);
-			var ab_ = ValidEncounter?.StatusElement;
-			var ac_ = ab_?.Value;
-			var ad_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ac_);
-			var ae_ = context.Operators.Equal(ad_, "finished");
-			var af_ = context.Operators.And(aa_, ae_);
+			CqlInterval<CqlDateTime> x_ = this.Measurement_Period();
+			Period y_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, null);
+			Code<Encounter.EncounterStatus> ab_ = ValidEncounter?.StatusElement;
+			Encounter.EncounterStatus? ac_ = ab_?.Value;
+			Code<Encounter.EncounterStatus> ad_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ac_);
+			bool? ae_ = context.Operators.Equal(ad_, "finished");
+			bool? af_ = context.Operators.And(aa_, ae_);
 
 			return af_;
 		};
-		var v_ = context.Operators.Where<Encounter>(t_, u_);
-		var w_ = context.Operators.Exists<Encounter>(v_);
+		IEnumerable<Encounter> v_ = context.Operators.Where<Encounter>(t_, u_);
+		bool? w_ = context.Operators.Exists<Encounter>(v_);
 
 		return w_;
 	}
 
+    /// <seealso cref="Has_Outpatient_Visit_During_Measurement_Period_Value"/>
     [CqlDeclaration("Has Outpatient Visit During Measurement Period")]
 	public bool? Has_Outpatient_Visit_During_Measurement_Period() => 
 		__Has_Outpatient_Visit_During_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(18, 85, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var i_ = this.Has_Active_Diabetes_Overlaps_Measurement_Period();
-		var j_ = context.Operators.And(h_, i_);
-		var k_ = this.Has_Outpatient_Visit_During_Measurement_Period();
-		var l_ = context.Operators.And(j_, k_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(18, 85, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? k_ = this.Has_Active_Diabetes_Overlaps_Measurement_Period();
+		bool? l_ = context.Operators.And(j_, k_);
+		bool? m_ = this.Has_Outpatient_Visit_During_Measurement_Period();
+		bool? n_ = context.Operators.And(l_, m_);
 
-		return l_;
+		return n_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period"/>
 	private IEnumerable<Condition> Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period_Value()
 	{
-		var a_ = this.Chronic_Kidney_Disease__Stage_5();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.End_Stage_Renal_Disease();
-		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
-		var e_ = context.Operators.Union<Condition>(b_, d_);
+		CqlValueSet a_ = this.Chronic_Kidney_Disease__Stage_5();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet c_ = this.End_Stage_Renal_Disease();
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		bool? f_(Condition CKDOrESRD)
 		{
-			var h_ = QICoreCommon_2_0_000.ToPrevalenceInterval(CKDOrESRD);
-			var i_ = this.Measurement_Period();
-			var j_ = context.Operators.Overlaps(h_, i_, null);
-			var k_ = CKDOrESRD?.ClinicalStatus;
-			var l_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var m_ = this.active();
-			var n_ = context.Operators.ConvertCodeToConcept(m_);
-			var o_ = context.Operators.Equivalent(l_, n_);
-			var p_ = context.Operators.And(j_, o_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToPrevalenceInterval(CKDOrESRD);
+			CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
+			bool? j_ = context.Operators.Overlaps(h_, i_, null);
+			CodeableConcept k_ = CKDOrESRD?.ClinicalStatus;
+			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode m_ = this.active();
+			CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
+			bool? o_ = context.Operators.Equivalent(l_, n_);
+			bool? p_ = context.Operators.And(j_, o_);
 
 			return p_;
 		};
-		var g_ = context.Operators.Where<Condition>(e_, f_);
+		IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period_Value"/>
     [CqlDeclaration("Has CKD Stage 5 or ESRD Diagnosis Overlaps Measurement Period")]
 	public IEnumerable<Condition> Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period() => 
 		__Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = this.Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period();
-		var b_ = context.Operators.Exists<Condition>(a_);
-		var c_ = Hospice_6_9_000.Has_Hospice_Services();
-		var d_ = context.Operators.Or(b_, c_);
-		var e_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
-		var f_ = context.Operators.Or(d_, e_);
+		IEnumerable<Condition> a_ = this.Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period();
+		bool? b_ = context.Operators.Exists<Condition>(a_);
+		bool? c_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? d_ = context.Operators.Or(b_, c_);
+		bool? e_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		bool? f_ = context.Operators.Or(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Has_Kidney_Panel_Performed_During_Measurement_Period"/>
 	private bool? Has_Kidney_Panel_Performed_During_Measurement_Period_Value()
 	{
-		var a_ = this.Estimated_Glomerular_Filtration_Rate();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.Estimated_Glomerular_Filtration_Rate();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation eGFRTest)
 		{
-			var l_ = this.Measurement_Period();
-			var m_ = eGFRTest?.Effective;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var o_ = QICoreCommon_2_0_000.ToInterval(n_);
-			var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
-			var q_ = eGFRTest?.Value;
-			var r_ = FHIRHelpers_4_3_000.ToValue(q_);
-			var s_ = context.Operators.Not((bool?)(r_ is null));
-			var t_ = context.Operators.And(p_, s_);
-			var u_ = eGFRTest?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
-			var x_ = context.Operators.Convert<string>(w_);
-			var y_ = new string[]
+			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
+			DataType m_ = eGFRTest?.Effective;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval(n_);
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
+			DataType q_ = eGFRTest?.Value;
+			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
+			bool? s_ = context.Operators.Not((bool?)(r_ is null));
+			bool? t_ = context.Operators.And(p_, s_);
+			Code<ObservationStatus> u_ = eGFRTest?.StatusElement;
+			ObservationStatus? v_ = u_?.Value;
+			Code<ObservationStatus> w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
+			string x_ = context.Operators.Convert<string>(w_);
+			string[] y_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
-			var aa_ = context.Operators.And(t_, z_);
+			bool? z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
+			bool? aa_ = context.Operators.And(t_, z_);
 
 			return aa_;
 		};
-		var d_ = context.Operators.Where<Observation>(b_, c_);
-		var e_ = context.Operators.Exists<Observation>(d_);
-		var f_ = this.Urine_Albumin_Creatinine_Ratio();
-		var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
+		bool? e_ = context.Operators.Exists<Observation>(d_);
+		CqlValueSet f_ = this.Urine_Albumin_Creatinine_Ratio();
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 		bool? h_(Observation uACRTest)
 		{
-			var ab_ = this.Measurement_Period();
-			var ac_ = uACRTest?.Effective;
-			var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-			var ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
-			var af_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ab_, ae_, null);
-			var ag_ = uACRTest?.Value;
-			var ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
-			var ai_ = context.Operators.Not((bool?)(ah_ is null));
-			var aj_ = context.Operators.And(af_, ai_);
-			var ak_ = uACRTest?.StatusElement;
-			var al_ = ak_?.Value;
-			var am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
-			var an_ = context.Operators.Convert<string>(am_);
-			var ao_ = new string[]
+			CqlInterval<CqlDateTime> ab_ = this.Measurement_Period();
+			DataType ac_ = uACRTest?.Effective;
+			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
+			bool? af_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ab_, ae_, null);
+			DataType ag_ = uACRTest?.Value;
+			object ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
+			bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+			bool? aj_ = context.Operators.And(af_, ai_);
+			Code<ObservationStatus> ak_ = uACRTest?.StatusElement;
+			ObservationStatus? al_ = ak_?.Value;
+			Code<ObservationStatus> am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
+			string an_ = context.Operators.Convert<string>(am_);
+			string[] ao_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var ap_ = context.Operators.In<string>(an_, (ao_ as IEnumerable<string>));
-			var aq_ = context.Operators.And(aj_, ap_);
+			bool? ap_ = context.Operators.In<string>(an_, (ao_ as IEnumerable<string>));
+			bool? aq_ = context.Operators.And(aj_, ap_);
 
 			return aq_;
 		};
-		var i_ = context.Operators.Where<Observation>(g_, h_);
-		var j_ = context.Operators.Exists<Observation>(i_);
-		var k_ = context.Operators.And(e_, j_);
+		IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
+		bool? j_ = context.Operators.Exists<Observation>(i_);
+		bool? k_ = context.Operators.And(e_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Has_Kidney_Panel_Performed_During_Measurement_Period_Value"/>
     [CqlDeclaration("Has Kidney Panel Performed During Measurement Period")]
 	public bool? Has_Kidney_Panel_Performed_During_Measurement_Period() => 
 		__Has_Kidney_Panel_Performed_During_Measurement_Period.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Has_Kidney_Panel_Performed_During_Measurement_Period();
+		bool? a_ = this.Has_Kidney_Panel_Performed_During_Measurement_Period();
 
 		return a_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
@@ -88,56 +88,69 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Cancer"/>
 	private CqlValueSet Cancer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010", null);
 
+    /// <seealso cref="Cancer_Value"/>
     [CqlDeclaration("Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010")]
 	public CqlValueSet Cancer() => 
 		__Cancer.Value;
 
+    /// <seealso cref="Chemotherapy_Administration"/>
 	private CqlValueSet Chemotherapy_Administration_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027", null);
 
+    /// <seealso cref="Chemotherapy_Administration_Value"/>
     [CqlDeclaration("Chemotherapy Administration")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027")]
 	public CqlValueSet Chemotherapy_Administration() => 
 		__Chemotherapy_Administration.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Radiation_Treatment_Management"/>
 	private CqlValueSet Radiation_Treatment_Management_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026", null);
 
+    /// <seealso cref="Radiation_Treatment_Management_Value"/>
     [CqlDeclaration("Radiation Treatment Management")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026")]
 	public CqlValueSet Radiation_Treatment_Management() => 
 		__Radiation_Treatment_Management.Value;
 
+    /// <seealso cref="Standardized_Pain_Assessment_Tool"/>
 	private CqlValueSet Standardized_Pain_Assessment_Tool_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028", null);
 
+    /// <seealso cref="Standardized_Pain_Assessment_Tool_Value"/>
     [CqlDeclaration("Standardized Pain Assessment Tool")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028")]
 	public CqlValueSet Standardized_Pain_Assessment_Tool() => 
 		__Standardized_Pain_Assessment_Tool.Value;
 
+    /// <seealso cref="Radiation_treatment_management__5_treatments"/>
 	private CqlCode Radiation_treatment_management__5_treatments_Value() => 
 		new CqlCode("77427", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Radiation_treatment_management__5_treatments_Value"/>
     [CqlDeclaration("Radiation treatment management, 5 treatments")]
 	public CqlCode Radiation_treatment_management__5_treatments() => 
 		__Radiation_treatment_management__5_treatments.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("77427", "http://www.ama-assn.org/go/cpt", null, null),
 		};
@@ -145,77 +158,85 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("OncologyPainIntensityQuantifiedFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("OncologyPainIntensityQuantifiedFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period"/>
 	private IEnumerable<Procedure> Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period_Value()
 	{
-		var a_ = this.Chemotherapy_Administration();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		CqlValueSet a_ = this.Chemotherapy_Administration();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure ChemoAdministration)
 		{
-			var f_ = this.Measurement_Period();
-			var g_ = context.Operators.Start(f_);
-			var h_ = context.Operators.Quantity(31m, "days");
-			var i_ = context.Operators.Subtract(g_, h_);
-			var k_ = context.Operators.End(f_);
-			var l_ = context.Operators.Interval(i_, k_, true, true);
-			var m_ = ChemoAdministration?.Performed;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var o_ = QICoreCommon_2_0_000.toInterval(n_);
-			var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			CqlDateTime g_ = context.Operators.Start(f_);
+			CqlQuantity h_ = context.Operators.Quantity(31m, "days");
+			CqlDateTime i_ = context.Operators.Subtract(g_, h_);
+			CqlDateTime k_ = context.Operators.End(f_);
+			CqlInterval<CqlDateTime> l_ = context.Operators.Interval(i_, k_, true, true);
+			DataType m_ = ChemoAdministration?.Performed;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
 
 			return p_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period_Value"/>
     [CqlDeclaration("Chemotherapy Within 31 Days Prior and During Measurement Period")]
 	public IEnumerable<Procedure> Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period() => 
 		__Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period.Value;
 
+    /// <seealso cref="Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy"/>
 	private IEnumerable<Encounter> Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = Status_1_6_000.Finished_Encounter(b_);
-		var d_ = this.Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period();
-		var f_ = this.Cancer();
-		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
-		var h_ = context.Operators.CrossJoin<Encounter, Procedure, Procedure, Condition>(c_, d_, d_, g_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> c_ = Status_1_6_000.Finished_Encounter(b_);
+		IEnumerable<Procedure> d_ = this.Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period();
+		CqlValueSet f_ = this.Cancer();
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<ValueTuple<Encounter, Procedure, Procedure, Condition>> h_ = context.Operators.CrossJoin<Encounter, Procedure, Procedure, Condition>(c_, d_, d_, g_);
 		Tuple_CIBLiGZRIHjLJQMiTHPOROaSe i_(ValueTuple<Encounter, Procedure, Procedure, Condition> _valueTuple)
 		{
-			var o_ = new Tuple_CIBLiGZRIHjLJQMiTHPOROaSe
+			Tuple_CIBLiGZRIHjLJQMiTHPOROaSe o_ = new Tuple_CIBLiGZRIHjLJQMiTHPOROaSe
 			{
 				FaceToFaceOrTelehealthEncounter = _valueTuple.Item1,
 				ChemoBeforeEncounter = _valueTuple.Item2,
@@ -225,337 +246,360 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 
 			return o_;
 		};
-		var j_ = context.Operators.Select<ValueTuple<Encounter, Procedure, Procedure, Condition>, Tuple_CIBLiGZRIHjLJQMiTHPOROaSe>(h_, i_);
+		IEnumerable<Tuple_CIBLiGZRIHjLJQMiTHPOROaSe> j_ = context.Operators.Select<ValueTuple<Encounter, Procedure, Procedure, Condition>, Tuple_CIBLiGZRIHjLJQMiTHPOROaSe>(h_, i_);
 		bool? k_(Tuple_CIBLiGZRIHjLJQMiTHPOROaSe tuple_cibligzrihjljqmithporoase)
 		{
-			var p_ = QICoreCommon_2_0_000.isActive(tuple_cibligzrihjljqmithporoase.Cancer);
-			var q_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_cibligzrihjljqmithporoase.Cancer);
-			var r_ = tuple_cibligzrihjljqmithporoase.FaceToFaceOrTelehealthEncounter?.Period;
-			var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var t_ = context.Operators.Overlaps(q_, s_, null);
-			var u_ = context.Operators.And(p_, t_);
-			var v_ = tuple_cibligzrihjljqmithporoase.ChemoBeforeEncounter?.Performed;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = QICoreCommon_2_0_000.toInterval(w_);
-			var y_ = context.Operators.Start(x_);
-			var aa_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var ab_ = context.Operators.End(aa_);
-			var ac_ = context.Operators.Quantity(30m, "days");
-			var ad_ = context.Operators.Subtract(ab_, ac_);
-			var af_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var ag_ = context.Operators.End(af_);
-			var ah_ = context.Operators.Interval(ad_, ag_, true, true);
-			var ai_ = context.Operators.In<CqlDateTime>(y_, ah_, "day");
-			var ak_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var al_ = context.Operators.End(ak_);
-			var am_ = context.Operators.Not((bool?)(al_ is null));
-			var an_ = context.Operators.And(ai_, am_);
-			var ao_ = context.Operators.And(u_, an_);
-			var ap_ = tuple_cibligzrihjljqmithporoase.ChemoAfterEncounter?.Performed;
-			var aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
-			var ar_ = QICoreCommon_2_0_000.toInterval(aq_);
-			var as_ = context.Operators.Start(ar_);
-			var au_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var av_ = context.Operators.End(au_);
-			var ax_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var ay_ = context.Operators.End(ax_);
-			var ba_ = context.Operators.Add(ay_, ac_);
-			var bb_ = context.Operators.Interval(av_, ba_, true, true);
-			var bc_ = context.Operators.In<CqlDateTime>(as_, bb_, "day");
-			var be_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var bf_ = context.Operators.End(be_);
-			var bg_ = context.Operators.Not((bool?)(bf_ is null));
-			var bh_ = context.Operators.And(bc_, bg_);
-			var bi_ = context.Operators.And(ao_, bh_);
-			var bk_ = FHIRHelpers_4_3_000.ToValue(ap_);
-			var bl_ = QICoreCommon_2_0_000.toInterval(bk_);
-			var bn_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var bo_ = QICoreCommon_2_0_000.toInterval(bn_);
-			var bp_ = context.Operators.SameAs<CqlDateTime>(bl_, bo_, "day");
-			var bq_ = context.Operators.Not(bp_);
-			var br_ = context.Operators.And(bi_, bq_);
-			var bs_ = this.Measurement_Period();
-			var bu_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var bv_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bs_, bu_, null);
-			var bw_ = context.Operators.And(br_, bv_);
+			bool? p_ = QICoreCommon_2_0_000.isActive(tuple_cibligzrihjljqmithporoase.Cancer);
+			CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_cibligzrihjljqmithporoase.Cancer);
+			Period r_ = tuple_cibligzrihjljqmithporoase.FaceToFaceOrTelehealthEncounter?.Period;
+			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			bool? t_ = context.Operators.Overlaps(q_, s_, null);
+			bool? u_ = context.Operators.And(p_, t_);
+			DataType v_ = tuple_cibligzrihjljqmithporoase.ChemoBeforeEncounter?.Performed;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.toInterval(w_);
+			CqlDateTime y_ = context.Operators.Start(x_);
+			CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			CqlDateTime ab_ = context.Operators.End(aa_);
+			CqlQuantity ac_ = context.Operators.Quantity(30m, "days");
+			CqlDateTime ad_ = context.Operators.Subtract(ab_, ac_);
+			CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			CqlDateTime ag_ = context.Operators.End(af_);
+			CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ad_, ag_, true, true);
+			bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, "day");
+			CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			CqlDateTime al_ = context.Operators.End(ak_);
+			bool? am_ = context.Operators.Not((bool?)(al_ is null));
+			bool? an_ = context.Operators.And(ai_, am_);
+			bool? ao_ = context.Operators.And(u_, an_);
+			DataType ap_ = tuple_cibligzrihjljqmithporoase.ChemoAfterEncounter?.Performed;
+			object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+			CqlInterval<CqlDateTime> ar_ = QICoreCommon_2_0_000.toInterval(aq_);
+			CqlDateTime as_ = context.Operators.Start(ar_);
+			CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			CqlDateTime av_ = context.Operators.End(au_);
+			CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			CqlDateTime ay_ = context.Operators.End(ax_);
+			CqlDateTime ba_ = context.Operators.Add(ay_, ac_);
+			CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(av_, ba_, true, true);
+			bool? bc_ = context.Operators.In<CqlDateTime>(as_, bb_, "day");
+			CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			CqlDateTime bf_ = context.Operators.End(be_);
+			bool? bg_ = context.Operators.Not((bool?)(bf_ is null));
+			bool? bh_ = context.Operators.And(bc_, bg_);
+			bool? bi_ = context.Operators.And(ao_, bh_);
+			object bk_ = FHIRHelpers_4_3_000.ToValue(ap_);
+			CqlInterval<CqlDateTime> bl_ = QICoreCommon_2_0_000.toInterval(bk_);
+			object bn_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlInterval<CqlDateTime> bo_ = QICoreCommon_2_0_000.toInterval(bn_);
+			bool? bp_ = context.Operators.SameAs<CqlDateTime>(bl_, bo_, "day");
+			bool? bq_ = context.Operators.Not(bp_);
+			bool? br_ = context.Operators.And(bi_, bq_);
+			CqlInterval<CqlDateTime> bs_ = this.Measurement_Period();
+			CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			bool? bv_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bs_, bu_, null);
+			bool? bw_ = context.Operators.And(br_, bv_);
 
 			return bw_;
 		};
-		var l_ = context.Operators.Where<Tuple_CIBLiGZRIHjLJQMiTHPOROaSe>(j_, k_);
+		IEnumerable<Tuple_CIBLiGZRIHjLJQMiTHPOROaSe> l_ = context.Operators.Where<Tuple_CIBLiGZRIHjLJQMiTHPOROaSe>(j_, k_);
 		Encounter m_(Tuple_CIBLiGZRIHjLJQMiTHPOROaSe tuple_cibligzrihjljqmithporoase) => 
 			tuple_cibligzrihjljqmithporoase.FaceToFaceOrTelehealthEncounter;
-		var n_ = context.Operators.Select<Tuple_CIBLiGZRIHjLJQMiTHPOROaSe, Encounter>(l_, m_);
+		IEnumerable<Encounter> n_ = context.Operators.Select<Tuple_CIBLiGZRIHjLJQMiTHPOROaSe, Encounter>(l_, m_);
 
 		return n_;
 	}
 
+    /// <seealso cref="Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy_Value"/>
     [CqlDeclaration("Face to Face or Telehealth Encounter with Ongoing Chemotherapy")]
 	public IEnumerable<Encounter> Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy() => 
 		__Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy.Value;
 
+    /// <seealso cref="Initial_Population_1"/>
 	private IEnumerable<Encounter> Initial_Population_1_Value()
 	{
-		var a_ = this.Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy();
+		IEnumerable<Encounter> a_ = this.Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_1_Value"/>
     [CqlDeclaration("Initial Population 1")]
 	public IEnumerable<Encounter> Initial_Population_1() => 
 		__Initial_Population_1.Value;
 
+    /// <seealso cref="Denominator_1"/>
 	private IEnumerable<Encounter> Denominator_1_Value()
 	{
-		var a_ = this.Initial_Population_1();
+		IEnumerable<Encounter> a_ = this.Initial_Population_1();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_1_Value"/>
     [CqlDeclaration("Denominator 1")]
 	public IEnumerable<Encounter> Denominator_1() => 
 		__Denominator_1.Value;
 
+    /// <seealso cref="Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis"/>
 	private IEnumerable<Encounter> Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis_Value()
 	{
-		var a_ = this.Radiation_Treatment_Management();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = Status_1_6_000.Finished_Encounter(b_);
+		CqlValueSet a_ = this.Radiation_Treatment_Management();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> c_ = Status_1_6_000.Finished_Encounter(b_);
 		IEnumerable<Encounter> d_(Encounter RadiationTreatmentManagement)
 		{
-			var f_ = this.Cancer();
-			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			CqlValueSet f_ = this.Cancer();
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
 			bool? h_(Condition Cancer)
 			{
-				var l_ = QICoreCommon_2_0_000.isActive(Cancer);
-				var m_ = QICoreCommon_2_0_000.prevalenceInterval(Cancer);
-				var n_ = RadiationTreatmentManagement?.Period;
-				var o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var p_ = context.Operators.Overlaps(m_, o_, null);
-				var q_ = context.Operators.And(l_, p_);
-				var r_ = this.Measurement_Period();
-				var t_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, null);
-				var v_ = context.Operators.And(q_, u_);
+				bool? l_ = QICoreCommon_2_0_000.isActive(Cancer);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(Cancer);
+				Period n_ = RadiationTreatmentManagement?.Period;
+				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				bool? p_ = context.Operators.Overlaps(m_, o_, null);
+				bool? q_ = context.Operators.And(l_, p_);
+				CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
+				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				bool? u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, null);
+				bool? v_ = context.Operators.And(q_, u_);
 
 				return v_;
 			};
-			var i_ = context.Operators.Where<Condition>(g_, h_);
+			IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
 			Encounter j_(Condition Cancer) => 
 				RadiationTreatmentManagement;
-			var k_ = context.Operators.Select<Condition, Encounter>(i_, j_);
+			IEnumerable<Encounter> k_ = context.Operators.Select<Condition, Encounter>(i_, j_);
 
 			return k_;
 		};
-		var e_ = context.Operators.SelectMany<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.SelectMany<Encounter, Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis_Value"/>
     [CqlDeclaration("Radiation Treatment Management During Measurement Period with Cancer Diagnosis")]
 	public IEnumerable<Encounter> Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis() => 
 		__Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis.Value;
 
+    /// <seealso cref="Initial_Population_2"/>
 	private IEnumerable<Encounter> Initial_Population_2_Value()
 	{
-		var a_ = this.Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis();
+		IEnumerable<Encounter> a_ = this.Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_2_Value"/>
     [CqlDeclaration("Initial Population 2")]
 	public IEnumerable<Encounter> Initial_Population_2() => 
 		__Initial_Population_2.Value;
 
+    /// <seealso cref="Denominator_2"/>
 	private IEnumerable<Encounter> Denominator_2_Value()
 	{
-		var a_ = this.Initial_Population_2();
+		IEnumerable<Encounter> a_ = this.Initial_Population_2();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_2_Value"/>
     [CqlDeclaration("Denominator 2")]
 	public IEnumerable<Encounter> Denominator_2() => 
 		__Denominator_2.Value;
 
+    /// <seealso cref="Numerator_1"/>
 	private IEnumerable<Encounter> Numerator_1_Value()
 	{
-		var a_ = this.Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy();
+		IEnumerable<Encounter> a_ = this.Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy();
 		IEnumerable<Encounter> b_(Encounter FaceToFaceOrTelehealthEncounterWithChemo)
 		{
-			var d_ = this.Standardized_Pain_Assessment_Tool();
-			var e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			CqlValueSet d_ = this.Standardized_Pain_Assessment_Tool();
+			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
 			bool? f_(Observation PainAssessed)
 			{
-				var j_ = FaceToFaceOrTelehealthEncounterWithChemo?.Period;
-				var k_ = FHIRHelpers_4_3_000.ToInterval(j_);
-				var l_ = PainAssessed?.Effective;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = QICoreCommon_2_0_000.toInterval(m_);
-				var o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, null);
-				var p_ = PainAssessed?.Value;
-				var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-				var r_ = context.Operators.Not((bool?)(q_ is null));
-				var s_ = context.Operators.And(o_, r_);
-				var t_ = PainAssessed?.StatusElement;
-				var u_ = t_?.Value;
-				var v_ = context.Operators.Convert<Code<ObservationStatus>>(u_);
-				var w_ = context.Operators.Equal(v_, "final");
-				var x_ = context.Operators.And(s_, w_);
+				Period j_ = FaceToFaceOrTelehealthEncounterWithChemo?.Period;
+				CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_3_000.ToInterval(j_);
+				DataType l_ = PainAssessed?.Effective;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
+				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, null);
+				DataType p_ = PainAssessed?.Value;
+				object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+				bool? r_ = context.Operators.Not((bool?)(q_ is null));
+				bool? s_ = context.Operators.And(o_, r_);
+				Code<ObservationStatus> t_ = PainAssessed?.StatusElement;
+				ObservationStatus? u_ = t_?.Value;
+				Code<ObservationStatus> v_ = context.Operators.Convert<Code<ObservationStatus>>(u_);
+				bool? w_ = context.Operators.Equal(v_, "final");
+				bool? x_ = context.Operators.And(s_, w_);
 
 				return x_;
 			};
-			var g_ = context.Operators.Where<Observation>(e_, f_);
+			IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
 			Encounter h_(Observation PainAssessed) => 
 				FaceToFaceOrTelehealthEncounterWithChemo;
-			var i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_1_Value"/>
     [CqlDeclaration("Numerator 1")]
 	public IEnumerable<Encounter> Numerator_1() => 
 		__Numerator_1.Value;
 
+    /// <seealso cref="Numerator_2"/>
 	private IEnumerable<Encounter> Numerator_2_Value()
 	{
-		var a_ = this.Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis();
+		IEnumerable<Encounter> a_ = this.Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis();
 		IEnumerable<Encounter> b_(Encounter RadiationManagementEncounter)
 		{
-			var d_ = this.Standardized_Pain_Assessment_Tool();
-			var e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			CqlValueSet d_ = this.Standardized_Pain_Assessment_Tool();
+			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
 			bool? f_(Observation PainAssessed)
 			{
 				bool? j_()
 				{
 					bool t_()
 					{
-						var u_ = RadiationManagementEncounter?.Type;
+						List<CodeableConcept> u_ = RadiationManagementEncounter?.Type;
 						CqlConcept v_(CodeableConcept @this)
 						{
-							var aa_ = FHIRHelpers_4_3_000.ToConcept(@this);
+							CqlConcept aa_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 							return aa_;
 						};
-						var w_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)u_, v_);
+						IEnumerable<CqlConcept> w_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)u_, v_);
 						bool? x_(CqlConcept RadiationManagement)
 						{
-							var ab_ = this.Radiation_treatment_management__5_treatments();
-							var ac_ = context.Operators.ConvertCodeToConcept(ab_);
-							var ad_ = context.Operators.Equivalent(RadiationManagement, ac_);
+							CqlCode ab_ = this.Radiation_treatment_management__5_treatments();
+							CqlConcept ac_ = context.Operators.ConvertCodeToConcept(ab_);
+							bool? ad_ = context.Operators.Equivalent(RadiationManagement, ac_);
 
 							return ad_;
 						};
-						var y_ = context.Operators.Where<CqlConcept>(w_, x_);
-						var z_ = context.Operators.Exists<CqlConcept>(y_);
+						IEnumerable<CqlConcept> y_ = context.Operators.Where<CqlConcept>(w_, x_);
+						bool? z_ = context.Operators.Exists<CqlConcept>(y_);
 
 						return (z_ ?? false);
 					};
 					if (t_())
 					{
-						var ae_ = PainAssessed?.Effective;
-						var af_ = FHIRHelpers_4_3_000.ToValue(ae_);
-						var ag_ = QICoreCommon_2_0_000.toInterval(af_);
-						var ah_ = context.Operators.End(ag_);
-						var ai_ = RadiationManagementEncounter?.Period;
-						var aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-						var ak_ = context.Operators.Start(aj_);
-						var al_ = context.Operators.Quantity(6m, "days");
-						var am_ = context.Operators.Subtract(ak_, al_);
-						var ao_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-						var ap_ = context.Operators.Start(ao_);
-						var aq_ = context.Operators.Interval(am_, ap_, true, true);
-						var ar_ = context.Operators.In<CqlDateTime>(ah_, aq_, "day");
-						var at_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-						var au_ = context.Operators.Start(at_);
-						var av_ = context.Operators.Not((bool?)(au_ is null));
-						var aw_ = context.Operators.And(ar_, av_);
+						DataType ae_ = PainAssessed?.Effective;
+						object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
+						CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.toInterval(af_);
+						CqlDateTime ah_ = context.Operators.End(ag_);
+						Period ai_ = RadiationManagementEncounter?.Period;
+						CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+						CqlDateTime ak_ = context.Operators.Start(aj_);
+						CqlQuantity al_ = context.Operators.Quantity(6m, "days");
+						CqlDateTime am_ = context.Operators.Subtract(ak_, al_);
+						CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+						CqlDateTime ap_ = context.Operators.Start(ao_);
+						CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(am_, ap_, true, true);
+						bool? ar_ = context.Operators.In<CqlDateTime>(ah_, aq_, "day");
+						CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+						CqlDateTime au_ = context.Operators.Start(at_);
+						bool? av_ = context.Operators.Not((bool?)(au_ is null));
+						bool? aw_ = context.Operators.And(ar_, av_);
 
 						return aw_;
 					}
 					else
 					{
-						var ax_ = RadiationManagementEncounter?.Period;
-						var ay_ = FHIRHelpers_4_3_000.ToInterval(ax_);
-						var az_ = PainAssessed?.Effective;
-						var ba_ = FHIRHelpers_4_3_000.ToValue(az_);
-						var bb_ = QICoreCommon_2_0_000.toInterval(ba_);
-						var bc_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ay_, bb_, "day");
+						Period ax_ = RadiationManagementEncounter?.Period;
+						CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_3_000.ToInterval(ax_);
+						DataType az_ = PainAssessed?.Effective;
+						object ba_ = FHIRHelpers_4_3_000.ToValue(az_);
+						CqlInterval<CqlDateTime> bb_ = QICoreCommon_2_0_000.toInterval(ba_);
+						bool? bc_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ay_, bb_, "day");
 
 						return bc_;
 					}
 				};
-				var k_ = PainAssessed?.Value;
-				var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-				var m_ = context.Operators.Not((bool?)(l_ is null));
-				var n_ = context.Operators.And(j_(), m_);
-				var o_ = PainAssessed?.StatusElement;
-				var p_ = o_?.Value;
-				var q_ = context.Operators.Convert<Code<ObservationStatus>>(p_);
-				var r_ = context.Operators.Equal(q_, "final");
-				var s_ = context.Operators.And(n_, r_);
+				DataType k_ = PainAssessed?.Value;
+				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+				bool? m_ = context.Operators.Not((bool?)(l_ is null));
+				bool? n_ = context.Operators.And(j_(), m_);
+				Code<ObservationStatus> o_ = PainAssessed?.StatusElement;
+				ObservationStatus? p_ = o_?.Value;
+				Code<ObservationStatus> q_ = context.Operators.Convert<Code<ObservationStatus>>(p_);
+				bool? r_ = context.Operators.Equal(q_, "final");
+				bool? s_ = context.Operators.And(n_, r_);
 
 				return s_;
 			};
-			var g_ = context.Operators.Where<Observation>(e_, f_);
+			IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
 			Encounter h_(Observation PainAssessed) => 
 				RadiationManagementEncounter;
-			var i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Observation, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_2_Value"/>
     [CqlDeclaration("Numerator 2")]
 	public IEnumerable<Encounter> Numerator_2() => 
 		__Numerator_2.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
@@ -66,63 +66,78 @@ public class PCMaternal_5_16_000
 
     #endregion
 
+    /// <seealso cref="Delivery_Procedures"/>
 	private CqlValueSet Delivery_Procedures_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", null);
 
+    /// <seealso cref="Delivery_Procedures_Value"/>
     [CqlDeclaration("Delivery Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
 	public CqlValueSet Delivery_Procedures() => 
 		__Delivery_Procedures.Value;
 
+    /// <seealso cref="ED_Visit_and_OB_Triage"/>
 	private CqlValueSet ED_Visit_and_OB_Triage_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", null);
 
+    /// <seealso cref="ED_Visit_and_OB_Triage_Value"/>
     [CqlDeclaration("ED Visit and OB Triage")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369")]
 	public CqlValueSet ED_Visit_and_OB_Triage() => 
 		__ED_Visit_and_OB_Triage.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Estimated_Gestational_Age_at_Delivery"/>
 	private CqlValueSet Estimated_Gestational_Age_at_Delivery_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26", null);
 
+    /// <seealso cref="Estimated_Gestational_Age_at_Delivery_Value"/>
     [CqlDeclaration("Estimated Gestational Age at Delivery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26")]
 	public CqlValueSet Estimated_Gestational_Age_at_Delivery() => 
 		__Estimated_Gestational_Age_at_Delivery.Value;
 
+    /// <seealso cref="Observation_Services"/>
 	private CqlValueSet Observation_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
+    /// <seealso cref="Observation_Services_Value"/>
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
 	public CqlValueSet Observation_Services() => 
 		__Observation_Services.Value;
 
+    /// <seealso cref="Date_and_time_of_obstetric_delivery"/>
 	private CqlCode Date_and_time_of_obstetric_delivery_Value() => 
 		new CqlCode("93857-1", "http://loinc.org", null, null);
 
+    /// <seealso cref="Date_and_time_of_obstetric_delivery_Value"/>
     [CqlDeclaration("Date and time of obstetric delivery")]
 	public CqlCode Date_and_time_of_obstetric_delivery() => 
 		__Date_and_time_of_obstetric_delivery.Value;
 
+    /// <seealso cref="Delivery_date_Estimated"/>
 	private CqlCode Delivery_date_Estimated_Value() => 
 		new CqlCode("11778-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Delivery_date_Estimated_Value"/>
     [CqlDeclaration("Delivery date Estimated")]
 	public CqlCode Delivery_date_Estimated() => 
 		__Delivery_date_Estimated.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("93857-1", "http://loinc.org", null, null),
 			new CqlCode("11778-8", "http://loinc.org", null, null),
@@ -131,60 +146,67 @@ public class PCMaternal_5_16_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("PCMaternal-5.16.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("PCMaternal-5.16.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Encounter_with_Age_Range"/>
 	private IEnumerable<Encounter> Encounter_with_Age_Range_Value()
 	{
-		var a_ = CQMCommon_2_0_000.Inpatient_Encounter();
+		IEnumerable<Encounter> a_ = CQMCommon_2_0_000.Inpatient_Encounter();
 		bool? b_(Encounter InpatientEncounter)
 		{
-			var d_ = this.Patient();
-			var e_ = d_?.BirthDateElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.Convert<CqlDate>(f_);
-			var h_ = InpatientEncounter?.Period;
-			var i_ = FHIRHelpers_4_3_000.ToInterval(h_);
-			var j_ = context.Operators.Start(i_);
-			var k_ = context.Operators.DateFrom(j_);
-			var l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
-			var m_ = context.Operators.Interval(8, 65, true, false);
-			var n_ = context.Operators.In<int?>(l_, m_, null);
+			Patient d_ = this.Patient();
+			Date e_ = d_?.BirthDateElement;
+			string f_ = e_?.Value;
+			CqlDate g_ = context.Operators.Convert<CqlDate>(f_);
+			Period h_ = InpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
+			CqlDate k_ = context.Operators.DateFrom(j_);
+			int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
+			CqlInterval<int?> m_ = context.Operators.Interval(8, 65, true, false);
+			bool? n_ = context.Operators.In<int?>(l_, m_, null);
 
 			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Age_Range_Value"/>
     [CqlDeclaration("Encounter with Age Range")]
 	public IEnumerable<Encounter> Encounter_with_Age_Range() => 
 		__Encounter_with_Age_Range.Value;
@@ -192,270 +214,272 @@ public class PCMaternal_5_16_000
     [CqlDeclaration("hospitalizationWithEDOBTriageObservation")]
 	public CqlInterval<CqlDateTime> hospitalizationWithEDOBTriageObservation(Encounter TheEncounter)
 	{
-		var a_ = new Encounter[]
+		Encounter[] a_ = new Encounter[]
 		{
 			TheEncounter,
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.ED_Visit_and_OB_Triage();
-			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			CqlValueSet e_ = this.ED_Visit_and_OB_Triage();
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastEDOBTriage)
 			{
-				var af_ = LastEDOBTriage?.Period;
-				var ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-				var ah_ = context.Operators.End(ag_);
-				var ai_ = this.Observation_Services();
-				var aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				Period af_ = LastEDOBTriage?.Period;
+				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
+				CqlDateTime ah_ = context.Operators.End(ag_);
+				CqlValueSet ai_ = this.Observation_Services();
+				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
 				bool? ak_(Encounter LastObs)
 				{
-					var cg_ = LastObs?.Period;
-					var ch_ = FHIRHelpers_4_3_000.ToInterval(cg_);
-					var ci_ = context.Operators.End(ch_);
-					var cj_ = Visit?.Period;
-					var ck_ = FHIRHelpers_4_3_000.ToInterval(cj_);
-					var cl_ = context.Operators.Start(ck_);
-					var cm_ = context.Operators.Quantity(1m, "hour");
-					var cn_ = context.Operators.Subtract(cl_, cm_);
-					var cp_ = FHIRHelpers_4_3_000.ToInterval(cj_);
-					var cq_ = context.Operators.Start(cp_);
-					var cr_ = context.Operators.Interval(cn_, cq_, true, true);
-					var cs_ = context.Operators.In<CqlDateTime>(ci_, cr_, null);
-					var cu_ = FHIRHelpers_4_3_000.ToInterval(cj_);
-					var cv_ = context.Operators.Start(cu_);
-					var cw_ = context.Operators.Not((bool?)(cv_ is null));
-					var cx_ = context.Operators.And(cs_, cw_);
-					var cy_ = LastObs?.StatusElement;
-					var cz_ = cy_?.Value;
-					var da_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cz_);
-					var db_ = context.Operators.Equal(da_, "finished");
-					var dc_ = context.Operators.And(cx_, db_);
+					Period cg_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> ch_ = FHIRHelpers_4_3_000.ToInterval(cg_);
+					CqlDateTime ci_ = context.Operators.End(ch_);
+					Period cj_ = Visit?.Period;
+					CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_3_000.ToInterval(cj_);
+					CqlDateTime cl_ = context.Operators.Start(ck_);
+					CqlQuantity cm_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime cn_ = context.Operators.Subtract(cl_, cm_);
+					CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_3_000.ToInterval(cj_);
+					CqlDateTime cq_ = context.Operators.Start(cp_);
+					CqlInterval<CqlDateTime> cr_ = context.Operators.Interval(cn_, cq_, true, true);
+					bool? cs_ = context.Operators.In<CqlDateTime>(ci_, cr_, null);
+					CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_3_000.ToInterval(cj_);
+					CqlDateTime cv_ = context.Operators.Start(cu_);
+					bool? cw_ = context.Operators.Not((bool?)(cv_ is null));
+					bool? cx_ = context.Operators.And(cs_, cw_);
+					Code<Encounter.EncounterStatus> cy_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? cz_ = cy_?.Value;
+					Code<Encounter.EncounterStatus> da_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cz_);
+					bool? db_ = context.Operators.Equal(da_, "finished");
+					bool? dc_ = context.Operators.And(cx_, db_);
 
 					return dc_;
 				};
-				var al_ = context.Operators.Where<Encounter>(aj_, ak_);
+				IEnumerable<Encounter> al_ = context.Operators.Where<Encounter>(aj_, ak_);
 				object am_(Encounter @this)
 				{
-					var dd_ = @this?.Period;
-					var de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
-					var df_ = context.Operators.End(de_);
+					Period dd_ = @this?.Period;
+					CqlInterval<CqlDateTime> de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
+					CqlDateTime df_ = context.Operators.End(de_);
 
 					return df_;
 				};
-				var an_ = context.Operators.SortBy<Encounter>(al_, am_, System.ComponentModel.ListSortDirection.Ascending);
-				var ao_ = context.Operators.Last<Encounter>(an_);
-				var ap_ = ao_?.Period;
-				var aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				var ar_ = context.Operators.Start(aq_);
-				var as_ = Visit?.Period;
-				var at_ = FHIRHelpers_4_3_000.ToInterval(as_);
-				var au_ = context.Operators.Start(at_);
-				var av_ = context.Operators.Quantity(1m, "hour");
-				var aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
-				var ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> an_ = context.Operators.SortBy<Encounter>(al_, am_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter ao_ = context.Operators.Last<Encounter>(an_);
+				Period ap_ = ao_?.Period;
+				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
+				CqlDateTime ar_ = context.Operators.Start(aq_);
+				Period as_ = Visit?.Period;
+				CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_3_000.ToInterval(as_);
+				CqlDateTime au_ = context.Operators.Start(at_);
+				CqlQuantity av_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
+				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
 				bool? az_(Encounter LastObs)
 				{
-					var dg_ = LastObs?.Period;
-					var dh_ = FHIRHelpers_4_3_000.ToInterval(dg_);
-					var di_ = context.Operators.End(dh_);
-					var dj_ = Visit?.Period;
-					var dk_ = FHIRHelpers_4_3_000.ToInterval(dj_);
-					var dl_ = context.Operators.Start(dk_);
-					var dm_ = context.Operators.Quantity(1m, "hour");
-					var dn_ = context.Operators.Subtract(dl_, dm_);
-					var dp_ = FHIRHelpers_4_3_000.ToInterval(dj_);
-					var dq_ = context.Operators.Start(dp_);
-					var dr_ = context.Operators.Interval(dn_, dq_, true, true);
-					var ds_ = context.Operators.In<CqlDateTime>(di_, dr_, null);
-					var du_ = FHIRHelpers_4_3_000.ToInterval(dj_);
-					var dv_ = context.Operators.Start(du_);
-					var dw_ = context.Operators.Not((bool?)(dv_ is null));
-					var dx_ = context.Operators.And(ds_, dw_);
-					var dy_ = LastObs?.StatusElement;
-					var dz_ = dy_?.Value;
-					var ea_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dz_);
-					var eb_ = context.Operators.Equal(ea_, "finished");
-					var ec_ = context.Operators.And(dx_, eb_);
+					Period dg_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> dh_ = FHIRHelpers_4_3_000.ToInterval(dg_);
+					CqlDateTime di_ = context.Operators.End(dh_);
+					Period dj_ = Visit?.Period;
+					CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_3_000.ToInterval(dj_);
+					CqlDateTime dl_ = context.Operators.Start(dk_);
+					CqlQuantity dm_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime dn_ = context.Operators.Subtract(dl_, dm_);
+					CqlInterval<CqlDateTime> dp_ = FHIRHelpers_4_3_000.ToInterval(dj_);
+					CqlDateTime dq_ = context.Operators.Start(dp_);
+					CqlInterval<CqlDateTime> dr_ = context.Operators.Interval(dn_, dq_, true, true);
+					bool? ds_ = context.Operators.In<CqlDateTime>(di_, dr_, null);
+					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dj_);
+					CqlDateTime dv_ = context.Operators.Start(du_);
+					bool? dw_ = context.Operators.Not((bool?)(dv_ is null));
+					bool? dx_ = context.Operators.And(ds_, dw_);
+					Code<Encounter.EncounterStatus> dy_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? dz_ = dy_?.Value;
+					Code<Encounter.EncounterStatus> ea_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dz_);
+					bool? eb_ = context.Operators.Equal(ea_, "finished");
+					bool? ec_ = context.Operators.And(dx_, eb_);
 
 					return ec_;
 				};
-				var ba_ = context.Operators.Where<Encounter>(ay_, az_);
+				IEnumerable<Encounter> ba_ = context.Operators.Where<Encounter>(ay_, az_);
 				object bb_(Encounter @this)
 				{
-					var ed_ = @this?.Period;
-					var ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
-					var ef_ = context.Operators.End(ee_);
+					Period ed_ = @this?.Period;
+					CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
+					CqlDateTime ef_ = context.Operators.End(ee_);
 
 					return ef_;
 				};
-				var bc_ = context.Operators.SortBy<Encounter>(ba_, bb_, System.ComponentModel.ListSortDirection.Ascending);
-				var bd_ = context.Operators.Last<Encounter>(bc_);
-				var be_ = bd_?.Period;
-				var bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
-				var bg_ = context.Operators.Start(bf_);
-				var bi_ = FHIRHelpers_4_3_000.ToInterval(as_);
-				var bj_ = context.Operators.Start(bi_);
-				var bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
-				var bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, null);
-				var bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> bc_ = context.Operators.SortBy<Encounter>(ba_, bb_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bd_ = context.Operators.Last<Encounter>(bc_);
+				Period be_ = bd_?.Period;
+				CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_3_000.ToInterval(be_);
+				CqlDateTime bg_ = context.Operators.Start(bf_);
+				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(as_);
+				CqlDateTime bj_ = context.Operators.Start(bi_);
+				CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
+				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, null);
+				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
 				bool? bo_(Encounter LastObs)
 				{
-					var eg_ = LastObs?.Period;
-					var eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var ei_ = context.Operators.End(eh_);
-					var ej_ = Visit?.Period;
-					var ek_ = FHIRHelpers_4_3_000.ToInterval(ej_);
-					var el_ = context.Operators.Start(ek_);
-					var em_ = context.Operators.Quantity(1m, "hour");
-					var en_ = context.Operators.Subtract(el_, em_);
-					var ep_ = FHIRHelpers_4_3_000.ToInterval(ej_);
-					var eq_ = context.Operators.Start(ep_);
-					var er_ = context.Operators.Interval(en_, eq_, true, true);
-					var es_ = context.Operators.In<CqlDateTime>(ei_, er_, null);
-					var eu_ = FHIRHelpers_4_3_000.ToInterval(ej_);
-					var ev_ = context.Operators.Start(eu_);
-					var ew_ = context.Operators.Not((bool?)(ev_ is null));
-					var ex_ = context.Operators.And(es_, ew_);
-					var ey_ = LastObs?.StatusElement;
-					var ez_ = ey_?.Value;
-					var fa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ez_);
-					var fb_ = context.Operators.Equal(fa_, "finished");
-					var fc_ = context.Operators.And(ex_, fb_);
+					Period eg_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime ei_ = context.Operators.End(eh_);
+					Period ej_ = Visit?.Period;
+					CqlInterval<CqlDateTime> ek_ = FHIRHelpers_4_3_000.ToInterval(ej_);
+					CqlDateTime el_ = context.Operators.Start(ek_);
+					CqlQuantity em_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime en_ = context.Operators.Subtract(el_, em_);
+					CqlInterval<CqlDateTime> ep_ = FHIRHelpers_4_3_000.ToInterval(ej_);
+					CqlDateTime eq_ = context.Operators.Start(ep_);
+					CqlInterval<CqlDateTime> er_ = context.Operators.Interval(en_, eq_, true, true);
+					bool? es_ = context.Operators.In<CqlDateTime>(ei_, er_, null);
+					CqlInterval<CqlDateTime> eu_ = FHIRHelpers_4_3_000.ToInterval(ej_);
+					CqlDateTime ev_ = context.Operators.Start(eu_);
+					bool? ew_ = context.Operators.Not((bool?)(ev_ is null));
+					bool? ex_ = context.Operators.And(es_, ew_);
+					Code<Encounter.EncounterStatus> ey_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? ez_ = ey_?.Value;
+					Code<Encounter.EncounterStatus> fa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ez_);
+					bool? fb_ = context.Operators.Equal(fa_, "finished");
+					bool? fc_ = context.Operators.And(ex_, fb_);
 
 					return fc_;
 				};
-				var bp_ = context.Operators.Where<Encounter>(bn_, bo_);
+				IEnumerable<Encounter> bp_ = context.Operators.Where<Encounter>(bn_, bo_);
 				object bq_(Encounter @this)
 				{
-					var fd_ = @this?.Period;
-					var fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
-					var ff_ = context.Operators.End(fe_);
+					Period fd_ = @this?.Period;
+					CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
+					CqlDateTime ff_ = context.Operators.End(fe_);
 
 					return ff_;
 				};
-				var br_ = context.Operators.SortBy<Encounter>(bp_, bq_, System.ComponentModel.ListSortDirection.Ascending);
-				var bs_ = context.Operators.Last<Encounter>(br_);
-				var bt_ = bs_?.Period;
-				var bu_ = FHIRHelpers_4_3_000.ToInterval(bt_);
-				var bv_ = context.Operators.Start(bu_);
-				var bx_ = FHIRHelpers_4_3_000.ToInterval(as_);
-				var by_ = context.Operators.Start(bx_);
-				var bz_ = context.Operators.Not((bool?)((bv_ ?? by_) is null));
-				var ca_ = context.Operators.And(bl_, bz_);
-				var cb_ = LastEDOBTriage?.StatusElement;
-				var cc_ = cb_?.Value;
-				var cd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cc_);
-				var ce_ = context.Operators.Equal(cd_, "finished");
-				var cf_ = context.Operators.And(ca_, ce_);
+				IEnumerable<Encounter> br_ = context.Operators.SortBy<Encounter>(bp_, bq_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bs_ = context.Operators.Last<Encounter>(br_);
+				Period bt_ = bs_?.Period;
+				CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_3_000.ToInterval(bt_);
+				CqlDateTime bv_ = context.Operators.Start(bu_);
+				CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_3_000.ToInterval(as_);
+				CqlDateTime by_ = context.Operators.Start(bx_);
+				bool? bz_ = context.Operators.Not((bool?)((bv_ ?? by_) is null));
+				bool? ca_ = context.Operators.And(bl_, bz_);
+				Code<Encounter.EncounterStatus> cb_ = LastEDOBTriage?.StatusElement;
+				Encounter.EncounterStatus? cc_ = cb_?.Value;
+				Code<Encounter.EncounterStatus> cd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(cc_);
+				bool? ce_ = context.Operators.Equal(cd_, "finished");
+				bool? cf_ = context.Operators.And(ca_, ce_);
 
 				return cf_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var fg_ = @this?.Period;
-				var fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
-				var fi_ = context.Operators.End(fh_);
+				Period fg_ = @this?.Period;
+				CqlInterval<CqlDateTime> fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
+				CqlDateTime fi_ = context.Operators.End(fh_);
 
 				return fi_;
 			};
-			var j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Encounter>(j_);
-			var l_ = k_?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Observation_Services();
-			var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter k_ = context.Operators.Last<Encounter>(j_);
+			Period l_ = k_?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlValueSet o_ = this.Observation_Services();
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
 			bool? q_(Encounter LastObs)
 			{
-				var fj_ = LastObs?.Period;
-				var fk_ = FHIRHelpers_4_3_000.ToInterval(fj_);
-				var fl_ = context.Operators.End(fk_);
-				var fm_ = Visit?.Period;
-				var fn_ = FHIRHelpers_4_3_000.ToInterval(fm_);
-				var fo_ = context.Operators.Start(fn_);
-				var fp_ = context.Operators.Quantity(1m, "hour");
-				var fq_ = context.Operators.Subtract(fo_, fp_);
-				var fs_ = FHIRHelpers_4_3_000.ToInterval(fm_);
-				var ft_ = context.Operators.Start(fs_);
-				var fu_ = context.Operators.Interval(fq_, ft_, true, true);
-				var fv_ = context.Operators.In<CqlDateTime>(fl_, fu_, null);
-				var fx_ = FHIRHelpers_4_3_000.ToInterval(fm_);
-				var fy_ = context.Operators.Start(fx_);
-				var fz_ = context.Operators.Not((bool?)(fy_ is null));
-				var ga_ = context.Operators.And(fv_, fz_);
-				var gb_ = LastObs?.StatusElement;
-				var gc_ = gb_?.Value;
-				var gd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gc_);
-				var ge_ = context.Operators.Equal(gd_, "finished");
-				var gf_ = context.Operators.And(ga_, ge_);
+				Period fj_ = LastObs?.Period;
+				CqlInterval<CqlDateTime> fk_ = FHIRHelpers_4_3_000.ToInterval(fj_);
+				CqlDateTime fl_ = context.Operators.End(fk_);
+				Period fm_ = Visit?.Period;
+				CqlInterval<CqlDateTime> fn_ = FHIRHelpers_4_3_000.ToInterval(fm_);
+				CqlDateTime fo_ = context.Operators.Start(fn_);
+				CqlQuantity fp_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime fq_ = context.Operators.Subtract(fo_, fp_);
+				CqlInterval<CqlDateTime> fs_ = FHIRHelpers_4_3_000.ToInterval(fm_);
+				CqlDateTime ft_ = context.Operators.Start(fs_);
+				CqlInterval<CqlDateTime> fu_ = context.Operators.Interval(fq_, ft_, true, true);
+				bool? fv_ = context.Operators.In<CqlDateTime>(fl_, fu_, null);
+				CqlInterval<CqlDateTime> fx_ = FHIRHelpers_4_3_000.ToInterval(fm_);
+				CqlDateTime fy_ = context.Operators.Start(fx_);
+				bool? fz_ = context.Operators.Not((bool?)(fy_ is null));
+				bool? ga_ = context.Operators.And(fv_, fz_);
+				Code<Encounter.EncounterStatus> gb_ = LastObs?.StatusElement;
+				Encounter.EncounterStatus? gc_ = gb_?.Value;
+				Code<Encounter.EncounterStatus> gd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gc_);
+				bool? ge_ = context.Operators.Equal(gd_, "finished");
+				bool? gf_ = context.Operators.And(ga_, ge_);
 
 				return gf_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 			object s_(Encounter @this)
 			{
-				var gg_ = @this?.Period;
-				var gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
-				var gi_ = context.Operators.End(gh_);
+				Period gg_ = @this?.Period;
+				CqlInterval<CqlDateTime> gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
+				CqlDateTime gi_ = context.Operators.End(gh_);
 
 				return gi_;
 			};
-			var t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.Last<Encounter>(t_);
-			var v_ = u_?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
-			var y_ = Visit?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = context.Operators.Start(z_);
-			var ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var ad_ = context.Operators.End(ac_);
-			var ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
+			IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter u_ = context.Operators.Last<Encounter>(t_);
+			Period v_ = u_?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			Period y_ = Visit?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime aa_ = context.Operators.Start(z_);
+			CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime ad_ = context.Operators.End(ac_);
+			CqlInterval<CqlDateTime> ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
 
 			return ae_;
 		};
-		var c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
+		CqlInterval<CqlDateTime> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Delivery_Encounter_with_Age_Range"/>
 	private IEnumerable<Encounter> Delivery_Encounter_with_Age_Range_Value()
 	{
-		var a_ = this.Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_Range();
 		IEnumerable<Encounter> b_(Encounter EncounterWithAge)
 		{
-			var d_ = this.Delivery_Procedures();
-			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			CqlValueSet d_ = this.Delivery_Procedures();
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
 			bool? f_(Procedure DeliveryProcedure)
 			{
-				var j_ = DeliveryProcedure?.StatusElement;
-				var k_ = j_?.Value;
-				var l_ = context.Operators.Convert<string>(k_);
-				var m_ = context.Operators.Equal(l_, "completed");
-				var n_ = DeliveryProcedure?.Performed;
-				var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-				var p_ = QICoreCommon_2_0_000.toInterval(o_);
-				var q_ = context.Operators.Start(p_);
-				var r_ = this.hospitalizationWithEDOBTriageObservation(EncounterWithAge);
-				var s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
-				var t_ = context.Operators.And(m_, s_);
+				Code<EventStatus> j_ = DeliveryProcedure?.StatusElement;
+				EventStatus? k_ = j_?.Value;
+				string l_ = context.Operators.Convert<string>(k_);
+				bool? m_ = context.Operators.Equal(l_, "completed");
+				DataType n_ = DeliveryProcedure?.Performed;
+				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+				CqlDateTime q_ = context.Operators.Start(p_);
+				CqlInterval<CqlDateTime> r_ = this.hospitalizationWithEDOBTriageObservation(EncounterWithAge);
+				bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
+				bool? t_ = context.Operators.And(m_, s_);
 
 				return t_;
 			};
-			var g_ = context.Operators.Where<Procedure>(e_, f_);
+			IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
 			Encounter h_(Procedure DeliveryProcedure) => 
 				EncounterWithAge;
-			var i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounter_with_Age_Range_Value"/>
     [CqlDeclaration("Delivery Encounter with Age Range")]
 	public IEnumerable<Encounter> Delivery_Encounter_with_Age_Range() => 
 		__Delivery_Encounter_with_Age_Range.Value;
@@ -463,328 +487,331 @@ public class PCMaternal_5_16_000
     [CqlDeclaration("lastTimeOfDelivery")]
 	public CqlDateTime lastTimeOfDelivery(Encounter TheEncounter)
 	{
-		var a_ = this.Date_and_time_of_obstetric_delivery();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.Date_and_time_of_obstetric_delivery();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation TimeOfDelivery)
 		{
-			var j_ = TimeOfDelivery?.Value;
-			var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-			var l_ = context.Operators.Not((bool?)((k_ as CqlDateTime) is null));
-			var m_ = TimeOfDelivery?.StatusElement;
-			var n_ = m_?.Value;
-			var o_ = context.Operators.Convert<Code<ObservationStatus>>(n_);
-			var p_ = context.Operators.Convert<string>(o_);
-			var q_ = new string[]
+			DataType k_ = TimeOfDelivery?.Value;
+			object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+			bool? m_ = context.Operators.Not((bool?)((l_ as CqlDateTime) is null));
+			Code<ObservationStatus> n_ = TimeOfDelivery?.StatusElement;
+			ObservationStatus? o_ = n_?.Value;
+			Code<ObservationStatus> p_ = context.Operators.Convert<Code<ObservationStatus>>(o_);
+			string q_ = context.Operators.Convert<string>(p_);
+			string[] r_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var r_ = context.Operators.In<string>(p_, (q_ as IEnumerable<string>));
-			var s_ = context.Operators.And(l_, r_);
-			object t_()
+			bool? s_ = context.Operators.In<string>(q_, (r_ as IEnumerable<string>));
+			bool? t_ = context.Operators.And(m_, s_);
+			object u_()
 			{
-				bool ad_()
-				{
-					var ag_ = TimeOfDelivery?.Effective;
-					var ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
-					var ai_ = ah_ is CqlDateTime;
-
-					return ai_;
-				};
 				bool ae_()
 				{
-					var aj_ = TimeOfDelivery?.Effective;
-					var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-					var al_ = ak_ is CqlInterval<CqlDateTime>;
+					DataType ah_ = TimeOfDelivery?.Effective;
+					object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+					bool aj_ = ai_ is CqlDateTime;
 
-					return al_;
+					return aj_;
 				};
 				bool af_()
 				{
-					var am_ = TimeOfDelivery?.Effective;
-					var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-					var ao_ = an_ is CqlDateTime;
+					DataType ak_ = TimeOfDelivery?.Effective;
+					object al_ = FHIRHelpers_4_3_000.ToValue(ak_);
+					bool am_ = al_ is CqlInterval<CqlDateTime>;
 
-					return ao_;
+					return am_;
 				};
-				if (ad_())
+				bool ag_()
 				{
-					var ap_ = TimeOfDelivery?.Effective;
-					var aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+					DataType an_ = TimeOfDelivery?.Effective;
+					object ao_ = FHIRHelpers_4_3_000.ToValue(an_);
+					bool ap_ = ao_ is CqlDateTime;
 
-					return ((aq_ as CqlDateTime) as object);
-				}
-				else if (ae_())
+					return ap_;
+				};
+				if (ae_())
 				{
-					var ar_ = TimeOfDelivery?.Effective;
-					var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+					DataType aq_ = TimeOfDelivery?.Effective;
+					object ar_ = FHIRHelpers_4_3_000.ToValue(aq_);
 
-					return ((as_ as CqlInterval<CqlDateTime>) as object);
+					return ((ar_ as CqlDateTime) as object);
 				}
 				else if (af_())
 				{
-					var at_ = TimeOfDelivery?.Effective;
-					var au_ = FHIRHelpers_4_3_000.ToValue(at_);
+					DataType as_ = TimeOfDelivery?.Effective;
+					object at_ = FHIRHelpers_4_3_000.ToValue(as_);
 
-					return ((au_ as CqlDateTime) as object);
+					return ((at_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (ag_())
+				{
+					DataType au_ = TimeOfDelivery?.Effective;
+					object av_ = FHIRHelpers_4_3_000.ToValue(au_);
+
+					return ((av_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var u_ = QICoreCommon_2_0_000.earliest(t_());
-			var v_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
-			var w_ = context.Operators.In<CqlDateTime>(u_, v_, null);
-			var x_ = context.Operators.And(s_, w_);
-			var z_ = FHIRHelpers_4_3_000.ToValue(j_);
-			var ab_ = context.Operators.In<CqlDateTime>((z_ as CqlDateTime), v_, null);
-			var ac_ = context.Operators.And(x_, ab_);
+			CqlDateTime v_ = QICoreCommon_2_0_000.earliest(u_());
+			CqlInterval<CqlDateTime> w_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
+			bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, null);
+			bool? y_ = context.Operators.And(t_, x_);
+			object aa_ = FHIRHelpers_4_3_000.ToValue(k_);
+			bool? ac_ = context.Operators.In<CqlDateTime>((aa_ as CqlDateTime), w_, null);
+			bool? ad_ = context.Operators.And(y_, ac_);
 
-			return ac_;
+			return ad_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			object av_()
+			object aw_()
 			{
-				bool ax_()
-				{
-					var ba_ = @this?.Effective;
-					var bb_ = FHIRHelpers_4_3_000.ToValue(ba_);
-					var bc_ = bb_ is CqlDateTime;
-
-					return bc_;
-				};
 				bool ay_()
 				{
-					var bd_ = @this?.Effective;
-					var be_ = FHIRHelpers_4_3_000.ToValue(bd_);
-					var bf_ = be_ is CqlInterval<CqlDateTime>;
+					DataType bb_ = @this?.Effective;
+					object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+					bool bd_ = bc_ is CqlDateTime;
 
-					return bf_;
+					return bd_;
 				};
 				bool az_()
 				{
-					var bg_ = @this?.Effective;
-					var bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
-					var bi_ = bh_ is CqlDateTime;
+					DataType be_ = @this?.Effective;
+					object bf_ = FHIRHelpers_4_3_000.ToValue(be_);
+					bool bg_ = bf_ is CqlInterval<CqlDateTime>;
 
-					return bi_;
+					return bg_;
 				};
-				if (ax_())
+				bool ba_()
 				{
-					var bj_ = @this?.Effective;
-					var bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+					DataType bh_ = @this?.Effective;
+					object bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
+					bool bj_ = bi_ is CqlDateTime;
 
-					return ((bk_ as CqlDateTime) as object);
-				}
-				else if (ay_())
+					return bj_;
+				};
+				if (ay_())
 				{
-					var bl_ = @this?.Effective;
-					var bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
+					DataType bk_ = @this?.Effective;
+					object bl_ = FHIRHelpers_4_3_000.ToValue(bk_);
 
-					return ((bm_ as CqlInterval<CqlDateTime>) as object);
+					return ((bl_ as CqlDateTime) as object);
 				}
 				else if (az_())
 				{
-					var bn_ = @this?.Effective;
-					var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+					DataType bm_ = @this?.Effective;
+					object bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
 
-					return ((bo_ as CqlDateTime) as object);
+					return ((bn_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (ba_())
+				{
+					DataType bo_ = @this?.Effective;
+					object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
+
+					return ((bp_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var aw_ = QICoreCommon_2_0_000.earliest(av_());
+			CqlDateTime ax_ = QICoreCommon_2_0_000.earliest(aw_());
 
-			return aw_;
+			return ax_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = FHIRHelpers_4_3_000.ToValue(h_?.Value);
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		DataType i_ = h_?.Value;
+		object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 
-		return (i_ as CqlDateTime);
+		return (j_ as CqlDateTime);
 	}
 
     [CqlDeclaration("lastEstimatedDeliveryDate")]
 	public CqlDateTime lastEstimatedDeliveryDate(Encounter TheEncounter)
 	{
-		var a_ = this.Delivery_date_Estimated();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.Delivery_date_Estimated();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation EstimatedDateOfDelivery)
 		{
-			var j_ = EstimatedDateOfDelivery?.Value;
-			var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-			var l_ = context.Operators.Not((bool?)((k_ as CqlDateTime) is null));
-			var m_ = EstimatedDateOfDelivery?.StatusElement;
-			var n_ = m_?.Value;
-			var o_ = context.Operators.Convert<Code<ObservationStatus>>(n_);
-			var p_ = context.Operators.Convert<string>(o_);
-			var q_ = new string[]
+			DataType k_ = EstimatedDateOfDelivery?.Value;
+			object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+			bool? m_ = context.Operators.Not((bool?)((l_ as CqlDateTime) is null));
+			Code<ObservationStatus> n_ = EstimatedDateOfDelivery?.StatusElement;
+			ObservationStatus? o_ = n_?.Value;
+			Code<ObservationStatus> p_ = context.Operators.Convert<Code<ObservationStatus>>(o_);
+			string q_ = context.Operators.Convert<string>(p_);
+			string[] r_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var r_ = context.Operators.In<string>(p_, (q_ as IEnumerable<string>));
-			var s_ = context.Operators.And(l_, r_);
-			object t_()
+			bool? s_ = context.Operators.In<string>(q_, (r_ as IEnumerable<string>));
+			bool? t_ = context.Operators.And(m_, s_);
+			object u_()
 			{
-				bool af_()
-				{
-					var ai_ = EstimatedDateOfDelivery?.Effective;
-					var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-					var ak_ = aj_ is CqlDateTime;
-
-					return ak_;
-				};
 				bool ag_()
 				{
-					var al_ = EstimatedDateOfDelivery?.Effective;
-					var am_ = FHIRHelpers_4_3_000.ToValue(al_);
-					var an_ = am_ is CqlInterval<CqlDateTime>;
+					DataType aj_ = EstimatedDateOfDelivery?.Effective;
+					object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+					bool al_ = ak_ is CqlDateTime;
 
-					return an_;
+					return al_;
 				};
 				bool ah_()
 				{
-					var ao_ = EstimatedDateOfDelivery?.Effective;
-					var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-					var aq_ = ap_ is CqlDateTime;
+					DataType am_ = EstimatedDateOfDelivery?.Effective;
+					object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+					bool ao_ = an_ is CqlInterval<CqlDateTime>;
 
-					return aq_;
+					return ao_;
 				};
-				if (af_())
+				bool ai_()
 				{
-					var ar_ = EstimatedDateOfDelivery?.Effective;
-					var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+					DataType ap_ = EstimatedDateOfDelivery?.Effective;
+					object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+					bool ar_ = aq_ is CqlDateTime;
 
-					return ((as_ as CqlDateTime) as object);
-				}
-				else if (ag_())
+					return ar_;
+				};
+				if (ag_())
 				{
-					var at_ = EstimatedDateOfDelivery?.Effective;
-					var au_ = FHIRHelpers_4_3_000.ToValue(at_);
+					DataType as_ = EstimatedDateOfDelivery?.Effective;
+					object at_ = FHIRHelpers_4_3_000.ToValue(as_);
 
-					return ((au_ as CqlInterval<CqlDateTime>) as object);
+					return ((at_ as CqlDateTime) as object);
 				}
 				else if (ah_())
 				{
-					var av_ = EstimatedDateOfDelivery?.Effective;
-					var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+					DataType au_ = EstimatedDateOfDelivery?.Effective;
+					object av_ = FHIRHelpers_4_3_000.ToValue(au_);
 
-					return ((aw_ as CqlDateTime) as object);
+					return ((av_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (ai_())
+				{
+					DataType aw_ = EstimatedDateOfDelivery?.Effective;
+					object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+
+					return ((ax_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var u_ = QICoreCommon_2_0_000.earliest(t_());
-			var v_ = this.lastTimeOfDelivery(TheEncounter);
-			var w_ = context.Operators.Quantity(42m, "weeks");
-			var x_ = context.Operators.Subtract(v_, w_);
-			var z_ = context.Operators.Interval(x_, v_, true, true);
-			var aa_ = context.Operators.In<CqlDateTime>(u_, z_, null);
-			var ac_ = context.Operators.Not((bool?)(v_ is null));
-			var ad_ = context.Operators.And(aa_, ac_);
-			var ae_ = context.Operators.And(s_, ad_);
+			CqlDateTime v_ = QICoreCommon_2_0_000.earliest(u_());
+			CqlDateTime w_ = this.lastTimeOfDelivery(TheEncounter);
+			CqlQuantity x_ = context.Operators.Quantity(42m, "weeks");
+			CqlDateTime y_ = context.Operators.Subtract(w_, x_);
+			CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(y_, w_, true, true);
+			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, null);
+			bool? ad_ = context.Operators.Not((bool?)(w_ is null));
+			bool? ae_ = context.Operators.And(ab_, ad_);
+			bool? af_ = context.Operators.And(t_, ae_);
 
-			return ae_;
+			return af_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			object ax_()
+			object ay_()
 			{
-				bool az_()
-				{
-					var bc_ = @this?.Effective;
-					var bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
-					var be_ = bd_ is CqlDateTime;
-
-					return be_;
-				};
 				bool ba_()
 				{
-					var bf_ = @this?.Effective;
-					var bg_ = FHIRHelpers_4_3_000.ToValue(bf_);
-					var bh_ = bg_ is CqlInterval<CqlDateTime>;
+					DataType bd_ = @this?.Effective;
+					object be_ = FHIRHelpers_4_3_000.ToValue(bd_);
+					bool bf_ = be_ is CqlDateTime;
 
-					return bh_;
+					return bf_;
 				};
 				bool bb_()
 				{
-					var bi_ = @this?.Effective;
-					var bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
-					var bk_ = bj_ is CqlDateTime;
+					DataType bg_ = @this?.Effective;
+					object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+					bool bi_ = bh_ is CqlInterval<CqlDateTime>;
 
-					return bk_;
+					return bi_;
 				};
-				if (az_())
+				bool bc_()
 				{
-					var bl_ = @this?.Effective;
-					var bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
+					DataType bj_ = @this?.Effective;
+					object bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+					bool bl_ = bk_ is CqlDateTime;
 
-					return ((bm_ as CqlDateTime) as object);
-				}
-				else if (ba_())
+					return bl_;
+				};
+				if (ba_())
 				{
-					var bn_ = @this?.Effective;
-					var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+					DataType bm_ = @this?.Effective;
+					object bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
 
-					return ((bo_ as CqlInterval<CqlDateTime>) as object);
+					return ((bn_ as CqlDateTime) as object);
 				}
 				else if (bb_())
 				{
-					var bp_ = @this?.Effective;
-					var bq_ = FHIRHelpers_4_3_000.ToValue(bp_);
+					DataType bo_ = @this?.Effective;
+					object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
 
-					return ((bq_ as CqlDateTime) as object);
+					return ((bp_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (bc_())
+				{
+					DataType bq_ = @this?.Effective;
+					object br_ = FHIRHelpers_4_3_000.ToValue(bq_);
+
+					return ((br_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var ay_ = QICoreCommon_2_0_000.earliest(ax_());
+			CqlDateTime az_ = QICoreCommon_2_0_000.earliest(ay_());
 
-			return ay_;
+			return az_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = FHIRHelpers_4_3_000.ToValue(h_?.Value);
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		DataType i_ = h_?.Value;
+		object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 
-		return (i_ as CqlDateTime);
+		return (j_ as CqlDateTime);
 	}
 
     [CqlDeclaration("calculatedGestationalAge")]
 	public int? calculatedGestationalAge(Encounter TheEncounter)
 	{
-		var a_ = this.lastTimeOfDelivery(TheEncounter);
-		var b_ = this.lastEstimatedDeliveryDate(TheEncounter);
-		var c_ = context.Operators.DifferenceBetween(a_, b_, "day");
-		var d_ = context.Operators.Subtract(280, c_);
-		var e_ = context.Operators.TruncatedDivide(d_, 7);
+		CqlDateTime a_ = this.lastTimeOfDelivery(TheEncounter);
+		CqlDateTime b_ = this.lastEstimatedDeliveryDate(TheEncounter);
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		int? d_ = context.Operators.Subtract(280, c_);
+		int? e_ = context.Operators.TruncatedDivide(d_, 7);
 
 		return e_;
 	}
 
+    /// <seealso cref="Variable_Calculated_Gestational_Age"/>
 	private IEnumerable<Tuple_QRZgNJCaGQEYIeOSBhjLZNSO> Variable_Calculated_Gestational_Age_Value()
 	{
-		var a_ = this.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounter_with_Age_Range();
 		Tuple_QRZgNJCaGQEYIeOSBhjLZNSO b_(Encounter DeliveryEncounter)
 		{
-			var d_ = DeliveryEncounter?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.calculatedGestationalAge(DeliveryEncounter);
-			var g_ = new Tuple_QRZgNJCaGQEYIeOSBhjLZNSO
+			Id d_ = DeliveryEncounter?.IdElement;
+			string e_ = d_?.Value;
+			int? f_ = this.calculatedGestationalAge(DeliveryEncounter);
+			Tuple_QRZgNJCaGQEYIeOSBhjLZNSO g_ = new Tuple_QRZgNJCaGQEYIeOSBhjLZNSO
 			{
 				EncounterID = e_,
 				CalculatedCGA = f_,
@@ -792,11 +819,12 @@ public class PCMaternal_5_16_000
 
 			return g_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_QRZgNJCaGQEYIeOSBhjLZNSO>(a_, b_);
+		IEnumerable<Tuple_QRZgNJCaGQEYIeOSBhjLZNSO> c_ = context.Operators.Select<Encounter, Tuple_QRZgNJCaGQEYIeOSBhjLZNSO>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Variable_Calculated_Gestational_Age_Value"/>
     [CqlDeclaration("Variable Calculated Gestational Age")]
 	public IEnumerable<Tuple_QRZgNJCaGQEYIeOSBhjLZNSO> Variable_Calculated_Gestational_Age() => 
 		__Variable_Calculated_Gestational_Age.Value;
@@ -804,267 +832,268 @@ public class PCMaternal_5_16_000
     [CqlDeclaration("lastEstimatedGestationalAge")]
 	public CqlQuantity lastEstimatedGestationalAge(Encounter TheEncounter)
 	{
-		var a_ = this.Estimated_Gestational_Age_at_Delivery();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.Estimated_Gestational_Age_at_Delivery();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation EstimatedGestationalAge)
 		{
-			object i_()
+			object j_()
 			{
-				bool as_()
-				{
-					var av_ = EstimatedGestationalAge?.Effective;
-					var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-					var ax_ = aw_ is CqlDateTime;
-
-					return ax_;
-				};
 				bool at_()
 				{
-					var ay_ = EstimatedGestationalAge?.Effective;
-					var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-					var ba_ = az_ is CqlInterval<CqlDateTime>;
+					DataType aw_ = EstimatedGestationalAge?.Effective;
+					object ax_ = FHIRHelpers_4_3_000.ToValue(aw_);
+					bool ay_ = ax_ is CqlDateTime;
 
-					return ba_;
+					return ay_;
 				};
 				bool au_()
 				{
-					var bb_ = EstimatedGestationalAge?.Effective;
-					var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
-					var bd_ = bc_ is CqlDateTime;
+					DataType az_ = EstimatedGestationalAge?.Effective;
+					object ba_ = FHIRHelpers_4_3_000.ToValue(az_);
+					bool bb_ = ba_ is CqlInterval<CqlDateTime>;
 
-					return bd_;
+					return bb_;
 				};
-				if (as_())
+				bool av_()
 				{
-					var be_ = EstimatedGestationalAge?.Effective;
-					var bf_ = FHIRHelpers_4_3_000.ToValue(be_);
+					DataType bc_ = EstimatedGestationalAge?.Effective;
+					object bd_ = FHIRHelpers_4_3_000.ToValue(bc_);
+					bool be_ = bd_ is CqlDateTime;
 
-					return ((bf_ as CqlDateTime) as object);
-				}
-				else if (at_())
+					return be_;
+				};
+				if (at_())
 				{
-					var bg_ = EstimatedGestationalAge?.Effective;
-					var bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+					DataType bf_ = EstimatedGestationalAge?.Effective;
+					object bg_ = FHIRHelpers_4_3_000.ToValue(bf_);
 
-					return ((bh_ as CqlInterval<CqlDateTime>) as object);
+					return ((bg_ as CqlDateTime) as object);
 				}
 				else if (au_())
 				{
-					var bi_ = EstimatedGestationalAge?.Effective;
-					var bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
+					DataType bh_ = EstimatedGestationalAge?.Effective;
+					object bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
 
-					return ((bj_ as CqlDateTime) as object);
+					return ((bi_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (av_())
+				{
+					DataType bj_ = EstimatedGestationalAge?.Effective;
+					object bk_ = FHIRHelpers_4_3_000.ToValue(bj_);
+
+					return ((bk_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var j_ = QICoreCommon_2_0_000.earliest(i_());
-			var k_ = this.lastTimeOfDelivery(TheEncounter);
-			var l_ = context.Operators.Quantity(24m, "hours");
-			var m_ = context.Operators.Subtract(k_, l_);
-			var o_ = context.Operators.Interval(m_, k_, true, true);
-			var p_ = context.Operators.In<CqlDateTime>(j_, o_, null);
-			var r_ = context.Operators.Not((bool?)(k_ is null));
-			var s_ = context.Operators.And(p_, r_);
-			var t_ = EstimatedGestationalAge?.Value;
-			var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-			var v_ = context.Operators.Not((bool?)(u_ is null));
-			var w_ = context.Operators.And(s_, v_);
-			var x_ = EstimatedGestationalAge?.StatusElement;
-			var y_ = x_?.Value;
-			var z_ = context.Operators.Convert<Code<ObservationStatus>>(y_);
-			var aa_ = context.Operators.Convert<string>(z_);
-			var ab_ = new string[]
+			CqlDateTime k_ = QICoreCommon_2_0_000.earliest(j_());
+			CqlDateTime l_ = this.lastTimeOfDelivery(TheEncounter);
+			CqlQuantity m_ = context.Operators.Quantity(24m, "hours");
+			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
+			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(n_, l_, true, true);
+			bool? q_ = context.Operators.In<CqlDateTime>(k_, p_, null);
+			bool? s_ = context.Operators.Not((bool?)(l_ is null));
+			bool? t_ = context.Operators.And(q_, s_);
+			DataType u_ = EstimatedGestationalAge?.Value;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			bool? w_ = context.Operators.Not((bool?)(v_ is null));
+			bool? x_ = context.Operators.And(t_, w_);
+			Code<ObservationStatus> y_ = EstimatedGestationalAge?.StatusElement;
+			ObservationStatus? z_ = y_?.Value;
+			Code<ObservationStatus> aa_ = context.Operators.Convert<Code<ObservationStatus>>(z_);
+			string ab_ = context.Operators.Convert<string>(aa_);
+			string[] ac_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var ac_ = context.Operators.In<string>(aa_, (ab_ as IEnumerable<string>));
-			var ad_ = context.Operators.And(w_, ac_);
-			object ae_()
+			bool? ad_ = context.Operators.In<string>(ab_, (ac_ as IEnumerable<string>));
+			bool? ae_ = context.Operators.And(x_, ad_);
+			object af_()
 			{
-				bool bk_()
-				{
-					var bn_ = EstimatedGestationalAge?.Effective;
-					var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
-					var bp_ = bo_ is CqlDateTime;
-
-					return bp_;
-				};
 				bool bl_()
 				{
-					var bq_ = EstimatedGestationalAge?.Effective;
-					var br_ = FHIRHelpers_4_3_000.ToValue(bq_);
-					var bs_ = br_ is CqlInterval<CqlDateTime>;
+					DataType bo_ = EstimatedGestationalAge?.Effective;
+					object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
+					bool bq_ = bp_ is CqlDateTime;
 
-					return bs_;
+					return bq_;
 				};
 				bool bm_()
 				{
-					var bt_ = EstimatedGestationalAge?.Effective;
-					var bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
-					var bv_ = bu_ is CqlDateTime;
+					DataType br_ = EstimatedGestationalAge?.Effective;
+					object bs_ = FHIRHelpers_4_3_000.ToValue(br_);
+					bool bt_ = bs_ is CqlInterval<CqlDateTime>;
 
-					return bv_;
+					return bt_;
 				};
-				if (bk_())
+				bool bn_()
 				{
-					var bw_ = EstimatedGestationalAge?.Effective;
-					var bx_ = FHIRHelpers_4_3_000.ToValue(bw_);
+					DataType bu_ = EstimatedGestationalAge?.Effective;
+					object bv_ = FHIRHelpers_4_3_000.ToValue(bu_);
+					bool bw_ = bv_ is CqlDateTime;
 
-					return ((bx_ as CqlDateTime) as object);
-				}
-				else if (bl_())
+					return bw_;
+				};
+				if (bl_())
 				{
-					var by_ = EstimatedGestationalAge?.Effective;
-					var bz_ = FHIRHelpers_4_3_000.ToValue(by_);
+					DataType bx_ = EstimatedGestationalAge?.Effective;
+					object by_ = FHIRHelpers_4_3_000.ToValue(bx_);
 
-					return ((bz_ as CqlInterval<CqlDateTime>) as object);
+					return ((by_ as CqlDateTime) as object);
 				}
 				else if (bm_())
 				{
-					var ca_ = EstimatedGestationalAge?.Effective;
-					var cb_ = FHIRHelpers_4_3_000.ToValue(ca_);
+					DataType bz_ = EstimatedGestationalAge?.Effective;
+					object ca_ = FHIRHelpers_4_3_000.ToValue(bz_);
 
-					return ((cb_ as CqlDateTime) as object);
+					return ((ca_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (bn_())
+				{
+					DataType cb_ = EstimatedGestationalAge?.Effective;
+					object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+
+					return ((cc_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var af_ = QICoreCommon_2_0_000.earliest(ae_());
-			var ah_ = context.Operators.SameAs(af_, k_, "day");
-			object ai_()
+			CqlDateTime ag_ = QICoreCommon_2_0_000.earliest(af_());
+			bool? ai_ = context.Operators.SameAs(ag_, l_, "day");
+			object aj_()
 			{
-				bool cc_()
-				{
-					var cf_ = EstimatedGestationalAge?.Effective;
-					var cg_ = FHIRHelpers_4_3_000.ToValue(cf_);
-					var ch_ = cg_ is CqlDateTime;
-
-					return ch_;
-				};
 				bool cd_()
 				{
-					var ci_ = EstimatedGestationalAge?.Effective;
-					var cj_ = FHIRHelpers_4_3_000.ToValue(ci_);
-					var ck_ = cj_ is CqlInterval<CqlDateTime>;
+					DataType cg_ = EstimatedGestationalAge?.Effective;
+					object ch_ = FHIRHelpers_4_3_000.ToValue(cg_);
+					bool ci_ = ch_ is CqlDateTime;
 
-					return ck_;
+					return ci_;
 				};
 				bool ce_()
 				{
-					var cl_ = EstimatedGestationalAge?.Effective;
-					var cm_ = FHIRHelpers_4_3_000.ToValue(cl_);
-					var cn_ = cm_ is CqlDateTime;
+					DataType cj_ = EstimatedGestationalAge?.Effective;
+					object ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
+					bool cl_ = ck_ is CqlInterval<CqlDateTime>;
 
-					return cn_;
+					return cl_;
 				};
-				if (cc_())
+				bool cf_()
 				{
-					var co_ = EstimatedGestationalAge?.Effective;
-					var cp_ = FHIRHelpers_4_3_000.ToValue(co_);
+					DataType cm_ = EstimatedGestationalAge?.Effective;
+					object cn_ = FHIRHelpers_4_3_000.ToValue(cm_);
+					bool co_ = cn_ is CqlDateTime;
 
-					return ((cp_ as CqlDateTime) as object);
-				}
-				else if (cd_())
+					return co_;
+				};
+				if (cd_())
 				{
-					var cq_ = EstimatedGestationalAge?.Effective;
-					var cr_ = FHIRHelpers_4_3_000.ToValue(cq_);
+					DataType cp_ = EstimatedGestationalAge?.Effective;
+					object cq_ = FHIRHelpers_4_3_000.ToValue(cp_);
 
-					return ((cr_ as CqlInterval<CqlDateTime>) as object);
+					return ((cq_ as CqlDateTime) as object);
 				}
 				else if (ce_())
 				{
-					var cs_ = EstimatedGestationalAge?.Effective;
-					var ct_ = FHIRHelpers_4_3_000.ToValue(cs_);
+					DataType cr_ = EstimatedGestationalAge?.Effective;
+					object cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
 
-					return ((ct_ as CqlDateTime) as object);
+					return ((cs_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (cf_())
+				{
+					DataType ct_ = EstimatedGestationalAge?.Effective;
+					object cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
+
+					return ((cu_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var aj_ = QICoreCommon_2_0_000.earliest(ai_());
-			var ak_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
-			var al_ = context.Operators.In<CqlDateTime>(aj_, ak_, null);
-			var am_ = context.Operators.And(ah_, al_);
-			var ao_ = FHIRHelpers_4_3_000.ToValue(t_);
-			var ap_ = context.Operators.Not((bool?)(ao_ is null));
-			var aq_ = context.Operators.And(am_, ap_);
-			var ar_ = context.Operators.Or(ad_, aq_);
+			CqlDateTime ak_ = QICoreCommon_2_0_000.earliest(aj_());
+			CqlInterval<CqlDateTime> al_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
+			bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, null);
+			bool? an_ = context.Operators.And(ai_, am_);
+			object ap_ = FHIRHelpers_4_3_000.ToValue(u_);
+			bool? aq_ = context.Operators.Not((bool?)(ap_ is null));
+			bool? ar_ = context.Operators.And(an_, aq_);
+			bool? as_ = context.Operators.Or(ae_, ar_);
 
-			return ar_;
+			return as_;
 		};
-		var d_ = context.Operators.Where<Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		object e_(Observation @this)
 		{
-			object cu_()
+			object cv_()
 			{
-				bool cw_()
-				{
-					var cz_ = @this?.Effective;
-					var da_ = FHIRHelpers_4_3_000.ToValue(cz_);
-					var db_ = da_ is CqlDateTime;
-
-					return db_;
-				};
 				bool cx_()
 				{
-					var dc_ = @this?.Effective;
-					var dd_ = FHIRHelpers_4_3_000.ToValue(dc_);
-					var de_ = dd_ is CqlInterval<CqlDateTime>;
+					DataType da_ = @this?.Effective;
+					object db_ = FHIRHelpers_4_3_000.ToValue(da_);
+					bool dc_ = db_ is CqlDateTime;
 
-					return de_;
+					return dc_;
 				};
 				bool cy_()
 				{
-					var df_ = @this?.Effective;
-					var dg_ = FHIRHelpers_4_3_000.ToValue(df_);
-					var dh_ = dg_ is CqlDateTime;
+					DataType dd_ = @this?.Effective;
+					object de_ = FHIRHelpers_4_3_000.ToValue(dd_);
+					bool df_ = de_ is CqlInterval<CqlDateTime>;
 
-					return dh_;
+					return df_;
 				};
-				if (cw_())
+				bool cz_()
 				{
-					var di_ = @this?.Effective;
-					var dj_ = FHIRHelpers_4_3_000.ToValue(di_);
+					DataType dg_ = @this?.Effective;
+					object dh_ = FHIRHelpers_4_3_000.ToValue(dg_);
+					bool di_ = dh_ is CqlDateTime;
 
-					return ((dj_ as CqlDateTime) as object);
-				}
-				else if (cx_())
+					return di_;
+				};
+				if (cx_())
 				{
-					var dk_ = @this?.Effective;
-					var dl_ = FHIRHelpers_4_3_000.ToValue(dk_);
+					DataType dj_ = @this?.Effective;
+					object dk_ = FHIRHelpers_4_3_000.ToValue(dj_);
 
-					return ((dl_ as CqlInterval<CqlDateTime>) as object);
+					return ((dk_ as CqlDateTime) as object);
 				}
 				else if (cy_())
 				{
-					var dm_ = @this?.Effective;
-					var dn_ = FHIRHelpers_4_3_000.ToValue(dm_);
+					DataType dl_ = @this?.Effective;
+					object dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
 
-					return ((dn_ as CqlDateTime) as object);
+					return ((dm_ as CqlInterval<CqlDateTime>) as object);
+				}
+				else if (cz_())
+				{
+					DataType dn_ = @this?.Effective;
+					object do_ = FHIRHelpers_4_3_000.ToValue(dn_);
+
+					return ((do_ as CqlDateTime) as object);
 				}
 				else
 				{
 					return null;
 				}
 			};
-			var cv_ = QICoreCommon_2_0_000.earliest(cu_());
+			CqlDateTime cw_ = QICoreCommon_2_0_000.earliest(cv_());
 
-			return cv_;
+			return cw_;
 		};
-		var f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-		var g_ = context.Operators.Last<Observation>(f_);
-		var h_ = FHIRHelpers_4_3_000.ToValue(g_?.Value);
+		IEnumerable<Observation> f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation g_ = context.Operators.Last<Observation>(f_);
+		DataType h_ = g_?.Value;
+		object i_ = FHIRHelpers_4_3_000.ToValue(h_);
 
-		return (h_ as CqlQuantity);
+		return (i_ as CqlQuantity);
 	}
 
 }

--- a/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
@@ -160,170 +160,213 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 
     #endregion
 
+    /// <seealso cref="Diagnosis_of_Hypertension"/>
 	private CqlValueSet Diagnosis_of_Hypertension_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263", null);
 
+    /// <seealso cref="Diagnosis_of_Hypertension_Value"/>
     [CqlDeclaration("Diagnosis of Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263")]
 	public CqlValueSet Diagnosis_of_Hypertension() => 
 		__Diagnosis_of_Hypertension.Value;
 
+    /// <seealso cref="Dietary_Recommendations"/>
 	private CqlValueSet Dietary_Recommendations_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515", null);
 
+    /// <seealso cref="Dietary_Recommendations_Value"/>
     [CqlDeclaration("Dietary Recommendations")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515")]
 	public CqlValueSet Dietary_Recommendations() => 
 		__Dietary_Recommendations.Value;
 
+    /// <seealso cref="Encounter_to_Screen_for_Blood_Pressure"/>
 	private CqlValueSet Encounter_to_Screen_for_Blood_Pressure_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920", null);
 
+    /// <seealso cref="Encounter_to_Screen_for_Blood_Pressure_Value"/>
     [CqlDeclaration("Encounter to Screen for Blood Pressure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920")]
 	public CqlValueSet Encounter_to_Screen_for_Blood_Pressure() => 
 		__Encounter_to_Screen_for_Blood_Pressure.Value;
 
+    /// <seealso cref="Finding_of_Elevated_Blood_Pressure_or_Hypertension"/>
 	private CqlValueSet Finding_of_Elevated_Blood_Pressure_or_Hypertension_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514", null);
 
+    /// <seealso cref="Finding_of_Elevated_Blood_Pressure_or_Hypertension_Value"/>
     [CqlDeclaration("Finding of Elevated Blood Pressure or Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514")]
 	public CqlValueSet Finding_of_Elevated_Blood_Pressure_or_Hypertension() => 
 		__Finding_of_Elevated_Blood_Pressure_or_Hypertension.Value;
 
+    /// <seealso cref="Follow_Up_Within_4_Weeks"/>
 	private CqlValueSet Follow_Up_Within_4_Weeks_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578", null);
 
+    /// <seealso cref="Follow_Up_Within_4_Weeks_Value"/>
     [CqlDeclaration("Follow Up Within 4 Weeks")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578")]
 	public CqlValueSet Follow_Up_Within_4_Weeks() => 
 		__Follow_Up_Within_4_Weeks.Value;
 
+    /// <seealso cref="Laboratory_Tests_for_Hypertension"/>
 	private CqlValueSet Laboratory_Tests_for_Hypertension_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482", null);
 
+    /// <seealso cref="Laboratory_Tests_for_Hypertension_Value"/>
     [CqlDeclaration("Laboratory Tests for Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482")]
 	public CqlValueSet Laboratory_Tests_for_Hypertension() => 
 		__Laboratory_Tests_for_Hypertension.Value;
 
+    /// <seealso cref="Lifestyle_Recommendation"/>
 	private CqlValueSet Lifestyle_Recommendation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581", null);
 
+    /// <seealso cref="Lifestyle_Recommendation_Value"/>
     [CqlDeclaration("Lifestyle Recommendation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581")]
 	public CqlValueSet Lifestyle_Recommendation() => 
 		__Lifestyle_Recommendation.Value;
 
+    /// <seealso cref="Medical_Reason"/>
 	private CqlValueSet Medical_Reason_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
 
+    /// <seealso cref="Medical_Reason_Value"/>
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
 	public CqlValueSet Medical_Reason() => 
 		__Medical_Reason.Value;
 
+    /// <seealso cref="Patient_Declined"/>
 	private CqlValueSet Patient_Declined_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582", null);
 
+    /// <seealso cref="Patient_Declined_Value"/>
     [CqlDeclaration("Patient Declined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582")]
 	public CqlValueSet Patient_Declined() => 
 		__Patient_Declined.Value;
 
+    /// <seealso cref="Pharmacologic_Therapy_for_Hypertension"/>
 	private CqlValueSet Pharmacologic_Therapy_for_Hypertension_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577", null);
 
+    /// <seealso cref="Pharmacologic_Therapy_for_Hypertension_Value"/>
     [CqlDeclaration("Pharmacologic Therapy for Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577")]
 	public CqlValueSet Pharmacologic_Therapy_for_Hypertension() => 
 		__Pharmacologic_Therapy_for_Hypertension.Value;
 
+    /// <seealso cref="Recommendation_to_Increase_Physical_Activity"/>
 	private CqlValueSet Recommendation_to_Increase_Physical_Activity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518", null);
 
+    /// <seealso cref="Recommendation_to_Increase_Physical_Activity_Value"/>
     [CqlDeclaration("Recommendation to Increase Physical Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518")]
 	public CqlValueSet Recommendation_to_Increase_Physical_Activity() => 
 		__Recommendation_to_Increase_Physical_Activity.Value;
 
+    /// <seealso cref="Referral_or_Counseling_for_Alcohol_Consumption"/>
 	private CqlValueSet Referral_or_Counseling_for_Alcohol_Consumption_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583", null);
 
+    /// <seealso cref="Referral_or_Counseling_for_Alcohol_Consumption_Value"/>
     [CqlDeclaration("Referral or Counseling for Alcohol Consumption")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583")]
 	public CqlValueSet Referral_or_Counseling_for_Alcohol_Consumption() => 
 		__Referral_or_Counseling_for_Alcohol_Consumption.Value;
 
+    /// <seealso cref="Referral_to_Primary_Care_or_Alternate_Provider"/>
 	private CqlValueSet Referral_to_Primary_Care_or_Alternate_Provider_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580", null);
 
+    /// <seealso cref="Referral_to_Primary_Care_or_Alternate_Provider_Value"/>
     [CqlDeclaration("Referral to Primary Care or Alternate Provider")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580")]
 	public CqlValueSet Referral_to_Primary_Care_or_Alternate_Provider() => 
 		__Referral_to_Primary_Care_or_Alternate_Provider.Value;
 
+    /// <seealso cref="Weight_Reduction_Recommended"/>
 	private CqlValueSet Weight_Reduction_Recommended_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510", null);
 
+    /// <seealso cref="Weight_Reduction_Recommended_Value"/>
     [CqlDeclaration("Weight Reduction Recommended")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510")]
 	public CqlValueSet Weight_Reduction_Recommended() => 
 		__Weight_Reduction_Recommended.Value;
 
+    /// <seealso cref="Diastolic_blood_pressure"/>
 	private CqlCode Diastolic_blood_pressure_Value() => 
 		new CqlCode("8462-4", "http://loinc.org", null, null);
 
+    /// <seealso cref="Diastolic_blood_pressure_Value"/>
     [CqlDeclaration("Diastolic blood pressure")]
 	public CqlCode Diastolic_blood_pressure() => 
 		__Diastolic_blood_pressure.Value;
 
+    /// <seealso cref="_12_lead_EKG_panel"/>
 	private CqlCode _12_lead_EKG_panel_Value() => 
 		new CqlCode("34534-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="_12_lead_EKG_panel_Value"/>
     [CqlDeclaration("12 lead EKG panel")]
 	public CqlCode _12_lead_EKG_panel() => 
 		___12_lead_EKG_panel.Value;
 
+    /// <seealso cref="EKG_study"/>
 	private CqlCode EKG_study_Value() => 
 		new CqlCode("11524-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="EKG_study_Value"/>
     [CqlDeclaration("EKG study")]
 	public CqlCode EKG_study() => 
 		__EKG_study.Value;
 
+    /// <seealso cref="Follow_up_2_3_months__finding_"/>
 	private CqlCode Follow_up_2_3_months__finding__Value() => 
 		new CqlCode("183624006", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Follow_up_2_3_months__finding__Value"/>
     [CqlDeclaration("Follow-up 2-3 months (finding)")]
 	public CqlCode Follow_up_2_3_months__finding_() => 
 		__Follow_up_2_3_months__finding_.Value;
 
+    /// <seealso cref="Follow_up_4_6_months__finding_"/>
 	private CqlCode Follow_up_4_6_months__finding__Value() => 
 		new CqlCode("183625007", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Follow_up_4_6_months__finding__Value"/>
     [CqlDeclaration("Follow-up 4-6 months (finding)")]
 	public CqlCode Follow_up_4_6_months__finding_() => 
 		__Follow_up_4_6_months__finding_.Value;
 
+    /// <seealso cref="Systolic_blood_pressure"/>
 	private CqlCode Systolic_blood_pressure_Value() => 
 		new CqlCode("8480-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Systolic_blood_pressure_Value"/>
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
 		__Systolic_blood_pressure.Value;
 
+    /// <seealso cref="@virtual"/>
 	private CqlCode @virtual_Value() => 
 		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="@virtual_Value"/>
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 		};
@@ -331,13 +374,15 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("8462-4", "http://loinc.org", null, null),
 			new CqlCode("34534-8", "http://loinc.org", null, null),
@@ -348,13 +393,15 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("183624006", "http://snomed.info/sct", null, null),
 			new CqlCode("183625007", "http://snomed.info/sct", null, null),
@@ -363,125 +410,137 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("PCSBPScreeningFollowUpFHIR-0.2.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("PCSBPScreeningFollowUpFHIR-0.2.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounter_during_Measurement_Period"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period_Value()
 	{
-		var a_ = this.Encounter_to_Screen_for_Blood_Pressure();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_to_Screen_for_Blood_Pressure();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter ValidEncounter)
 		{
-			var e_ = this.Measurement_Period();
-			var f_ = ValidEncounter?.Period;
-			var g_ = FHIRHelpers_4_3_000.ToInterval(f_);
-			var h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
-			var i_ = ValidEncounter?.StatusElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(j_);
-			var l_ = context.Operators.Equivalent(k_, "finished");
-			var m_ = context.Operators.And(h_, l_);
-			var n_ = ValidEncounter?.Class;
-			var o_ = FHIRHelpers_4_3_000.ToCode(n_);
-			var p_ = this.@virtual();
-			var q_ = context.Operators.Equivalent(o_, p_);
-			var r_ = context.Operators.Not(q_);
-			var s_ = context.Operators.And(m_, r_);
+			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+			Period f_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_3_000.ToInterval(f_);
+			bool? h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
+			Code<Encounter.EncounterStatus> i_ = ValidEncounter?.StatusElement;
+			Encounter.EncounterStatus? j_ = i_?.Value;
+			Code<Encounter.EncounterStatus> k_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(j_);
+			bool? l_ = context.Operators.Equivalent(k_, "finished");
+			bool? m_ = context.Operators.And(h_, l_);
+			Coding n_ = ValidEncounter?.Class;
+			CqlCode o_ = FHIRHelpers_4_3_000.ToCode(n_);
+			CqlCode p_ = this.@virtual();
+			bool? q_ = context.Operators.Equivalent(o_, p_);
+			bool? r_ = context.Operators.Not(q_);
+			bool? s_ = context.Operators.And(m_, r_);
 
 			return s_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_during_Measurement_Period_Value"/>
     [CqlDeclaration("Qualifying Encounter during Measurement Period")]
 	public IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period() => 
 		__Qualifying_Encounter_during_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var d_ = this.Patient();
-			var e_ = d_?.BirthDateElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.ConvertStringToDateTime(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.Start(h_);
-			var j_ = context.Operators.CalculateAgeAt(g_, i_, "year");
-			var k_ = context.Operators.GreaterOrEqual(j_, 18);
+			Patient d_ = this.Patient();
+			Date e_ = d_?.BirthDateElement;
+			string f_ = e_?.Value;
+			CqlDateTime g_ = context.Operators.ConvertStringToDateTime(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			CqlDateTime i_ = context.Operators.Start(h_);
+			int? j_ = context.Operators.CalculateAgeAt(g_, i_, "year");
+			bool? k_ = context.Operators.GreaterOrEqual(j_, 18);
 
 			return k_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		IEnumerable<Encounter> a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private IEnumerable<Encounter> Denominator_Exclusions_Value()
 	{
-		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		IEnumerable<Encounter> b_(Encounter QualifyingEncounter)
 		{
-			var d_ = this.Diagnosis_of_Hypertension();
-			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			CqlValueSet d_ = this.Diagnosis_of_Hypertension();
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
 			bool? f_(Condition Hypertension)
 			{
-				var j_ = QICoreCommon_2_0_000.isProblemListItem(Hypertension);
-				var k_ = QICoreCommon_2_0_000.isHealthConcern(Hypertension);
-				var l_ = context.Operators.Or(j_, k_);
-				var m_ = QICoreCommon_2_0_000.isActive(Hypertension);
-				var n_ = context.Operators.And(l_, m_);
+				bool? j_ = QICoreCommon_2_0_000.isProblemListItem(Hypertension);
+				bool? k_ = QICoreCommon_2_0_000.isHealthConcern(Hypertension);
+				bool? l_ = context.Operators.Or(j_, k_);
+				bool? m_ = QICoreCommon_2_0_000.isActive(Hypertension);
+				bool? n_ = context.Operators.And(l_, m_);
 				CqlInterval<CqlDateTime> o_()
 				{
 					bool t_()
 					{
-						var u_ = QICoreCommon_2_0_000.prevalenceInterval(Hypertension);
-						var v_ = context.Operators.Start(u_);
+						CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.prevalenceInterval(Hypertension);
+						CqlDateTime v_ = context.Operators.Start(u_);
 
 						return (v_ is null);
 					};
@@ -491,2528 +550,2587 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 					}
 					else
 					{
-						var w_ = QICoreCommon_2_0_000.prevalenceInterval(Hypertension);
-						var x_ = context.Operators.Start(w_);
-						var z_ = context.Operators.Start(w_);
-						var aa_ = context.Operators.Interval(x_, z_, true, true);
+						CqlInterval<CqlDateTime> w_ = QICoreCommon_2_0_000.prevalenceInterval(Hypertension);
+						CqlDateTime x_ = context.Operators.Start(w_);
+						CqlDateTime z_ = context.Operators.Start(w_);
+						CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(x_, z_, true, true);
 
 						return aa_;
 					}
 				};
-				var p_ = QualifyingEncounter?.Period;
-				var q_ = FHIRHelpers_4_3_000.ToInterval(p_);
-				var r_ = context.Operators.SameOrBefore(o_(), q_, "day");
-				var s_ = context.Operators.And(n_, r_);
+				Period p_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
+				bool? r_ = context.Operators.SameOrBefore(o_(), q_, "day");
+				bool? s_ = context.Operators.And(n_, r_);
 
 				return s_;
 			};
-			var g_ = context.Operators.Where<Condition>(e_, f_);
+			IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 			Encounter h_(Condition Hypertension) => 
 				QualifyingEncounter;
-			var i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public IEnumerable<Encounter> Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Encounter_with_Normal_Blood_Pressure_Reading"/>
 	private IEnumerable<Encounter> Encounter_with_Normal_Blood_Pressure_Reading_Value()
 	{
-		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? e_(Observation BloodPressure)
 			{
-				var ak_ = BloodPressure?.Effective;
-				var al_ = FHIRHelpers_4_3_000.ToValue(ak_);
-				var am_ = QICoreCommon_2_0_000.toInterval(al_);
-				var an_ = context.Operators.End(am_);
-				var ao_ = QualifyingEncounter?.Period;
-				var ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
-				var aq_ = context.Operators.In<CqlDateTime>(an_, ap_, null);
-				var ar_ = BloodPressure?.StatusElement;
-				var as_ = ar_?.Value;
-				var at_ = context.Operators.Convert<string>(as_);
-				var au_ = new string[]
+				DataType ak_ = BloodPressure?.Effective;
+				object al_ = FHIRHelpers_4_3_000.ToValue(ak_);
+				CqlInterval<CqlDateTime> am_ = QICoreCommon_2_0_000.toInterval(al_);
+				CqlDateTime an_ = context.Operators.End(am_);
+				Period ao_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
+				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, null);
+				Code<ObservationStatus> ar_ = BloodPressure?.StatusElement;
+				ObservationStatus? as_ = ar_?.Value;
+				string at_ = context.Operators.Convert<string>(as_);
+				string[] au_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var av_ = context.Operators.In<string>(at_, (au_ as IEnumerable<string>));
-				var aw_ = context.Operators.And(aq_, av_);
+				bool? av_ = context.Operators.In<string>(at_, (au_ as IEnumerable<string>));
+				bool? aw_ = context.Operators.And(aq_, av_);
 
 				return aw_;
 			};
-			var f_ = context.Operators.Where<Observation>(d_, e_);
+			IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 			object g_(Observation @this)
 			{
-				var ax_ = @this?.Effective;
-				var ay_ = FHIRHelpers_4_3_000.ToValue(ax_);
-				var az_ = QICoreCommon_2_0_000.toInterval(ay_);
-				var ba_ = context.Operators.Start(az_);
+				DataType ax_ = @this?.Effective;
+				object ay_ = FHIRHelpers_4_3_000.ToValue(ax_);
+				CqlInterval<CqlDateTime> az_ = QICoreCommon_2_0_000.toInterval(ay_);
+				CqlDateTime ba_ = context.Operators.Start(az_);
 
 				return ba_;
 			};
-			var h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
-			var i_ = context.Operators.Last<Observation>(h_);
-			var j_ = i_?.Component;
+			IEnumerable<Observation> h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation i_ = context.Operators.Last<Observation>(h_);
+			List<Observation.ComponentComponent> j_ = i_?.Component;
 			bool? k_(Observation.ComponentComponent @this)
 			{
-				var bb_ = @this?.Code;
-				var bc_ = bb_?.Coding;
-				var bd_ = context.Operators.First<Coding>((IEnumerable<Coding>)bc_);
-				var be_ = bd_?.SystemElement;
-				var bf_ = FHIRHelpers_4_3_000.ToString(be_);
-				var bg_ = context.Operators.Equal(bf_, "http://loinc.org");
-				var bi_ = bb_?.Coding;
-				var bj_ = context.Operators.First<Coding>((IEnumerable<Coding>)bi_);
-				var bk_ = bj_?.CodeElement;
-				var bl_ = FHIRHelpers_4_3_000.ToString(bk_);
-				var bm_ = context.Operators.Equal(bl_, "8480-6");
-				var bn_ = context.Operators.And(bg_, bm_);
+				CodeableConcept bb_ = @this?.Code;
+				List<Coding> bc_ = bb_?.Coding;
+				Coding bd_ = context.Operators.First<Coding>((IEnumerable<Coding>)bc_);
+				FhirUri be_ = bd_?.SystemElement;
+				string bf_ = FHIRHelpers_4_3_000.ToString(be_);
+				bool? bg_ = context.Operators.Equal(bf_, "http://loinc.org");
+				List<Coding> bi_ = bb_?.Coding;
+				Coding bj_ = context.Operators.First<Coding>((IEnumerable<Coding>)bi_);
+				Code bk_ = bj_?.CodeElement;
+				string bl_ = FHIRHelpers_4_3_000.ToString(bk_);
+				bool? bm_ = context.Operators.Equal(bl_, "8480-6");
+				bool? bn_ = context.Operators.And(bg_, bm_);
 
 				return bn_;
 			};
-			var l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
-			var m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
-			var n_ = m_?.Value;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = context.Operators.Quantity(1m, "mm[Hg]");
-			var q_ = context.Operators.Quantity(120m, "mm[Hg]");
-			var r_ = context.Operators.Interval(p_, q_, true, false);
-			var s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, null);
+			IEnumerable<Observation.ComponentComponent> l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
+			Observation.ComponentComponent m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
+			DataType n_ = m_?.Value;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			CqlQuantity p_ = context.Operators.Quantity(1m, "mm[Hg]");
+			CqlQuantity q_ = context.Operators.Quantity(120m, "mm[Hg]");
+			CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, false);
+			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, null);
 			bool? u_(Observation BloodPressure)
 			{
-				var bo_ = BloodPressure?.Effective;
-				var bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
-				var bq_ = QICoreCommon_2_0_000.toInterval(bp_);
-				var br_ = context.Operators.End(bq_);
-				var bs_ = QualifyingEncounter?.Period;
-				var bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
-				var bu_ = context.Operators.In<CqlDateTime>(br_, bt_, null);
-				var bv_ = BloodPressure?.StatusElement;
-				var bw_ = bv_?.Value;
-				var bx_ = context.Operators.Convert<string>(bw_);
-				var by_ = new string[]
+				DataType bo_ = BloodPressure?.Effective;
+				object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
+				CqlInterval<CqlDateTime> bq_ = QICoreCommon_2_0_000.toInterval(bp_);
+				CqlDateTime br_ = context.Operators.End(bq_);
+				Period bs_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
+				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, null);
+				Code<ObservationStatus> bv_ = BloodPressure?.StatusElement;
+				ObservationStatus? bw_ = bv_?.Value;
+				string bx_ = context.Operators.Convert<string>(bw_);
+				string[] by_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bz_ = context.Operators.In<string>(bx_, (by_ as IEnumerable<string>));
-				var ca_ = context.Operators.And(bu_, bz_);
+				bool? bz_ = context.Operators.In<string>(bx_, (by_ as IEnumerable<string>));
+				bool? ca_ = context.Operators.And(bu_, bz_);
 
 				return ca_;
 			};
-			var v_ = context.Operators.Where<Observation>(d_, u_);
+			IEnumerable<Observation> v_ = context.Operators.Where<Observation>(d_, u_);
 			object w_(Observation @this)
 			{
-				var cb_ = @this?.Effective;
-				var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
-				var cd_ = QICoreCommon_2_0_000.toInterval(cc_);
-				var ce_ = context.Operators.Start(cd_);
+				DataType cb_ = @this?.Effective;
+				object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+				CqlInterval<CqlDateTime> cd_ = QICoreCommon_2_0_000.toInterval(cc_);
+				CqlDateTime ce_ = context.Operators.Start(cd_);
 
 				return ce_;
 			};
-			var x_ = context.Operators.SortBy<Observation>(v_, w_, System.ComponentModel.ListSortDirection.Ascending);
-			var y_ = context.Operators.Last<Observation>(x_);
-			var z_ = y_?.Component;
+			IEnumerable<Observation> x_ = context.Operators.SortBy<Observation>(v_, w_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation y_ = context.Operators.Last<Observation>(x_);
+			List<Observation.ComponentComponent> z_ = y_?.Component;
 			bool? aa_(Observation.ComponentComponent @this)
 			{
-				var cf_ = @this?.Code;
-				var cg_ = cf_?.Coding;
-				var ch_ = context.Operators.First<Coding>((IEnumerable<Coding>)cg_);
-				var ci_ = ch_?.SystemElement;
-				var cj_ = FHIRHelpers_4_3_000.ToString(ci_);
-				var ck_ = context.Operators.Equal(cj_, "http://loinc.org");
-				var cm_ = cf_?.Coding;
-				var cn_ = context.Operators.First<Coding>((IEnumerable<Coding>)cm_);
-				var co_ = cn_?.CodeElement;
-				var cp_ = FHIRHelpers_4_3_000.ToString(co_);
-				var cq_ = context.Operators.Equal(cp_, "8462-4");
-				var cr_ = context.Operators.And(ck_, cq_);
+				CodeableConcept cf_ = @this?.Code;
+				List<Coding> cg_ = cf_?.Coding;
+				Coding ch_ = context.Operators.First<Coding>((IEnumerable<Coding>)cg_);
+				FhirUri ci_ = ch_?.SystemElement;
+				string cj_ = FHIRHelpers_4_3_000.ToString(ci_);
+				bool? ck_ = context.Operators.Equal(cj_, "http://loinc.org");
+				List<Coding> cm_ = cf_?.Coding;
+				Coding cn_ = context.Operators.First<Coding>((IEnumerable<Coding>)cm_);
+				Code co_ = cn_?.CodeElement;
+				string cp_ = FHIRHelpers_4_3_000.ToString(co_);
+				bool? cq_ = context.Operators.Equal(cp_, "8462-4");
+				bool? cr_ = context.Operators.And(ck_, cq_);
 
 				return cr_;
 			};
-			var ab_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)z_, aa_);
-			var ac_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ab_);
-			var ad_ = ac_?.Value;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var ag_ = context.Operators.Quantity(80m, "mm[Hg]");
-			var ah_ = context.Operators.Interval(p_, ag_, true, false);
-			var ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, null);
-			var aj_ = context.Operators.And(s_, ai_);
+			IEnumerable<Observation.ComponentComponent> ab_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)z_, aa_);
+			Observation.ComponentComponent ac_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ab_);
+			DataType ad_ = ac_?.Value;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlQuantity ag_ = context.Operators.Quantity(80m, "mm[Hg]");
+			CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(p_, ag_, true, false);
+			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, null);
+			bool? aj_ = context.Operators.And(s_, ai_);
 
 			return aj_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Normal_Blood_Pressure_Reading_Value"/>
     [CqlDeclaration("Encounter with Normal Blood Pressure Reading")]
 	public IEnumerable<Encounter> Encounter_with_Normal_Blood_Pressure_Reading() => 
 		__Encounter_with_Normal_Blood_Pressure_Reading.Value;
 
+    /// <seealso cref="Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80"/>
 	private IEnumerable<Encounter> Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_Value()
 	{
-		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? e_(Observation BloodPressure)
 			{
-				var ak_ = BloodPressure?.Effective;
-				var al_ = FHIRHelpers_4_3_000.ToValue(ak_);
-				var am_ = QICoreCommon_2_0_000.toInterval(al_);
-				var an_ = context.Operators.End(am_);
-				var ao_ = QualifyingEncounter?.Period;
-				var ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
-				var aq_ = context.Operators.In<CqlDateTime>(an_, ap_, null);
-				var ar_ = BloodPressure?.StatusElement;
-				var as_ = ar_?.Value;
-				var at_ = context.Operators.Convert<string>(as_);
-				var au_ = new string[]
+				DataType ak_ = BloodPressure?.Effective;
+				object al_ = FHIRHelpers_4_3_000.ToValue(ak_);
+				CqlInterval<CqlDateTime> am_ = QICoreCommon_2_0_000.toInterval(al_);
+				CqlDateTime an_ = context.Operators.End(am_);
+				Period ao_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
+				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, null);
+				Code<ObservationStatus> ar_ = BloodPressure?.StatusElement;
+				ObservationStatus? as_ = ar_?.Value;
+				string at_ = context.Operators.Convert<string>(as_);
+				string[] au_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var av_ = context.Operators.In<string>(at_, (au_ as IEnumerable<string>));
-				var aw_ = context.Operators.And(aq_, av_);
+				bool? av_ = context.Operators.In<string>(at_, (au_ as IEnumerable<string>));
+				bool? aw_ = context.Operators.And(aq_, av_);
 
 				return aw_;
 			};
-			var f_ = context.Operators.Where<Observation>(d_, e_);
+			IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 			object g_(Observation @this)
 			{
-				var ax_ = @this?.Effective;
-				var ay_ = FHIRHelpers_4_3_000.ToValue(ax_);
-				var az_ = QICoreCommon_2_0_000.toInterval(ay_);
-				var ba_ = context.Operators.Start(az_);
+				DataType ax_ = @this?.Effective;
+				object ay_ = FHIRHelpers_4_3_000.ToValue(ax_);
+				CqlInterval<CqlDateTime> az_ = QICoreCommon_2_0_000.toInterval(ay_);
+				CqlDateTime ba_ = context.Operators.Start(az_);
 
 				return ba_;
 			};
-			var h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
-			var i_ = context.Operators.Last<Observation>(h_);
-			var j_ = i_?.Component;
+			IEnumerable<Observation> h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation i_ = context.Operators.Last<Observation>(h_);
+			List<Observation.ComponentComponent> j_ = i_?.Component;
 			bool? k_(Observation.ComponentComponent @this)
 			{
-				var bb_ = @this?.Code;
-				var bc_ = bb_?.Coding;
-				var bd_ = context.Operators.First<Coding>((IEnumerable<Coding>)bc_);
-				var be_ = bd_?.SystemElement;
-				var bf_ = FHIRHelpers_4_3_000.ToString(be_);
-				var bg_ = context.Operators.Equal(bf_, "http://loinc.org");
-				var bi_ = bb_?.Coding;
-				var bj_ = context.Operators.First<Coding>((IEnumerable<Coding>)bi_);
-				var bk_ = bj_?.CodeElement;
-				var bl_ = FHIRHelpers_4_3_000.ToString(bk_);
-				var bm_ = context.Operators.Equal(bl_, "8480-6");
-				var bn_ = context.Operators.And(bg_, bm_);
+				CodeableConcept bb_ = @this?.Code;
+				List<Coding> bc_ = bb_?.Coding;
+				Coding bd_ = context.Operators.First<Coding>((IEnumerable<Coding>)bc_);
+				FhirUri be_ = bd_?.SystemElement;
+				string bf_ = FHIRHelpers_4_3_000.ToString(be_);
+				bool? bg_ = context.Operators.Equal(bf_, "http://loinc.org");
+				List<Coding> bi_ = bb_?.Coding;
+				Coding bj_ = context.Operators.First<Coding>((IEnumerable<Coding>)bi_);
+				Code bk_ = bj_?.CodeElement;
+				string bl_ = FHIRHelpers_4_3_000.ToString(bk_);
+				bool? bm_ = context.Operators.Equal(bl_, "8480-6");
+				bool? bn_ = context.Operators.And(bg_, bm_);
 
 				return bn_;
 			};
-			var l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
-			var m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
-			var n_ = m_?.Value;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = context.Operators.Quantity(120m, "mm[Hg]");
-			var q_ = context.Operators.Quantity(129m, "mm[Hg]");
-			var r_ = context.Operators.Interval(p_, q_, true, true);
-			var s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, null);
+			IEnumerable<Observation.ComponentComponent> l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
+			Observation.ComponentComponent m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
+			DataType n_ = m_?.Value;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			CqlQuantity p_ = context.Operators.Quantity(120m, "mm[Hg]");
+			CqlQuantity q_ = context.Operators.Quantity(129m, "mm[Hg]");
+			CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, true);
+			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, null);
 			bool? u_(Observation BloodPressure)
 			{
-				var bo_ = BloodPressure?.Effective;
-				var bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
-				var bq_ = QICoreCommon_2_0_000.toInterval(bp_);
-				var br_ = context.Operators.End(bq_);
-				var bs_ = QualifyingEncounter?.Period;
-				var bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
-				var bu_ = context.Operators.In<CqlDateTime>(br_, bt_, null);
-				var bv_ = BloodPressure?.StatusElement;
-				var bw_ = bv_?.Value;
-				var bx_ = context.Operators.Convert<string>(bw_);
-				var by_ = new string[]
+				DataType bo_ = BloodPressure?.Effective;
+				object bp_ = FHIRHelpers_4_3_000.ToValue(bo_);
+				CqlInterval<CqlDateTime> bq_ = QICoreCommon_2_0_000.toInterval(bp_);
+				CqlDateTime br_ = context.Operators.End(bq_);
+				Period bs_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
+				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, null);
+				Code<ObservationStatus> bv_ = BloodPressure?.StatusElement;
+				ObservationStatus? bw_ = bv_?.Value;
+				string bx_ = context.Operators.Convert<string>(bw_);
+				string[] by_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bz_ = context.Operators.In<string>(bx_, (by_ as IEnumerable<string>));
-				var ca_ = context.Operators.And(bu_, bz_);
+				bool? bz_ = context.Operators.In<string>(bx_, (by_ as IEnumerable<string>));
+				bool? ca_ = context.Operators.And(bu_, bz_);
 
 				return ca_;
 			};
-			var v_ = context.Operators.Where<Observation>(d_, u_);
+			IEnumerable<Observation> v_ = context.Operators.Where<Observation>(d_, u_);
 			object w_(Observation @this)
 			{
-				var cb_ = @this?.Effective;
-				var cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
-				var cd_ = QICoreCommon_2_0_000.toInterval(cc_);
-				var ce_ = context.Operators.Start(cd_);
+				DataType cb_ = @this?.Effective;
+				object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
+				CqlInterval<CqlDateTime> cd_ = QICoreCommon_2_0_000.toInterval(cc_);
+				CqlDateTime ce_ = context.Operators.Start(cd_);
 
 				return ce_;
 			};
-			var x_ = context.Operators.SortBy<Observation>(v_, w_, System.ComponentModel.ListSortDirection.Ascending);
-			var y_ = context.Operators.Last<Observation>(x_);
-			var z_ = y_?.Component;
+			IEnumerable<Observation> x_ = context.Operators.SortBy<Observation>(v_, w_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation y_ = context.Operators.Last<Observation>(x_);
+			List<Observation.ComponentComponent> z_ = y_?.Component;
 			bool? aa_(Observation.ComponentComponent @this)
 			{
-				var cf_ = @this?.Code;
-				var cg_ = cf_?.Coding;
-				var ch_ = context.Operators.First<Coding>((IEnumerable<Coding>)cg_);
-				var ci_ = ch_?.SystemElement;
-				var cj_ = FHIRHelpers_4_3_000.ToString(ci_);
-				var ck_ = context.Operators.Equal(cj_, "http://loinc.org");
-				var cm_ = cf_?.Coding;
-				var cn_ = context.Operators.First<Coding>((IEnumerable<Coding>)cm_);
-				var co_ = cn_?.CodeElement;
-				var cp_ = FHIRHelpers_4_3_000.ToString(co_);
-				var cq_ = context.Operators.Equal(cp_, "8462-4");
-				var cr_ = context.Operators.And(ck_, cq_);
+				CodeableConcept cf_ = @this?.Code;
+				List<Coding> cg_ = cf_?.Coding;
+				Coding ch_ = context.Operators.First<Coding>((IEnumerable<Coding>)cg_);
+				FhirUri ci_ = ch_?.SystemElement;
+				string cj_ = FHIRHelpers_4_3_000.ToString(ci_);
+				bool? ck_ = context.Operators.Equal(cj_, "http://loinc.org");
+				List<Coding> cm_ = cf_?.Coding;
+				Coding cn_ = context.Operators.First<Coding>((IEnumerable<Coding>)cm_);
+				Code co_ = cn_?.CodeElement;
+				string cp_ = FHIRHelpers_4_3_000.ToString(co_);
+				bool? cq_ = context.Operators.Equal(cp_, "8462-4");
+				bool? cr_ = context.Operators.And(ck_, cq_);
 
 				return cr_;
 			};
-			var ab_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)z_, aa_);
-			var ac_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ab_);
-			var ad_ = ac_?.Value;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = context.Operators.Quantity(1m, "mm[Hg]");
-			var ag_ = context.Operators.Quantity(80m, "mm[Hg]");
-			var ah_ = context.Operators.Interval(af_, ag_, true, false);
-			var ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, null);
-			var aj_ = context.Operators.And(s_, ai_);
+			IEnumerable<Observation.ComponentComponent> ab_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)z_, aa_);
+			Observation.ComponentComponent ac_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ab_);
+			DataType ad_ = ac_?.Value;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlQuantity af_ = context.Operators.Quantity(1m, "mm[Hg]");
+			CqlQuantity ag_ = context.Operators.Quantity(80m, "mm[Hg]");
+			CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(af_, ag_, true, false);
+			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, null);
+			bool? aj_ = context.Operators.And(s_, ai_);
 
 			return aj_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_Value"/>
     [CqlDeclaration("Encounter with Elevated Blood Pressure Reading SBP 120 to 129 AND DBP less than 80")]
 	public IEnumerable<Encounter> Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80() => 
 		__Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80.Value;
 
+    /// <seealso cref="Follow_up_with_Rescreen_in_2_to_6_Months"/>
 	private IEnumerable<ServiceRequest> Follow_up_with_Rescreen_in_2_to_6_Months_Value()
 	{
-		var a_ = this.Follow_up_2_3_months__finding_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
-		var d_ = this.Follow_up_4_6_months__finding_();
-		var e_ = context.Operators.ToList<CqlCode>(d_);
-		var f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
-		var g_ = context.Operators.Union<ServiceRequest>(c_, f_);
+		CqlCode a_ = this.Follow_up_2_3_months__finding_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
+		CqlCode d_ = this.Follow_up_4_6_months__finding_();
+		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
+		IEnumerable<ServiceRequest> g_ = context.Operators.Union<ServiceRequest>(c_, f_);
 		bool? h_(ServiceRequest FollowUp)
 		{
-			var j_ = FollowUp?.IntentElement;
-			var k_ = j_?.Value;
-			var l_ = context.Operators.Convert<Code<RequestIntent>>(k_);
-			var m_ = context.Operators.Equivalent(l_, "order");
+			Code<RequestIntent> j_ = FollowUp?.IntentElement;
+			RequestIntent? k_ = j_?.Value;
+			Code<RequestIntent> l_ = context.Operators.Convert<Code<RequestIntent>>(k_);
+			bool? m_ = context.Operators.Equivalent(l_, "order");
 
 			return m_;
 		};
-		var i_ = context.Operators.Where<ServiceRequest>(g_, h_);
+		IEnumerable<ServiceRequest> i_ = context.Operators.Where<ServiceRequest>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Follow_up_with_Rescreen_in_2_to_6_Months_Value"/>
     [CqlDeclaration("Follow up with Rescreen in 2 to 6 Months")]
 	public IEnumerable<ServiceRequest> Follow_up_with_Rescreen_in_2_to_6_Months() => 
 		__Follow_up_with_Rescreen_in_2_to_6_Months.Value;
 
+    /// <seealso cref="NonPharmacological_Interventions"/>
 	private IEnumerable<ServiceRequest> NonPharmacological_Interventions_Value()
 	{
-		var a_ = this.Lifestyle_Recommendation();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var c_ = this.Weight_Reduction_Recommended();
-		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
-		var e_ = context.Operators.Union<ServiceRequest>(b_, d_);
-		var f_ = this.Dietary_Recommendations();
-		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
-		var h_ = this.Recommendation_to_Increase_Physical_Activity();
-		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
-		var j_ = context.Operators.Union<ServiceRequest>(g_, i_);
-		var k_ = context.Operators.Union<ServiceRequest>(e_, j_);
-		var l_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
-		var m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
-		var n_ = context.Operators.Union<ServiceRequest>(k_, m_);
+		CqlValueSet a_ = this.Lifestyle_Recommendation();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		CqlValueSet c_ = this.Weight_Reduction_Recommended();
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
+		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
+		CqlValueSet f_ = this.Dietary_Recommendations();
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		CqlValueSet h_ = this.Recommendation_to_Increase_Physical_Activity();
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
+		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
+		CqlValueSet l_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
+		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
+		IEnumerable<ServiceRequest> n_ = context.Operators.Union<ServiceRequest>(k_, m_);
 		bool? o_(ServiceRequest NonPharmaInterventions)
 		{
-			var q_ = NonPharmaInterventions?.IntentElement;
-			var r_ = q_?.Value;
-			var s_ = context.Operators.Convert<Code<RequestIntent>>(r_);
-			var t_ = context.Operators.Equivalent(s_, "order");
+			Code<RequestIntent> q_ = NonPharmaInterventions?.IntentElement;
+			RequestIntent? r_ = q_?.Value;
+			Code<RequestIntent> s_ = context.Operators.Convert<Code<RequestIntent>>(r_);
+			bool? t_ = context.Operators.Equivalent(s_, "order");
 
 			return t_;
 		};
-		var p_ = context.Operators.Where<ServiceRequest>(n_, o_);
+		IEnumerable<ServiceRequest> p_ = context.Operators.Where<ServiceRequest>(n_, o_);
 
 		return p_;
 	}
 
+    /// <seealso cref="NonPharmacological_Interventions_Value"/>
     [CqlDeclaration("NonPharmacological Interventions")]
 	public IEnumerable<ServiceRequest> NonPharmacological_Interventions() => 
 		__NonPharmacological_Interventions.Value;
 
+    /// <seealso cref="Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading"/>
 	private IEnumerable<ServiceRequest> Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading_Value()
 	{
-		var a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		CqlValueSet a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
 		bool? c_(ServiceRequest Referral)
 		{
-			var e_ = Referral?.ReasonCode;
+			List<CodeableConcept> e_ = Referral?.ReasonCode;
 			CqlConcept f_(CodeableConcept @this)
 			{
-				var o_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return o_;
 			};
-			var g_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, f_);
-			var h_ = this.Finding_of_Elevated_Blood_Pressure_or_Hypertension();
-			var i_ = context.Operators.ConceptsInValueSet(g_, h_);
-			var j_ = Referral?.IntentElement;
-			var k_ = j_?.Value;
-			var l_ = context.Operators.Convert<Code<RequestIntent>>(k_);
-			var m_ = context.Operators.Equivalent(l_, "order");
-			var n_ = context.Operators.And(i_, m_);
+			IEnumerable<CqlConcept> g_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)e_, f_);
+			CqlValueSet h_ = this.Finding_of_Elevated_Blood_Pressure_or_Hypertension();
+			bool? i_ = context.Operators.ConceptsInValueSet(g_, h_);
+			Code<RequestIntent> j_ = Referral?.IntentElement;
+			RequestIntent? k_ = j_?.Value;
+			Code<RequestIntent> l_ = context.Operators.Convert<Code<RequestIntent>>(k_);
+			bool? m_ = context.Operators.Equivalent(l_, "order");
+			bool? n_ = context.Operators.And(i_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<ServiceRequest>(b_, c_);
+		IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading_Value"/>
     [CqlDeclaration("Referral to Alternate or Primary Healthcare Professional for Hypertensive Reading")]
 	public IEnumerable<ServiceRequest> Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading() => 
 		__Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading.Value;
 
+    /// <seealso cref="Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions"/>
 	private IEnumerable<Encounter> Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions_Value()
 	{
-		var a_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80();
 		IEnumerable<Encounter> b_(Encounter ElevatedEncounter)
 		{
-			var j_ = this.Follow_up_with_Rescreen_in_2_to_6_Months();
+			IEnumerable<ServiceRequest> j_ = this.Follow_up_with_Rescreen_in_2_to_6_Months();
 			bool? k_(ServiceRequest Twoto6MonthRescreen)
 			{
-				var o_ = Twoto6MonthRescreen?.AuthoredOnElement;
-				var p_ = context.Operators.Convert<CqlDateTime>(o_);
-				var q_ = ElevatedEncounter?.Period;
-				var r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				var s_ = context.Operators.In<CqlDateTime>(p_, r_, "day");
+				FhirDateTime o_ = Twoto6MonthRescreen?.AuthoredOnElement;
+				CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
+				Period q_ = ElevatedEncounter?.Period;
+				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
+				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, "day");
 
 				return s_;
 			};
-			var l_ = context.Operators.Where<ServiceRequest>(j_, k_);
+			IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
 			Encounter m_(ServiceRequest Twoto6MonthRescreen) => 
 				ElevatedEncounter;
-			var n_ = context.Operators.Select<ServiceRequest, Encounter>(l_, m_);
+			IEnumerable<Encounter> n_ = context.Operators.Select<ServiceRequest, Encounter>(l_, m_);
 
 			return n_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 		IEnumerable<Encounter> d_(Encounter ElevatedEncounter)
 		{
-			var t_ = this.NonPharmacological_Interventions();
+			IEnumerable<ServiceRequest> t_ = this.NonPharmacological_Interventions();
 			bool? u_(ServiceRequest NonPharmInterventions)
 			{
-				var y_ = NonPharmInterventions?.AuthoredOnElement;
-				var z_ = context.Operators.Convert<CqlDateTime>(y_);
-				var aa_ = ElevatedEncounter?.Period;
-				var ab_ = FHIRHelpers_4_3_000.ToInterval(aa_);
-				var ac_ = context.Operators.In<CqlDateTime>(z_, ab_, "day");
+				FhirDateTime y_ = NonPharmInterventions?.AuthoredOnElement;
+				CqlDateTime z_ = context.Operators.Convert<CqlDateTime>(y_);
+				Period aa_ = ElevatedEncounter?.Period;
+				CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_3_000.ToInterval(aa_);
+				bool? ac_ = context.Operators.In<CqlDateTime>(z_, ab_, "day");
 
 				return ac_;
 			};
-			var v_ = context.Operators.Where<ServiceRequest>(t_, u_);
+			IEnumerable<ServiceRequest> v_ = context.Operators.Where<ServiceRequest>(t_, u_);
 			Encounter w_(ServiceRequest NonPharmInterventions) => 
 				ElevatedEncounter;
-			var x_ = context.Operators.Select<ServiceRequest, Encounter>(v_, w_);
+			IEnumerable<Encounter> x_ = context.Operators.Select<ServiceRequest, Encounter>(v_, w_);
 
 			return x_;
 		};
-		var e_ = context.Operators.SelectMany<Encounter, Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.SelectMany<Encounter, Encounter>(c_, d_);
 		IEnumerable<Encounter> g_(Encounter ElevatedEncounter)
 		{
-			var ad_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
+			IEnumerable<ServiceRequest> ad_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
 			bool? ae_(ServiceRequest Referral)
 			{
-				var ai_ = Referral?.AuthoredOnElement;
-				var aj_ = context.Operators.Convert<CqlDateTime>(ai_);
-				var ak_ = ElevatedEncounter?.Period;
-				var al_ = FHIRHelpers_4_3_000.ToInterval(ak_);
-				var am_ = context.Operators.In<CqlDateTime>(aj_, al_, "day");
+				FhirDateTime ai_ = Referral?.AuthoredOnElement;
+				CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(ai_);
+				Period ak_ = ElevatedEncounter?.Period;
+				CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_3_000.ToInterval(ak_);
+				bool? am_ = context.Operators.In<CqlDateTime>(aj_, al_, "day");
 
 				return am_;
 			};
-			var af_ = context.Operators.Where<ServiceRequest>(ad_, ae_);
+			IEnumerable<ServiceRequest> af_ = context.Operators.Where<ServiceRequest>(ad_, ae_);
 			Encounter ag_(ServiceRequest Referral) => 
 				ElevatedEncounter;
-			var ah_ = context.Operators.Select<ServiceRequest, Encounter>(af_, ag_);
+			IEnumerable<Encounter> ah_ = context.Operators.Select<ServiceRequest, Encounter>(af_, ag_);
 
 			return ah_;
 		};
-		var h_ = context.Operators.SelectMany<Encounter, Encounter>(a_, g_);
-		var i_ = context.Operators.Union<Encounter>(e_, h_);
+		IEnumerable<Encounter> h_ = context.Operators.SelectMany<Encounter, Encounter>(a_, g_);
+		IEnumerable<Encounter> i_ = context.Operators.Union<Encounter>(e_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions_Value"/>
     [CqlDeclaration("Encounter with Elevated Blood Pressure Reading SBP 120 to 129 AND DBP less than 80 and Interventions")]
 	public IEnumerable<Encounter> Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions() => 
 		__Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions.Value;
 
+    /// <seealso cref="Encounter_with_Hypertensive_Reading_Within_Year_Prior"/>
 	private IEnumerable<Encounter> Encounter_with_Hypertensive_Reading_Within_Year_Prior_Value()
 	{
-		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? e_(Observation BloodPressure)
 			{
-				var bk_ = BloodPressure?.Effective;
-				var bl_ = FHIRHelpers_4_3_000.ToValue(bk_);
-				var bm_ = QICoreCommon_2_0_000.toInterval(bl_);
-				var bn_ = context.Operators.End(bm_);
-				var bo_ = QualifyingEncounter?.Period;
-				var bp_ = FHIRHelpers_4_3_000.ToInterval(bo_);
-				var bq_ = context.Operators.Start(bp_);
-				var br_ = context.Operators.Quantity(1m, "year");
-				var bs_ = context.Operators.Subtract(bq_, br_);
-				var bu_ = FHIRHelpers_4_3_000.ToInterval(bo_);
-				var bv_ = context.Operators.Start(bu_);
-				var bw_ = context.Operators.Interval(bs_, bv_, true, true);
-				var bx_ = context.Operators.In<CqlDateTime>(bn_, bw_, null);
-				var bz_ = FHIRHelpers_4_3_000.ToInterval(bo_);
-				var ca_ = context.Operators.Start(bz_);
-				var cb_ = context.Operators.Not((bool?)(ca_ is null));
-				var cc_ = context.Operators.And(bx_, cb_);
-				var cd_ = BloodPressure?.StatusElement;
-				var ce_ = cd_?.Value;
-				var cf_ = context.Operators.Convert<string>(ce_);
-				var cg_ = new string[]
+				DataType bk_ = BloodPressure?.Effective;
+				object bl_ = FHIRHelpers_4_3_000.ToValue(bk_);
+				CqlInterval<CqlDateTime> bm_ = QICoreCommon_2_0_000.toInterval(bl_);
+				CqlDateTime bn_ = context.Operators.End(bm_);
+				Period bo_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_3_000.ToInterval(bo_);
+				CqlDateTime bq_ = context.Operators.Start(bp_);
+				CqlQuantity br_ = context.Operators.Quantity(1m, "year");
+				CqlDateTime bs_ = context.Operators.Subtract(bq_, br_);
+				CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_3_000.ToInterval(bo_);
+				CqlDateTime bv_ = context.Operators.Start(bu_);
+				CqlInterval<CqlDateTime> bw_ = context.Operators.Interval(bs_, bv_, true, true);
+				bool? bx_ = context.Operators.In<CqlDateTime>(bn_, bw_, null);
+				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(bo_);
+				CqlDateTime ca_ = context.Operators.Start(bz_);
+				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
+				bool? cc_ = context.Operators.And(bx_, cb_);
+				Code<ObservationStatus> cd_ = BloodPressure?.StatusElement;
+				ObservationStatus? ce_ = cd_?.Value;
+				string cf_ = context.Operators.Convert<string>(ce_);
+				string[] cg_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ch_ = context.Operators.In<string>(cf_, (cg_ as IEnumerable<string>));
-				var ci_ = context.Operators.And(cc_, ch_);
+				bool? ch_ = context.Operators.In<string>(cf_, (cg_ as IEnumerable<string>));
+				bool? ci_ = context.Operators.And(cc_, ch_);
 
 				return ci_;
 			};
-			var f_ = context.Operators.Where<Observation>(d_, e_);
+			IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 			object g_(Observation @this)
 			{
-				var cj_ = @this?.Effective;
-				var ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
-				var cl_ = QICoreCommon_2_0_000.toInterval(ck_);
-				var cm_ = context.Operators.Start(cl_);
+				DataType cj_ = @this?.Effective;
+				object ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
+				CqlInterval<CqlDateTime> cl_ = QICoreCommon_2_0_000.toInterval(ck_);
+				CqlDateTime cm_ = context.Operators.Start(cl_);
 
 				return cm_;
 			};
-			var h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
-			var i_ = context.Operators.Last<Observation>(h_);
-			var j_ = i_?.Component;
+			IEnumerable<Observation> h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation i_ = context.Operators.Last<Observation>(h_);
+			List<Observation.ComponentComponent> j_ = i_?.Component;
 			bool? k_(Observation.ComponentComponent @this)
 			{
-				var cn_ = @this?.Code;
-				var co_ = cn_?.Coding;
-				var cp_ = context.Operators.First<Coding>((IEnumerable<Coding>)co_);
-				var cq_ = cp_?.SystemElement;
-				var cr_ = FHIRHelpers_4_3_000.ToString(cq_);
-				var cs_ = context.Operators.Equal(cr_, "http://loinc.org");
-				var cu_ = cn_?.Coding;
-				var cv_ = context.Operators.First<Coding>((IEnumerable<Coding>)cu_);
-				var cw_ = cv_?.CodeElement;
-				var cx_ = FHIRHelpers_4_3_000.ToString(cw_);
-				var cy_ = context.Operators.Equal(cx_, "8480-6");
-				var cz_ = context.Operators.And(cs_, cy_);
+				CodeableConcept cn_ = @this?.Code;
+				List<Coding> co_ = cn_?.Coding;
+				Coding cp_ = context.Operators.First<Coding>((IEnumerable<Coding>)co_);
+				FhirUri cq_ = cp_?.SystemElement;
+				string cr_ = FHIRHelpers_4_3_000.ToString(cq_);
+				bool? cs_ = context.Operators.Equal(cr_, "http://loinc.org");
+				List<Coding> cu_ = cn_?.Coding;
+				Coding cv_ = context.Operators.First<Coding>((IEnumerable<Coding>)cu_);
+				Code cw_ = cv_?.CodeElement;
+				string cx_ = FHIRHelpers_4_3_000.ToString(cw_);
+				bool? cy_ = context.Operators.Equal(cx_, "8480-6");
+				bool? cz_ = context.Operators.And(cs_, cy_);
 
 				return cz_;
 			};
-			var l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
-			var m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
-			var n_ = m_?.Value;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = context.Operators.Quantity(0m, "mm[Hg]");
-			var q_ = context.Operators.Greater((o_ as CqlQuantity), p_);
+			IEnumerable<Observation.ComponentComponent> l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
+			Observation.ComponentComponent m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
+			DataType n_ = m_?.Value;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			CqlQuantity p_ = context.Operators.Quantity(0m, "mm[Hg]");
+			bool? q_ = context.Operators.Greater((o_ as CqlQuantity), p_);
 			bool? s_(Observation BloodPressure)
 			{
-				var da_ = BloodPressure?.Effective;
-				var db_ = FHIRHelpers_4_3_000.ToValue(da_);
-				var dc_ = QICoreCommon_2_0_000.toInterval(db_);
-				var dd_ = context.Operators.End(dc_);
-				var de_ = QualifyingEncounter?.Period;
-				var df_ = FHIRHelpers_4_3_000.ToInterval(de_);
-				var dg_ = context.Operators.Start(df_);
-				var dh_ = context.Operators.Quantity(1m, "year");
-				var di_ = context.Operators.Subtract(dg_, dh_);
-				var dk_ = FHIRHelpers_4_3_000.ToInterval(de_);
-				var dl_ = context.Operators.Start(dk_);
-				var dm_ = context.Operators.Interval(di_, dl_, true, true);
-				var dn_ = context.Operators.In<CqlDateTime>(dd_, dm_, null);
-				var dp_ = FHIRHelpers_4_3_000.ToInterval(de_);
-				var dq_ = context.Operators.Start(dp_);
-				var dr_ = context.Operators.Not((bool?)(dq_ is null));
-				var ds_ = context.Operators.And(dn_, dr_);
-				var dt_ = BloodPressure?.StatusElement;
-				var du_ = dt_?.Value;
-				var dv_ = context.Operators.Convert<string>(du_);
-				var dw_ = new string[]
+				DataType da_ = BloodPressure?.Effective;
+				object db_ = FHIRHelpers_4_3_000.ToValue(da_);
+				CqlInterval<CqlDateTime> dc_ = QICoreCommon_2_0_000.toInterval(db_);
+				CqlDateTime dd_ = context.Operators.End(dc_);
+				Period de_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_3_000.ToInterval(de_);
+				CqlDateTime dg_ = context.Operators.Start(df_);
+				CqlQuantity dh_ = context.Operators.Quantity(1m, "year");
+				CqlDateTime di_ = context.Operators.Subtract(dg_, dh_);
+				CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_3_000.ToInterval(de_);
+				CqlDateTime dl_ = context.Operators.Start(dk_);
+				CqlInterval<CqlDateTime> dm_ = context.Operators.Interval(di_, dl_, true, true);
+				bool? dn_ = context.Operators.In<CqlDateTime>(dd_, dm_, null);
+				CqlInterval<CqlDateTime> dp_ = FHIRHelpers_4_3_000.ToInterval(de_);
+				CqlDateTime dq_ = context.Operators.Start(dp_);
+				bool? dr_ = context.Operators.Not((bool?)(dq_ is null));
+				bool? ds_ = context.Operators.And(dn_, dr_);
+				Code<ObservationStatus> dt_ = BloodPressure?.StatusElement;
+				ObservationStatus? du_ = dt_?.Value;
+				string dv_ = context.Operators.Convert<string>(du_);
+				string[] dw_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var dx_ = context.Operators.In<string>(dv_, (dw_ as IEnumerable<string>));
-				var dy_ = context.Operators.And(ds_, dx_);
+				bool? dx_ = context.Operators.In<string>(dv_, (dw_ as IEnumerable<string>));
+				bool? dy_ = context.Operators.And(ds_, dx_);
 
 				return dy_;
 			};
-			var t_ = context.Operators.Where<Observation>(d_, s_);
+			IEnumerable<Observation> t_ = context.Operators.Where<Observation>(d_, s_);
 			object u_(Observation @this)
 			{
-				var dz_ = @this?.Effective;
-				var ea_ = FHIRHelpers_4_3_000.ToValue(dz_);
-				var eb_ = QICoreCommon_2_0_000.toInterval(ea_);
-				var ec_ = context.Operators.Start(eb_);
+				DataType dz_ = @this?.Effective;
+				object ea_ = FHIRHelpers_4_3_000.ToValue(dz_);
+				CqlInterval<CqlDateTime> eb_ = QICoreCommon_2_0_000.toInterval(ea_);
+				CqlDateTime ec_ = context.Operators.Start(eb_);
 
 				return ec_;
 			};
-			var v_ = context.Operators.SortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
-			var w_ = context.Operators.Last<Observation>(v_);
-			var x_ = w_?.Component;
+			IEnumerable<Observation> v_ = context.Operators.SortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation w_ = context.Operators.Last<Observation>(v_);
+			List<Observation.ComponentComponent> x_ = w_?.Component;
 			bool? y_(Observation.ComponentComponent @this)
 			{
-				var ed_ = @this?.Code;
-				var ee_ = ed_?.Coding;
-				var ef_ = context.Operators.First<Coding>((IEnumerable<Coding>)ee_);
-				var eg_ = ef_?.SystemElement;
-				var eh_ = FHIRHelpers_4_3_000.ToString(eg_);
-				var ei_ = context.Operators.Equal(eh_, "http://loinc.org");
-				var ek_ = ed_?.Coding;
-				var el_ = context.Operators.First<Coding>((IEnumerable<Coding>)ek_);
-				var em_ = el_?.CodeElement;
-				var en_ = FHIRHelpers_4_3_000.ToString(em_);
-				var eo_ = context.Operators.Equal(en_, "8462-4");
-				var ep_ = context.Operators.And(ei_, eo_);
+				CodeableConcept ed_ = @this?.Code;
+				List<Coding> ee_ = ed_?.Coding;
+				Coding ef_ = context.Operators.First<Coding>((IEnumerable<Coding>)ee_);
+				FhirUri eg_ = ef_?.SystemElement;
+				string eh_ = FHIRHelpers_4_3_000.ToString(eg_);
+				bool? ei_ = context.Operators.Equal(eh_, "http://loinc.org");
+				List<Coding> ek_ = ed_?.Coding;
+				Coding el_ = context.Operators.First<Coding>((IEnumerable<Coding>)ek_);
+				Code em_ = el_?.CodeElement;
+				string en_ = FHIRHelpers_4_3_000.ToString(em_);
+				bool? eo_ = context.Operators.Equal(en_, "8462-4");
+				bool? ep_ = context.Operators.And(ei_, eo_);
 
 				return ep_;
 			};
-			var z_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)x_, y_);
-			var aa_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(z_);
-			var ab_ = aa_?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ae_ = context.Operators.Greater((ac_ as CqlQuantity), p_);
-			var af_ = context.Operators.And(q_, ae_);
+			IEnumerable<Observation.ComponentComponent> z_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)x_, y_);
+			Observation.ComponentComponent aa_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(z_);
+			DataType ab_ = aa_?.Value;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			bool? ae_ = context.Operators.Greater((ac_ as CqlQuantity), p_);
+			bool? af_ = context.Operators.And(q_, ae_);
 			bool? ah_(Observation BloodPressure)
 			{
-				var eq_ = BloodPressure?.Effective;
-				var er_ = FHIRHelpers_4_3_000.ToValue(eq_);
-				var es_ = QICoreCommon_2_0_000.toInterval(er_);
-				var et_ = context.Operators.End(es_);
-				var eu_ = QualifyingEncounter?.Period;
-				var ev_ = FHIRHelpers_4_3_000.ToInterval(eu_);
-				var ew_ = context.Operators.Start(ev_);
-				var ex_ = context.Operators.Quantity(1m, "year");
-				var ey_ = context.Operators.Subtract(ew_, ex_);
-				var fa_ = FHIRHelpers_4_3_000.ToInterval(eu_);
-				var fb_ = context.Operators.Start(fa_);
-				var fc_ = context.Operators.Interval(ey_, fb_, true, true);
-				var fd_ = context.Operators.In<CqlDateTime>(et_, fc_, null);
-				var ff_ = FHIRHelpers_4_3_000.ToInterval(eu_);
-				var fg_ = context.Operators.Start(ff_);
-				var fh_ = context.Operators.Not((bool?)(fg_ is null));
-				var fi_ = context.Operators.And(fd_, fh_);
-				var fj_ = BloodPressure?.StatusElement;
-				var fk_ = fj_?.Value;
-				var fl_ = context.Operators.Convert<string>(fk_);
-				var fm_ = new string[]
+				DataType eq_ = BloodPressure?.Effective;
+				object er_ = FHIRHelpers_4_3_000.ToValue(eq_);
+				CqlInterval<CqlDateTime> es_ = QICoreCommon_2_0_000.toInterval(er_);
+				CqlDateTime et_ = context.Operators.End(es_);
+				Period eu_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> ev_ = FHIRHelpers_4_3_000.ToInterval(eu_);
+				CqlDateTime ew_ = context.Operators.Start(ev_);
+				CqlQuantity ex_ = context.Operators.Quantity(1m, "year");
+				CqlDateTime ey_ = context.Operators.Subtract(ew_, ex_);
+				CqlInterval<CqlDateTime> fa_ = FHIRHelpers_4_3_000.ToInterval(eu_);
+				CqlDateTime fb_ = context.Operators.Start(fa_);
+				CqlInterval<CqlDateTime> fc_ = context.Operators.Interval(ey_, fb_, true, true);
+				bool? fd_ = context.Operators.In<CqlDateTime>(et_, fc_, null);
+				CqlInterval<CqlDateTime> ff_ = FHIRHelpers_4_3_000.ToInterval(eu_);
+				CqlDateTime fg_ = context.Operators.Start(ff_);
+				bool? fh_ = context.Operators.Not((bool?)(fg_ is null));
+				bool? fi_ = context.Operators.And(fd_, fh_);
+				Code<ObservationStatus> fj_ = BloodPressure?.StatusElement;
+				ObservationStatus? fk_ = fj_?.Value;
+				string fl_ = context.Operators.Convert<string>(fk_);
+				string[] fm_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var fn_ = context.Operators.In<string>(fl_, (fm_ as IEnumerable<string>));
-				var fo_ = context.Operators.And(fi_, fn_);
+				bool? fn_ = context.Operators.In<string>(fl_, (fm_ as IEnumerable<string>));
+				bool? fo_ = context.Operators.And(fi_, fn_);
 
 				return fo_;
 			};
-			var ai_ = context.Operators.Where<Observation>(d_, ah_);
+			IEnumerable<Observation> ai_ = context.Operators.Where<Observation>(d_, ah_);
 			object aj_(Observation @this)
 			{
-				var fp_ = @this?.Effective;
-				var fq_ = FHIRHelpers_4_3_000.ToValue(fp_);
-				var fr_ = QICoreCommon_2_0_000.toInterval(fq_);
-				var fs_ = context.Operators.Start(fr_);
+				DataType fp_ = @this?.Effective;
+				object fq_ = FHIRHelpers_4_3_000.ToValue(fp_);
+				CqlInterval<CqlDateTime> fr_ = QICoreCommon_2_0_000.toInterval(fq_);
+				CqlDateTime fs_ = context.Operators.Start(fr_);
 
 				return fs_;
 			};
-			var ak_ = context.Operators.SortBy<Observation>(ai_, aj_, System.ComponentModel.ListSortDirection.Ascending);
-			var al_ = context.Operators.Last<Observation>(ak_);
-			var am_ = al_?.Component;
+			IEnumerable<Observation> ak_ = context.Operators.SortBy<Observation>(ai_, aj_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation al_ = context.Operators.Last<Observation>(ak_);
+			List<Observation.ComponentComponent> am_ = al_?.Component;
 			bool? an_(Observation.ComponentComponent @this)
 			{
-				var ft_ = @this?.Code;
-				var fu_ = ft_?.Coding;
-				var fv_ = context.Operators.First<Coding>((IEnumerable<Coding>)fu_);
-				var fw_ = fv_?.SystemElement;
-				var fx_ = FHIRHelpers_4_3_000.ToString(fw_);
-				var fy_ = context.Operators.Equal(fx_, "http://loinc.org");
-				var ga_ = ft_?.Coding;
-				var gb_ = context.Operators.First<Coding>((IEnumerable<Coding>)ga_);
-				var gc_ = gb_?.CodeElement;
-				var gd_ = FHIRHelpers_4_3_000.ToString(gc_);
-				var ge_ = context.Operators.Equal(gd_, "8480-6");
-				var gf_ = context.Operators.And(fy_, ge_);
+				CodeableConcept ft_ = @this?.Code;
+				List<Coding> fu_ = ft_?.Coding;
+				Coding fv_ = context.Operators.First<Coding>((IEnumerable<Coding>)fu_);
+				FhirUri fw_ = fv_?.SystemElement;
+				string fx_ = FHIRHelpers_4_3_000.ToString(fw_);
+				bool? fy_ = context.Operators.Equal(fx_, "http://loinc.org");
+				List<Coding> ga_ = ft_?.Coding;
+				Coding gb_ = context.Operators.First<Coding>((IEnumerable<Coding>)ga_);
+				Code gc_ = gb_?.CodeElement;
+				string gd_ = FHIRHelpers_4_3_000.ToString(gc_);
+				bool? ge_ = context.Operators.Equal(gd_, "8480-6");
+				bool? gf_ = context.Operators.And(fy_, ge_);
 
 				return gf_;
 			};
-			var ao_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)am_, an_);
-			var ap_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ao_);
-			var aq_ = ap_?.Value;
-			var ar_ = FHIRHelpers_4_3_000.ToValue(aq_);
-			var as_ = context.Operators.Quantity(130m, "mm[Hg]");
-			var at_ = context.Operators.GreaterOrEqual((ar_ as CqlQuantity), as_);
+			IEnumerable<Observation.ComponentComponent> ao_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)am_, an_);
+			Observation.ComponentComponent ap_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ao_);
+			DataType aq_ = ap_?.Value;
+			object ar_ = FHIRHelpers_4_3_000.ToValue(aq_);
+			CqlQuantity as_ = context.Operators.Quantity(130m, "mm[Hg]");
+			bool? at_ = context.Operators.GreaterOrEqual((ar_ as CqlQuantity), as_);
 			bool? av_(Observation BloodPressure)
 			{
-				var gg_ = BloodPressure?.Effective;
-				var gh_ = FHIRHelpers_4_3_000.ToValue(gg_);
-				var gi_ = QICoreCommon_2_0_000.toInterval(gh_);
-				var gj_ = context.Operators.End(gi_);
-				var gk_ = QualifyingEncounter?.Period;
-				var gl_ = FHIRHelpers_4_3_000.ToInterval(gk_);
-				var gm_ = context.Operators.Start(gl_);
-				var gn_ = context.Operators.Quantity(1m, "year");
-				var go_ = context.Operators.Subtract(gm_, gn_);
-				var gq_ = FHIRHelpers_4_3_000.ToInterval(gk_);
-				var gr_ = context.Operators.Start(gq_);
-				var gs_ = context.Operators.Interval(go_, gr_, true, true);
-				var gt_ = context.Operators.In<CqlDateTime>(gj_, gs_, null);
-				var gv_ = FHIRHelpers_4_3_000.ToInterval(gk_);
-				var gw_ = context.Operators.Start(gv_);
-				var gx_ = context.Operators.Not((bool?)(gw_ is null));
-				var gy_ = context.Operators.And(gt_, gx_);
-				var gz_ = BloodPressure?.StatusElement;
-				var ha_ = gz_?.Value;
-				var hb_ = context.Operators.Convert<string>(ha_);
-				var hc_ = new string[]
+				DataType gg_ = BloodPressure?.Effective;
+				object gh_ = FHIRHelpers_4_3_000.ToValue(gg_);
+				CqlInterval<CqlDateTime> gi_ = QICoreCommon_2_0_000.toInterval(gh_);
+				CqlDateTime gj_ = context.Operators.End(gi_);
+				Period gk_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> gl_ = FHIRHelpers_4_3_000.ToInterval(gk_);
+				CqlDateTime gm_ = context.Operators.Start(gl_);
+				CqlQuantity gn_ = context.Operators.Quantity(1m, "year");
+				CqlDateTime go_ = context.Operators.Subtract(gm_, gn_);
+				CqlInterval<CqlDateTime> gq_ = FHIRHelpers_4_3_000.ToInterval(gk_);
+				CqlDateTime gr_ = context.Operators.Start(gq_);
+				CqlInterval<CqlDateTime> gs_ = context.Operators.Interval(go_, gr_, true, true);
+				bool? gt_ = context.Operators.In<CqlDateTime>(gj_, gs_, null);
+				CqlInterval<CqlDateTime> gv_ = FHIRHelpers_4_3_000.ToInterval(gk_);
+				CqlDateTime gw_ = context.Operators.Start(gv_);
+				bool? gx_ = context.Operators.Not((bool?)(gw_ is null));
+				bool? gy_ = context.Operators.And(gt_, gx_);
+				Code<ObservationStatus> gz_ = BloodPressure?.StatusElement;
+				ObservationStatus? ha_ = gz_?.Value;
+				string hb_ = context.Operators.Convert<string>(ha_);
+				string[] hc_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var hd_ = context.Operators.In<string>(hb_, (hc_ as IEnumerable<string>));
-				var he_ = context.Operators.And(gy_, hd_);
+				bool? hd_ = context.Operators.In<string>(hb_, (hc_ as IEnumerable<string>));
+				bool? he_ = context.Operators.And(gy_, hd_);
 
 				return he_;
 			};
-			var aw_ = context.Operators.Where<Observation>(d_, av_);
+			IEnumerable<Observation> aw_ = context.Operators.Where<Observation>(d_, av_);
 			object ax_(Observation @this)
 			{
-				var hf_ = @this?.Effective;
-				var hg_ = FHIRHelpers_4_3_000.ToValue(hf_);
-				var hh_ = QICoreCommon_2_0_000.toInterval(hg_);
-				var hi_ = context.Operators.Start(hh_);
+				DataType hf_ = @this?.Effective;
+				object hg_ = FHIRHelpers_4_3_000.ToValue(hf_);
+				CqlInterval<CqlDateTime> hh_ = QICoreCommon_2_0_000.toInterval(hg_);
+				CqlDateTime hi_ = context.Operators.Start(hh_);
 
 				return hi_;
 			};
-			var ay_ = context.Operators.SortBy<Observation>(aw_, ax_, System.ComponentModel.ListSortDirection.Ascending);
-			var az_ = context.Operators.Last<Observation>(ay_);
-			var ba_ = az_?.Component;
+			IEnumerable<Observation> ay_ = context.Operators.SortBy<Observation>(aw_, ax_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation az_ = context.Operators.Last<Observation>(ay_);
+			List<Observation.ComponentComponent> ba_ = az_?.Component;
 			bool? bb_(Observation.ComponentComponent @this)
 			{
-				var hj_ = @this?.Code;
-				var hk_ = hj_?.Coding;
-				var hl_ = context.Operators.First<Coding>((IEnumerable<Coding>)hk_);
-				var hm_ = hl_?.SystemElement;
-				var hn_ = FHIRHelpers_4_3_000.ToString(hm_);
-				var ho_ = context.Operators.Equal(hn_, "http://loinc.org");
-				var hq_ = hj_?.Coding;
-				var hr_ = context.Operators.First<Coding>((IEnumerable<Coding>)hq_);
-				var hs_ = hr_?.CodeElement;
-				var ht_ = FHIRHelpers_4_3_000.ToString(hs_);
-				var hu_ = context.Operators.Equal(ht_, "8462-4");
-				var hv_ = context.Operators.And(ho_, hu_);
+				CodeableConcept hj_ = @this?.Code;
+				List<Coding> hk_ = hj_?.Coding;
+				Coding hl_ = context.Operators.First<Coding>((IEnumerable<Coding>)hk_);
+				FhirUri hm_ = hl_?.SystemElement;
+				string hn_ = FHIRHelpers_4_3_000.ToString(hm_);
+				bool? ho_ = context.Operators.Equal(hn_, "http://loinc.org");
+				List<Coding> hq_ = hj_?.Coding;
+				Coding hr_ = context.Operators.First<Coding>((IEnumerable<Coding>)hq_);
+				Code hs_ = hr_?.CodeElement;
+				string ht_ = FHIRHelpers_4_3_000.ToString(hs_);
+				bool? hu_ = context.Operators.Equal(ht_, "8462-4");
+				bool? hv_ = context.Operators.And(ho_, hu_);
 
 				return hv_;
 			};
-			var bc_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ba_, bb_);
-			var bd_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(bc_);
-			var be_ = bd_?.Value;
-			var bf_ = FHIRHelpers_4_3_000.ToValue(be_);
-			var bg_ = context.Operators.Quantity(80m, "mm[Hg]");
-			var bh_ = context.Operators.GreaterOrEqual((bf_ as CqlQuantity), bg_);
-			var bi_ = context.Operators.Or(at_, bh_);
-			var bj_ = context.Operators.And(af_, bi_);
+			IEnumerable<Observation.ComponentComponent> bc_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ba_, bb_);
+			Observation.ComponentComponent bd_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(bc_);
+			DataType be_ = bd_?.Value;
+			object bf_ = FHIRHelpers_4_3_000.ToValue(be_);
+			CqlQuantity bg_ = context.Operators.Quantity(80m, "mm[Hg]");
+			bool? bh_ = context.Operators.GreaterOrEqual((bf_ as CqlQuantity), bg_);
+			bool? bi_ = context.Operators.Or(at_, bh_);
+			bool? bj_ = context.Operators.And(af_, bi_);
 
 			return bj_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Hypertensive_Reading_Within_Year_Prior_Value"/>
     [CqlDeclaration("Encounter with Hypertensive Reading Within Year Prior")]
 	public IEnumerable<Encounter> Encounter_with_Hypertensive_Reading_Within_Year_Prior() => 
 		__Encounter_with_Hypertensive_Reading_Within_Year_Prior.Value;
 
+    /// <seealso cref="Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80"/>
 	private IEnumerable<Encounter> Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_Value()
 	{
-		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? g_(Observation BloodPressure)
 			{
-				var bm_ = BloodPressure?.Effective;
-				var bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
-				var bo_ = QICoreCommon_2_0_000.toInterval(bn_);
-				var bp_ = context.Operators.End(bo_);
-				var bq_ = QualifyingEncounter?.Period;
-				var br_ = FHIRHelpers_4_3_000.ToInterval(bq_);
-				var bs_ = context.Operators.In<CqlDateTime>(bp_, br_, "day");
+				DataType bm_ = BloodPressure?.Effective;
+				object bn_ = FHIRHelpers_4_3_000.ToValue(bm_);
+				CqlInterval<CqlDateTime> bo_ = QICoreCommon_2_0_000.toInterval(bn_);
+				CqlDateTime bp_ = context.Operators.End(bo_);
+				Period bq_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_3_000.ToInterval(bq_);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bp_, br_, "day");
 
 				return bs_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			object i_(Observation @this)
 			{
-				var bt_ = @this?.Effective;
-				var bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
-				var bv_ = QICoreCommon_2_0_000.toInterval(bu_);
-				var bw_ = context.Operators.Start(bv_);
+				DataType bt_ = @this?.Effective;
+				object bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
+				CqlInterval<CqlDateTime> bv_ = QICoreCommon_2_0_000.toInterval(bu_);
+				CqlDateTime bw_ = context.Operators.Start(bv_);
 
 				return bw_;
 			};
-			var j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Observation>(j_);
-			var l_ = k_?.Component;
+			IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation k_ = context.Operators.Last<Observation>(j_);
+			List<Observation.ComponentComponent> l_ = k_?.Component;
 			bool? m_(Observation.ComponentComponent @this)
 			{
-				var bx_ = @this?.Code;
-				var by_ = bx_?.Coding;
-				var bz_ = context.Operators.First<Coding>((IEnumerable<Coding>)by_);
-				var ca_ = bz_?.SystemElement;
-				var cb_ = FHIRHelpers_4_3_000.ToString(ca_);
-				var cc_ = context.Operators.Equal(cb_, "http://loinc.org");
-				var ce_ = bx_?.Coding;
-				var cf_ = context.Operators.First<Coding>((IEnumerable<Coding>)ce_);
-				var cg_ = cf_?.CodeElement;
-				var ch_ = FHIRHelpers_4_3_000.ToString(cg_);
-				var ci_ = context.Operators.Equal(ch_, "8480-6");
-				var cj_ = context.Operators.And(cc_, ci_);
+				CodeableConcept bx_ = @this?.Code;
+				List<Coding> by_ = bx_?.Coding;
+				Coding bz_ = context.Operators.First<Coding>((IEnumerable<Coding>)by_);
+				FhirUri ca_ = bz_?.SystemElement;
+				string cb_ = FHIRHelpers_4_3_000.ToString(ca_);
+				bool? cc_ = context.Operators.Equal(cb_, "http://loinc.org");
+				List<Coding> ce_ = bx_?.Coding;
+				Coding cf_ = context.Operators.First<Coding>((IEnumerable<Coding>)ce_);
+				Code cg_ = cf_?.CodeElement;
+				string ch_ = FHIRHelpers_4_3_000.ToString(cg_);
+				bool? ci_ = context.Operators.Equal(ch_, "8480-6");
+				bool? cj_ = context.Operators.And(cc_, ci_);
 
 				return cj_;
 			};
-			var n_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)l_, m_);
-			var o_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(n_);
-			var p_ = o_?.Value;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = context.Operators.Quantity(0m, "mm[Hg]");
-			var s_ = context.Operators.Greater((q_ as CqlQuantity), r_);
+			IEnumerable<Observation.ComponentComponent> n_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)l_, m_);
+			Observation.ComponentComponent o_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(n_);
+			DataType p_ = o_?.Value;
+			object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+			CqlQuantity r_ = context.Operators.Quantity(0m, "mm[Hg]");
+			bool? s_ = context.Operators.Greater((q_ as CqlQuantity), r_);
 			bool? u_(Observation BloodPressure)
 			{
-				var ck_ = BloodPressure?.Effective;
-				var cl_ = FHIRHelpers_4_3_000.ToValue(ck_);
-				var cm_ = QICoreCommon_2_0_000.toInterval(cl_);
-				var cn_ = context.Operators.End(cm_);
-				var co_ = QualifyingEncounter?.Period;
-				var cp_ = FHIRHelpers_4_3_000.ToInterval(co_);
-				var cq_ = context.Operators.In<CqlDateTime>(cn_, cp_, "day");
+				DataType ck_ = BloodPressure?.Effective;
+				object cl_ = FHIRHelpers_4_3_000.ToValue(ck_);
+				CqlInterval<CqlDateTime> cm_ = QICoreCommon_2_0_000.toInterval(cl_);
+				CqlDateTime cn_ = context.Operators.End(cm_);
+				Period co_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_3_000.ToInterval(co_);
+				bool? cq_ = context.Operators.In<CqlDateTime>(cn_, cp_, "day");
 
 				return cq_;
 			};
-			var v_ = context.Operators.Where<Observation>(f_, u_);
+			IEnumerable<Observation> v_ = context.Operators.Where<Observation>(f_, u_);
 			object w_(Observation @this)
 			{
-				var cr_ = @this?.Effective;
-				var cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
-				var ct_ = QICoreCommon_2_0_000.toInterval(cs_);
-				var cu_ = context.Operators.Start(ct_);
+				DataType cr_ = @this?.Effective;
+				object cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
+				CqlInterval<CqlDateTime> ct_ = QICoreCommon_2_0_000.toInterval(cs_);
+				CqlDateTime cu_ = context.Operators.Start(ct_);
 
 				return cu_;
 			};
-			var x_ = context.Operators.SortBy<Observation>(v_, w_, System.ComponentModel.ListSortDirection.Ascending);
-			var y_ = context.Operators.Last<Observation>(x_);
-			var z_ = y_?.Component;
+			IEnumerable<Observation> x_ = context.Operators.SortBy<Observation>(v_, w_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation y_ = context.Operators.Last<Observation>(x_);
+			List<Observation.ComponentComponent> z_ = y_?.Component;
 			bool? aa_(Observation.ComponentComponent @this)
 			{
-				var cv_ = @this?.Code;
-				var cw_ = cv_?.Coding;
-				var cx_ = context.Operators.First<Coding>((IEnumerable<Coding>)cw_);
-				var cy_ = cx_?.SystemElement;
-				var cz_ = FHIRHelpers_4_3_000.ToString(cy_);
-				var da_ = context.Operators.Equal(cz_, "http://loinc.org");
-				var dc_ = cv_?.Coding;
-				var dd_ = context.Operators.First<Coding>((IEnumerable<Coding>)dc_);
-				var de_ = dd_?.CodeElement;
-				var df_ = FHIRHelpers_4_3_000.ToString(de_);
-				var dg_ = context.Operators.Equal(df_, "8462-4");
-				var dh_ = context.Operators.And(da_, dg_);
+				CodeableConcept cv_ = @this?.Code;
+				List<Coding> cw_ = cv_?.Coding;
+				Coding cx_ = context.Operators.First<Coding>((IEnumerable<Coding>)cw_);
+				FhirUri cy_ = cx_?.SystemElement;
+				string cz_ = FHIRHelpers_4_3_000.ToString(cy_);
+				bool? da_ = context.Operators.Equal(cz_, "http://loinc.org");
+				List<Coding> dc_ = cv_?.Coding;
+				Coding dd_ = context.Operators.First<Coding>((IEnumerable<Coding>)dc_);
+				Code de_ = dd_?.CodeElement;
+				string df_ = FHIRHelpers_4_3_000.ToString(de_);
+				bool? dg_ = context.Operators.Equal(df_, "8462-4");
+				bool? dh_ = context.Operators.And(da_, dg_);
 
 				return dh_;
 			};
-			var ab_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)z_, aa_);
-			var ac_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ab_);
-			var ad_ = ac_?.Value;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var ag_ = context.Operators.Greater((ae_ as CqlQuantity), r_);
-			var ah_ = context.Operators.And(s_, ag_);
+			IEnumerable<Observation.ComponentComponent> ab_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)z_, aa_);
+			Observation.ComponentComponent ac_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ab_);
+			DataType ad_ = ac_?.Value;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			bool? ag_ = context.Operators.Greater((ae_ as CqlQuantity), r_);
+			bool? ah_ = context.Operators.And(s_, ag_);
 			bool? aj_(Observation BloodPressure)
 			{
-				var di_ = BloodPressure?.Effective;
-				var dj_ = FHIRHelpers_4_3_000.ToValue(di_);
-				var dk_ = QICoreCommon_2_0_000.toInterval(dj_);
-				var dl_ = context.Operators.End(dk_);
-				var dm_ = QualifyingEncounter?.Period;
-				var dn_ = FHIRHelpers_4_3_000.ToInterval(dm_);
-				var do_ = context.Operators.In<CqlDateTime>(dl_, dn_, "day");
+				DataType di_ = BloodPressure?.Effective;
+				object dj_ = FHIRHelpers_4_3_000.ToValue(di_);
+				CqlInterval<CqlDateTime> dk_ = QICoreCommon_2_0_000.toInterval(dj_);
+				CqlDateTime dl_ = context.Operators.End(dk_);
+				Period dm_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> dn_ = FHIRHelpers_4_3_000.ToInterval(dm_);
+				bool? do_ = context.Operators.In<CqlDateTime>(dl_, dn_, "day");
 
 				return do_;
 			};
-			var ak_ = context.Operators.Where<Observation>(f_, aj_);
+			IEnumerable<Observation> ak_ = context.Operators.Where<Observation>(f_, aj_);
 			object al_(Observation @this)
 			{
-				var dp_ = @this?.Effective;
-				var dq_ = FHIRHelpers_4_3_000.ToValue(dp_);
-				var dr_ = QICoreCommon_2_0_000.toInterval(dq_);
-				var ds_ = context.Operators.Start(dr_);
+				DataType dp_ = @this?.Effective;
+				object dq_ = FHIRHelpers_4_3_000.ToValue(dp_);
+				CqlInterval<CqlDateTime> dr_ = QICoreCommon_2_0_000.toInterval(dq_);
+				CqlDateTime ds_ = context.Operators.Start(dr_);
 
 				return ds_;
 			};
-			var am_ = context.Operators.SortBy<Observation>(ak_, al_, System.ComponentModel.ListSortDirection.Ascending);
-			var an_ = context.Operators.Last<Observation>(am_);
-			var ao_ = an_?.Component;
+			IEnumerable<Observation> am_ = context.Operators.SortBy<Observation>(ak_, al_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation an_ = context.Operators.Last<Observation>(am_);
+			List<Observation.ComponentComponent> ao_ = an_?.Component;
 			bool? ap_(Observation.ComponentComponent @this)
 			{
-				var dt_ = @this?.Code;
-				var du_ = dt_?.Coding;
-				var dv_ = context.Operators.First<Coding>((IEnumerable<Coding>)du_);
-				var dw_ = dv_?.SystemElement;
-				var dx_ = FHIRHelpers_4_3_000.ToString(dw_);
-				var dy_ = context.Operators.Equal(dx_, "http://loinc.org");
-				var ea_ = dt_?.Coding;
-				var eb_ = context.Operators.First<Coding>((IEnumerable<Coding>)ea_);
-				var ec_ = eb_?.CodeElement;
-				var ed_ = FHIRHelpers_4_3_000.ToString(ec_);
-				var ee_ = context.Operators.Equal(ed_, "8480-6");
-				var ef_ = context.Operators.And(dy_, ee_);
+				CodeableConcept dt_ = @this?.Code;
+				List<Coding> du_ = dt_?.Coding;
+				Coding dv_ = context.Operators.First<Coding>((IEnumerable<Coding>)du_);
+				FhirUri dw_ = dv_?.SystemElement;
+				string dx_ = FHIRHelpers_4_3_000.ToString(dw_);
+				bool? dy_ = context.Operators.Equal(dx_, "http://loinc.org");
+				List<Coding> ea_ = dt_?.Coding;
+				Coding eb_ = context.Operators.First<Coding>((IEnumerable<Coding>)ea_);
+				Code ec_ = eb_?.CodeElement;
+				string ed_ = FHIRHelpers_4_3_000.ToString(ec_);
+				bool? ee_ = context.Operators.Equal(ed_, "8480-6");
+				bool? ef_ = context.Operators.And(dy_, ee_);
 
 				return ef_;
 			};
-			var aq_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ao_, ap_);
-			var ar_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(aq_);
-			var as_ = ar_?.Value;
-			var at_ = FHIRHelpers_4_3_000.ToValue(as_);
-			var au_ = context.Operators.Quantity(130m, "mm[Hg]");
-			var av_ = context.Operators.GreaterOrEqual((at_ as CqlQuantity), au_);
+			IEnumerable<Observation.ComponentComponent> aq_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ao_, ap_);
+			Observation.ComponentComponent ar_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(aq_);
+			DataType as_ = ar_?.Value;
+			object at_ = FHIRHelpers_4_3_000.ToValue(as_);
+			CqlQuantity au_ = context.Operators.Quantity(130m, "mm[Hg]");
+			bool? av_ = context.Operators.GreaterOrEqual((at_ as CqlQuantity), au_);
 			bool? ax_(Observation BloodPressure)
 			{
-				var eg_ = BloodPressure?.Effective;
-				var eh_ = FHIRHelpers_4_3_000.ToValue(eg_);
-				var ei_ = QICoreCommon_2_0_000.toInterval(eh_);
-				var ej_ = context.Operators.End(ei_);
-				var ek_ = QualifyingEncounter?.Period;
-				var el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
-				var em_ = context.Operators.In<CqlDateTime>(ej_, el_, "day");
+				DataType eg_ = BloodPressure?.Effective;
+				object eh_ = FHIRHelpers_4_3_000.ToValue(eg_);
+				CqlInterval<CqlDateTime> ei_ = QICoreCommon_2_0_000.toInterval(eh_);
+				CqlDateTime ej_ = context.Operators.End(ei_);
+				Period ek_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
+				bool? em_ = context.Operators.In<CqlDateTime>(ej_, el_, "day");
 
 				return em_;
 			};
-			var ay_ = context.Operators.Where<Observation>(f_, ax_);
+			IEnumerable<Observation> ay_ = context.Operators.Where<Observation>(f_, ax_);
 			object az_(Observation @this)
 			{
-				var en_ = @this?.Effective;
-				var eo_ = FHIRHelpers_4_3_000.ToValue(en_);
-				var ep_ = QICoreCommon_2_0_000.toInterval(eo_);
-				var eq_ = context.Operators.Start(ep_);
+				DataType en_ = @this?.Effective;
+				object eo_ = FHIRHelpers_4_3_000.ToValue(en_);
+				CqlInterval<CqlDateTime> ep_ = QICoreCommon_2_0_000.toInterval(eo_);
+				CqlDateTime eq_ = context.Operators.Start(ep_);
 
 				return eq_;
 			};
-			var ba_ = context.Operators.SortBy<Observation>(ay_, az_, System.ComponentModel.ListSortDirection.Ascending);
-			var bb_ = context.Operators.Last<Observation>(ba_);
-			var bc_ = bb_?.Component;
+			IEnumerable<Observation> ba_ = context.Operators.SortBy<Observation>(ay_, az_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation bb_ = context.Operators.Last<Observation>(ba_);
+			List<Observation.ComponentComponent> bc_ = bb_?.Component;
 			bool? bd_(Observation.ComponentComponent @this)
 			{
-				var er_ = @this?.Code;
-				var es_ = er_?.Coding;
-				var et_ = context.Operators.First<Coding>((IEnumerable<Coding>)es_);
-				var eu_ = et_?.SystemElement;
-				var ev_ = FHIRHelpers_4_3_000.ToString(eu_);
-				var ew_ = context.Operators.Equal(ev_, "http://loinc.org");
-				var ey_ = er_?.Coding;
-				var ez_ = context.Operators.First<Coding>((IEnumerable<Coding>)ey_);
-				var fa_ = ez_?.CodeElement;
-				var fb_ = FHIRHelpers_4_3_000.ToString(fa_);
-				var fc_ = context.Operators.Equal(fb_, "8462-4");
-				var fd_ = context.Operators.And(ew_, fc_);
+				CodeableConcept er_ = @this?.Code;
+				List<Coding> es_ = er_?.Coding;
+				Coding et_ = context.Operators.First<Coding>((IEnumerable<Coding>)es_);
+				FhirUri eu_ = et_?.SystemElement;
+				string ev_ = FHIRHelpers_4_3_000.ToString(eu_);
+				bool? ew_ = context.Operators.Equal(ev_, "http://loinc.org");
+				List<Coding> ey_ = er_?.Coding;
+				Coding ez_ = context.Operators.First<Coding>((IEnumerable<Coding>)ey_);
+				Code fa_ = ez_?.CodeElement;
+				string fb_ = FHIRHelpers_4_3_000.ToString(fa_);
+				bool? fc_ = context.Operators.Equal(fb_, "8462-4");
+				bool? fd_ = context.Operators.And(ew_, fc_);
 
 				return fd_;
 			};
-			var be_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)bc_, bd_);
-			var bf_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(be_);
-			var bg_ = bf_?.Value;
-			var bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
-			var bi_ = context.Operators.Quantity(80m, "mm[Hg]");
-			var bj_ = context.Operators.GreaterOrEqual((bh_ as CqlQuantity), bi_);
-			var bk_ = context.Operators.Or(av_, bj_);
-			var bl_ = context.Operators.And(ah_, bk_);
+			IEnumerable<Observation.ComponentComponent> be_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)bc_, bd_);
+			Observation.ComponentComponent bf_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(be_);
+			DataType bg_ = bf_?.Value;
+			object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+			CqlQuantity bi_ = context.Operators.Quantity(80m, "mm[Hg]");
+			bool? bj_ = context.Operators.GreaterOrEqual((bh_ as CqlQuantity), bi_);
+			bool? bk_ = context.Operators.Or(av_, bj_);
+			bool? bl_ = context.Operators.And(ah_, bk_);
 
 			return bl_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
-		var d_ = this.Encounter_with_Hypertensive_Reading_Within_Year_Prior();
-		var e_ = context.Operators.Except<Encounter>(c_, d_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.Encounter_with_Hypertensive_Reading_Within_Year_Prior();
+		IEnumerable<Encounter> e_ = context.Operators.Except<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_Value"/>
     [CqlDeclaration("Encounter with First Hypertensive Reading SBP Greater than or Equal to 130 OR DBP Greater than or Equal to 80")]
 	public IEnumerable<Encounter> Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80() => 
 		__Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80.Value;
 
+    /// <seealso cref="First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional"/>
 	private IEnumerable<ServiceRequest> First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional_Value()
 	{
-		var a_ = this.Follow_Up_Within_4_Weeks();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		CqlValueSet a_ = this.Follow_Up_Within_4_Weeks();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
 		IEnumerable<ServiceRequest> c_(ServiceRequest FourWeekRescreen)
 		{
-			var g_ = this.NonPharmacological_Interventions();
+			IEnumerable<ServiceRequest> g_ = this.NonPharmacological_Interventions();
 			bool? h_(ServiceRequest NonPharmInterventionsHTN)
 			{
-				var l_ = FourWeekRescreen?.AuthoredOnElement;
-				var m_ = context.Operators.Convert<CqlDateTime>(l_);
-				var n_ = this.Measurement_Period();
-				var o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
-				var p_ = NonPharmInterventionsHTN?.AuthoredOnElement;
-				var q_ = context.Operators.Convert<CqlDateTime>(p_);
-				var s_ = context.Operators.In<CqlDateTime>(q_, n_, "day");
-				var t_ = context.Operators.And(o_, s_);
-				var u_ = FourWeekRescreen?.IntentElement;
-				var v_ = u_?.Value;
-				var w_ = context.Operators.Convert<Code<RequestIntent>>(v_);
-				var x_ = context.Operators.Equivalent(w_, "order");
-				var y_ = context.Operators.And(t_, x_);
+				FhirDateTime l_ = FourWeekRescreen?.AuthoredOnElement;
+				CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
+				CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
+				bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
+				FhirDateTime p_ = NonPharmInterventionsHTN?.AuthoredOnElement;
+				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+				bool? s_ = context.Operators.In<CqlDateTime>(q_, n_, "day");
+				bool? t_ = context.Operators.And(o_, s_);
+				Code<RequestIntent> u_ = FourWeekRescreen?.IntentElement;
+				RequestIntent? v_ = u_?.Value;
+				Code<RequestIntent> w_ = context.Operators.Convert<Code<RequestIntent>>(v_);
+				bool? x_ = context.Operators.Equivalent(w_, "order");
+				bool? y_ = context.Operators.And(t_, x_);
 
 				return y_;
 			};
-			var i_ = context.Operators.Where<ServiceRequest>(g_, h_);
+			IEnumerable<ServiceRequest> i_ = context.Operators.Where<ServiceRequest>(g_, h_);
 			ServiceRequest j_(ServiceRequest NonPharmInterventionsHTN) => 
 				FourWeekRescreen;
-			var k_ = context.Operators.Select<ServiceRequest, ServiceRequest>(i_, j_);
+			IEnumerable<ServiceRequest> k_ = context.Operators.Select<ServiceRequest, ServiceRequest>(i_, j_);
 
 			return k_;
 		};
-		var d_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(b_, c_);
-		var e_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
-		var f_ = context.Operators.Union<ServiceRequest>(d_, e_);
+		IEnumerable<ServiceRequest> d_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(b_, c_);
+		IEnumerable<ServiceRequest> e_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
+		IEnumerable<ServiceRequest> f_ = context.Operators.Union<ServiceRequest>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional_Value"/>
     [CqlDeclaration("First Hypertensive Reading Interventions or Referral to Alternate Professional")]
 	public IEnumerable<ServiceRequest> First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional() => 
 		__First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional.Value;
 
+    /// <seealso cref="Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions"/>
 	private IEnumerable<Encounter> Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions_Value()
 	{
-		var a_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80();
+		IEnumerable<Encounter> a_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80();
 		IEnumerable<Encounter> b_(Encounter FirstHTNEncounter)
 		{
-			var d_ = this.First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional();
+			IEnumerable<ServiceRequest> d_ = this.First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional();
 			bool? e_(ServiceRequest FirstHTNIntervention)
 			{
-				var i_ = FirstHTNIntervention?.AuthoredOnElement;
-				var j_ = context.Operators.Convert<CqlDateTime>(i_);
-				var k_ = FirstHTNEncounter?.Period;
-				var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var m_ = context.Operators.In<CqlDateTime>(j_, l_, "day");
+				FhirDateTime i_ = FirstHTNIntervention?.AuthoredOnElement;
+				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+				Period k_ = FirstHTNEncounter?.Period;
+				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, "day");
 
 				return m_;
 			};
-			var f_ = context.Operators.Where<ServiceRequest>(d_, e_);
+			IEnumerable<ServiceRequest> f_ = context.Operators.Where<ServiceRequest>(d_, e_);
 			Encounter g_(ServiceRequest FirstHTNIntervention) => 
 				FirstHTNEncounter;
-			var h_ = context.Operators.Select<ServiceRequest, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<ServiceRequest, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions_Value"/>
     [CqlDeclaration("Encounter with First Hypertensive Reading SBP Greater than or Equal to 130 OR DBP Greater than or Equal to 80 and Interventions")]
 	public IEnumerable<Encounter> Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions() => 
 		__Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions.Value;
 
+    /// <seealso cref="Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89"/>
 	private IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Value()
 	{
-		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? e_(Observation BloodPressure)
 			{
-				var bs_ = BloodPressure?.Effective;
-				var bt_ = FHIRHelpers_4_3_000.ToValue(bs_);
-				var bu_ = QICoreCommon_2_0_000.toInterval(bt_);
-				var bv_ = context.Operators.End(bu_);
-				var bw_ = QualifyingEncounter?.Period;
-				var bx_ = FHIRHelpers_4_3_000.ToInterval(bw_);
-				var by_ = context.Operators.In<CqlDateTime>(bv_, bx_, "day");
-				var bz_ = BloodPressure?.StatusElement;
-				var ca_ = bz_?.Value;
-				var cb_ = context.Operators.Convert<string>(ca_);
-				var cc_ = new string[]
+				DataType bs_ = BloodPressure?.Effective;
+				object bt_ = FHIRHelpers_4_3_000.ToValue(bs_);
+				CqlInterval<CqlDateTime> bu_ = QICoreCommon_2_0_000.toInterval(bt_);
+				CqlDateTime bv_ = context.Operators.End(bu_);
+				Period bw_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_3_000.ToInterval(bw_);
+				bool? by_ = context.Operators.In<CqlDateTime>(bv_, bx_, "day");
+				Code<ObservationStatus> bz_ = BloodPressure?.StatusElement;
+				ObservationStatus? ca_ = bz_?.Value;
+				string cb_ = context.Operators.Convert<string>(ca_);
+				string[] cc_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var cd_ = context.Operators.In<string>(cb_, (cc_ as IEnumerable<string>));
-				var ce_ = context.Operators.And(by_, cd_);
+				bool? cd_ = context.Operators.In<string>(cb_, (cc_ as IEnumerable<string>));
+				bool? ce_ = context.Operators.And(by_, cd_);
 
 				return ce_;
 			};
-			var f_ = context.Operators.Where<Observation>(d_, e_);
+			IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 			object g_(Observation @this)
 			{
-				var cf_ = @this?.Effective;
-				var cg_ = FHIRHelpers_4_3_000.ToValue(cf_);
-				var ch_ = QICoreCommon_2_0_000.toInterval(cg_);
-				var ci_ = context.Operators.Start(ch_);
+				DataType cf_ = @this?.Effective;
+				object cg_ = FHIRHelpers_4_3_000.ToValue(cf_);
+				CqlInterval<CqlDateTime> ch_ = QICoreCommon_2_0_000.toInterval(cg_);
+				CqlDateTime ci_ = context.Operators.Start(ch_);
 
 				return ci_;
 			};
-			var h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
-			var i_ = context.Operators.Last<Observation>(h_);
-			var j_ = i_?.Component;
+			IEnumerable<Observation> h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation i_ = context.Operators.Last<Observation>(h_);
+			List<Observation.ComponentComponent> j_ = i_?.Component;
 			bool? k_(Observation.ComponentComponent @this)
 			{
-				var cj_ = @this?.Code;
-				var ck_ = cj_?.Coding;
-				var cl_ = context.Operators.First<Coding>((IEnumerable<Coding>)ck_);
-				var cm_ = cl_?.SystemElement;
-				var cn_ = FHIRHelpers_4_3_000.ToString(cm_);
-				var co_ = context.Operators.Equal(cn_, "http://loinc.org");
-				var cq_ = cj_?.Coding;
-				var cr_ = context.Operators.First<Coding>((IEnumerable<Coding>)cq_);
-				var cs_ = cr_?.CodeElement;
-				var ct_ = FHIRHelpers_4_3_000.ToString(cs_);
-				var cu_ = context.Operators.Equal(ct_, "8480-6");
-				var cv_ = context.Operators.And(co_, cu_);
+				CodeableConcept cj_ = @this?.Code;
+				List<Coding> ck_ = cj_?.Coding;
+				Coding cl_ = context.Operators.First<Coding>((IEnumerable<Coding>)ck_);
+				FhirUri cm_ = cl_?.SystemElement;
+				string cn_ = FHIRHelpers_4_3_000.ToString(cm_);
+				bool? co_ = context.Operators.Equal(cn_, "http://loinc.org");
+				List<Coding> cq_ = cj_?.Coding;
+				Coding cr_ = context.Operators.First<Coding>((IEnumerable<Coding>)cq_);
+				Code cs_ = cr_?.CodeElement;
+				string ct_ = FHIRHelpers_4_3_000.ToString(cs_);
+				bool? cu_ = context.Operators.Equal(ct_, "8480-6");
+				bool? cv_ = context.Operators.And(co_, cu_);
 
 				return cv_;
 			};
-			var l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
-			var m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
-			var n_ = m_?.Value;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = context.Operators.Quantity(130m, "mm[Hg]");
-			var q_ = context.Operators.Quantity(139m, "mm[Hg]");
-			var r_ = context.Operators.Interval(p_, q_, true, true);
-			var s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, null);
+			IEnumerable<Observation.ComponentComponent> l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
+			Observation.ComponentComponent m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
+			DataType n_ = m_?.Value;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			CqlQuantity p_ = context.Operators.Quantity(130m, "mm[Hg]");
+			CqlQuantity q_ = context.Operators.Quantity(139m, "mm[Hg]");
+			CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, true);
+			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, null);
 			bool? u_(Observation BloodPressure)
 			{
-				var cw_ = BloodPressure?.Effective;
-				var cx_ = FHIRHelpers_4_3_000.ToValue(cw_);
-				var cy_ = QICoreCommon_2_0_000.toInterval(cx_);
-				var cz_ = context.Operators.End(cy_);
-				var da_ = QualifyingEncounter?.Period;
-				var db_ = FHIRHelpers_4_3_000.ToInterval(da_);
-				var dc_ = context.Operators.In<CqlDateTime>(cz_, db_, "day");
-				var dd_ = BloodPressure?.StatusElement;
-				var de_ = dd_?.Value;
-				var df_ = context.Operators.Convert<string>(de_);
-				var dg_ = new string[]
+				DataType cw_ = BloodPressure?.Effective;
+				object cx_ = FHIRHelpers_4_3_000.ToValue(cw_);
+				CqlInterval<CqlDateTime> cy_ = QICoreCommon_2_0_000.toInterval(cx_);
+				CqlDateTime cz_ = context.Operators.End(cy_);
+				Period da_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> db_ = FHIRHelpers_4_3_000.ToInterval(da_);
+				bool? dc_ = context.Operators.In<CqlDateTime>(cz_, db_, "day");
+				Code<ObservationStatus> dd_ = BloodPressure?.StatusElement;
+				ObservationStatus? de_ = dd_?.Value;
+				string df_ = context.Operators.Convert<string>(de_);
+				string[] dg_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var dh_ = context.Operators.In<string>(df_, (dg_ as IEnumerable<string>));
-				var di_ = context.Operators.And(dc_, dh_);
+				bool? dh_ = context.Operators.In<string>(df_, (dg_ as IEnumerable<string>));
+				bool? di_ = context.Operators.And(dc_, dh_);
 
 				return di_;
 			};
-			var v_ = context.Operators.Where<Observation>(d_, u_);
+			IEnumerable<Observation> v_ = context.Operators.Where<Observation>(d_, u_);
 			object w_(Observation @this)
 			{
-				var dj_ = @this?.Effective;
-				var dk_ = FHIRHelpers_4_3_000.ToValue(dj_);
-				var dl_ = QICoreCommon_2_0_000.toInterval(dk_);
-				var dm_ = context.Operators.Start(dl_);
+				DataType dj_ = @this?.Effective;
+				object dk_ = FHIRHelpers_4_3_000.ToValue(dj_);
+				CqlInterval<CqlDateTime> dl_ = QICoreCommon_2_0_000.toInterval(dk_);
+				CqlDateTime dm_ = context.Operators.Start(dl_);
 
 				return dm_;
 			};
-			var x_ = context.Operators.SortBy<Observation>(v_, w_, System.ComponentModel.ListSortDirection.Ascending);
-			var y_ = context.Operators.Last<Observation>(x_);
-			var z_ = y_?.Component;
+			IEnumerable<Observation> x_ = context.Operators.SortBy<Observation>(v_, w_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation y_ = context.Operators.Last<Observation>(x_);
+			List<Observation.ComponentComponent> z_ = y_?.Component;
 			bool? aa_(Observation.ComponentComponent @this)
 			{
-				var dn_ = @this?.Code;
-				var do_ = dn_?.Coding;
-				var dp_ = context.Operators.First<Coding>((IEnumerable<Coding>)do_);
-				var dq_ = dp_?.SystemElement;
-				var dr_ = FHIRHelpers_4_3_000.ToString(dq_);
-				var ds_ = context.Operators.Equal(dr_, "http://loinc.org");
-				var du_ = dn_?.Coding;
-				var dv_ = context.Operators.First<Coding>((IEnumerable<Coding>)du_);
-				var dw_ = dv_?.CodeElement;
-				var dx_ = FHIRHelpers_4_3_000.ToString(dw_);
-				var dy_ = context.Operators.Equal(dx_, "8462-4");
-				var dz_ = context.Operators.And(ds_, dy_);
+				CodeableConcept dn_ = @this?.Code;
+				List<Coding> do_ = dn_?.Coding;
+				Coding dp_ = context.Operators.First<Coding>((IEnumerable<Coding>)do_);
+				FhirUri dq_ = dp_?.SystemElement;
+				string dr_ = FHIRHelpers_4_3_000.ToString(dq_);
+				bool? ds_ = context.Operators.Equal(dr_, "http://loinc.org");
+				List<Coding> du_ = dn_?.Coding;
+				Coding dv_ = context.Operators.First<Coding>((IEnumerable<Coding>)du_);
+				Code dw_ = dv_?.CodeElement;
+				string dx_ = FHIRHelpers_4_3_000.ToString(dw_);
+				bool? dy_ = context.Operators.Equal(dx_, "8462-4");
+				bool? dz_ = context.Operators.And(ds_, dy_);
 
 				return dz_;
 			};
-			var ab_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)z_, aa_);
-			var ac_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ab_);
-			var ad_ = ac_?.Value;
-			var ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
-			var af_ = context.Operators.Quantity(80m, "mm[Hg]");
-			var ag_ = context.Operators.Quantity(89m, "mm[Hg]");
-			var ah_ = context.Operators.Interval(af_, ag_, true, true);
-			var ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, null);
-			var aj_ = context.Operators.Or(s_, ai_);
+			IEnumerable<Observation.ComponentComponent> ab_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)z_, aa_);
+			Observation.ComponentComponent ac_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ab_);
+			DataType ad_ = ac_?.Value;
+			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
+			CqlQuantity af_ = context.Operators.Quantity(80m, "mm[Hg]");
+			CqlQuantity ag_ = context.Operators.Quantity(89m, "mm[Hg]");
+			CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(af_, ag_, true, true);
+			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, null);
+			bool? aj_ = context.Operators.Or(s_, ai_);
 			bool? al_(Observation BloodPressure)
 			{
-				var ea_ = BloodPressure?.Effective;
-				var eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
-				var ec_ = QICoreCommon_2_0_000.toInterval(eb_);
-				var ed_ = context.Operators.End(ec_);
-				var ee_ = QualifyingEncounter?.Period;
-				var ef_ = FHIRHelpers_4_3_000.ToInterval(ee_);
-				var eg_ = context.Operators.In<CqlDateTime>(ed_, ef_, "day");
-				var eh_ = BloodPressure?.StatusElement;
-				var ei_ = eh_?.Value;
-				var ej_ = context.Operators.Convert<string>(ei_);
-				var ek_ = new string[]
+				DataType ea_ = BloodPressure?.Effective;
+				object eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
+				CqlInterval<CqlDateTime> ec_ = QICoreCommon_2_0_000.toInterval(eb_);
+				CqlDateTime ed_ = context.Operators.End(ec_);
+				Period ee_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_3_000.ToInterval(ee_);
+				bool? eg_ = context.Operators.In<CqlDateTime>(ed_, ef_, "day");
+				Code<ObservationStatus> eh_ = BloodPressure?.StatusElement;
+				ObservationStatus? ei_ = eh_?.Value;
+				string ej_ = context.Operators.Convert<string>(ei_);
+				string[] ek_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var el_ = context.Operators.In<string>(ej_, (ek_ as IEnumerable<string>));
-				var em_ = context.Operators.And(eg_, el_);
+				bool? el_ = context.Operators.In<string>(ej_, (ek_ as IEnumerable<string>));
+				bool? em_ = context.Operators.And(eg_, el_);
 
 				return em_;
 			};
-			var am_ = context.Operators.Where<Observation>(d_, al_);
+			IEnumerable<Observation> am_ = context.Operators.Where<Observation>(d_, al_);
 			object an_(Observation @this)
 			{
-				var en_ = @this?.Effective;
-				var eo_ = FHIRHelpers_4_3_000.ToValue(en_);
-				var ep_ = QICoreCommon_2_0_000.toInterval(eo_);
-				var eq_ = context.Operators.Start(ep_);
+				DataType en_ = @this?.Effective;
+				object eo_ = FHIRHelpers_4_3_000.ToValue(en_);
+				CqlInterval<CqlDateTime> ep_ = QICoreCommon_2_0_000.toInterval(eo_);
+				CqlDateTime eq_ = context.Operators.Start(ep_);
 
 				return eq_;
 			};
-			var ao_ = context.Operators.SortBy<Observation>(am_, an_, System.ComponentModel.ListSortDirection.Ascending);
-			var ap_ = context.Operators.Last<Observation>(ao_);
-			var aq_ = ap_?.Component;
+			IEnumerable<Observation> ao_ = context.Operators.SortBy<Observation>(am_, an_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation ap_ = context.Operators.Last<Observation>(ao_);
+			List<Observation.ComponentComponent> aq_ = ap_?.Component;
 			bool? ar_(Observation.ComponentComponent @this)
 			{
-				var er_ = @this?.Code;
-				var es_ = er_?.Coding;
-				var et_ = context.Operators.First<Coding>((IEnumerable<Coding>)es_);
-				var eu_ = et_?.SystemElement;
-				var ev_ = FHIRHelpers_4_3_000.ToString(eu_);
-				var ew_ = context.Operators.Equal(ev_, "http://loinc.org");
-				var ey_ = er_?.Coding;
-				var ez_ = context.Operators.First<Coding>((IEnumerable<Coding>)ey_);
-				var fa_ = ez_?.CodeElement;
-				var fb_ = FHIRHelpers_4_3_000.ToString(fa_);
-				var fc_ = context.Operators.Equal(fb_, "8480-6");
-				var fd_ = context.Operators.And(ew_, fc_);
+				CodeableConcept er_ = @this?.Code;
+				List<Coding> es_ = er_?.Coding;
+				Coding et_ = context.Operators.First<Coding>((IEnumerable<Coding>)es_);
+				FhirUri eu_ = et_?.SystemElement;
+				string ev_ = FHIRHelpers_4_3_000.ToString(eu_);
+				bool? ew_ = context.Operators.Equal(ev_, "http://loinc.org");
+				List<Coding> ey_ = er_?.Coding;
+				Coding ez_ = context.Operators.First<Coding>((IEnumerable<Coding>)ey_);
+				Code fa_ = ez_?.CodeElement;
+				string fb_ = FHIRHelpers_4_3_000.ToString(fa_);
+				bool? fc_ = context.Operators.Equal(fb_, "8480-6");
+				bool? fd_ = context.Operators.And(ew_, fc_);
 
 				return fd_;
 			};
-			var as_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)aq_, ar_);
-			var at_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(as_);
-			var au_ = at_?.Value;
-			var av_ = FHIRHelpers_4_3_000.ToValue(au_);
-			var aw_ = context.Operators.Quantity(140m, "mm[Hg]");
-			var ax_ = context.Operators.GreaterOrEqual((av_ as CqlQuantity), aw_);
+			IEnumerable<Observation.ComponentComponent> as_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)aq_, ar_);
+			Observation.ComponentComponent at_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(as_);
+			DataType au_ = at_?.Value;
+			object av_ = FHIRHelpers_4_3_000.ToValue(au_);
+			CqlQuantity aw_ = context.Operators.Quantity(140m, "mm[Hg]");
+			bool? ax_ = context.Operators.GreaterOrEqual((av_ as CqlQuantity), aw_);
 			bool? az_(Observation BloodPressure)
 			{
-				var fe_ = BloodPressure?.Effective;
-				var ff_ = FHIRHelpers_4_3_000.ToValue(fe_);
-				var fg_ = QICoreCommon_2_0_000.toInterval(ff_);
-				var fh_ = context.Operators.End(fg_);
-				var fi_ = QualifyingEncounter?.Period;
-				var fj_ = FHIRHelpers_4_3_000.ToInterval(fi_);
-				var fk_ = context.Operators.In<CqlDateTime>(fh_, fj_, "day");
-				var fl_ = BloodPressure?.StatusElement;
-				var fm_ = fl_?.Value;
-				var fn_ = context.Operators.Convert<string>(fm_);
-				var fo_ = new string[]
+				DataType fe_ = BloodPressure?.Effective;
+				object ff_ = FHIRHelpers_4_3_000.ToValue(fe_);
+				CqlInterval<CqlDateTime> fg_ = QICoreCommon_2_0_000.toInterval(ff_);
+				CqlDateTime fh_ = context.Operators.End(fg_);
+				Period fi_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> fj_ = FHIRHelpers_4_3_000.ToInterval(fi_);
+				bool? fk_ = context.Operators.In<CqlDateTime>(fh_, fj_, "day");
+				Code<ObservationStatus> fl_ = BloodPressure?.StatusElement;
+				ObservationStatus? fm_ = fl_?.Value;
+				string fn_ = context.Operators.Convert<string>(fm_);
+				string[] fo_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var fp_ = context.Operators.In<string>(fn_, (fo_ as IEnumerable<string>));
-				var fq_ = context.Operators.And(fk_, fp_);
+				bool? fp_ = context.Operators.In<string>(fn_, (fo_ as IEnumerable<string>));
+				bool? fq_ = context.Operators.And(fk_, fp_);
 
 				return fq_;
 			};
-			var ba_ = context.Operators.Where<Observation>(d_, az_);
+			IEnumerable<Observation> ba_ = context.Operators.Where<Observation>(d_, az_);
 			object bb_(Observation @this)
 			{
-				var fr_ = @this?.Effective;
-				var fs_ = FHIRHelpers_4_3_000.ToValue(fr_);
-				var ft_ = QICoreCommon_2_0_000.toInterval(fs_);
-				var fu_ = context.Operators.Start(ft_);
+				DataType fr_ = @this?.Effective;
+				object fs_ = FHIRHelpers_4_3_000.ToValue(fr_);
+				CqlInterval<CqlDateTime> ft_ = QICoreCommon_2_0_000.toInterval(fs_);
+				CqlDateTime fu_ = context.Operators.Start(ft_);
 
 				return fu_;
 			};
-			var bc_ = context.Operators.SortBy<Observation>(ba_, bb_, System.ComponentModel.ListSortDirection.Ascending);
-			var bd_ = context.Operators.Last<Observation>(bc_);
-			var be_ = bd_?.Component;
+			IEnumerable<Observation> bc_ = context.Operators.SortBy<Observation>(ba_, bb_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation bd_ = context.Operators.Last<Observation>(bc_);
+			List<Observation.ComponentComponent> be_ = bd_?.Component;
 			bool? bf_(Observation.ComponentComponent @this)
 			{
-				var fv_ = @this?.Code;
-				var fw_ = fv_?.Coding;
-				var fx_ = context.Operators.First<Coding>((IEnumerable<Coding>)fw_);
-				var fy_ = fx_?.SystemElement;
-				var fz_ = FHIRHelpers_4_3_000.ToString(fy_);
-				var ga_ = context.Operators.Equal(fz_, "http://loinc.org");
-				var gc_ = fv_?.Coding;
-				var gd_ = context.Operators.First<Coding>((IEnumerable<Coding>)gc_);
-				var ge_ = gd_?.CodeElement;
-				var gf_ = FHIRHelpers_4_3_000.ToString(ge_);
-				var gg_ = context.Operators.Equal(gf_, "8462-4");
-				var gh_ = context.Operators.And(ga_, gg_);
+				CodeableConcept fv_ = @this?.Code;
+				List<Coding> fw_ = fv_?.Coding;
+				Coding fx_ = context.Operators.First<Coding>((IEnumerable<Coding>)fw_);
+				FhirUri fy_ = fx_?.SystemElement;
+				string fz_ = FHIRHelpers_4_3_000.ToString(fy_);
+				bool? ga_ = context.Operators.Equal(fz_, "http://loinc.org");
+				List<Coding> gc_ = fv_?.Coding;
+				Coding gd_ = context.Operators.First<Coding>((IEnumerable<Coding>)gc_);
+				Code ge_ = gd_?.CodeElement;
+				string gf_ = FHIRHelpers_4_3_000.ToString(ge_);
+				bool? gg_ = context.Operators.Equal(gf_, "8462-4");
+				bool? gh_ = context.Operators.And(ga_, gg_);
 
 				return gh_;
 			};
-			var bg_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)be_, bf_);
-			var bh_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(bg_);
-			var bi_ = bh_?.Value;
-			var bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
-			var bk_ = context.Operators.Quantity(90m, "mm[Hg]");
-			var bl_ = context.Operators.GreaterOrEqual((bj_ as CqlQuantity), bk_);
-			var bm_ = context.Operators.Or(ax_, bl_);
-			var bn_ = context.Operators.Not(bm_);
-			var bo_ = context.Operators.And(aj_, bn_);
-			var bp_ = this.Encounter_with_Hypertensive_Reading_Within_Year_Prior();
-			var bq_ = context.Operators.Exists<Encounter>(bp_);
-			var br_ = context.Operators.And(bo_, bq_);
+			IEnumerable<Observation.ComponentComponent> bg_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)be_, bf_);
+			Observation.ComponentComponent bh_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(bg_);
+			DataType bi_ = bh_?.Value;
+			object bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
+			CqlQuantity bk_ = context.Operators.Quantity(90m, "mm[Hg]");
+			bool? bl_ = context.Operators.GreaterOrEqual((bj_ as CqlQuantity), bk_);
+			bool? bm_ = context.Operators.Or(ax_, bl_);
+			bool? bn_ = context.Operators.Not(bm_);
+			bool? bo_ = context.Operators.And(aj_, bn_);
+			IEnumerable<Encounter> bp_ = this.Encounter_with_Hypertensive_Reading_Within_Year_Prior();
+			bool? bq_ = context.Operators.Exists<Encounter>(bp_);
+			bool? br_ = context.Operators.And(bo_, bq_);
 
 			return br_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Value"/>
     [CqlDeclaration("Encounter with Second Hypertensive Reading SBP 130 to 139 OR DBP 80 to 89")]
 	public IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89() => 
 		__Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89.Value;
 
+    /// <seealso cref="Laboratory_Test_or_ECG_for_Hypertension"/>
 	private IEnumerable<ServiceRequest> Laboratory_Test_or_ECG_for_Hypertension_Value()
 	{
-		var a_ = this._12_lead_EKG_panel();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
-		var d_ = this.EKG_study();
-		var e_ = context.Operators.ToList<CqlCode>(d_);
-		var f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
-		var g_ = context.Operators.Union<ServiceRequest>(c_, f_);
-		var h_ = this.Laboratory_Tests_for_Hypertension();
-		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
-		var j_ = context.Operators.Union<ServiceRequest>(g_, i_);
+		CqlCode a_ = this._12_lead_EKG_panel();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
+		CqlCode d_ = this.EKG_study();
+		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
+		IEnumerable<ServiceRequest> g_ = context.Operators.Union<ServiceRequest>(c_, f_);
+		CqlValueSet h_ = this.Laboratory_Tests_for_Hypertension();
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
 		bool? k_(ServiceRequest EKGLab)
 		{
-			var m_ = EKGLab?.IntentElement;
-			var n_ = m_?.Value;
-			var o_ = context.Operators.Convert<Code<RequestIntent>>(n_);
-			var p_ = context.Operators.Equivalent(o_, "order");
+			Code<RequestIntent> m_ = EKGLab?.IntentElement;
+			RequestIntent? n_ = m_?.Value;
+			Code<RequestIntent> o_ = context.Operators.Convert<Code<RequestIntent>>(n_);
+			bool? p_ = context.Operators.Equivalent(o_, "order");
 
 			return p_;
 		};
-		var l_ = context.Operators.Where<ServiceRequest>(j_, k_);
+		IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Laboratory_Test_or_ECG_for_Hypertension_Value"/>
     [CqlDeclaration("Laboratory Test or ECG for Hypertension")]
 	public IEnumerable<ServiceRequest> Laboratory_Test_or_ECG_for_Hypertension() => 
 		__Laboratory_Test_or_ECG_for_Hypertension.Value;
 
+    /// <seealso cref="Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions"/>
 	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions_Value()
 	{
-		var a_ = this.Follow_up_with_Rescreen_in_2_to_6_Months();
+		IEnumerable<ServiceRequest> a_ = this.Follow_up_with_Rescreen_in_2_to_6_Months();
 		IEnumerable<ServiceRequest> b_(ServiceRequest Rescreen2to6)
 		{
-			var f_ = this.Laboratory_Test_or_ECG_for_Hypertension();
+			IEnumerable<ServiceRequest> f_ = this.Laboratory_Test_or_ECG_for_Hypertension();
 			bool? g_(ServiceRequest LabECGIntervention)
 			{
-				var k_ = Rescreen2to6?.AuthoredOnElement;
-				var l_ = context.Operators.Convert<CqlDateTime>(k_);
-				var m_ = this.Measurement_Period();
-				var n_ = context.Operators.In<CqlDateTime>(l_, m_, "day");
-				var o_ = LabECGIntervention?.AuthoredOnElement;
-				var p_ = context.Operators.Convert<CqlDateTime>(o_);
-				var r_ = context.Operators.In<CqlDateTime>(p_, m_, "day");
-				var s_ = context.Operators.And(n_, r_);
+				FhirDateTime k_ = Rescreen2to6?.AuthoredOnElement;
+				CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+				CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, "day");
+				FhirDateTime o_ = LabECGIntervention?.AuthoredOnElement;
+				CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
+				bool? r_ = context.Operators.In<CqlDateTime>(p_, m_, "day");
+				bool? s_ = context.Operators.And(n_, r_);
 
 				return s_;
 			};
-			var h_ = context.Operators.Where<ServiceRequest>(f_, g_);
+			IEnumerable<ServiceRequest> h_ = context.Operators.Where<ServiceRequest>(f_, g_);
 			ServiceRequest i_(ServiceRequest LabECGIntervention) => 
 				Rescreen2to6;
-			var j_ = context.Operators.Select<ServiceRequest, ServiceRequest>(h_, i_);
+			IEnumerable<ServiceRequest> j_ = context.Operators.Select<ServiceRequest, ServiceRequest>(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(a_, b_);
+		IEnumerable<ServiceRequest> c_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(a_, b_);
 		IEnumerable<ServiceRequest> d_(ServiceRequest Rescreen2to6)
 		{
-			var t_ = this.NonPharmacological_Interventions();
+			IEnumerable<ServiceRequest> t_ = this.NonPharmacological_Interventions();
 			bool? u_(ServiceRequest NonPharmSecondIntervention)
 			{
-				var y_ = NonPharmSecondIntervention?.AuthoredOnElement;
-				var z_ = context.Operators.Convert<CqlDateTime>(y_);
-				var aa_ = this.Measurement_Period();
-				var ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
+				FhirDateTime y_ = NonPharmSecondIntervention?.AuthoredOnElement;
+				CqlDateTime z_ = context.Operators.Convert<CqlDateTime>(y_);
+				CqlInterval<CqlDateTime> aa_ = this.Measurement_Period();
+				bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
 
 				return ab_;
 			};
-			var v_ = context.Operators.Where<ServiceRequest>(t_, u_);
+			IEnumerable<ServiceRequest> v_ = context.Operators.Where<ServiceRequest>(t_, u_);
 			ServiceRequest w_(ServiceRequest NonPharmSecondIntervention) => 
 				Rescreen2to6;
-			var x_ = context.Operators.Select<ServiceRequest, ServiceRequest>(v_, w_);
+			IEnumerable<ServiceRequest> x_ = context.Operators.Select<ServiceRequest, ServiceRequest>(v_, w_);
 
 			return x_;
 		};
-		var e_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(c_, d_);
+		IEnumerable<ServiceRequest> e_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions_Value"/>
     [CqlDeclaration("Second Hypertensive Reading SBP 130 to 139 OR DBP 80 to 89 and Interventions")]
 	public IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions() => 
 		__Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions.Value;
 
+    /// <seealso cref="Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions"/>
 	private IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions_Value()
 	{
-		var a_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89();
 		IEnumerable<Encounter> b_(Encounter SecondHTNEncounterReading)
 		{
-			var h_ = this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions();
+			IEnumerable<ServiceRequest> h_ = this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions();
 			bool? i_(ServiceRequest EncounterInterventions)
 			{
-				var m_ = EncounterInterventions?.AuthoredOnElement;
-				var n_ = context.Operators.Convert<CqlDateTime>(m_);
-				var o_ = SecondHTNEncounterReading?.Period;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+				FhirDateTime m_ = EncounterInterventions?.AuthoredOnElement;
+				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+				Period o_ = SecondHTNEncounterReading?.Period;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
 
 				return q_;
 			};
-			var j_ = context.Operators.Where<ServiceRequest>(h_, i_);
+			IEnumerable<ServiceRequest> j_ = context.Operators.Where<ServiceRequest>(h_, i_);
 			Encounter k_(ServiceRequest EncounterInterventions) => 
 				SecondHTNEncounterReading;
-			var l_ = context.Operators.Select<ServiceRequest, Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Select<ServiceRequest, Encounter>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 		IEnumerable<Encounter> e_(Encounter SecondHTNEncounterReading)
 		{
-			var r_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
+			IEnumerable<ServiceRequest> r_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
 			bool? s_(ServiceRequest ReferralForHTN)
 			{
-				var w_ = ReferralForHTN?.AuthoredOnElement;
-				var x_ = context.Operators.Convert<CqlDateTime>(w_);
-				var y_ = SecondHTNEncounterReading?.Period;
-				var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-				var aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
+				FhirDateTime w_ = ReferralForHTN?.AuthoredOnElement;
+				CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+				Period y_ = SecondHTNEncounterReading?.Period;
+				CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+				bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
 
 				return aa_;
 			};
-			var t_ = context.Operators.Where<ServiceRequest>(r_, s_);
+			IEnumerable<ServiceRequest> t_ = context.Operators.Where<ServiceRequest>(r_, s_);
 			Encounter u_(ServiceRequest ReferralForHTN) => 
 				SecondHTNEncounterReading;
-			var v_ = context.Operators.Select<ServiceRequest, Encounter>(t_, u_);
+			IEnumerable<Encounter> v_ = context.Operators.Select<ServiceRequest, Encounter>(t_, u_);
 
 			return v_;
 		};
-		var f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
-		var g_ = context.Operators.Union<Encounter>(c_, f_);
+		IEnumerable<Encounter> f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
+		IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions_Value"/>
     [CqlDeclaration("Encounter with Second Hypertensive Reading SBP 130 to 139 OR DBP 80 to 89 and Interventions")]
 	public IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions() => 
 		__Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions.Value;
 
+    /// <seealso cref="Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90"/>
 	private IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Value()
 	{
-		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? e_(Observation BloodPressure)
 			{
-				var bn_ = BloodPressure?.Effective;
-				var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
-				var bp_ = QICoreCommon_2_0_000.toInterval(bo_);
-				var bq_ = context.Operators.End(bp_);
-				var br_ = QualifyingEncounter?.Period;
-				var bs_ = FHIRHelpers_4_3_000.ToInterval(br_);
-				var bt_ = context.Operators.In<CqlDateTime>(bq_, bs_, null);
-				var bu_ = BloodPressure?.StatusElement;
-				var bv_ = bu_?.Value;
-				var bw_ = context.Operators.Convert<string>(bv_);
-				var bx_ = new string[]
+				DataType bn_ = BloodPressure?.Effective;
+				object bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+				CqlInterval<CqlDateTime> bp_ = QICoreCommon_2_0_000.toInterval(bo_);
+				CqlDateTime bq_ = context.Operators.End(bp_);
+				Period br_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> bs_ = FHIRHelpers_4_3_000.ToInterval(br_);
+				bool? bt_ = context.Operators.In<CqlDateTime>(bq_, bs_, null);
+				Code<ObservationStatus> bu_ = BloodPressure?.StatusElement;
+				ObservationStatus? bv_ = bu_?.Value;
+				string bw_ = context.Operators.Convert<string>(bv_);
+				string[] bx_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var by_ = context.Operators.In<string>(bw_, (bx_ as IEnumerable<string>));
-				var bz_ = context.Operators.And(bt_, by_);
+				bool? by_ = context.Operators.In<string>(bw_, (bx_ as IEnumerable<string>));
+				bool? bz_ = context.Operators.And(bt_, by_);
 
 				return bz_;
 			};
-			var f_ = context.Operators.Where<Observation>(d_, e_);
+			IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 			object g_(Observation @this)
 			{
-				var ca_ = @this?.Effective;
-				var cb_ = FHIRHelpers_4_3_000.ToValue(ca_);
-				var cc_ = QICoreCommon_2_0_000.toInterval(cb_);
-				var cd_ = context.Operators.Start(cc_);
+				DataType ca_ = @this?.Effective;
+				object cb_ = FHIRHelpers_4_3_000.ToValue(ca_);
+				CqlInterval<CqlDateTime> cc_ = QICoreCommon_2_0_000.toInterval(cb_);
+				CqlDateTime cd_ = context.Operators.Start(cc_);
 
 				return cd_;
 			};
-			var h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
-			var i_ = context.Operators.Last<Observation>(h_);
-			var j_ = i_?.Component;
+			IEnumerable<Observation> h_ = context.Operators.SortBy<Observation>(f_, g_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation i_ = context.Operators.Last<Observation>(h_);
+			List<Observation.ComponentComponent> j_ = i_?.Component;
 			bool? k_(Observation.ComponentComponent @this)
 			{
-				var ce_ = @this?.Code;
-				var cf_ = ce_?.Coding;
-				var cg_ = context.Operators.First<Coding>((IEnumerable<Coding>)cf_);
-				var ch_ = cg_?.SystemElement;
-				var ci_ = FHIRHelpers_4_3_000.ToString(ch_);
-				var cj_ = context.Operators.Equal(ci_, "http://loinc.org");
-				var cl_ = ce_?.Coding;
-				var cm_ = context.Operators.First<Coding>((IEnumerable<Coding>)cl_);
-				var cn_ = cm_?.CodeElement;
-				var co_ = FHIRHelpers_4_3_000.ToString(cn_);
-				var cp_ = context.Operators.Equal(co_, "8480-6");
-				var cq_ = context.Operators.And(cj_, cp_);
+				CodeableConcept ce_ = @this?.Code;
+				List<Coding> cf_ = ce_?.Coding;
+				Coding cg_ = context.Operators.First<Coding>((IEnumerable<Coding>)cf_);
+				FhirUri ch_ = cg_?.SystemElement;
+				string ci_ = FHIRHelpers_4_3_000.ToString(ch_);
+				bool? cj_ = context.Operators.Equal(ci_, "http://loinc.org");
+				List<Coding> cl_ = ce_?.Coding;
+				Coding cm_ = context.Operators.First<Coding>((IEnumerable<Coding>)cl_);
+				Code cn_ = cm_?.CodeElement;
+				string co_ = FHIRHelpers_4_3_000.ToString(cn_);
+				bool? cp_ = context.Operators.Equal(co_, "8480-6");
+				bool? cq_ = context.Operators.And(cj_, cp_);
 
 				return cq_;
 			};
-			var l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
-			var m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
-			var n_ = m_?.Value;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = context.Operators.Quantity(0m, "mm[Hg]");
-			var q_ = context.Operators.Greater((o_ as CqlQuantity), p_);
+			IEnumerable<Observation.ComponentComponent> l_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)j_, k_);
+			Observation.ComponentComponent m_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(l_);
+			DataType n_ = m_?.Value;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			CqlQuantity p_ = context.Operators.Quantity(0m, "mm[Hg]");
+			bool? q_ = context.Operators.Greater((o_ as CqlQuantity), p_);
 			bool? s_(Observation BloodPressure)
 			{
-				var cr_ = BloodPressure?.Effective;
-				var cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
-				var ct_ = QICoreCommon_2_0_000.toInterval(cs_);
-				var cu_ = context.Operators.End(ct_);
-				var cv_ = QualifyingEncounter?.Period;
-				var cw_ = FHIRHelpers_4_3_000.ToInterval(cv_);
-				var cx_ = context.Operators.In<CqlDateTime>(cu_, cw_, null);
-				var cy_ = BloodPressure?.StatusElement;
-				var cz_ = cy_?.Value;
-				var da_ = context.Operators.Convert<string>(cz_);
-				var db_ = new string[]
+				DataType cr_ = BloodPressure?.Effective;
+				object cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
+				CqlInterval<CqlDateTime> ct_ = QICoreCommon_2_0_000.toInterval(cs_);
+				CqlDateTime cu_ = context.Operators.End(ct_);
+				Period cv_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> cw_ = FHIRHelpers_4_3_000.ToInterval(cv_);
+				bool? cx_ = context.Operators.In<CqlDateTime>(cu_, cw_, null);
+				Code<ObservationStatus> cy_ = BloodPressure?.StatusElement;
+				ObservationStatus? cz_ = cy_?.Value;
+				string da_ = context.Operators.Convert<string>(cz_);
+				string[] db_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var dc_ = context.Operators.In<string>(da_, (db_ as IEnumerable<string>));
-				var dd_ = context.Operators.And(cx_, dc_);
+				bool? dc_ = context.Operators.In<string>(da_, (db_ as IEnumerable<string>));
+				bool? dd_ = context.Operators.And(cx_, dc_);
 
 				return dd_;
 			};
-			var t_ = context.Operators.Where<Observation>(d_, s_);
+			IEnumerable<Observation> t_ = context.Operators.Where<Observation>(d_, s_);
 			object u_(Observation @this)
 			{
-				var de_ = @this?.Effective;
-				var df_ = FHIRHelpers_4_3_000.ToValue(de_);
-				var dg_ = QICoreCommon_2_0_000.toInterval(df_);
-				var dh_ = context.Operators.Start(dg_);
+				DataType de_ = @this?.Effective;
+				object df_ = FHIRHelpers_4_3_000.ToValue(de_);
+				CqlInterval<CqlDateTime> dg_ = QICoreCommon_2_0_000.toInterval(df_);
+				CqlDateTime dh_ = context.Operators.Start(dg_);
 
 				return dh_;
 			};
-			var v_ = context.Operators.SortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
-			var w_ = context.Operators.Last<Observation>(v_);
-			var x_ = w_?.Component;
+			IEnumerable<Observation> v_ = context.Operators.SortBy<Observation>(t_, u_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation w_ = context.Operators.Last<Observation>(v_);
+			List<Observation.ComponentComponent> x_ = w_?.Component;
 			bool? y_(Observation.ComponentComponent @this)
 			{
-				var di_ = @this?.Code;
-				var dj_ = di_?.Coding;
-				var dk_ = context.Operators.First<Coding>((IEnumerable<Coding>)dj_);
-				var dl_ = dk_?.SystemElement;
-				var dm_ = FHIRHelpers_4_3_000.ToString(dl_);
-				var dn_ = context.Operators.Equal(dm_, "http://loinc.org");
-				var dp_ = di_?.Coding;
-				var dq_ = context.Operators.First<Coding>((IEnumerable<Coding>)dp_);
-				var dr_ = dq_?.CodeElement;
-				var ds_ = FHIRHelpers_4_3_000.ToString(dr_);
-				var dt_ = context.Operators.Equal(ds_, "8462-4");
-				var du_ = context.Operators.And(dn_, dt_);
+				CodeableConcept di_ = @this?.Code;
+				List<Coding> dj_ = di_?.Coding;
+				Coding dk_ = context.Operators.First<Coding>((IEnumerable<Coding>)dj_);
+				FhirUri dl_ = dk_?.SystemElement;
+				string dm_ = FHIRHelpers_4_3_000.ToString(dl_);
+				bool? dn_ = context.Operators.Equal(dm_, "http://loinc.org");
+				List<Coding> dp_ = di_?.Coding;
+				Coding dq_ = context.Operators.First<Coding>((IEnumerable<Coding>)dp_);
+				Code dr_ = dq_?.CodeElement;
+				string ds_ = FHIRHelpers_4_3_000.ToString(dr_);
+				bool? dt_ = context.Operators.Equal(ds_, "8462-4");
+				bool? du_ = context.Operators.And(dn_, dt_);
 
 				return du_;
 			};
-			var z_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)x_, y_);
-			var aa_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(z_);
-			var ab_ = aa_?.Value;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ae_ = context.Operators.Greater((ac_ as CqlQuantity), p_);
-			var af_ = context.Operators.And(q_, ae_);
+			IEnumerable<Observation.ComponentComponent> z_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)x_, y_);
+			Observation.ComponentComponent aa_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(z_);
+			DataType ab_ = aa_?.Value;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			bool? ae_ = context.Operators.Greater((ac_ as CqlQuantity), p_);
+			bool? af_ = context.Operators.And(q_, ae_);
 			bool? ah_(Observation BloodPressure)
 			{
-				var dv_ = BloodPressure?.Effective;
-				var dw_ = FHIRHelpers_4_3_000.ToValue(dv_);
-				var dx_ = QICoreCommon_2_0_000.toInterval(dw_);
-				var dy_ = context.Operators.End(dx_);
-				var dz_ = QualifyingEncounter?.Period;
-				var ea_ = FHIRHelpers_4_3_000.ToInterval(dz_);
-				var eb_ = context.Operators.In<CqlDateTime>(dy_, ea_, null);
-				var ec_ = BloodPressure?.StatusElement;
-				var ed_ = ec_?.Value;
-				var ee_ = context.Operators.Convert<string>(ed_);
-				var ef_ = new string[]
+				DataType dv_ = BloodPressure?.Effective;
+				object dw_ = FHIRHelpers_4_3_000.ToValue(dv_);
+				CqlInterval<CqlDateTime> dx_ = QICoreCommon_2_0_000.toInterval(dw_);
+				CqlDateTime dy_ = context.Operators.End(dx_);
+				Period dz_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_3_000.ToInterval(dz_);
+				bool? eb_ = context.Operators.In<CqlDateTime>(dy_, ea_, null);
+				Code<ObservationStatus> ec_ = BloodPressure?.StatusElement;
+				ObservationStatus? ed_ = ec_?.Value;
+				string ee_ = context.Operators.Convert<string>(ed_);
+				string[] ef_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var eg_ = context.Operators.In<string>(ee_, (ef_ as IEnumerable<string>));
-				var eh_ = context.Operators.And(eb_, eg_);
+				bool? eg_ = context.Operators.In<string>(ee_, (ef_ as IEnumerable<string>));
+				bool? eh_ = context.Operators.And(eb_, eg_);
 
 				return eh_;
 			};
-			var ai_ = context.Operators.Where<Observation>(d_, ah_);
+			IEnumerable<Observation> ai_ = context.Operators.Where<Observation>(d_, ah_);
 			object aj_(Observation @this)
 			{
-				var ei_ = @this?.Effective;
-				var ej_ = FHIRHelpers_4_3_000.ToValue(ei_);
-				var ek_ = QICoreCommon_2_0_000.toInterval(ej_);
-				var el_ = context.Operators.Start(ek_);
+				DataType ei_ = @this?.Effective;
+				object ej_ = FHIRHelpers_4_3_000.ToValue(ei_);
+				CqlInterval<CqlDateTime> ek_ = QICoreCommon_2_0_000.toInterval(ej_);
+				CqlDateTime el_ = context.Operators.Start(ek_);
 
 				return el_;
 			};
-			var ak_ = context.Operators.SortBy<Observation>(ai_, aj_, System.ComponentModel.ListSortDirection.Ascending);
-			var al_ = context.Operators.Last<Observation>(ak_);
-			var am_ = al_?.Component;
+			IEnumerable<Observation> ak_ = context.Operators.SortBy<Observation>(ai_, aj_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation al_ = context.Operators.Last<Observation>(ak_);
+			List<Observation.ComponentComponent> am_ = al_?.Component;
 			bool? an_(Observation.ComponentComponent @this)
 			{
-				var em_ = @this?.Code;
-				var en_ = em_?.Coding;
-				var eo_ = context.Operators.First<Coding>((IEnumerable<Coding>)en_);
-				var ep_ = eo_?.SystemElement;
-				var eq_ = FHIRHelpers_4_3_000.ToString(ep_);
-				var er_ = context.Operators.Equal(eq_, "http://loinc.org");
-				var et_ = em_?.Coding;
-				var eu_ = context.Operators.First<Coding>((IEnumerable<Coding>)et_);
-				var ev_ = eu_?.CodeElement;
-				var ew_ = FHIRHelpers_4_3_000.ToString(ev_);
-				var ex_ = context.Operators.Equal(ew_, "8480-6");
-				var ey_ = context.Operators.And(er_, ex_);
+				CodeableConcept em_ = @this?.Code;
+				List<Coding> en_ = em_?.Coding;
+				Coding eo_ = context.Operators.First<Coding>((IEnumerable<Coding>)en_);
+				FhirUri ep_ = eo_?.SystemElement;
+				string eq_ = FHIRHelpers_4_3_000.ToString(ep_);
+				bool? er_ = context.Operators.Equal(eq_, "http://loinc.org");
+				List<Coding> et_ = em_?.Coding;
+				Coding eu_ = context.Operators.First<Coding>((IEnumerable<Coding>)et_);
+				Code ev_ = eu_?.CodeElement;
+				string ew_ = FHIRHelpers_4_3_000.ToString(ev_);
+				bool? ex_ = context.Operators.Equal(ew_, "8480-6");
+				bool? ey_ = context.Operators.And(er_, ex_);
 
 				return ey_;
 			};
-			var ao_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)am_, an_);
-			var ap_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ao_);
-			var aq_ = ap_?.Value;
-			var ar_ = FHIRHelpers_4_3_000.ToValue(aq_);
-			var as_ = context.Operators.Quantity(140m, "mm[Hg]");
-			var at_ = context.Operators.GreaterOrEqual((ar_ as CqlQuantity), as_);
+			IEnumerable<Observation.ComponentComponent> ao_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)am_, an_);
+			Observation.ComponentComponent ap_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(ao_);
+			DataType aq_ = ap_?.Value;
+			object ar_ = FHIRHelpers_4_3_000.ToValue(aq_);
+			CqlQuantity as_ = context.Operators.Quantity(140m, "mm[Hg]");
+			bool? at_ = context.Operators.GreaterOrEqual((ar_ as CqlQuantity), as_);
 			bool? av_(Observation BloodPressure)
 			{
-				var ez_ = BloodPressure?.Effective;
-				var fa_ = FHIRHelpers_4_3_000.ToValue(ez_);
-				var fb_ = QICoreCommon_2_0_000.toInterval(fa_);
-				var fc_ = context.Operators.End(fb_);
-				var fd_ = QualifyingEncounter?.Period;
-				var fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
-				var ff_ = context.Operators.In<CqlDateTime>(fc_, fe_, null);
-				var fg_ = BloodPressure?.StatusElement;
-				var fh_ = fg_?.Value;
-				var fi_ = context.Operators.Convert<string>(fh_);
-				var fj_ = new string[]
+				DataType ez_ = BloodPressure?.Effective;
+				object fa_ = FHIRHelpers_4_3_000.ToValue(ez_);
+				CqlInterval<CqlDateTime> fb_ = QICoreCommon_2_0_000.toInterval(fa_);
+				CqlDateTime fc_ = context.Operators.End(fb_);
+				Period fd_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
+				bool? ff_ = context.Operators.In<CqlDateTime>(fc_, fe_, null);
+				Code<ObservationStatus> fg_ = BloodPressure?.StatusElement;
+				ObservationStatus? fh_ = fg_?.Value;
+				string fi_ = context.Operators.Convert<string>(fh_);
+				string[] fj_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var fk_ = context.Operators.In<string>(fi_, (fj_ as IEnumerable<string>));
-				var fl_ = context.Operators.And(ff_, fk_);
+				bool? fk_ = context.Operators.In<string>(fi_, (fj_ as IEnumerable<string>));
+				bool? fl_ = context.Operators.And(ff_, fk_);
 
 				return fl_;
 			};
-			var aw_ = context.Operators.Where<Observation>(d_, av_);
+			IEnumerable<Observation> aw_ = context.Operators.Where<Observation>(d_, av_);
 			object ax_(Observation @this)
 			{
-				var fm_ = @this?.Effective;
-				var fn_ = FHIRHelpers_4_3_000.ToValue(fm_);
-				var fo_ = QICoreCommon_2_0_000.toInterval(fn_);
-				var fp_ = context.Operators.Start(fo_);
+				DataType fm_ = @this?.Effective;
+				object fn_ = FHIRHelpers_4_3_000.ToValue(fm_);
+				CqlInterval<CqlDateTime> fo_ = QICoreCommon_2_0_000.toInterval(fn_);
+				CqlDateTime fp_ = context.Operators.Start(fo_);
 
 				return fp_;
 			};
-			var ay_ = context.Operators.SortBy<Observation>(aw_, ax_, System.ComponentModel.ListSortDirection.Ascending);
-			var az_ = context.Operators.Last<Observation>(ay_);
-			var ba_ = az_?.Component;
+			IEnumerable<Observation> ay_ = context.Operators.SortBy<Observation>(aw_, ax_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation az_ = context.Operators.Last<Observation>(ay_);
+			List<Observation.ComponentComponent> ba_ = az_?.Component;
 			bool? bb_(Observation.ComponentComponent @this)
 			{
-				var fq_ = @this?.Code;
-				var fr_ = fq_?.Coding;
-				var fs_ = context.Operators.First<Coding>((IEnumerable<Coding>)fr_);
-				var ft_ = fs_?.SystemElement;
-				var fu_ = FHIRHelpers_4_3_000.ToString(ft_);
-				var fv_ = context.Operators.Equal(fu_, "http://loinc.org");
-				var fx_ = fq_?.Coding;
-				var fy_ = context.Operators.First<Coding>((IEnumerable<Coding>)fx_);
-				var fz_ = fy_?.CodeElement;
-				var ga_ = FHIRHelpers_4_3_000.ToString(fz_);
-				var gb_ = context.Operators.Equal(ga_, "8462-4");
-				var gc_ = context.Operators.And(fv_, gb_);
+				CodeableConcept fq_ = @this?.Code;
+				List<Coding> fr_ = fq_?.Coding;
+				Coding fs_ = context.Operators.First<Coding>((IEnumerable<Coding>)fr_);
+				FhirUri ft_ = fs_?.SystemElement;
+				string fu_ = FHIRHelpers_4_3_000.ToString(ft_);
+				bool? fv_ = context.Operators.Equal(fu_, "http://loinc.org");
+				List<Coding> fx_ = fq_?.Coding;
+				Coding fy_ = context.Operators.First<Coding>((IEnumerable<Coding>)fx_);
+				Code fz_ = fy_?.CodeElement;
+				string ga_ = FHIRHelpers_4_3_000.ToString(fz_);
+				bool? gb_ = context.Operators.Equal(ga_, "8462-4");
+				bool? gc_ = context.Operators.And(fv_, gb_);
 
 				return gc_;
 			};
-			var bc_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ba_, bb_);
-			var bd_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(bc_);
-			var be_ = bd_?.Value;
-			var bf_ = FHIRHelpers_4_3_000.ToValue(be_);
-			var bg_ = context.Operators.Quantity(90m, "mm[Hg]");
-			var bh_ = context.Operators.GreaterOrEqual((bf_ as CqlQuantity), bg_);
-			var bi_ = context.Operators.Or(at_, bh_);
-			var bj_ = context.Operators.And(af_, bi_);
-			var bk_ = this.Encounter_with_Hypertensive_Reading_Within_Year_Prior();
-			var bl_ = context.Operators.Exists<Encounter>(bk_);
-			var bm_ = context.Operators.And(bj_, bl_);
+			IEnumerable<Observation.ComponentComponent> bc_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)ba_, bb_);
+			Observation.ComponentComponent bd_ = context.Operators.SingletonFrom<Observation.ComponentComponent>(bc_);
+			DataType be_ = bd_?.Value;
+			object bf_ = FHIRHelpers_4_3_000.ToValue(be_);
+			CqlQuantity bg_ = context.Operators.Quantity(90m, "mm[Hg]");
+			bool? bh_ = context.Operators.GreaterOrEqual((bf_ as CqlQuantity), bg_);
+			bool? bi_ = context.Operators.Or(at_, bh_);
+			bool? bj_ = context.Operators.And(af_, bi_);
+			IEnumerable<Encounter> bk_ = this.Encounter_with_Hypertensive_Reading_Within_Year_Prior();
+			bool? bl_ = context.Operators.Exists<Encounter>(bk_);
+			bool? bm_ = context.Operators.And(bj_, bl_);
 
 			return bm_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Value"/>
     [CqlDeclaration("Encounter with Second Hypertensive Reading SBP Greater than or Equal to 140 OR DBP Greater than or Equal to 90")]
 	public IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90() => 
 		__Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90.Value;
 
+    /// <seealso cref="Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions"/>
 	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Value()
 	{
-		var a_ = this.Follow_Up_Within_4_Weeks();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		CqlValueSet a_ = this.Follow_Up_Within_4_Weeks();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
 		IEnumerable<ServiceRequest> c_(ServiceRequest WeeksRescreen)
 		{
-			var i_ = this.Laboratory_Test_or_ECG_for_Hypertension();
+			IEnumerable<ServiceRequest> i_ = this.Laboratory_Test_or_ECG_for_Hypertension();
 			bool? j_(ServiceRequest ECGLabTest)
 			{
-				var n_ = WeeksRescreen?.AuthoredOnElement;
-				var o_ = context.Operators.Convert<CqlDateTime>(n_);
-				var p_ = this.Measurement_Period();
-				var q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
-				var r_ = ECGLabTest?.AuthoredOnElement;
-				var s_ = context.Operators.Convert<CqlDateTime>(r_);
-				var u_ = context.Operators.In<CqlDateTime>(s_, p_, "day");
-				var v_ = context.Operators.And(q_, u_);
-				var w_ = WeeksRescreen?.IntentElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Convert<Code<RequestIntent>>(x_);
-				var z_ = context.Operators.Equivalent(y_, "order");
-				var aa_ = context.Operators.And(v_, z_);
-				var ab_ = ECGLabTest?.IntentElement;
-				var ac_ = ab_?.Value;
-				var ad_ = context.Operators.Convert<Code<RequestIntent>>(ac_);
-				var ae_ = context.Operators.Equivalent(ad_, "order");
-				var af_ = context.Operators.And(aa_, ae_);
+				FhirDateTime n_ = WeeksRescreen?.AuthoredOnElement;
+				CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+				CqlInterval<CqlDateTime> p_ = this.Measurement_Period();
+				bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+				FhirDateTime r_ = ECGLabTest?.AuthoredOnElement;
+				CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(r_);
+				bool? u_ = context.Operators.In<CqlDateTime>(s_, p_, "day");
+				bool? v_ = context.Operators.And(q_, u_);
+				Code<RequestIntent> w_ = WeeksRescreen?.IntentElement;
+				RequestIntent? x_ = w_?.Value;
+				Code<RequestIntent> y_ = context.Operators.Convert<Code<RequestIntent>>(x_);
+				bool? z_ = context.Operators.Equivalent(y_, "order");
+				bool? aa_ = context.Operators.And(v_, z_);
+				Code<RequestIntent> ab_ = ECGLabTest?.IntentElement;
+				RequestIntent? ac_ = ab_?.Value;
+				Code<RequestIntent> ad_ = context.Operators.Convert<Code<RequestIntent>>(ac_);
+				bool? ae_ = context.Operators.Equivalent(ad_, "order");
+				bool? af_ = context.Operators.And(aa_, ae_);
 
 				return af_;
 			};
-			var k_ = context.Operators.Where<ServiceRequest>(i_, j_);
+			IEnumerable<ServiceRequest> k_ = context.Operators.Where<ServiceRequest>(i_, j_);
 			ServiceRequest l_(ServiceRequest ECGLabTest) => 
 				WeeksRescreen;
-			var m_ = context.Operators.Select<ServiceRequest, ServiceRequest>(k_, l_);
+			IEnumerable<ServiceRequest> m_ = context.Operators.Select<ServiceRequest, ServiceRequest>(k_, l_);
 
 			return m_;
 		};
-		var d_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(b_, c_);
+		IEnumerable<ServiceRequest> d_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(b_, c_);
 		IEnumerable<ServiceRequest> e_(ServiceRequest WeeksRescreen)
 		{
-			var ag_ = this.NonPharmacological_Interventions();
+			IEnumerable<ServiceRequest> ag_ = this.NonPharmacological_Interventions();
 			bool? ah_(ServiceRequest HTNInterventions)
 			{
-				var al_ = HTNInterventions?.AuthoredOnElement;
-				var am_ = context.Operators.Convert<CqlDateTime>(al_);
-				var an_ = this.Measurement_Period();
-				var ao_ = context.Operators.In<CqlDateTime>(am_, an_, "day");
+				FhirDateTime al_ = HTNInterventions?.AuthoredOnElement;
+				CqlDateTime am_ = context.Operators.Convert<CqlDateTime>(al_);
+				CqlInterval<CqlDateTime> an_ = this.Measurement_Period();
+				bool? ao_ = context.Operators.In<CqlDateTime>(am_, an_, "day");
 
 				return ao_;
 			};
-			var ai_ = context.Operators.Where<ServiceRequest>(ag_, ah_);
+			IEnumerable<ServiceRequest> ai_ = context.Operators.Where<ServiceRequest>(ag_, ah_);
 			ServiceRequest aj_(ServiceRequest HTNInterventions) => 
 				WeeksRescreen;
-			var ak_ = context.Operators.Select<ServiceRequest, ServiceRequest>(ai_, aj_);
+			IEnumerable<ServiceRequest> ak_ = context.Operators.Select<ServiceRequest, ServiceRequest>(ai_, aj_);
 
 			return ak_;
 		};
-		var f_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(d_, e_);
+		IEnumerable<ServiceRequest> f_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(d_, e_);
 		IEnumerable<ServiceRequest> g_(ServiceRequest WeeksRescreen)
 		{
-			var ap_ = this.Pharmacologic_Therapy_for_Hypertension();
-			var aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
-			var as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
-			var at_ = context.Operators.Union<MedicationRequest>(aq_, as_);
+			CqlValueSet ap_ = this.Pharmacologic_Therapy_for_Hypertension();
+			IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
+			IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
+			IEnumerable<MedicationRequest> at_ = context.Operators.Union<MedicationRequest>(aq_, as_);
 			bool? au_(MedicationRequest Medications)
 			{
-				var ay_ = Medications?.AuthoredOnElement;
-				var az_ = context.Operators.Convert<CqlDateTime>(ay_);
-				var ba_ = this.Measurement_Period();
-				var bb_ = context.Operators.In<CqlDateTime>(az_, ba_, "day");
-				var bc_ = Medications?.StatusElement;
-				var bd_ = bc_?.Value;
-				var be_ = context.Operators.Convert<string>(bd_);
-				var bf_ = context.Operators.Equivalent(be_, "active");
-				var bg_ = context.Operators.And(bb_, bf_);
+				FhirDateTime ay_ = Medications?.AuthoredOnElement;
+				CqlDateTime az_ = context.Operators.Convert<CqlDateTime>(ay_);
+				CqlInterval<CqlDateTime> ba_ = this.Measurement_Period();
+				bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, "day");
+				Code<MedicationRequest.MedicationrequestStatus> bc_ = Medications?.StatusElement;
+				MedicationRequest.MedicationrequestStatus? bd_ = bc_?.Value;
+				string be_ = context.Operators.Convert<string>(bd_);
+				bool? bf_ = context.Operators.Equivalent(be_, "active");
+				bool? bg_ = context.Operators.And(bb_, bf_);
 
 				return bg_;
 			};
-			var av_ = context.Operators.Where<MedicationRequest>(at_, au_);
+			IEnumerable<MedicationRequest> av_ = context.Operators.Where<MedicationRequest>(at_, au_);
 			ServiceRequest aw_(MedicationRequest Medications) => 
 				WeeksRescreen;
-			var ax_ = context.Operators.Select<MedicationRequest, ServiceRequest>(av_, aw_);
+			IEnumerable<ServiceRequest> ax_ = context.Operators.Select<MedicationRequest, ServiceRequest>(av_, aw_);
 
 			return ax_;
 		};
-		var h_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(f_, g_);
+		IEnumerable<ServiceRequest> h_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(f_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Value"/>
     [CqlDeclaration("Second Hypertensive Reading SBP Greater than or Equal to 140 OR DBP Greater than or Equal to 90 Interventions")]
 	public IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions() => 
 		__Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions.Value;
 
+    /// <seealso cref="Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions"/>
 	private IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions_Value()
 	{
-		var a_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90();
 		IEnumerable<Encounter> b_(Encounter SecondHTNEncounterReading140Over90)
 		{
-			var h_ = this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions();
+			IEnumerable<ServiceRequest> h_ = this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions();
 			bool? i_(ServiceRequest SecondHTN140Over90Interventions)
 			{
-				var m_ = SecondHTN140Over90Interventions?.AuthoredOnElement;
-				var n_ = context.Operators.Convert<CqlDateTime>(m_);
-				var o_ = SecondHTNEncounterReading140Over90?.Period;
-				var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				var q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+				FhirDateTime m_ = SecondHTN140Over90Interventions?.AuthoredOnElement;
+				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+				Period o_ = SecondHTNEncounterReading140Over90?.Period;
+				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
 
 				return q_;
 			};
-			var j_ = context.Operators.Where<ServiceRequest>(h_, i_);
+			IEnumerable<ServiceRequest> j_ = context.Operators.Where<ServiceRequest>(h_, i_);
 			Encounter k_(ServiceRequest SecondHTN140Over90Interventions) => 
 				SecondHTNEncounterReading140Over90;
-			var l_ = context.Operators.Select<ServiceRequest, Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Select<ServiceRequest, Encounter>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 		IEnumerable<Encounter> e_(Encounter SecondHTNEncounterReading140Over90)
 		{
-			var r_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
+			IEnumerable<ServiceRequest> r_ = this.Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading();
 			bool? s_(ServiceRequest ReferralToProfessional)
 			{
-				var w_ = ReferralToProfessional?.AuthoredOnElement;
-				var x_ = context.Operators.Convert<CqlDateTime>(w_);
-				var y_ = SecondHTNEncounterReading140Over90?.Period;
-				var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-				var aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
+				FhirDateTime w_ = ReferralToProfessional?.AuthoredOnElement;
+				CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+				Period y_ = SecondHTNEncounterReading140Over90?.Period;
+				CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+				bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
 
 				return aa_;
 			};
-			var t_ = context.Operators.Where<ServiceRequest>(r_, s_);
+			IEnumerable<ServiceRequest> t_ = context.Operators.Where<ServiceRequest>(r_, s_);
 			Encounter u_(ServiceRequest ReferralToProfessional) => 
 				SecondHTNEncounterReading140Over90;
-			var v_ = context.Operators.Select<ServiceRequest, Encounter>(t_, u_);
+			IEnumerable<Encounter> v_ = context.Operators.Select<ServiceRequest, Encounter>(t_, u_);
 
 			return v_;
 		};
-		var f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
-		var g_ = context.Operators.Union<Encounter>(c_, f_);
+		IEnumerable<Encounter> f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
+		IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions_Value"/>
     [CqlDeclaration("Encounter with Second Hypertensive Reading SBP Greater than or Equal to 140 OR DBP Greater than or Equal to 90 and Interventions")]
 	public IEnumerable<Encounter> Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions() => 
 		__Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Encounter_with_Normal_Blood_Pressure_Reading();
-		var b_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
-		var d_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions();
-		var e_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions();
-		var f_ = context.Operators.Union<Encounter>(d_, e_);
-		var g_ = context.Operators.Union<Encounter>(c_, f_);
-		var h_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions();
-		var i_ = context.Operators.Union<Encounter>(g_, h_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_Normal_Blood_Pressure_Reading();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80_and_Interventions();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80_and_Interventions();
+		IEnumerable<Encounter> e_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_and_Interventions();
+		IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(d_, e_);
+		IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
+		IEnumerable<Encounter> h_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_and_Interventions();
+		IEnumerable<Encounter> i_ = context.Operators.Union<Encounter>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement"/>
 	private IEnumerable<Encounter> Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement_Value()
 	{
-		var a_ = this.Qualifying_Encounter_during_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		IEnumerable<Encounter> b_(Encounter QualifyingEncounter)
 		{
-			var d_ = this.Systolic_blood_pressure();
-			var e_ = context.Operators.ToList<CqlCode>(d_);
-			var f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
-			var g_ = this.Diastolic_blood_pressure();
-			var h_ = context.Operators.ToList<CqlCode>(g_);
-			var i_ = context.Operators.RetrieveByCodes<Observation>(h_, null);
-			var j_ = context.Operators.Union<Observation>(f_, i_);
+			CqlCode d_ = this.Systolic_blood_pressure();
+			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			CqlCode g_ = this.Diastolic_blood_pressure();
+			IEnumerable<CqlCode> h_ = context.Operators.ToList<CqlCode>(g_);
+			IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, null);
+			IEnumerable<Observation> j_ = context.Operators.Union<Observation>(f_, i_);
 			bool? k_(Observation NoBPScreen)
 			{
-				var o_ = NoBPScreen?.IssuedElement;
-				var p_ = o_?.Value;
-				var q_ = context.Operators.Convert<CqlDateTime>(p_);
-				var r_ = QualifyingEncounter?.Period;
-				var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
+				Instant o_ = NoBPScreen?.IssuedElement;
+				DateTimeOffset? p_ = o_?.Value;
+				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+				Period r_ = QualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
 				bool? u_(Extension @this)
 				{
-					var at_ = @this?.Url;
-					var au_ = context.Operators.Convert<FhirUri>(at_);
-					var av_ = FHIRHelpers_4_3_000.ToString(au_);
-					var aw_ = context.Operators.Equal(av_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+					string at_ = @this?.Url;
+					FhirUri au_ = context.Operators.Convert<FhirUri>(at_);
+					string av_ = FHIRHelpers_4_3_000.ToString(au_);
+					bool? aw_ = context.Operators.Equal(av_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
 
 					return aw_;
 				};
-				var v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoBPScreen is DomainResource)
+				IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoBPScreen is DomainResource)
 						? ((NoBPScreen as DomainResource).Extension)
 						: null), u_);
 				DataType w_(Extension @this)
 				{
-					var ax_ = @this?.Value;
+					DataType ax_ = @this?.Value;
 
 					return ax_;
 				};
-				var x_ = context.Operators.Select<Extension, DataType>(v_, w_);
-				var y_ = context.Operators.SingletonFrom<DataType>(x_);
-				var z_ = context.Operators.Convert<CodeableConcept>(y_);
-				var aa_ = FHIRHelpers_4_3_000.ToConcept(z_);
-				var ab_ = this.Patient_Declined();
-				var ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+				IEnumerable<DataType> x_ = context.Operators.Select<Extension, DataType>(v_, w_);
+				DataType y_ = context.Operators.SingletonFrom<DataType>(x_);
+				CodeableConcept z_ = context.Operators.Convert<CodeableConcept>(y_);
+				CqlConcept aa_ = FHIRHelpers_4_3_000.ToConcept(z_);
+				CqlValueSet ab_ = this.Patient_Declined();
+				bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
 				bool? ad_(Extension @this)
 				{
-					var ay_ = @this?.Url;
-					var az_ = context.Operators.Convert<FhirUri>(ay_);
-					var ba_ = FHIRHelpers_4_3_000.ToString(az_);
-					var bb_ = context.Operators.Equal(ba_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+					string ay_ = @this?.Url;
+					FhirUri az_ = context.Operators.Convert<FhirUri>(ay_);
+					string ba_ = FHIRHelpers_4_3_000.ToString(az_);
+					bool? bb_ = context.Operators.Equal(ba_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
 
 					return bb_;
 				};
-				var ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoBPScreen is DomainResource)
+				IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoBPScreen is DomainResource)
 						? ((NoBPScreen as DomainResource).Extension)
 						: null), ad_);
 				DataType af_(Extension @this)
 				{
-					var bc_ = @this?.Value;
+					DataType bc_ = @this?.Value;
 
 					return bc_;
 				};
-				var ag_ = context.Operators.Select<Extension, DataType>(ae_, af_);
-				var ah_ = context.Operators.SingletonFrom<DataType>(ag_);
-				var ai_ = context.Operators.Convert<CodeableConcept>(ah_);
-				var aj_ = FHIRHelpers_4_3_000.ToConcept(ai_);
-				var ak_ = this.Medical_Reason();
-				var al_ = context.Operators.ConceptInValueSet(aj_, ak_);
-				var am_ = context.Operators.Or(ac_, al_);
-				var an_ = context.Operators.And(t_, am_);
-				var ao_ = NoBPScreen?.StatusElement;
-				var ap_ = ao_?.Value;
-				var aq_ = context.Operators.Convert<Code<ObservationStatus>>(ap_);
-				var ar_ = context.Operators.Equal(aq_, "cancelled");
-				var as_ = context.Operators.And(an_, ar_);
+				IEnumerable<DataType> ag_ = context.Operators.Select<Extension, DataType>(ae_, af_);
+				DataType ah_ = context.Operators.SingletonFrom<DataType>(ag_);
+				CodeableConcept ai_ = context.Operators.Convert<CodeableConcept>(ah_);
+				CqlConcept aj_ = FHIRHelpers_4_3_000.ToConcept(ai_);
+				CqlValueSet ak_ = this.Medical_Reason();
+				bool? al_ = context.Operators.ConceptInValueSet(aj_, ak_);
+				bool? am_ = context.Operators.Or(ac_, al_);
+				bool? an_ = context.Operators.And(t_, am_);
+				Code<ObservationStatus> ao_ = NoBPScreen?.StatusElement;
+				ObservationStatus? ap_ = ao_?.Value;
+				Code<ObservationStatus> aq_ = context.Operators.Convert<Code<ObservationStatus>>(ap_);
+				bool? ar_ = context.Operators.Equal(aq_, "cancelled");
+				bool? as_ = context.Operators.And(an_, ar_);
 
 				return as_;
 			};
-			var l_ = context.Operators.Where<Observation>(j_, k_);
+			IEnumerable<Observation> l_ = context.Operators.Where<Observation>(j_, k_);
 			Encounter m_(Observation NoBPScreen) => 
 				QualifyingEncounter;
-			var n_ = context.Operators.Select<Observation, Encounter>(l_, m_);
+			IEnumerable<Encounter> n_ = context.Operators.Select<Observation, Encounter>(l_, m_);
 
 			return n_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement_Value"/>
     [CqlDeclaration("Encounter with Medical Reason for Not Obtaining or Patient Declined Blood Pressure Measurement")]
 	public IEnumerable<Encounter> Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement() => 
 		__Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement.Value;
 
+    /// <seealso cref="NonPharmacological_Intervention_Not_Ordered"/>
 	private IEnumerable<ServiceRequest> NonPharmacological_Intervention_Not_Ordered_Value()
 	{
-		var a_ = this.Lifestyle_Recommendation();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var e_ = context.Operators.Union<ServiceRequest>(b_, d_);
-		var f_ = this.Weight_Reduction_Recommended();
-		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
-		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
-		var j_ = context.Operators.Union<ServiceRequest>(g_, i_);
-		var k_ = context.Operators.Union<ServiceRequest>(e_, j_);
-		var l_ = this.Dietary_Recommendations();
-		var m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
-		var o_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
-		var p_ = context.Operators.Union<ServiceRequest>(m_, o_);
-		var q_ = context.Operators.Union<ServiceRequest>(k_, p_);
-		var r_ = this.Recommendation_to_Increase_Physical_Activity();
-		var s_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, null);
-		var u_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, null);
-		var v_ = context.Operators.Union<ServiceRequest>(s_, u_);
-		var w_ = context.Operators.Union<ServiceRequest>(q_, v_);
-		var x_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
-		var y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
-		var aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
-		var ab_ = context.Operators.Union<ServiceRequest>(y_, aa_);
-		var ac_ = context.Operators.Union<ServiceRequest>(w_, ab_);
+		CqlValueSet a_ = this.Lifestyle_Recommendation();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
+		CqlValueSet f_ = this.Weight_Reduction_Recommended();
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
+		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
+		CqlValueSet l_ = this.Dietary_Recommendations();
+		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
+		IEnumerable<ServiceRequest> o_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
+		IEnumerable<ServiceRequest> p_ = context.Operators.Union<ServiceRequest>(m_, o_);
+		IEnumerable<ServiceRequest> q_ = context.Operators.Union<ServiceRequest>(k_, p_);
+		CqlValueSet r_ = this.Recommendation_to_Increase_Physical_Activity();
+		IEnumerable<ServiceRequest> s_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, null);
+		IEnumerable<ServiceRequest> u_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, null);
+		IEnumerable<ServiceRequest> v_ = context.Operators.Union<ServiceRequest>(s_, u_);
+		IEnumerable<ServiceRequest> w_ = context.Operators.Union<ServiceRequest>(q_, v_);
+		CqlValueSet x_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
+		IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+		IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+		IEnumerable<ServiceRequest> ab_ = context.Operators.Union<ServiceRequest>(y_, aa_);
+		IEnumerable<ServiceRequest> ac_ = context.Operators.Union<ServiceRequest>(w_, ab_);
 		bool? ad_(ServiceRequest NonPharmIntervention)
 		{
 			bool? af_(Extension @this)
 			{
-				var at_ = @this?.Url;
-				var au_ = context.Operators.Convert<FhirUri>(at_);
-				var av_ = FHIRHelpers_4_3_000.ToString(au_);
-				var aw_ = context.Operators.Equal(av_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+				string at_ = @this?.Url;
+				FhirUri au_ = context.Operators.Convert<FhirUri>(at_);
+				string av_ = FHIRHelpers_4_3_000.ToString(au_);
+				bool? aw_ = context.Operators.Equal(av_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
 
 				return aw_;
 			};
-			var ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NonPharmIntervention is DomainResource)
+			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NonPharmIntervention is DomainResource)
 					? ((NonPharmIntervention as DomainResource).Extension)
 					: null), af_);
 			DataType ah_(Extension @this)
 			{
-				var ax_ = @this?.Value;
+				DataType ax_ = @this?.Value;
 
 				return ax_;
 			};
-			var ai_ = context.Operators.Select<Extension, DataType>(ag_, ah_);
-			var aj_ = context.Operators.SingletonFrom<DataType>(ai_);
-			var ak_ = context.Operators.Convert<CodeableConcept>(aj_);
-			var al_ = FHIRHelpers_4_3_000.ToConcept(ak_);
-			var am_ = this.Patient_Declined();
-			var an_ = context.Operators.ConceptInValueSet(al_, am_);
-			var ao_ = NonPharmIntervention?.StatusElement;
-			var ap_ = ao_?.Value;
-			var aq_ = context.Operators.Convert<Code<RequestStatus>>(ap_);
-			var ar_ = context.Operators.Equal(aq_, "completed");
-			var as_ = context.Operators.And(an_, ar_);
+			IEnumerable<DataType> ai_ = context.Operators.Select<Extension, DataType>(ag_, ah_);
+			DataType aj_ = context.Operators.SingletonFrom<DataType>(ai_);
+			CodeableConcept ak_ = context.Operators.Convert<CodeableConcept>(aj_);
+			CqlConcept al_ = FHIRHelpers_4_3_000.ToConcept(ak_);
+			CqlValueSet am_ = this.Patient_Declined();
+			bool? an_ = context.Operators.ConceptInValueSet(al_, am_);
+			Code<RequestStatus> ao_ = NonPharmIntervention?.StatusElement;
+			RequestStatus? ap_ = ao_?.Value;
+			Code<RequestStatus> aq_ = context.Operators.Convert<Code<RequestStatus>>(ap_);
+			bool? ar_ = context.Operators.Equal(aq_, "completed");
+			bool? as_ = context.Operators.And(an_, ar_);
 
 			return as_;
 		};
-		var ae_ = context.Operators.Where<ServiceRequest>(ac_, ad_);
+		IEnumerable<ServiceRequest> ae_ = context.Operators.Where<ServiceRequest>(ac_, ad_);
 
 		return ae_;
 	}
 
+    /// <seealso cref="NonPharmacological_Intervention_Not_Ordered_Value"/>
     [CqlDeclaration("NonPharmacological Intervention Not Ordered")]
 	public IEnumerable<ServiceRequest> NonPharmacological_Intervention_Not_Ordered() => 
 		__NonPharmacological_Intervention_Not_Ordered.Value;
 
+    /// <seealso cref="Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered"/>
 	private IEnumerable<ServiceRequest> Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered_Value()
 	{
-		var a_ = this._12_lead_EKG_panel();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
-		var d_ = this.EKG_study();
-		var e_ = context.Operators.ToList<CqlCode>(d_);
-		var f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
-		var g_ = context.Operators.Union<ServiceRequest>(c_, f_);
-		var h_ = this.Laboratory_Tests_for_Hypertension();
-		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
-		var k_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
-		var l_ = context.Operators.Union<ServiceRequest>(i_, k_);
-		var m_ = context.Operators.Union<ServiceRequest>(g_, l_);
+		CqlCode a_ = this._12_lead_EKG_panel();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
+		CqlCode d_ = this.EKG_study();
+		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
+		IEnumerable<ServiceRequest> g_ = context.Operators.Union<ServiceRequest>(c_, f_);
+		CqlValueSet h_ = this.Laboratory_Tests_for_Hypertension();
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		IEnumerable<ServiceRequest> l_ = context.Operators.Union<ServiceRequest>(i_, k_);
+		IEnumerable<ServiceRequest> m_ = context.Operators.Union<ServiceRequest>(g_, l_);
 		bool? n_(ServiceRequest LabECGNotDone)
 		{
 			bool? p_(Extension @this)
 			{
-				var y_ = @this?.Url;
-				var z_ = context.Operators.Convert<FhirUri>(y_);
-				var aa_ = FHIRHelpers_4_3_000.ToString(z_);
-				var ab_ = context.Operators.Equal(aa_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+				string y_ = @this?.Url;
+				FhirUri z_ = context.Operators.Convert<FhirUri>(y_);
+				string aa_ = FHIRHelpers_4_3_000.ToString(z_);
+				bool? ab_ = context.Operators.Equal(aa_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
 
 				return ab_;
 			};
-			var q_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((LabECGNotDone is DomainResource)
+			IEnumerable<Extension> q_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((LabECGNotDone is DomainResource)
 					? ((LabECGNotDone as DomainResource).Extension)
 					: null), p_);
 			DataType r_(Extension @this)
 			{
-				var ac_ = @this?.Value;
+				DataType ac_ = @this?.Value;
 
 				return ac_;
 			};
-			var s_ = context.Operators.Select<Extension, DataType>(q_, r_);
-			var t_ = context.Operators.SingletonFrom<DataType>(s_);
-			var u_ = context.Operators.Convert<CodeableConcept>(t_);
-			var v_ = FHIRHelpers_4_3_000.ToConcept(u_);
-			var w_ = this.Patient_Declined();
-			var x_ = context.Operators.ConceptInValueSet(v_, w_);
+			IEnumerable<DataType> s_ = context.Operators.Select<Extension, DataType>(q_, r_);
+			DataType t_ = context.Operators.SingletonFrom<DataType>(s_);
+			CodeableConcept u_ = context.Operators.Convert<CodeableConcept>(t_);
+			CqlConcept v_ = FHIRHelpers_4_3_000.ToConcept(u_);
+			CqlValueSet w_ = this.Patient_Declined();
+			bool? x_ = context.Operators.ConceptInValueSet(v_, w_);
 
 			return x_;
 		};
-		var o_ = context.Operators.Where<ServiceRequest>(m_, n_);
+		IEnumerable<ServiceRequest> o_ = context.Operators.Where<ServiceRequest>(m_, n_);
 
 		return o_;
 	}
 
+    /// <seealso cref="Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered_Value"/>
     [CqlDeclaration("Laboratory Test or ECG for Hypertension Not Ordered")]
 	public IEnumerable<ServiceRequest> Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered() => 
 		__Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered.Value;
 
+    /// <seealso cref="Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined"/>
 	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined_Value()
 	{
-		var a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var e_ = context.Operators.Union<ServiceRequest>(b_, d_);
-		var f_ = this.Follow_up_2_3_months__finding_();
-		var g_ = context.Operators.ToList<CqlCode>(f_);
-		var h_ = context.Operators.RetrieveByCodes<ServiceRequest>(g_, null);
-		var i_ = this.Follow_up_4_6_months__finding_();
-		var j_ = context.Operators.ToList<CqlCode>(i_);
-		var k_ = context.Operators.RetrieveByCodes<ServiceRequest>(j_, null);
-		var l_ = context.Operators.Union<ServiceRequest>(h_, k_);
-		var m_ = context.Operators.Union<ServiceRequest>(e_, l_);
+		CqlValueSet a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
+		CqlCode f_ = this.Follow_up_2_3_months__finding_();
+		IEnumerable<CqlCode> g_ = context.Operators.ToList<CqlCode>(f_);
+		IEnumerable<ServiceRequest> h_ = context.Operators.RetrieveByCodes<ServiceRequest>(g_, null);
+		CqlCode i_ = this.Follow_up_4_6_months__finding_();
+		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
+		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByCodes<ServiceRequest>(j_, null);
+		IEnumerable<ServiceRequest> l_ = context.Operators.Union<ServiceRequest>(h_, k_);
+		IEnumerable<ServiceRequest> m_ = context.Operators.Union<ServiceRequest>(e_, l_);
 		bool? n_(ServiceRequest SecondHTNDeclinedReferralAndFollowUp)
 		{
 			bool? t_(Extension @this)
 			{
-				var ah_ = @this?.Url;
-				var ai_ = context.Operators.Convert<FhirUri>(ah_);
-				var aj_ = FHIRHelpers_4_3_000.ToString(ai_);
-				var ak_ = context.Operators.Equal(aj_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+				string ah_ = @this?.Url;
+				FhirUri ai_ = context.Operators.Convert<FhirUri>(ah_);
+				string aj_ = FHIRHelpers_4_3_000.ToString(ai_);
+				bool? ak_ = context.Operators.Equal(aj_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
 
 				return ak_;
 			};
-			var u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((SecondHTNDeclinedReferralAndFollowUp is DomainResource)
+			IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((SecondHTNDeclinedReferralAndFollowUp is DomainResource)
 					? ((SecondHTNDeclinedReferralAndFollowUp as DomainResource).Extension)
 					: null), t_);
 			DataType v_(Extension @this)
 			{
-				var al_ = @this?.Value;
+				DataType al_ = @this?.Value;
 
 				return al_;
 			};
-			var w_ = context.Operators.Select<Extension, DataType>(u_, v_);
-			var x_ = context.Operators.SingletonFrom<DataType>(w_);
-			var y_ = context.Operators.Convert<CodeableConcept>(x_);
-			var z_ = FHIRHelpers_4_3_000.ToConcept(y_);
-			var aa_ = this.Patient_Declined();
-			var ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-			var ac_ = SecondHTNDeclinedReferralAndFollowUp?.StatusElement;
-			var ad_ = ac_?.Value;
-			var ae_ = context.Operators.Convert<Code<RequestStatus>>(ad_);
-			var af_ = context.Operators.Equal(ae_, "completed");
-			var ag_ = context.Operators.And(ab_, af_);
+			IEnumerable<DataType> w_ = context.Operators.Select<Extension, DataType>(u_, v_);
+			DataType x_ = context.Operators.SingletonFrom<DataType>(w_);
+			CodeableConcept y_ = context.Operators.Convert<CodeableConcept>(x_);
+			CqlConcept z_ = FHIRHelpers_4_3_000.ToConcept(y_);
+			CqlValueSet aa_ = this.Patient_Declined();
+			bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+			Code<RequestStatus> ac_ = SecondHTNDeclinedReferralAndFollowUp?.StatusElement;
+			RequestStatus? ad_ = ac_?.Value;
+			Code<RequestStatus> ae_ = context.Operators.Convert<Code<RequestStatus>>(ad_);
+			bool? af_ = context.Operators.Equal(ae_, "completed");
+			bool? ag_ = context.Operators.And(ab_, af_);
 
 			return ag_;
 		};
-		var o_ = context.Operators.Where<ServiceRequest>(m_, n_);
-		var p_ = this.Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered();
-		var q_ = context.Operators.Union<ServiceRequest>(o_, p_);
-		var r_ = this.NonPharmacological_Intervention_Not_Ordered();
-		var s_ = context.Operators.Union<ServiceRequest>(q_, r_);
+		IEnumerable<ServiceRequest> o_ = context.Operators.Where<ServiceRequest>(m_, n_);
+		IEnumerable<ServiceRequest> p_ = this.Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered();
+		IEnumerable<ServiceRequest> q_ = context.Operators.Union<ServiceRequest>(o_, p_);
+		IEnumerable<ServiceRequest> r_ = this.NonPharmacological_Intervention_Not_Ordered();
+		IEnumerable<ServiceRequest> s_ = context.Operators.Union<ServiceRequest>(q_, r_);
 
 		return s_;
 	}
 
+    /// <seealso cref="Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined_Value"/>
     [CqlDeclaration("Second Hypertensive Reading SBP 130 to 139 OR DBP 80 to 89 Interventions Declined")]
 	public IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined() => 
 		__Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined.Value;
 
+    /// <seealso cref="Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined"/>
 	private IEnumerable<object> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined_Value()
 	{
-		var a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var e_ = context.Operators.Union<ServiceRequest>(b_, d_);
-		var f_ = this.Follow_Up_Within_4_Weeks();
-		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
-		var i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
-		var j_ = context.Operators.Union<ServiceRequest>(g_, i_);
-		var k_ = context.Operators.Union<ServiceRequest>(e_, j_);
+		CqlValueSet a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
+		CqlValueSet f_ = this.Follow_Up_Within_4_Weeks();
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
+		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
 		bool? l_(ServiceRequest SecondHTN140Over90ReferralFollowUpNotDone)
 		{
 			bool? z_(Extension @this)
 			{
-				var an_ = @this?.Url;
-				var ao_ = context.Operators.Convert<FhirUri>(an_);
-				var ap_ = FHIRHelpers_4_3_000.ToString(ao_);
-				var aq_ = context.Operators.Equal(ap_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+				string an_ = @this?.Url;
+				FhirUri ao_ = context.Operators.Convert<FhirUri>(an_);
+				string ap_ = FHIRHelpers_4_3_000.ToString(ao_);
+				bool? aq_ = context.Operators.Equal(ap_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
 
 				return aq_;
 			};
-			var aa_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((SecondHTN140Over90ReferralFollowUpNotDone is DomainResource)
+			IEnumerable<Extension> aa_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((SecondHTN140Over90ReferralFollowUpNotDone is DomainResource)
 					? ((SecondHTN140Over90ReferralFollowUpNotDone as DomainResource).Extension)
 					: null), z_);
 			DataType ab_(Extension @this)
 			{
-				var ar_ = @this?.Value;
+				DataType ar_ = @this?.Value;
 
 				return ar_;
 			};
-			var ac_ = context.Operators.Select<Extension, DataType>(aa_, ab_);
-			var ad_ = context.Operators.SingletonFrom<DataType>(ac_);
-			var ae_ = context.Operators.Convert<CodeableConcept>(ad_);
-			var af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
-			var ag_ = this.Patient_Declined();
-			var ah_ = context.Operators.ConceptInValueSet(af_, ag_);
-			var ai_ = SecondHTN140Over90ReferralFollowUpNotDone?.StatusElement;
-			var aj_ = ai_?.Value;
-			var ak_ = context.Operators.Convert<Code<RequestStatus>>(aj_);
-			var al_ = context.Operators.Equal(ak_, "completed");
-			var am_ = context.Operators.And(ah_, al_);
+			IEnumerable<DataType> ac_ = context.Operators.Select<Extension, DataType>(aa_, ab_);
+			DataType ad_ = context.Operators.SingletonFrom<DataType>(ac_);
+			CodeableConcept ae_ = context.Operators.Convert<CodeableConcept>(ad_);
+			CqlConcept af_ = FHIRHelpers_4_3_000.ToConcept(ae_);
+			CqlValueSet ag_ = this.Patient_Declined();
+			bool? ah_ = context.Operators.ConceptInValueSet(af_, ag_);
+			Code<RequestStatus> ai_ = SecondHTN140Over90ReferralFollowUpNotDone?.StatusElement;
+			RequestStatus? aj_ = ai_?.Value;
+			Code<RequestStatus> ak_ = context.Operators.Convert<Code<RequestStatus>>(aj_);
+			bool? al_ = context.Operators.Equal(ak_, "completed");
+			bool? am_ = context.Operators.And(ah_, al_);
 
 			return am_;
 		};
-		var m_ = context.Operators.Where<ServiceRequest>(k_, l_);
-		var n_ = this.Pharmacologic_Therapy_for_Hypertension();
-		var o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
-		var q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
-		var r_ = context.Operators.Union<MedicationRequest>(o_, q_);
+		IEnumerable<ServiceRequest> m_ = context.Operators.Where<ServiceRequest>(k_, l_);
+		CqlValueSet n_ = this.Pharmacologic_Therapy_for_Hypertension();
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		IEnumerable<MedicationRequest> r_ = context.Operators.Union<MedicationRequest>(o_, q_);
 		bool? s_(MedicationRequest MedicationRequestNotOrdered)
 		{
-			var as_ = MedicationRequestNotOrdered?.StatusElement;
-			var at_ = as_?.Value;
-			var au_ = context.Operators.Convert<string>(at_);
-			var av_ = context.Operators.Equal(au_, "completed");
+			Code<MedicationRequest.MedicationrequestStatus> as_ = MedicationRequestNotOrdered?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? at_ = as_?.Value;
+			string au_ = context.Operators.Convert<string>(at_);
+			bool? av_ = context.Operators.Equal(au_, "completed");
 
 			return av_;
 		};
-		var t_ = context.Operators.Where<MedicationRequest>(r_, s_);
-		var u_ = context.Operators.Union<object>((m_ as IEnumerable<object>), (t_ as IEnumerable<object>));
-		var v_ = this.Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered();
-		var w_ = context.Operators.Union<object>(u_, (v_ as IEnumerable<object>));
-		var x_ = this.NonPharmacological_Intervention_Not_Ordered();
-		var y_ = context.Operators.Union<object>(w_, (x_ as IEnumerable<object>));
+		IEnumerable<MedicationRequest> t_ = context.Operators.Where<MedicationRequest>(r_, s_);
+		IEnumerable<object> u_ = context.Operators.Union<object>((m_ as IEnumerable<object>), (t_ as IEnumerable<object>));
+		IEnumerable<ServiceRequest> v_ = this.Laboratory_Test_or_ECG_for_Hypertension_Not_Ordered();
+		IEnumerable<object> w_ = context.Operators.Union<object>(u_, (v_ as IEnumerable<object>));
+		IEnumerable<ServiceRequest> x_ = this.NonPharmacological_Intervention_Not_Ordered();
+		IEnumerable<object> y_ = context.Operators.Union<object>(w_, (x_ as IEnumerable<object>));
 
 		return y_;
 	}
 
+    /// <seealso cref="Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined_Value"/>
     [CqlDeclaration("Second Hypertensive Reading SBP Greater than or Equal to 140 OR DBP Greater than or Equal to 90 Interventions Declined")]
 	public IEnumerable<object> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined() => 
 		__Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined.Value;
 
+    /// <seealso cref="Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient"/>
 	private IEnumerable<Encounter> Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient_Value()
 	{
-		var a_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Elevated_Blood_Pressure_Reading_SBP_120_to_129_AND_DBP_less_than_80();
 		IEnumerable<Encounter> b_(Encounter ElevatedBPEncounter)
 		{
-			var x_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-			var y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
-			var aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
-			var ab_ = context.Operators.Union<ServiceRequest>(y_, aa_);
-			var ac_ = this.Follow_up_2_3_months__finding_();
-			var ad_ = context.Operators.ToList<CqlCode>(ac_);
-			var ae_ = context.Operators.RetrieveByCodes<ServiceRequest>(ad_, null);
-			var af_ = this.Follow_up_4_6_months__finding_();
-			var ag_ = context.Operators.ToList<CqlCode>(af_);
-			var ah_ = context.Operators.RetrieveByCodes<ServiceRequest>(ag_, null);
-			var ai_ = context.Operators.Union<ServiceRequest>(ae_, ah_);
-			var aj_ = context.Operators.Union<ServiceRequest>(ab_, ai_);
+			CqlValueSet x_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+			IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+			IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+			IEnumerable<ServiceRequest> ab_ = context.Operators.Union<ServiceRequest>(y_, aa_);
+			CqlCode ac_ = this.Follow_up_2_3_months__finding_();
+			IEnumerable<CqlCode> ad_ = context.Operators.ToList<CqlCode>(ac_);
+			IEnumerable<ServiceRequest> ae_ = context.Operators.RetrieveByCodes<ServiceRequest>(ad_, null);
+			CqlCode af_ = this.Follow_up_4_6_months__finding_();
+			IEnumerable<CqlCode> ag_ = context.Operators.ToList<CqlCode>(af_);
+			IEnumerable<ServiceRequest> ah_ = context.Operators.RetrieveByCodes<ServiceRequest>(ag_, null);
+			IEnumerable<ServiceRequest> ai_ = context.Operators.Union<ServiceRequest>(ae_, ah_);
+			IEnumerable<ServiceRequest> aj_ = context.Operators.Union<ServiceRequest>(ab_, ai_);
 			bool? ak_(ServiceRequest ElevatedBPDeclinedInterventions)
 			{
 				bool? ao_(Extension @this)
 				{
-					var bi_ = @this?.Url;
-					var bj_ = context.Operators.Convert<FhirUri>(bi_);
-					var bk_ = FHIRHelpers_4_3_000.ToString(bj_);
-					var bl_ = context.Operators.Equal(bk_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+					string bi_ = @this?.Url;
+					FhirUri bj_ = context.Operators.Convert<FhirUri>(bi_);
+					string bk_ = FHIRHelpers_4_3_000.ToString(bj_);
+					bool? bl_ = context.Operators.Equal(bk_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
 
 					return bl_;
 				};
-				var ap_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((ElevatedBPDeclinedInterventions is DomainResource)
+				IEnumerable<Extension> ap_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((ElevatedBPDeclinedInterventions is DomainResource)
 						? ((ElevatedBPDeclinedInterventions as DomainResource).Extension)
 						: null), ao_);
 				DataType aq_(Extension @this)
 				{
-					var bm_ = @this?.Value;
+					DataType bm_ = @this?.Value;
 
 					return bm_;
 				};
-				var ar_ = context.Operators.Select<Extension, DataType>(ap_, aq_);
-				var as_ = context.Operators.SingletonFrom<DataType>(ar_);
-				var at_ = context.Operators.Convert<CodeableConcept>(as_);
-				var au_ = FHIRHelpers_4_3_000.ToConcept(at_);
-				var av_ = this.Patient_Declined();
-				var aw_ = context.Operators.ConceptInValueSet(au_, av_);
-				var ax_ = ElevatedBPDeclinedInterventions?.AuthoredOnElement;
-				var ay_ = context.Operators.Convert<CqlDateTime>(ax_);
-				var az_ = ElevatedBPEncounter?.Period;
-				var ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
-				var bb_ = context.Operators.In<CqlDateTime>(ay_, ba_, "day");
-				var bc_ = context.Operators.And(aw_, bb_);
-				var bd_ = ElevatedBPDeclinedInterventions?.StatusElement;
-				var be_ = bd_?.Value;
-				var bf_ = context.Operators.Convert<Code<RequestStatus>>(be_);
-				var bg_ = context.Operators.Equal(bf_, "completed");
-				var bh_ = context.Operators.And(bc_, bg_);
+				IEnumerable<DataType> ar_ = context.Operators.Select<Extension, DataType>(ap_, aq_);
+				DataType as_ = context.Operators.SingletonFrom<DataType>(ar_);
+				CodeableConcept at_ = context.Operators.Convert<CodeableConcept>(as_);
+				CqlConcept au_ = FHIRHelpers_4_3_000.ToConcept(at_);
+				CqlValueSet av_ = this.Patient_Declined();
+				bool? aw_ = context.Operators.ConceptInValueSet(au_, av_);
+				FhirDateTime ax_ = ElevatedBPDeclinedInterventions?.AuthoredOnElement;
+				CqlDateTime ay_ = context.Operators.Convert<CqlDateTime>(ax_);
+				Period az_ = ElevatedBPEncounter?.Period;
+				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
+				bool? bb_ = context.Operators.In<CqlDateTime>(ay_, ba_, "day");
+				bool? bc_ = context.Operators.And(aw_, bb_);
+				Code<RequestStatus> bd_ = ElevatedBPDeclinedInterventions?.StatusElement;
+				RequestStatus? be_ = bd_?.Value;
+				Code<RequestStatus> bf_ = context.Operators.Convert<Code<RequestStatus>>(be_);
+				bool? bg_ = context.Operators.Equal(bf_, "completed");
+				bool? bh_ = context.Operators.And(bc_, bg_);
 
 				return bh_;
 			};
-			var al_ = context.Operators.Where<ServiceRequest>(aj_, ak_);
+			IEnumerable<ServiceRequest> al_ = context.Operators.Where<ServiceRequest>(aj_, ak_);
 			Encounter am_(ServiceRequest ElevatedBPDeclinedInterventions) => 
 				ElevatedBPEncounter;
-			var an_ = context.Operators.Select<ServiceRequest, Encounter>(al_, am_);
+			IEnumerable<Encounter> an_ = context.Operators.Select<ServiceRequest, Encounter>(al_, am_);
 
 			return an_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 		IEnumerable<Encounter> e_(Encounter ElevatedBPEncounter)
 		{
-			var bn_ = this.NonPharmacological_Intervention_Not_Ordered();
+			IEnumerable<ServiceRequest> bn_ = this.NonPharmacological_Intervention_Not_Ordered();
 			bool? bo_(ServiceRequest NotOrdered)
 			{
-				var bs_ = NotOrdered?.AuthoredOnElement;
-				var bt_ = context.Operators.Convert<CqlDateTime>(bs_);
-				var bu_ = ElevatedBPEncounter?.Period;
-				var bv_ = FHIRHelpers_4_3_000.ToInterval(bu_);
-				var bw_ = context.Operators.In<CqlDateTime>(bt_, bv_, "day");
+				FhirDateTime bs_ = NotOrdered?.AuthoredOnElement;
+				CqlDateTime bt_ = context.Operators.Convert<CqlDateTime>(bs_);
+				Period bu_ = ElevatedBPEncounter?.Period;
+				CqlInterval<CqlDateTime> bv_ = FHIRHelpers_4_3_000.ToInterval(bu_);
+				bool? bw_ = context.Operators.In<CqlDateTime>(bt_, bv_, "day");
 
 				return bw_;
 			};
-			var bp_ = context.Operators.Where<ServiceRequest>(bn_, bo_);
+			IEnumerable<ServiceRequest> bp_ = context.Operators.Where<ServiceRequest>(bn_, bo_);
 			Encounter bq_(ServiceRequest NotOrdered) => 
 				ElevatedBPEncounter;
-			var br_ = context.Operators.Select<ServiceRequest, Encounter>(bp_, bq_);
+			IEnumerable<Encounter> br_ = context.Operators.Select<ServiceRequest, Encounter>(bp_, bq_);
 
 			return br_;
 		};
-		var f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
-		var g_ = context.Operators.Union<Encounter>(c_, f_);
-		var h_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80();
+		IEnumerable<Encounter> f_ = context.Operators.SelectMany<Encounter, Encounter>(a_, e_);
+		IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
+		IEnumerable<Encounter> h_ = this.Encounter_with_First_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_130_OR_DBP_Greater_than_or_Equal_to_80();
 		IEnumerable<Encounter> i_(Encounter FirstHTNEncounter)
 		{
-			var bx_ = this.Follow_Up_Within_4_Weeks();
-			var by_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, null);
-			var ca_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, null);
-			var cb_ = context.Operators.Union<ServiceRequest>(by_, ca_);
-			var cc_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-			var cd_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, null);
-			var cf_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, null);
-			var cg_ = context.Operators.Union<ServiceRequest>(cd_, cf_);
-			var ch_ = context.Operators.Union<ServiceRequest>(cb_, cg_);
+			CqlValueSet bx_ = this.Follow_Up_Within_4_Weeks();
+			IEnumerable<ServiceRequest> by_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, null);
+			IEnumerable<ServiceRequest> ca_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, null);
+			IEnumerable<ServiceRequest> cb_ = context.Operators.Union<ServiceRequest>(by_, ca_);
+			CqlValueSet cc_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
+			IEnumerable<ServiceRequest> cd_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, null);
+			IEnumerable<ServiceRequest> cf_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, null);
+			IEnumerable<ServiceRequest> cg_ = context.Operators.Union<ServiceRequest>(cd_, cf_);
+			IEnumerable<ServiceRequest> ch_ = context.Operators.Union<ServiceRequest>(cb_, cg_);
 			bool? ci_(ServiceRequest FirstHTNDeclinedInterventions)
 			{
 				bool? cm_(Extension @this)
 				{
-					var dg_ = @this?.Url;
-					var dh_ = context.Operators.Convert<FhirUri>(dg_);
-					var di_ = FHIRHelpers_4_3_000.ToString(dh_);
-					var dj_ = context.Operators.Equal(di_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
+					string dg_ = @this?.Url;
+					FhirUri dh_ = context.Operators.Convert<FhirUri>(dg_);
+					string di_ = FHIRHelpers_4_3_000.ToString(dh_);
+					bool? dj_ = context.Operators.Equal(di_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerformReason");
 
 					return dj_;
 				};
-				var cn_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((FirstHTNDeclinedInterventions is DomainResource)
+				IEnumerable<Extension> cn_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((FirstHTNDeclinedInterventions is DomainResource)
 						? ((FirstHTNDeclinedInterventions as DomainResource).Extension)
 						: null), cm_);
 				DataType co_(Extension @this)
 				{
-					var dk_ = @this?.Value;
+					DataType dk_ = @this?.Value;
 
 					return dk_;
 				};
-				var cp_ = context.Operators.Select<Extension, DataType>(cn_, co_);
-				var cq_ = context.Operators.SingletonFrom<DataType>(cp_);
-				var cr_ = context.Operators.Convert<CodeableConcept>(cq_);
-				var cs_ = FHIRHelpers_4_3_000.ToConcept(cr_);
-				var ct_ = this.Patient_Declined();
-				var cu_ = context.Operators.ConceptInValueSet(cs_, ct_);
-				var cv_ = FirstHTNDeclinedInterventions?.AuthoredOnElement;
-				var cw_ = context.Operators.Convert<CqlDateTime>(cv_);
-				var cx_ = FirstHTNEncounter?.Period;
-				var cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
-				var cz_ = context.Operators.In<CqlDateTime>(cw_, cy_, "day");
-				var da_ = context.Operators.And(cu_, cz_);
-				var db_ = FirstHTNDeclinedInterventions?.StatusElement;
-				var dc_ = db_?.Value;
-				var dd_ = context.Operators.Convert<Code<RequestStatus>>(dc_);
-				var de_ = context.Operators.Equal(dd_, "completed");
-				var df_ = context.Operators.And(da_, de_);
+				IEnumerable<DataType> cp_ = context.Operators.Select<Extension, DataType>(cn_, co_);
+				DataType cq_ = context.Operators.SingletonFrom<DataType>(cp_);
+				CodeableConcept cr_ = context.Operators.Convert<CodeableConcept>(cq_);
+				CqlConcept cs_ = FHIRHelpers_4_3_000.ToConcept(cr_);
+				CqlValueSet ct_ = this.Patient_Declined();
+				bool? cu_ = context.Operators.ConceptInValueSet(cs_, ct_);
+				FhirDateTime cv_ = FirstHTNDeclinedInterventions?.AuthoredOnElement;
+				CqlDateTime cw_ = context.Operators.Convert<CqlDateTime>(cv_);
+				Period cx_ = FirstHTNEncounter?.Period;
+				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
+				bool? cz_ = context.Operators.In<CqlDateTime>(cw_, cy_, "day");
+				bool? da_ = context.Operators.And(cu_, cz_);
+				Code<RequestStatus> db_ = FirstHTNDeclinedInterventions?.StatusElement;
+				RequestStatus? dc_ = db_?.Value;
+				Code<RequestStatus> dd_ = context.Operators.Convert<Code<RequestStatus>>(dc_);
+				bool? de_ = context.Operators.Equal(dd_, "completed");
+				bool? df_ = context.Operators.And(da_, de_);
 
 				return df_;
 			};
-			var cj_ = context.Operators.Where<ServiceRequest>(ch_, ci_);
+			IEnumerable<ServiceRequest> cj_ = context.Operators.Where<ServiceRequest>(ch_, ci_);
 			Encounter ck_(ServiceRequest FirstHTNDeclinedInterventions) => 
 				FirstHTNEncounter;
-			var cl_ = context.Operators.Select<ServiceRequest, Encounter>(cj_, ck_);
+			IEnumerable<Encounter> cl_ = context.Operators.Select<ServiceRequest, Encounter>(cj_, ck_);
 
 			return cl_;
 		};
-		var j_ = context.Operators.SelectMany<Encounter, Encounter>(h_, i_);
+		IEnumerable<Encounter> j_ = context.Operators.SelectMany<Encounter, Encounter>(h_, i_);
 		IEnumerable<Encounter> l_(Encounter FirstHTNEncounter)
 		{
-			var dl_ = this.NonPharmacological_Intervention_Not_Ordered();
+			IEnumerable<ServiceRequest> dl_ = this.NonPharmacological_Intervention_Not_Ordered();
 			bool? dm_(ServiceRequest NoNonPharm)
 			{
-				var dq_ = NoNonPharm?.AuthoredOnElement;
-				var dr_ = context.Operators.Convert<CqlDateTime>(dq_);
-				var ds_ = FirstHTNEncounter?.Period;
-				var dt_ = FHIRHelpers_4_3_000.ToInterval(ds_);
-				var du_ = context.Operators.In<CqlDateTime>(dr_, dt_, "day");
+				FhirDateTime dq_ = NoNonPharm?.AuthoredOnElement;
+				CqlDateTime dr_ = context.Operators.Convert<CqlDateTime>(dq_);
+				Period ds_ = FirstHTNEncounter?.Period;
+				CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(ds_);
+				bool? du_ = context.Operators.In<CqlDateTime>(dr_, dt_, "day");
 
 				return du_;
 			};
-			var dn_ = context.Operators.Where<ServiceRequest>(dl_, dm_);
+			IEnumerable<ServiceRequest> dn_ = context.Operators.Where<ServiceRequest>(dl_, dm_);
 			Encounter do_(ServiceRequest NoNonPharm) => 
 				FirstHTNEncounter;
-			var dp_ = context.Operators.Select<ServiceRequest, Encounter>(dn_, do_);
+			IEnumerable<Encounter> dp_ = context.Operators.Select<ServiceRequest, Encounter>(dn_, do_);
 
 			return dp_;
 		};
-		var m_ = context.Operators.SelectMany<Encounter, Encounter>(h_, l_);
-		var n_ = context.Operators.Union<Encounter>(j_, m_);
-		var o_ = context.Operators.Union<Encounter>(g_, n_);
-		var p_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89();
+		IEnumerable<Encounter> m_ = context.Operators.SelectMany<Encounter, Encounter>(h_, l_);
+		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(j_, m_);
+		IEnumerable<Encounter> o_ = context.Operators.Union<Encounter>(g_, n_);
+		IEnumerable<Encounter> p_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89();
 		IEnumerable<Encounter> q_(Encounter SecondHTNEncounter)
 		{
-			var dv_ = this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined();
+			IEnumerable<ServiceRequest> dv_ = this.Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined();
 			bool? dw_(ServiceRequest SecondHTNDeclinedInterventions)
 			{
-				var ea_ = SecondHTNDeclinedInterventions?.AuthoredOnElement;
-				var eb_ = context.Operators.Convert<CqlDateTime>(ea_);
-				var ec_ = SecondHTNEncounter?.Period;
-				var ed_ = FHIRHelpers_4_3_000.ToInterval(ec_);
-				var ee_ = context.Operators.In<CqlDateTime>(eb_, ed_, "day");
+				FhirDateTime ea_ = SecondHTNDeclinedInterventions?.AuthoredOnElement;
+				CqlDateTime eb_ = context.Operators.Convert<CqlDateTime>(ea_);
+				Period ec_ = SecondHTNEncounter?.Period;
+				CqlInterval<CqlDateTime> ed_ = FHIRHelpers_4_3_000.ToInterval(ec_);
+				bool? ee_ = context.Operators.In<CqlDateTime>(eb_, ed_, "day");
 
 				return ee_;
 			};
-			var dx_ = context.Operators.Where<ServiceRequest>(dv_, dw_);
+			IEnumerable<ServiceRequest> dx_ = context.Operators.Where<ServiceRequest>(dv_, dw_);
 			Encounter dy_(ServiceRequest SecondHTNDeclinedInterventions) => 
 				SecondHTNEncounter;
-			var dz_ = context.Operators.Select<ServiceRequest, Encounter>(dx_, dy_);
+			IEnumerable<Encounter> dz_ = context.Operators.Select<ServiceRequest, Encounter>(dx_, dy_);
 
 			return dz_;
 		};
-		var r_ = context.Operators.SelectMany<Encounter, Encounter>(p_, q_);
-		var s_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90();
+		IEnumerable<Encounter> r_ = context.Operators.SelectMany<Encounter, Encounter>(p_, q_);
+		IEnumerable<Encounter> s_ = this.Encounter_with_Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90();
 		IEnumerable<Encounter> t_(Encounter SecondHTN140Over90Encounter)
 		{
-			var ef_ = this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined();
+			IEnumerable<object> ef_ = this.Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined();
 			bool? eg_(object SecondHTN140Over90DeclinedInterventions)
 			{
-				var ek_ = context.Operators.LateBoundProperty<object>(SecondHTN140Over90DeclinedInterventions, "authoredOn");
-				var el_ = context.Operators.LateBoundProperty<CqlDateTime>(ek_, "value");
-				var em_ = SecondHTN140Over90Encounter?.Period;
-				var en_ = FHIRHelpers_4_3_000.ToInterval(em_);
-				var eo_ = context.Operators.In<CqlDateTime>(el_, en_, "day");
+				object ek_ = context.Operators.LateBoundProperty<object>(SecondHTN140Over90DeclinedInterventions, "authoredOn");
+				CqlDateTime el_ = context.Operators.LateBoundProperty<CqlDateTime>(ek_, "value");
+				Period em_ = SecondHTN140Over90Encounter?.Period;
+				CqlInterval<CqlDateTime> en_ = FHIRHelpers_4_3_000.ToInterval(em_);
+				bool? eo_ = context.Operators.In<CqlDateTime>(el_, en_, "day");
 
 				return eo_;
 			};
-			var eh_ = context.Operators.Where<object>(ef_, eg_);
+			IEnumerable<object> eh_ = context.Operators.Where<object>(ef_, eg_);
 			Encounter ei_(object SecondHTN140Over90DeclinedInterventions) => 
 				SecondHTN140Over90Encounter;
-			var ej_ = context.Operators.Select<object, Encounter>(eh_, ei_);
+			IEnumerable<Encounter> ej_ = context.Operators.Select<object, Encounter>(eh_, ei_);
 
 			return ej_;
 		};
-		var u_ = context.Operators.SelectMany<Encounter, Encounter>(s_, t_);
-		var v_ = context.Operators.Union<Encounter>(r_, u_);
-		var w_ = context.Operators.Union<Encounter>(o_, v_);
+		IEnumerable<Encounter> u_ = context.Operators.SelectMany<Encounter, Encounter>(s_, t_);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(r_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(o_, v_);
 
 		return w_;
 	}
 
+    /// <seealso cref="Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient_Value"/>
     [CqlDeclaration("Encounter with Order for Hypertension Follow Up Declined by Patient")]
 	public IEnumerable<Encounter> Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient() => 
 		__Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient.Value;
 
+    /// <seealso cref="Denominator_Exceptions"/>
 	private IEnumerable<Encounter> Denominator_Exceptions_Value()
 	{
-		var a_ = this.Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement();
-		var b_ = this.Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Encounter_with_Medical_Reason_for_Not_Obtaining_or_Patient_Declined_Blood_Pressure_Measurement();
+		IEnumerable<Encounter> b_ = this.Encounter_with_Order_for_Hypertension_Follow_Up_Declined_by_Patient();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Exceptions_Value"/>
     [CqlDeclaration("Denominator Exceptions")]
 	public IEnumerable<Encounter> Denominator_Exceptions() => 
 		__Denominator_Exceptions.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
@@ -98,103 +98,128 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility"/>
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility_Value"/>
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
 	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
+    /// <seealso cref="Cup_to_Disc_Ratio"/>
 	private CqlValueSet Cup_to_Disc_Ratio_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333", null);
 
+    /// <seealso cref="Cup_to_Disc_Ratio_Value"/>
     [CqlDeclaration("Cup to Disc Ratio")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333")]
 	public CqlValueSet Cup_to_Disc_Ratio() => 
 		__Cup_to_Disc_Ratio.Value;
 
+    /// <seealso cref="Face_to_Face_Interaction"/>
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
 
+    /// <seealso cref="Face_to_Face_Interaction_Value"/>
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
 	public CqlValueSet Face_to_Face_Interaction() => 
 		__Face_to_Face_Interaction.Value;
 
+    /// <seealso cref="Medical_Reason"/>
 	private CqlValueSet Medical_Reason_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
 
+    /// <seealso cref="Medical_Reason_Value"/>
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
 	public CqlValueSet Medical_Reason() => 
 		__Medical_Reason.Value;
 
+    /// <seealso cref="Nursing_Facility_Visit"/>
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
+    /// <seealso cref="Nursing_Facility_Visit_Value"/>
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
 	public CqlValueSet Nursing_Facility_Visit() => 
 		__Nursing_Facility_Visit.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Ophthalmological_Services"/>
 	private CqlValueSet Ophthalmological_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
 
+    /// <seealso cref="Ophthalmological_Services_Value"/>
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
 	public CqlValueSet Ophthalmological_Services() => 
 		__Ophthalmological_Services.Value;
 
+    /// <seealso cref="Optic_Disc_Exam_for_Structural_Abnormalities"/>
 	private CqlValueSet Optic_Disc_Exam_for_Structural_Abnormalities_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334", null);
 
+    /// <seealso cref="Optic_Disc_Exam_for_Structural_Abnormalities_Value"/>
     [CqlDeclaration("Optic Disc Exam for Structural Abnormalities")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334")]
 	public CqlValueSet Optic_Disc_Exam_for_Structural_Abnormalities() => 
 		__Optic_Disc_Exam_for_Structural_Abnormalities.Value;
 
+    /// <seealso cref="Outpatient_Consultation"/>
 	private CqlValueSet Outpatient_Consultation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
+    /// <seealso cref="Outpatient_Consultation_Value"/>
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
 	public CqlValueSet Outpatient_Consultation() => 
 		__Outpatient_Consultation.Value;
 
+    /// <seealso cref="Primary_Open_Angle_Glaucoma"/>
 	private CqlValueSet Primary_Open_Angle_Glaucoma_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326", null);
 
+    /// <seealso cref="Primary_Open_Angle_Glaucoma_Value"/>
     [CqlDeclaration("Primary Open-Angle Glaucoma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326")]
 	public CqlValueSet Primary_Open_Angle_Glaucoma() => 
 		__Primary_Open_Angle_Glaucoma.Value;
 
+    /// <seealso cref="@virtual"/>
 	private CqlCode @virtual_Value() => 
 		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="@virtual_Value"/>
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
+    /// <seealso cref="AMB"/>
 	private CqlCode AMB_Value() => 
 		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="AMB_Value"/>
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
 		__AMB.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
@@ -203,475 +228,510 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("POAGOpticNerveEvaluationFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("POAGOpticNerveEvaluationFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounter_During_Measurement_Period"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Ophthalmological_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Outpatient_Consultation();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Nursing_Facility_Visit();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = context.Operators.Union<Encounter>(k_, m_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Ophthalmological_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Outpatient_Consultation();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Nursing_Facility_Visit();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter QualifyingEncounter)
 		{
-			var q_ = this.Measurement_Period();
-			var r_ = QualifyingEncounter?.Period;
-			var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			var t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, null);
-			var u_ = QualifyingEncounter?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
-			var x_ = context.Operators.Equal(w_, "finished");
-			var y_ = context.Operators.And(t_, x_);
-			var z_ = QualifyingEncounter?.Class;
-			var aa_ = FHIRHelpers_4_3_000.ToCode(z_);
-			var ab_ = this.@virtual();
-			var ac_ = context.Operators.Equivalent(aa_, ab_);
-			var ad_ = context.Operators.Not(ac_);
-			var ae_ = context.Operators.And(y_, ad_);
+			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
+			Period r_ = QualifyingEncounter?.Period;
+			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, null);
+			Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
+			Encounter.EncounterStatus? v_ = u_?.Value;
+			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+			bool? x_ = context.Operators.Equal(w_, "finished");
+			bool? y_ = context.Operators.And(t_, x_);
+			Coding z_ = QualifyingEncounter?.Class;
+			CqlCode aa_ = FHIRHelpers_4_3_000.ToCode(z_);
+			CqlCode ab_ = this.@virtual();
+			bool? ac_ = context.Operators.Equivalent(aa_, ab_);
+			bool? ad_ = context.Operators.Not(ac_);
+			bool? ae_ = context.Operators.And(y_, ad_);
 
 			return ae_;
 		};
-		var p_ = context.Operators.Where<Encounter>(n_, o_);
+		IEnumerable<Encounter> p_ = context.Operators.Where<Encounter>(n_, o_);
 
 		return p_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_During_Measurement_Period_Value"/>
     [CqlDeclaration("Qualifying Encounter During Measurement Period")]
 	public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period() => 
 		__Qualifying_Encounter_During_Measurement_Period.Value;
 
+    /// <seealso cref="Primary_Open_Angle_Glaucoma_Encounter"/>
 	private IEnumerable<Encounter> Primary_Open_Angle_Glaucoma_Encounter_Value()
 	{
-		var a_ = this.Qualifying_Encounter_During_Measurement_Period();
+		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_During_Measurement_Period();
 		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
 		{
-			var d_ = this.Primary_Open_Angle_Glaucoma();
-			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			CqlValueSet d_ = this.Primary_Open_Angle_Glaucoma();
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
 			bool? f_(Condition PrimaryOpenAngleGlaucoma)
 			{
-				var j_ = QICoreCommon_2_0_000.prevalenceInterval(PrimaryOpenAngleGlaucoma);
-				var k_ = ValidQualifyingEncounter?.Period;
-				var l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				var m_ = context.Operators.Overlaps(j_, l_, null);
-				var n_ = QICoreCommon_2_0_000.isActive(PrimaryOpenAngleGlaucoma);
-				var o_ = context.Operators.And(m_, n_);
-				var p_ = PrimaryOpenAngleGlaucoma?.VerificationStatus;
-				var q_ = FHIRHelpers_4_3_000.ToConcept(p_);
-				var r_ = QICoreCommon_2_0_000.unconfirmed();
-				var s_ = context.Operators.ConvertCodeToConcept(r_);
-				var t_ = context.Operators.Equivalent(q_, s_);
-				var v_ = FHIRHelpers_4_3_000.ToConcept(p_);
-				var w_ = QICoreCommon_2_0_000.refuted();
-				var x_ = context.Operators.ConvertCodeToConcept(w_);
-				var y_ = context.Operators.Equivalent(v_, x_);
-				var z_ = context.Operators.Or(t_, y_);
-				var ab_ = FHIRHelpers_4_3_000.ToConcept(p_);
-				var ac_ = QICoreCommon_2_0_000.entered_in_error();
-				var ad_ = context.Operators.ConvertCodeToConcept(ac_);
-				var ae_ = context.Operators.Equivalent(ab_, ad_);
-				var af_ = context.Operators.Or(z_, ae_);
-				var ag_ = context.Operators.Not(af_);
-				var ah_ = context.Operators.And(o_, ag_);
+				CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.prevalenceInterval(PrimaryOpenAngleGlaucoma);
+				Period k_ = ValidQualifyingEncounter?.Period;
+				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
+				bool? m_ = context.Operators.Overlaps(j_, l_, null);
+				bool? n_ = QICoreCommon_2_0_000.isActive(PrimaryOpenAngleGlaucoma);
+				bool? o_ = context.Operators.And(m_, n_);
+				CodeableConcept p_ = PrimaryOpenAngleGlaucoma?.VerificationStatus;
+				CqlConcept q_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				CqlCode r_ = QICoreCommon_2_0_000.unconfirmed();
+				CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+				bool? t_ = context.Operators.Equivalent(q_, s_);
+				CqlConcept v_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				CqlCode w_ = QICoreCommon_2_0_000.refuted();
+				CqlConcept x_ = context.Operators.ConvertCodeToConcept(w_);
+				bool? y_ = context.Operators.Equivalent(v_, x_);
+				bool? z_ = context.Operators.Or(t_, y_);
+				CqlConcept ab_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				CqlCode ac_ = QICoreCommon_2_0_000.entered_in_error();
+				CqlConcept ad_ = context.Operators.ConvertCodeToConcept(ac_);
+				bool? ae_ = context.Operators.Equivalent(ab_, ad_);
+				bool? af_ = context.Operators.Or(z_, ae_);
+				bool? ag_ = context.Operators.Not(af_);
+				bool? ah_ = context.Operators.And(o_, ag_);
 
 				return ah_;
 			};
-			var g_ = context.Operators.Where<Condition>(e_, f_);
+			IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 			Encounter h_(Condition PrimaryOpenAngleGlaucoma) => 
 				ValidQualifyingEncounter;
-			var i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Primary_Open_Angle_Glaucoma_Encounter_Value"/>
     [CqlDeclaration("Primary Open Angle Glaucoma Encounter")]
 	public IEnumerable<Encounter> Primary_Open_Angle_Glaucoma_Encounter() => 
 		__Primary_Open_Angle_Glaucoma_Encounter.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 18);
-		var h_ = this.Primary_Open_Angle_Glaucoma_Encounter();
-		var i_ = context.Operators.Exists<Encounter>(h_);
-		var j_ = context.Operators.And(g_, i_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+		IEnumerable<Encounter> j_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
+		bool? l_ = context.Operators.And(i_, k_);
 
-		return j_;
+		return l_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio"/>
 	private IEnumerable<Observation> Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio_Value()
 	{
-		var a_ = this.Cup_to_Disc_Ratio();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var e_ = context.Operators.Union<Observation>(b_, d_);
+		CqlValueSet a_ = this.Cup_to_Disc_Ratio();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation CupToDiscExamNotPerformed)
 		{
-			var j_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+			IEnumerable<Encounter> j_ = this.Primary_Open_Angle_Glaucoma_Encounter();
 			bool? k_(Encounter EncounterWithPOAG)
 			{
-				var o_ = CupToDiscExamNotPerformed?.IssuedElement;
-				var p_ = o_?.Value;
-				var q_ = context.Operators.Convert<CqlDateTime>(p_);
-				var r_ = EncounterWithPOAG?.Period;
-				var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
+				Instant o_ = CupToDiscExamNotPerformed?.IssuedElement;
+				DateTimeOffset? p_ = o_?.Value;
+				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+				Period r_ = EncounterWithPOAG?.Period;
+				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
 
 				return t_;
 			};
-			var l_ = context.Operators.Where<Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
 			Observation m_(Encounter EncounterWithPOAG) => 
 				CupToDiscExamNotPerformed;
-			var n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
+			IEnumerable<Observation> n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
 
 			return n_;
 		};
-		var g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
+		IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
 		bool? h_(Observation CupToDiscExamNotPerformed)
 		{
 			bool? u_(Extension @this)
 			{
-				var ad_ = @this?.Url;
-				var ae_ = context.Operators.Convert<FhirUri>(ad_);
-				var af_ = FHIRHelpers_4_3_000.ToString(ae_);
-				var ag_ = context.Operators.Equal(af_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+				string ad_ = @this?.Url;
+				FhirUri ae_ = context.Operators.Convert<FhirUri>(ad_);
+				string af_ = FHIRHelpers_4_3_000.ToString(ae_);
+				bool? ag_ = context.Operators.Equal(af_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
 
 				return ag_;
 			};
-			var v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((CupToDiscExamNotPerformed is DomainResource)
+			IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((CupToDiscExamNotPerformed is DomainResource)
 					? ((CupToDiscExamNotPerformed as DomainResource).Extension)
 					: null), u_);
 			DataType w_(Extension @this)
 			{
-				var ah_ = @this?.Value;
+				DataType ah_ = @this?.Value;
 
 				return ah_;
 			};
-			var x_ = context.Operators.Select<Extension, DataType>(v_, w_);
-			var y_ = context.Operators.SingletonFrom<DataType>(x_);
-			var z_ = context.Operators.Convert<CodeableConcept>(y_);
-			var aa_ = FHIRHelpers_4_3_000.ToConcept(z_);
-			var ab_ = this.Medical_Reason();
-			var ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+			IEnumerable<DataType> x_ = context.Operators.Select<Extension, DataType>(v_, w_);
+			DataType y_ = context.Operators.SingletonFrom<DataType>(x_);
+			CodeableConcept z_ = context.Operators.Convert<CodeableConcept>(y_);
+			CqlConcept aa_ = FHIRHelpers_4_3_000.ToConcept(z_);
+			CqlValueSet ab_ = this.Medical_Reason();
+			bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
 
 			return ac_;
 		};
-		var i_ = context.Operators.Where<Observation>(g_, h_);
+		IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio_Value"/>
     [CqlDeclaration("Medical Reason for Not Performing Cup to Disc Ratio")]
 	public IEnumerable<Observation> Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio() => 
 		__Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio.Value;
 
+    /// <seealso cref="Medical_Reason_for_Not_Performing_Optic_Disc_Exam"/>
 	private IEnumerable<Observation> Medical_Reason_for_Not_Performing_Optic_Disc_Exam_Value()
 	{
-		var a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var e_ = context.Operators.Union<Observation>(b_, d_);
+		CqlValueSet a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation OpticDiscExamNotPerformed)
 		{
-			var j_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+			IEnumerable<Encounter> j_ = this.Primary_Open_Angle_Glaucoma_Encounter();
 			bool? k_(Encounter EncounterWithPOAG)
 			{
-				var o_ = OpticDiscExamNotPerformed?.IssuedElement;
-				var p_ = o_?.Value;
-				var q_ = context.Operators.Convert<CqlDateTime>(p_);
-				var r_ = EncounterWithPOAG?.Period;
-				var s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				var t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
+				Instant o_ = OpticDiscExamNotPerformed?.IssuedElement;
+				DateTimeOffset? p_ = o_?.Value;
+				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
+				Period r_ = EncounterWithPOAG?.Period;
+				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
 
 				return t_;
 			};
-			var l_ = context.Operators.Where<Encounter>(j_, k_);
+			IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
 			Observation m_(Encounter EncounterWithPOAG) => 
 				OpticDiscExamNotPerformed;
-			var n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
+			IEnumerable<Observation> n_ = context.Operators.Select<Encounter, Observation>(l_, m_);
 
 			return n_;
 		};
-		var g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
+		IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
 		bool? h_(Observation OpticDiscExamNotPerformed)
 		{
 			bool? u_(Extension @this)
 			{
-				var ad_ = @this?.Url;
-				var ae_ = context.Operators.Convert<FhirUri>(ad_);
-				var af_ = FHIRHelpers_4_3_000.ToString(ae_);
-				var ag_ = context.Operators.Equal(af_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+				string ad_ = @this?.Url;
+				FhirUri ae_ = context.Operators.Convert<FhirUri>(ad_);
+				string af_ = FHIRHelpers_4_3_000.ToString(ae_);
+				bool? ag_ = context.Operators.Equal(af_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
 
 				return ag_;
 			};
-			var v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((OpticDiscExamNotPerformed is DomainResource)
+			IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((OpticDiscExamNotPerformed is DomainResource)
 					? ((OpticDiscExamNotPerformed as DomainResource).Extension)
 					: null), u_);
 			DataType w_(Extension @this)
 			{
-				var ah_ = @this?.Value;
+				DataType ah_ = @this?.Value;
 
 				return ah_;
 			};
-			var x_ = context.Operators.Select<Extension, DataType>(v_, w_);
-			var y_ = context.Operators.SingletonFrom<DataType>(x_);
-			var z_ = context.Operators.Convert<CodeableConcept>(y_);
-			var aa_ = FHIRHelpers_4_3_000.ToConcept(z_);
-			var ab_ = this.Medical_Reason();
-			var ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
+			IEnumerable<DataType> x_ = context.Operators.Select<Extension, DataType>(v_, w_);
+			DataType y_ = context.Operators.SingletonFrom<DataType>(x_);
+			CodeableConcept z_ = context.Operators.Convert<CodeableConcept>(y_);
+			CqlConcept aa_ = FHIRHelpers_4_3_000.ToConcept(z_);
+			CqlValueSet ab_ = this.Medical_Reason();
+			bool? ac_ = context.Operators.ConceptInValueSet(aa_, ab_);
 
 			return ac_;
 		};
-		var i_ = context.Operators.Where<Observation>(g_, h_);
+		IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 
 		return i_;
 	}
 
+    /// <seealso cref="Medical_Reason_for_Not_Performing_Optic_Disc_Exam_Value"/>
     [CqlDeclaration("Medical Reason for Not Performing Optic Disc Exam")]
 	public IEnumerable<Observation> Medical_Reason_for_Not_Performing_Optic_Disc_Exam() => 
 		__Medical_Reason_for_Not_Performing_Optic_Disc_Exam.Value;
 
+    /// <seealso cref="Denominator_Exceptions"/>
 	private bool? Denominator_Exceptions_Value()
 	{
-		var a_ = this.Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio();
-		var b_ = context.Operators.Exists<Observation>(a_);
-		var c_ = this.Medical_Reason_for_Not_Performing_Optic_Disc_Exam();
-		var d_ = context.Operators.Exists<Observation>(c_);
-		var e_ = context.Operators.Or(b_, d_);
+		IEnumerable<Observation> a_ = this.Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> c_ = this.Medical_Reason_for_Not_Performing_Optic_Disc_Exam();
+		bool? d_ = context.Operators.Exists<Observation>(c_);
+		bool? e_ = context.Operators.Or(b_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Denominator_Exceptions_Value"/>
     [CqlDeclaration("Denominator Exceptions")]
 	public bool? Denominator_Exceptions() => 
 		__Denominator_Exceptions.Value;
 
+    /// <seealso cref="Cup_to_Disc_Ratio_Performed_with_Result"/>
 	private IEnumerable<Observation> Cup_to_Disc_Ratio_Performed_with_Result_Value()
 	{
-		var a_ = this.Cup_to_Disc_Ratio();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.Cup_to_Disc_Ratio();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		IEnumerable<Observation> c_(Observation CupToDiscExamPerformed)
 		{
-			var g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+			IEnumerable<Encounter> g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
 			bool? h_(Encounter EncounterWithPOAG)
 			{
-				var l_ = EncounterWithPOAG?.Period;
-				var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-				var n_ = CupToDiscExamPerformed?.Effective;
-				var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-				var p_ = QICoreCommon_2_0_000.toInterval(o_);
-				var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
+				Period l_ = EncounterWithPOAG?.Period;
+				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+				DataType n_ = CupToDiscExamPerformed?.Effective;
+				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
 
 				return q_;
 			};
-			var i_ = context.Operators.Where<Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
 			Observation j_(Encounter EncounterWithPOAG) => 
 				CupToDiscExamPerformed;
-			var k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+			IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
 
 			return k_;
 		};
-		var d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
 		bool? e_(Observation CupToDiscExamPerformed)
 		{
-			var r_ = CupToDiscExamPerformed?.Value;
-			var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-			var t_ = context.Operators.Not((bool?)(s_ is null));
-			var u_ = CupToDiscExamPerformed?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
-			var x_ = context.Operators.Convert<string>(w_);
-			var y_ = new string[]
+			DataType r_ = CupToDiscExamPerformed?.Value;
+			object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+			bool? t_ = context.Operators.Not((bool?)(s_ is null));
+			Code<ObservationStatus> u_ = CupToDiscExamPerformed?.StatusElement;
+			ObservationStatus? v_ = u_?.Value;
+			Code<ObservationStatus> w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
+			string x_ = context.Operators.Convert<string>(w_);
+			string[] y_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
-			var aa_ = context.Operators.And(t_, z_);
+			bool? z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
+			bool? aa_ = context.Operators.And(t_, z_);
 
 			return aa_;
 		};
-		var f_ = context.Operators.Where<Observation>(d_, e_);
+		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Cup_to_Disc_Ratio_Performed_with_Result_Value"/>
     [CqlDeclaration("Cup to Disc Ratio Performed with Result")]
 	public IEnumerable<Observation> Cup_to_Disc_Ratio_Performed_with_Result() => 
 		__Cup_to_Disc_Ratio_Performed_with_Result.Value;
 
+    /// <seealso cref="Optic_Disc_Exam_Performed_with_Result"/>
 	private IEnumerable<Observation> Optic_Disc_Exam_Performed_with_Result_Value()
 	{
-		var a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		IEnumerable<Observation> c_(Observation OpticDiscExamPerformed)
 		{
-			var g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
+			IEnumerable<Encounter> g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
 			bool? h_(Encounter EncounterWithPOAG)
 			{
-				var l_ = EncounterWithPOAG?.Period;
-				var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-				var n_ = OpticDiscExamPerformed?.Effective;
-				var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-				var p_ = QICoreCommon_2_0_000.toInterval(o_);
-				var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
+				Period l_ = EncounterWithPOAG?.Period;
+				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+				DataType n_ = OpticDiscExamPerformed?.Effective;
+				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
 
 				return q_;
 			};
-			var i_ = context.Operators.Where<Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
 			Observation j_(Encounter EncounterWithPOAG) => 
 				OpticDiscExamPerformed;
-			var k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+			IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
 
 			return k_;
 		};
-		var d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
 		bool? e_(Observation OpticDiscExamPerformed)
 		{
-			var r_ = OpticDiscExamPerformed?.Value;
-			var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-			var t_ = context.Operators.Not((bool?)(s_ is null));
-			var u_ = OpticDiscExamPerformed?.StatusElement;
-			var v_ = u_?.Value;
-			var w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
-			var x_ = context.Operators.Convert<string>(w_);
-			var y_ = new string[]
+			DataType r_ = OpticDiscExamPerformed?.Value;
+			object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+			bool? t_ = context.Operators.Not((bool?)(s_ is null));
+			Code<ObservationStatus> u_ = OpticDiscExamPerformed?.StatusElement;
+			ObservationStatus? v_ = u_?.Value;
+			Code<ObservationStatus> w_ = context.Operators.Convert<Code<ObservationStatus>>(v_);
+			string x_ = context.Operators.Convert<string>(w_);
+			string[] y_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
-			var aa_ = context.Operators.And(t_, z_);
+			bool? z_ = context.Operators.In<string>(x_, (y_ as IEnumerable<string>));
+			bool? aa_ = context.Operators.And(t_, z_);
 
 			return aa_;
 		};
-		var f_ = context.Operators.Where<Observation>(d_, e_);
+		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Optic_Disc_Exam_Performed_with_Result_Value"/>
     [CqlDeclaration("Optic Disc Exam Performed with Result")]
 	public IEnumerable<Observation> Optic_Disc_Exam_Performed_with_Result() => 
 		__Optic_Disc_Exam_Performed_with_Result.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Cup_to_Disc_Ratio_Performed_with_Result();
-		var b_ = context.Operators.Exists<Observation>(a_);
-		var c_ = this.Optic_Disc_Exam_Performed_with_Result();
-		var d_ = context.Operators.Exists<Observation>(c_);
-		var e_ = context.Operators.And(b_, d_);
+		IEnumerable<Observation> a_ = this.Cup_to_Disc_Ratio_Performed_with_Result();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> c_ = this.Optic_Disc_Exam_Performed_with_Result();
+		bool? d_ = context.Operators.Exists<Observation>(c_);
+		bool? e_ = context.Operators.And(b_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;

--- a/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
@@ -56,40 +56,49 @@ public class PalliativeCare_1_9_000
 
     #endregion
 
+    /// <seealso cref="Palliative_Care_Encounter"/>
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", null);
 
+    /// <seealso cref="Palliative_Care_Encounter_Value"/>
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090")]
 	public CqlValueSet Palliative_Care_Encounter() => 
 		__Palliative_Care_Encounter.Value;
 
+    /// <seealso cref="Palliative_Care_Intervention"/>
 	private CqlValueSet Palliative_Care_Intervention_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", null);
 
+    /// <seealso cref="Palliative_Care_Intervention_Value"/>
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135")]
 	public CqlValueSet Palliative_Care_Intervention() => 
 		__Palliative_Care_Intervention.Value;
 
+    /// <seealso cref="Palliative_Care_Diagnosis"/>
 	private CqlValueSet Palliative_Care_Diagnosis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167", null);
 
+    /// <seealso cref="Palliative_Care_Diagnosis_Value"/>
     [CqlDeclaration("Palliative Care Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167")]
 	public CqlValueSet Palliative_Care_Diagnosis() => 
 		__Palliative_Care_Diagnosis.Value;
 
+    /// <seealso cref="Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_"/>
 	private CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value() => 
 		new CqlCode("71007-9", "http://loinc.org", null, null);
 
+    /// <seealso cref="Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value"/>
     [CqlDeclaration("Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)")]
 	public CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_() => 
 		__Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("71007-9", "http://loinc.org", null, null),
 		};
@@ -97,100 +106,107 @@ public class PalliativeCare_1_9_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.ResolveParameter("PalliativeCare-1.9.000", "Measurement Period", null);
+		object a_ = context.ResolveParameter("PalliativeCare-1.9.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Has_Palliative_Care_in_the_Measurement_Period"/>
 	private bool? Has_Palliative_Care_in_the_Measurement_Period_Value()
 	{
-		var a_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = Status_1_6_000.isAssessmentPerformed(c_);
+		CqlCode a_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> d_ = Status_1_6_000.isAssessmentPerformed(c_);
 		bool? e_(Observation PalliativeAssessment)
 		{
-			var ab_ = PalliativeAssessment?.Effective;
-			var ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
-			var ad_ = QICoreCommon_2_0_000.toInterval(ac_);
-			var ae_ = this.Measurement_Period();
-			var af_ = context.Operators.Overlaps(ad_, ae_, "day");
+			DataType ab_ = PalliativeAssessment?.Effective;
+			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
+			CqlInterval<CqlDateTime> ad_ = QICoreCommon_2_0_000.toInterval(ac_);
+			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
+			bool? af_ = context.Operators.Overlaps(ad_, ae_, "day");
 
 			return af_;
 		};
-		var f_ = context.Operators.Where<Observation>(d_, e_);
-		var g_ = context.Operators.Exists<Observation>(f_);
-		var h_ = this.Palliative_Care_Diagnosis();
-		var i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
+		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
+		bool? g_ = context.Operators.Exists<Observation>(f_);
+		CqlValueSet h_ = this.Palliative_Care_Diagnosis();
+		IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
 		bool? j_(Condition PalliativeDiagnosis)
 		{
-			var ag_ = QICoreCommon_2_0_000.prevalenceInterval(PalliativeDiagnosis);
-			var ah_ = this.Measurement_Period();
-			var ai_ = context.Operators.Overlaps(ag_, ah_, "day");
+			CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.prevalenceInterval(PalliativeDiagnosis);
+			CqlInterval<CqlDateTime> ah_ = this.Measurement_Period();
+			bool? ai_ = context.Operators.Overlaps(ag_, ah_, "day");
 
 			return ai_;
 		};
-		var k_ = context.Operators.Where<Condition>(i_, j_);
-		var l_ = context.Operators.Exists<Condition>(k_);
-		var m_ = context.Operators.Or(g_, l_);
-		var n_ = this.Palliative_Care_Encounter();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = Status_1_6_000.isEncounterPerformed(o_);
+		IEnumerable<Condition> k_ = context.Operators.Where<Condition>(i_, j_);
+		bool? l_ = context.Operators.Exists<Condition>(k_);
+		bool? m_ = context.Operators.Or(g_, l_);
+		CqlValueSet n_ = this.Palliative_Care_Encounter();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = Status_1_6_000.isEncounterPerformed(o_);
 		bool? q_(Encounter PalliativeEncounter)
 		{
-			var aj_ = PalliativeEncounter?.Period;
-			var ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
-			var al_ = QICoreCommon_2_0_000.toInterval((ak_ as object));
-			var am_ = this.Measurement_Period();
-			var an_ = context.Operators.Overlaps(al_, am_, "day");
+			Period aj_ = PalliativeEncounter?.Period;
+			CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
+			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.toInterval((ak_ as object));
+			CqlInterval<CqlDateTime> am_ = this.Measurement_Period();
+			bool? an_ = context.Operators.Overlaps(al_, am_, "day");
 
 			return an_;
 		};
-		var r_ = context.Operators.Where<Encounter>(p_, q_);
-		var s_ = context.Operators.Exists<Encounter>(r_);
-		var t_ = context.Operators.Or(m_, s_);
-		var u_ = this.Palliative_Care_Intervention();
-		var v_ = context.Operators.RetrieveByValueSet<Procedure>(u_, null);
-		var w_ = Status_1_6_000.isInterventionPerformed(v_);
+		IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
+		bool? s_ = context.Operators.Exists<Encounter>(r_);
+		bool? t_ = context.Operators.Or(m_, s_);
+		CqlValueSet u_ = this.Palliative_Care_Intervention();
+		IEnumerable<Procedure> v_ = context.Operators.RetrieveByValueSet<Procedure>(u_, null);
+		IEnumerable<Procedure> w_ = Status_1_6_000.isInterventionPerformed(v_);
 		bool? x_(Procedure PalliativeIntervention)
 		{
-			var ao_ = PalliativeIntervention?.Performed;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = QICoreCommon_2_0_000.toInterval(ap_);
-			var ar_ = this.Measurement_Period();
-			var as_ = context.Operators.Overlaps(aq_, ar_, "day");
+			DataType ao_ = PalliativeIntervention?.Performed;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.toInterval(ap_);
+			CqlInterval<CqlDateTime> ar_ = this.Measurement_Period();
+			bool? as_ = context.Operators.Overlaps(aq_, ar_, "day");
 
 			return as_;
 		};
-		var y_ = context.Operators.Where<Procedure>(w_, x_);
-		var z_ = context.Operators.Exists<Procedure>(y_);
-		var aa_ = context.Operators.Or(t_, z_);
+		IEnumerable<Procedure> y_ = context.Operators.Where<Procedure>(w_, x_);
+		bool? z_ = context.Operators.Exists<Procedure>(y_);
+		bool? aa_ = context.Operators.Or(t_, z_);
 
 		return aa_;
 	}
 
+    /// <seealso cref="Has_Palliative_Care_in_the_Measurement_Period_Value"/>
     [CqlDeclaration("Has Palliative Care in the Measurement Period")]
 	public bool? Has_Palliative_Care_in_the_Measurement_Period() => 
 		__Has_Palliative_Care_in_the_Measurement_Period.Value;

--- a/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
@@ -152,236 +152,295 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 
     #endregion
 
+    /// <seealso cref="Annual_Wellness_Visit"/>
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
+    /// <seealso cref="Annual_Wellness_Visit_Value"/>
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
 	public CqlValueSet Annual_Wellness_Visit() => 
 		__Annual_Wellness_Visit.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Limited_Life_Expectancy"/>
 	private CqlValueSet Limited_Life_Expectancy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259", null);
 
+    /// <seealso cref="Limited_Life_Expectancy_Value"/>
     [CqlDeclaration("Limited Life Expectancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259")]
 	public CqlValueSet Limited_Life_Expectancy() => 
 		__Limited_Life_Expectancy.Value;
 
+    /// <seealso cref="Medical_Reason"/>
 	private CqlValueSet Medical_Reason_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
 
+    /// <seealso cref="Medical_Reason_Value"/>
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
 	public CqlValueSet Medical_Reason() => 
 		__Medical_Reason.Value;
 
+    /// <seealso cref="Nutrition_Services"/>
 	private CqlValueSet Nutrition_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006", null);
 
+    /// <seealso cref="Nutrition_Services_Value"/>
     [CqlDeclaration("Nutrition Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006")]
 	public CqlValueSet Nutrition_Services() => 
 		__Nutrition_Services.Value;
 
+    /// <seealso cref="Occupational_Therapy_Evaluation"/>
 	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", null);
 
+    /// <seealso cref="Occupational_Therapy_Evaluation_Value"/>
     [CqlDeclaration("Occupational Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
 	public CqlValueSet Occupational_Therapy_Evaluation() => 
 		__Occupational_Therapy_Evaluation.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Ophthalmological_Services"/>
 	private CqlValueSet Ophthalmological_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
 
+    /// <seealso cref="Ophthalmological_Services_Value"/>
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
 	public CqlValueSet Ophthalmological_Services() => 
 		__Ophthalmological_Services.Value;
 
+    /// <seealso cref="Physical_Therapy_Evaluation"/>
 	private CqlValueSet Physical_Therapy_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", null);
 
+    /// <seealso cref="Physical_Therapy_Evaluation_Value"/>
     [CqlDeclaration("Physical Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022")]
 	public CqlValueSet Physical_Therapy_Evaluation() => 
 		__Physical_Therapy_Evaluation.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Group_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
 
+    /// <seealso cref="Preventive_Care_Services_Group_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
 	public CqlValueSet Preventive_Care_Services_Group_Counseling() => 
 		__Preventive_Care_Services_Group_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
 	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation"/>
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
 
+    /// <seealso cref="Psych_Visit_Diagnostic_Evaluation_Value"/>
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
 	public CqlValueSet Psych_Visit_Diagnostic_Evaluation() => 
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
+    /// <seealso cref="Psych_Visit_Psychotherapy"/>
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
 
+    /// <seealso cref="Psych_Visit_Psychotherapy_Value"/>
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
 	public CqlValueSet Psych_Visit_Psychotherapy() => 
 		__Psych_Visit_Psychotherapy.Value;
 
+    /// <seealso cref="Psychoanalysis"/>
 	private CqlValueSet Psychoanalysis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", null);
 
+    /// <seealso cref="Psychoanalysis_Value"/>
     [CqlDeclaration("Psychoanalysis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141")]
 	public CqlValueSet Psychoanalysis() => 
 		__Psychoanalysis.Value;
 
+    /// <seealso cref="Speech_and_Hearing_Evaluation"/>
 	private CqlValueSet Speech_and_Hearing_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530", null);
 
+    /// <seealso cref="Speech_and_Hearing_Evaluation_Value"/>
     [CqlDeclaration("Speech and Hearing Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530")]
 	public CqlValueSet Speech_and_Hearing_Evaluation() => 
 		__Speech_and_Hearing_Evaluation.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Tobacco_Non_User"/>
 	private CqlValueSet Tobacco_Non_User_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189", null);
 
+    /// <seealso cref="Tobacco_Non_User_Value"/>
     [CqlDeclaration("Tobacco Non User")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189")]
 	public CqlValueSet Tobacco_Non_User() => 
 		__Tobacco_Non_User.Value;
 
+    /// <seealso cref="Tobacco_Use_Cessation_Counseling"/>
 	private CqlValueSet Tobacco_Use_Cessation_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509", null);
 
+    /// <seealso cref="Tobacco_Use_Cessation_Counseling_Value"/>
     [CqlDeclaration("Tobacco Use Cessation Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509")]
 	public CqlValueSet Tobacco_Use_Cessation_Counseling() => 
 		__Tobacco_Use_Cessation_Counseling.Value;
 
+    /// <seealso cref="Tobacco_Use_Cessation_Pharmacotherapy"/>
 	private CqlValueSet Tobacco_Use_Cessation_Pharmacotherapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190", null);
 
+    /// <seealso cref="Tobacco_Use_Cessation_Pharmacotherapy_Value"/>
     [CqlDeclaration("Tobacco Use Cessation Pharmacotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190")]
 	public CqlValueSet Tobacco_Use_Cessation_Pharmacotherapy() => 
 		__Tobacco_Use_Cessation_Pharmacotherapy.Value;
 
+    /// <seealso cref="Tobacco_Use_Screening"/>
 	private CqlValueSet Tobacco_Use_Screening_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278", null);
 
+    /// <seealso cref="Tobacco_Use_Screening_Value"/>
     [CqlDeclaration("Tobacco Use Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278")]
 	public CqlValueSet Tobacco_Use_Screening() => 
 		__Tobacco_Use_Screening.Value;
 
+    /// <seealso cref="Tobacco_User"/>
 	private CqlValueSet Tobacco_User_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170", null);
 
+    /// <seealso cref="Tobacco_User_Value"/>
     [CqlDeclaration("Tobacco User")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170")]
 	public CqlValueSet Tobacco_User() => 
 		__Tobacco_User.Value;
 
+    /// <seealso cref="Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_"/>
 	private CqlCode Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making__Value() => 
 		new CqlCode("96156", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making__Value"/>
     [CqlDeclaration("Health behavior assessment, or re-assessment (ie, health-focused clinical interview, behavioral observations, clinical decision making)")]
 	public CqlCode Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_() => 
 		__Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_.Value;
 
+    /// <seealso cref="Health_behavior_intervention__individual__face_to_face__initial_30_minutes"/>
 	private CqlCode Health_behavior_intervention__individual__face_to_face__initial_30_minutes_Value() => 
 		new CqlCode("96158", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Health_behavior_intervention__individual__face_to_face__initial_30_minutes_Value"/>
     [CqlDeclaration("Health behavior intervention, individual, face-to-face; initial 30 minutes")]
 	public CqlCode Health_behavior_intervention__individual__face_to_face__initial_30_minutes() => 
 		__Health_behavior_intervention__individual__face_to_face__initial_30_minutes.Value;
 
+    /// <seealso cref="Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure"/>
 	private CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value() => 
 		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value"/>
     [CqlDeclaration("Postoperative follow-up visit, normally included in the surgical package, to indicate that an evaluation and management service was performed during a postoperative period for a reason(s) related to the original procedure")]
 	public CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure() => 
 		__Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure.Value;
 
+    /// <seealso cref="Tobacco_abuse_counseling"/>
 	private CqlCode Tobacco_abuse_counseling_Value() => 
 		new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
 
+    /// <seealso cref="Tobacco_abuse_counseling_Value"/>
     [CqlDeclaration("Tobacco abuse counseling")]
 	public CqlCode Tobacco_abuse_counseling() => 
 		__Tobacco_abuse_counseling.Value;
 
+    /// <seealso cref="Unlisted_preventive_medicine_service"/>
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
 		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Unlisted_preventive_medicine_service_Value"/>
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
 		__Unlisted_preventive_medicine_service.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("96156", "http://www.ama-assn.org/go/cpt", null, null),
 			new CqlCode("96158", "http://www.ama-assn.org/go/cpt", null, null),
@@ -392,13 +451,15 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="ICD10CM"/>
 	private CqlCode[] ICD10CM_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
 		};
@@ -406,607 +467,652 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		return a_;
 	}
 
+    /// <seealso cref="ICD10CM_Value"/>
     [CqlDeclaration("ICD10CM")]
 	public CqlCode[] ICD10CM() => 
 		__ICD10CM.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Visit_During_Measurement_Period"/>
 	private IEnumerable<Encounter> Qualifying_Visit_During_Measurement_Period_Value()
 	{
-		var a_ = this.Home_Healthcare_Services();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		CqlValueSet a_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
 		bool? d_(Encounter E)
 		{
-			var ar_ = E?.Type;
+			List<CodeableConcept> ar_ = E?.Type;
 			CqlConcept as_(CodeableConcept @this)
 			{
-				var ax_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept ax_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return ax_;
 			};
-			var at_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ar_, as_);
+			IEnumerable<CqlConcept> at_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ar_, as_);
 			bool? au_(CqlConcept T)
 			{
-				var ay_ = this.Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_();
-				var az_ = context.Operators.ConvertCodeToConcept(ay_);
-				var ba_ = context.Operators.Equivalent(T, az_);
+				CqlCode ay_ = this.Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_();
+				CqlConcept az_ = context.Operators.ConvertCodeToConcept(ay_);
+				bool? ba_ = context.Operators.Equivalent(T, az_);
 
 				return ba_;
 			};
-			var av_ = context.Operators.Where<CqlConcept>(at_, au_);
-			var aw_ = context.Operators.Exists<CqlConcept>(av_);
+			IEnumerable<CqlConcept> av_ = context.Operators.Where<CqlConcept>(at_, au_);
+			bool? aw_ = context.Operators.Exists<CqlConcept>(av_);
 
 			return aw_;
 		};
-		var e_ = context.Operators.Where<Encounter>(c_, d_);
-		var f_ = context.Operators.Union<Encounter>(b_, e_);
+		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
+		IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(b_, e_);
 		bool? h_(Encounter E)
 		{
-			var bb_ = E?.Type;
+			List<CodeableConcept> bb_ = E?.Type;
 			CqlConcept bc_(CodeableConcept @this)
 			{
-				var bh_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept bh_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return bh_;
 			};
-			var bd_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bb_, bc_);
+			IEnumerable<CqlConcept> bd_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bb_, bc_);
 			bool? be_(CqlConcept T)
 			{
-				var bi_ = this.Health_behavior_intervention__individual__face_to_face__initial_30_minutes();
-				var bj_ = context.Operators.ConvertCodeToConcept(bi_);
-				var bk_ = context.Operators.Equivalent(T, bj_);
+				CqlCode bi_ = this.Health_behavior_intervention__individual__face_to_face__initial_30_minutes();
+				CqlConcept bj_ = context.Operators.ConvertCodeToConcept(bi_);
+				bool? bk_ = context.Operators.Equivalent(T, bj_);
 
 				return bk_;
 			};
-			var bf_ = context.Operators.Where<CqlConcept>(bd_, be_);
-			var bg_ = context.Operators.Exists<CqlConcept>(bf_);
+			IEnumerable<CqlConcept> bf_ = context.Operators.Where<CqlConcept>(bd_, be_);
+			bool? bg_ = context.Operators.Exists<CqlConcept>(bf_);
 
 			return bg_;
 		};
-		var i_ = context.Operators.Where<Encounter>(c_, h_);
-		var j_ = this.Occupational_Therapy_Evaluation();
-		var k_ = context.Operators.RetrieveByValueSet<Encounter>(j_, null);
-		var l_ = context.Operators.Union<Encounter>(i_, k_);
-		var m_ = context.Operators.Union<Encounter>(f_, l_);
-		var n_ = this.Office_Visit();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = this.Ophthalmological_Services();
-		var q_ = context.Operators.RetrieveByValueSet<Encounter>(p_, null);
-		var r_ = context.Operators.Union<Encounter>(o_, q_);
-		var s_ = context.Operators.Union<Encounter>(m_, r_);
-		var t_ = this.Physical_Therapy_Evaluation();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = this.Psych_Visit_Diagnostic_Evaluation();
-		var w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
-		var x_ = context.Operators.Union<Encounter>(u_, w_);
-		var y_ = context.Operators.Union<Encounter>(s_, x_);
-		var z_ = this.Psych_Visit_Psychotherapy();
-		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
-		var ab_ = this.Psychoanalysis();
-		var ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, null);
-		var ad_ = context.Operators.Union<Encounter>(aa_, ac_);
-		var ae_ = context.Operators.Union<Encounter>(y_, ad_);
-		var af_ = this.Speech_and_Hearing_Evaluation();
-		var ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
-		var ah_ = this.Telephone_Visits();
-		var ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, null);
-		var aj_ = context.Operators.Union<Encounter>(ag_, ai_);
-		var ak_ = context.Operators.Union<Encounter>(ae_, aj_);
-		var al_ = this.Online_Assessments();
-		var am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
-		var an_ = context.Operators.Union<Encounter>(ak_, am_);
-		var ao_ = Status_1_6_000.isEncounterPerformed(an_);
+		IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(c_, h_);
+		CqlValueSet j_ = this.Occupational_Therapy_Evaluation();
+		IEnumerable<Encounter> k_ = context.Operators.RetrieveByValueSet<Encounter>(j_, null);
+		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(i_, k_);
+		IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(f_, l_);
+		CqlValueSet n_ = this.Office_Visit();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		CqlValueSet p_ = this.Ophthalmological_Services();
+		IEnumerable<Encounter> q_ = context.Operators.RetrieveByValueSet<Encounter>(p_, null);
+		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(o_, q_);
+		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(m_, r_);
+		CqlValueSet t_ = this.Physical_Therapy_Evaluation();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		CqlValueSet v_ = this.Psych_Visit_Diagnostic_Evaluation();
+		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
+		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(u_, w_);
+		IEnumerable<Encounter> y_ = context.Operators.Union<Encounter>(s_, x_);
+		CqlValueSet z_ = this.Psych_Visit_Psychotherapy();
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		CqlValueSet ab_ = this.Psychoanalysis();
+		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, null);
+		IEnumerable<Encounter> ad_ = context.Operators.Union<Encounter>(aa_, ac_);
+		IEnumerable<Encounter> ae_ = context.Operators.Union<Encounter>(y_, ad_);
+		CqlValueSet af_ = this.Speech_and_Hearing_Evaluation();
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		CqlValueSet ah_ = this.Telephone_Visits();
+		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, null);
+		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ag_, ai_);
+		IEnumerable<Encounter> ak_ = context.Operators.Union<Encounter>(ae_, aj_);
+		CqlValueSet al_ = this.Online_Assessments();
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
+		IEnumerable<Encounter> ao_ = Status_1_6_000.isEncounterPerformed(an_);
 		bool? ap_(Encounter OfficeBasedEncounter)
 		{
-			var bl_ = this.Measurement_Period();
-			var bm_ = OfficeBasedEncounter?.Period;
-			var bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-			var bo_ = QICoreCommon_2_0_000.toInterval((bn_ as object));
-			var bp_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bl_, bo_, "day");
+			CqlInterval<CqlDateTime> bl_ = this.Measurement_Period();
+			Period bm_ = OfficeBasedEncounter?.Period;
+			CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+			CqlInterval<CqlDateTime> bo_ = QICoreCommon_2_0_000.toInterval((bn_ as object));
+			bool? bp_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bl_, bo_, "day");
 
 			return bp_;
 		};
-		var aq_ = context.Operators.Where<Encounter>(ao_, ap_);
+		IEnumerable<Encounter> aq_ = context.Operators.Where<Encounter>(ao_, ap_);
 
 		return aq_;
 	}
 
+    /// <seealso cref="Qualifying_Visit_During_Measurement_Period_Value"/>
     [CqlDeclaration("Qualifying Visit During Measurement Period")]
 	public IEnumerable<Encounter> Qualifying_Visit_During_Measurement_Period() => 
 		__Qualifying_Visit_During_Measurement_Period.Value;
 
+    /// <seealso cref="Preventive_Visit_During_Measurement_Period"/>
 	private IEnumerable<Encounter> Preventive_Visit_During_Measurement_Period_Value()
 	{
-		var a_ = this.Annual_Wellness_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Group_Counseling();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		CqlValueSet a_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Group_Counseling();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
 		bool? i_(Encounter E)
 		{
-			var ac_ = E?.Type;
+			List<CodeableConcept> ac_ = E?.Type;
 			CqlConcept ad_(CodeableConcept @this)
 			{
-				var ai_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept ai_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return ai_;
 			};
-			var ae_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ad_);
+			IEnumerable<CqlConcept> ae_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ad_);
 			bool? af_(CqlConcept T)
 			{
-				var aj_ = this.Unlisted_preventive_medicine_service();
-				var ak_ = context.Operators.ConvertCodeToConcept(aj_);
-				var al_ = context.Operators.Equivalent(T, ak_);
+				CqlCode aj_ = this.Unlisted_preventive_medicine_service();
+				CqlConcept ak_ = context.Operators.ConvertCodeToConcept(aj_);
+				bool? al_ = context.Operators.Equivalent(T, ak_);
 
 				return al_;
 			};
-			var ag_ = context.Operators.Where<CqlConcept>(ae_, af_);
-			var ah_ = context.Operators.Exists<CqlConcept>(ag_);
+			IEnumerable<CqlConcept> ag_ = context.Operators.Where<CqlConcept>(ae_, af_);
+			bool? ah_ = context.Operators.Exists<CqlConcept>(ag_);
 
 			return ah_;
 		};
-		var j_ = context.Operators.Where<Encounter>(h_, i_);
-		var k_ = context.Operators.Union<Encounter>(g_, j_);
-		var l_ = context.Operators.Union<Encounter>(e_, k_);
-		var m_ = this.Preventive_Care_Services_Individual_Counseling();
-		var n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(g_, j_);
+		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(e_, k_);
+		CqlValueSet m_ = this.Preventive_Care_Services_Individual_Counseling();
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
 		bool? p_(Encounter E)
 		{
-			var am_ = E?.Type;
+			List<CodeableConcept> am_ = E?.Type;
 			CqlConcept an_(CodeableConcept @this)
 			{
-				var as_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept as_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return as_;
 			};
-			var ao_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)am_, an_);
+			IEnumerable<CqlConcept> ao_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)am_, an_);
 			bool? ap_(CqlConcept T)
 			{
-				var at_ = this.Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure();
-				var au_ = context.Operators.ConvertCodeToConcept(at_);
-				var av_ = context.Operators.Equivalent(T, au_);
+				CqlCode at_ = this.Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure();
+				CqlConcept au_ = context.Operators.ConvertCodeToConcept(at_);
+				bool? av_ = context.Operators.Equivalent(T, au_);
 
 				return av_;
 			};
-			var aq_ = context.Operators.Where<CqlConcept>(ao_, ap_);
-			var ar_ = context.Operators.Exists<CqlConcept>(aq_);
+			IEnumerable<CqlConcept> aq_ = context.Operators.Where<CqlConcept>(ao_, ap_);
+			bool? ar_ = context.Operators.Exists<CqlConcept>(aq_);
 
 			return ar_;
 		};
-		var q_ = context.Operators.Where<Encounter>(h_, p_);
-		var r_ = context.Operators.Union<Encounter>(n_, q_);
-		var s_ = context.Operators.Union<Encounter>(l_, r_);
-		var t_ = this.Nutrition_Services();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
-		var x_ = context.Operators.Union<Encounter>(u_, w_);
-		var y_ = context.Operators.Union<Encounter>(s_, x_);
-		var z_ = Status_1_6_000.isEncounterPerformed(y_);
+		IEnumerable<Encounter> q_ = context.Operators.Where<Encounter>(h_, p_);
+		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(n_, q_);
+		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(l_, r_);
+		CqlValueSet t_ = this.Nutrition_Services();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		CqlValueSet v_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
+		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(u_, w_);
+		IEnumerable<Encounter> y_ = context.Operators.Union<Encounter>(s_, x_);
+		IEnumerable<Encounter> z_ = Status_1_6_000.isEncounterPerformed(y_);
 		bool? aa_(Encounter PreventiveEncounter)
 		{
-			var aw_ = this.Measurement_Period();
-			var ax_ = PreventiveEncounter?.Period;
-			var ay_ = FHIRHelpers_4_3_000.ToInterval(ax_);
-			var az_ = QICoreCommon_2_0_000.toInterval((ay_ as object));
-			var ba_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, az_, "day");
+			CqlInterval<CqlDateTime> aw_ = this.Measurement_Period();
+			Period ax_ = PreventiveEncounter?.Period;
+			CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_3_000.ToInterval(ax_);
+			CqlInterval<CqlDateTime> az_ = QICoreCommon_2_0_000.toInterval((ay_ as object));
+			bool? ba_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, az_, "day");
 
 			return ba_;
 		};
-		var ab_ = context.Operators.Where<Encounter>(z_, aa_);
+		IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
 
 		return ab_;
 	}
 
+    /// <seealso cref="Preventive_Visit_During_Measurement_Period_Value"/>
     [CqlDeclaration("Preventive Visit During Measurement Period")]
 	public IEnumerable<Encounter> Preventive_Visit_During_Measurement_Period() => 
 		__Preventive_Visit_During_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 12);
-		var h_ = this.Qualifying_Visit_During_Measurement_Period();
-		var i_ = context.Operators.Count<Encounter>(h_);
-		var j_ = context.Operators.GreaterOrEqual(i_, 2);
-		var k_ = this.Preventive_Visit_During_Measurement_Period();
-		var l_ = context.Operators.Exists<Encounter>(k_);
-		var m_ = context.Operators.Or(j_, l_);
-		var n_ = context.Operators.And(g_, m_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 12);
+		IEnumerable<Encounter> j_ = this.Qualifying_Visit_During_Measurement_Period();
+		int? k_ = context.Operators.Count<Encounter>(j_);
+		bool? l_ = context.Operators.GreaterOrEqual(k_, 2);
+		IEnumerable<Encounter> m_ = this.Preventive_Visit_During_Measurement_Period();
+		bool? n_ = context.Operators.Exists<Encounter>(m_);
+		bool? o_ = context.Operators.Or(l_, n_);
+		bool? p_ = context.Operators.And(i_, o_);
 
-		return n_;
+		return p_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator_1"/>
 	private bool? Denominator_1_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_1_Value"/>
     [CqlDeclaration("Denominator 1")]
 	public bool? Denominator_1() => 
 		__Denominator_1.Value;
 
+    /// <seealso cref="Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User"/>
 	private Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User_Value()
 	{
-		var a_ = this.Tobacco_Use_Screening();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		CqlValueSet a_ = this.Tobacco_Use_Screening();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation TobaccoUseScreening)
 		{
-			var m_ = this.Measurement_Period();
-			var n_ = TobaccoUseScreening?.Effective;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = QICoreCommon_2_0_000.toInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
+			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
+			DataType n_ = TobaccoUseScreening?.Effective;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			var r_ = @this?.Effective;
-			var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-			var t_ = QICoreCommon_2_0_000.toInterval(s_);
-			var u_ = context.Operators.Start(t_);
+			DataType r_ = @this?.Effective;
+			object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.toInterval(s_);
+			CqlDateTime u_ = context.Operators.Start(t_);
 
 			return u_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = new Observation[]
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		Observation[] i_ = new Observation[]
 		{
 			h_,
 		};
 		bool? j_(Observation MostRecentTobaccoUseScreening)
 		{
-			var v_ = MostRecentTobaccoUseScreening?.Value;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = this.Tobacco_User();
-			var y_ = context.Operators.ConceptInValueSet((w_ as CqlConcept), x_);
+			DataType v_ = MostRecentTobaccoUseScreening?.Value;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlValueSet x_ = this.Tobacco_User();
+			bool? y_ = context.Operators.ConceptInValueSet((w_ as CqlConcept), x_);
 
 			return y_;
 		};
-		var k_ = context.Operators.Where<Observation>((IEnumerable<Observation>)i_, j_);
-		var l_ = context.Operators.SingletonFrom<Observation>(k_);
+		IEnumerable<Observation> k_ = context.Operators.Where<Observation>((IEnumerable<Observation>)i_, j_);
+		Observation l_ = context.Operators.SingletonFrom<Observation>(k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User_Value"/>
     [CqlDeclaration("Most Recent Tobacco Use Screening Indicates Tobacco User")]
 	public Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User() => 
 		__Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User.Value;
 
+    /// <seealso cref="Denominator_2"/>
 	private bool? Denominator_2_Value()
 	{
-		var a_ = this.Initial_Population();
-		var b_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User();
-		var c_ = context.Operators.Not((bool?)(b_ is null));
-		var d_ = context.Operators.And(a_, c_);
+		bool? a_ = this.Initial_Population();
+		Observation b_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User();
+		bool? c_ = context.Operators.Not((bool?)(b_ is null));
+		bool? d_ = context.Operators.And(a_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Denominator_2_Value"/>
     [CqlDeclaration("Denominator 2")]
 	public bool? Denominator_2() => 
 		__Denominator_2.Value;
 
+    /// <seealso cref="Denominator_3"/>
 	private bool? Denominator_3_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_3_Value"/>
     [CqlDeclaration("Denominator 3")]
 	public bool? Denominator_3() => 
 		__Denominator_3.Value;
 
+    /// <seealso cref="Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User"/>
 	private Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User_Value()
 	{
-		var a_ = this.Tobacco_Use_Screening();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		var c_ = Status_1_6_000.isAssessmentPerformed(b_);
+		CqlValueSet a_ = this.Tobacco_Use_Screening();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation TobaccoUseScreening)
 		{
-			var m_ = this.Measurement_Period();
-			var n_ = TobaccoUseScreening?.Effective;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = QICoreCommon_2_0_000.toInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
+			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
+			DataType n_ = TobaccoUseScreening?.Effective;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			var r_ = @this?.Effective;
-			var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-			var t_ = QICoreCommon_2_0_000.toInterval(s_);
-			var u_ = context.Operators.Start(t_);
+			DataType r_ = @this?.Effective;
+			object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.toInterval(s_);
+			CqlDateTime u_ = context.Operators.Start(t_);
 
 			return u_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = new Observation[]
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		Observation[] i_ = new Observation[]
 		{
 			h_,
 		};
 		bool? j_(Observation MostRecentTobaccoUseScreening)
 		{
-			var v_ = MostRecentTobaccoUseScreening?.Value;
-			var w_ = FHIRHelpers_4_3_000.ToValue(v_);
-			var x_ = this.Tobacco_Non_User();
-			var y_ = context.Operators.ConceptInValueSet((w_ as CqlConcept), x_);
+			DataType v_ = MostRecentTobaccoUseScreening?.Value;
+			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
+			CqlValueSet x_ = this.Tobacco_Non_User();
+			bool? y_ = context.Operators.ConceptInValueSet((w_ as CqlConcept), x_);
 
 			return y_;
 		};
-		var k_ = context.Operators.Where<Observation>((IEnumerable<Observation>)i_, j_);
-		var l_ = context.Operators.SingletonFrom<Observation>(k_);
+		IEnumerable<Observation> k_ = context.Operators.Where<Observation>((IEnumerable<Observation>)i_, j_);
+		Observation l_ = context.Operators.SingletonFrom<Observation>(k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User_Value"/>
     [CqlDeclaration("Most Recent Tobacco Use Screening Indicates Tobacco Non User")]
 	public Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User() => 
 		__Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User.Value;
 
+    /// <seealso cref="Numerator_1"/>
 	private bool? Numerator_1_Value()
 	{
-		var a_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User();
-		var b_ = context.Operators.Not((bool?)(a_ is null));
-		var c_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User();
-		var d_ = context.Operators.Not((bool?)(c_ is null));
-		var e_ = context.Operators.Or(b_, d_);
+		Observation a_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User();
+		bool? b_ = context.Operators.Not((bool?)(a_ is null));
+		Observation c_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User();
+		bool? d_ = context.Operators.Not((bool?)(c_ is null));
+		bool? e_ = context.Operators.Or(b_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Numerator_1_Value"/>
     [CqlDeclaration("Numerator 1")]
 	public bool? Numerator_1() => 
 		__Numerator_1.Value;
 
+    /// <seealso cref="Tobacco_Cessation_Counseling_Given"/>
 	private IEnumerable<object> Tobacco_Cessation_Counseling_Given_Value()
 	{
-		var a_ = this.Tobacco_Use_Cessation_Counseling();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.isInterventionPerformed(b_);
+		CqlValueSet a_ = this.Tobacco_Use_Cessation_Counseling();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.isInterventionPerformed(b_);
 		bool? d_(Procedure TobaccoCessationCounseling)
 		{
-			var l_ = this.Measurement_Period();
-			var m_ = context.Operators.Start(l_);
-			var n_ = context.Operators.Quantity(6m, "months");
-			var o_ = context.Operators.Subtract(m_, n_);
-			var q_ = context.Operators.End(l_);
-			var r_ = context.Operators.Interval(o_, q_, true, true);
-			var s_ = TobaccoCessationCounseling?.Performed;
-			var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-			var u_ = QICoreCommon_2_0_000.toInterval(t_);
-			var v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, "day");
+			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
+			CqlDateTime m_ = context.Operators.Start(l_);
+			CqlQuantity n_ = context.Operators.Quantity(6m, "months");
+			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
+			CqlDateTime q_ = context.Operators.End(l_);
+			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
+			DataType s_ = TobaccoCessationCounseling?.Performed;
+			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
+			bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, "day");
 
 			return v_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
-		var f_ = this.Tobacco_abuse_counseling();
-		var g_ = context.Operators.ToList<CqlCode>(f_);
-		var h_ = context.Operators.RetrieveByCodes<Condition>(g_, null);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
+		CqlCode f_ = this.Tobacco_abuse_counseling();
+		IEnumerable<CqlCode> g_ = context.Operators.ToList<CqlCode>(f_);
+		IEnumerable<Condition> h_ = context.Operators.RetrieveByCodes<Condition>(g_, null);
 		bool? i_(Condition TobaccoCounseling)
 		{
-			var w_ = QICoreCommon_2_0_000.prevalenceInterval(TobaccoCounseling);
-			var x_ = context.Operators.Start(w_);
-			var y_ = this.Measurement_Period();
-			var z_ = context.Operators.Start(y_);
-			var aa_ = context.Operators.Quantity(6m, "months");
-			var ab_ = context.Operators.Subtract(z_, aa_);
-			var ad_ = context.Operators.End(y_);
-			var ae_ = context.Operators.Interval(ab_, ad_, true, true);
-			var af_ = context.Operators.In<CqlDateTime>(x_, ae_, "day");
+			CqlInterval<CqlDateTime> w_ = QICoreCommon_2_0_000.prevalenceInterval(TobaccoCounseling);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			CqlInterval<CqlDateTime> y_ = this.Measurement_Period();
+			CqlDateTime z_ = context.Operators.Start(y_);
+			CqlQuantity aa_ = context.Operators.Quantity(6m, "months");
+			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
+			CqlDateTime ad_ = context.Operators.End(y_);
+			CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ab_, ad_, true, true);
+			bool? af_ = context.Operators.In<CqlDateTime>(x_, ae_, "day");
 
 			return af_;
 		};
-		var j_ = context.Operators.Where<Condition>(h_, i_);
-		var k_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
+		IEnumerable<Condition> j_ = context.Operators.Where<Condition>(h_, i_);
+		IEnumerable<object> k_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (j_ as IEnumerable<object>));
 
 		return k_;
 	}
 
+    /// <seealso cref="Tobacco_Cessation_Counseling_Given_Value"/>
     [CqlDeclaration("Tobacco Cessation Counseling Given")]
 	public IEnumerable<object> Tobacco_Cessation_Counseling_Given() => 
 		__Tobacco_Cessation_Counseling_Given.Value;
 
+    /// <seealso cref="Tobacco_Cessation_Pharmacotherapy_Ordered"/>
 	private IEnumerable<MedicationRequest> Tobacco_Cessation_Pharmacotherapy_Ordered_Value()
 	{
-		var a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = Status_1_6_000.isMedicationOrder(e_);
+		CqlValueSet a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = Status_1_6_000.isMedicationOrder(e_);
 		bool? g_(MedicationRequest CessationPharmacotherapyOrdered)
 		{
-			var i_ = CessationPharmacotherapyOrdered?.AuthoredOnElement;
-			var j_ = context.Operators.Convert<CqlDateTime>(i_);
-			var k_ = this.Measurement_Period();
-			var l_ = context.Operators.Start(k_);
-			var m_ = context.Operators.Quantity(6m, "months");
-			var n_ = context.Operators.Subtract(l_, m_);
-			var p_ = context.Operators.End(k_);
-			var q_ = context.Operators.Interval(n_, p_, true, true);
-			var r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
+			FhirDateTime i_ = CessationPharmacotherapyOrdered?.AuthoredOnElement;
+			CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
+			CqlDateTime l_ = context.Operators.Start(k_);
+			CqlQuantity m_ = context.Operators.Quantity(6m, "months");
+			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
+			CqlDateTime p_ = context.Operators.End(k_);
+			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
 
 			return r_;
 		};
-		var h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+		IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Tobacco_Cessation_Pharmacotherapy_Ordered_Value"/>
     [CqlDeclaration("Tobacco Cessation Pharmacotherapy Ordered")]
 	public IEnumerable<MedicationRequest> Tobacco_Cessation_Pharmacotherapy_Ordered() => 
 		__Tobacco_Cessation_Pharmacotherapy_Ordered.Value;
 
+    /// <seealso cref="Active_Pharmacotherapy_for_Tobacco_Cessation"/>
 	private IEnumerable<MedicationRequest> Active_Pharmacotherapy_for_Tobacco_Cessation_Value()
 	{
-		var a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = Status_1_6_000.isMedicationActive(e_);
+		CqlValueSet a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = Status_1_6_000.isMedicationActive(e_);
 		bool? g_(MedicationRequest TakingCessationPharmacotherapy)
 		{
-			var i_ = TakingCessationPharmacotherapy?.AuthoredOnElement;
-			var j_ = context.Operators.Convert<CqlDateTime>(i_);
-			var k_ = this.Measurement_Period();
-			var l_ = context.Operators.Start(k_);
-			var m_ = context.Operators.Quantity(6m, "months");
-			var n_ = context.Operators.Subtract(l_, m_);
-			var p_ = context.Operators.End(k_);
-			var q_ = context.Operators.Interval(n_, p_, true, true);
-			var r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
+			FhirDateTime i_ = TakingCessationPharmacotherapy?.AuthoredOnElement;
+			CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
+			CqlDateTime l_ = context.Operators.Start(k_);
+			CqlQuantity m_ = context.Operators.Quantity(6m, "months");
+			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
+			CqlDateTime p_ = context.Operators.End(k_);
+			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
 
 			return r_;
 		};
-		var h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+		IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Active_Pharmacotherapy_for_Tobacco_Cessation_Value"/>
     [CqlDeclaration("Active Pharmacotherapy for Tobacco Cessation")]
 	public IEnumerable<MedicationRequest> Active_Pharmacotherapy_for_Tobacco_Cessation() => 
 		__Active_Pharmacotherapy_for_Tobacco_Cessation.Value;
 
+    /// <seealso cref="Numerator_2"/>
 	private bool? Numerator_2_Value()
 	{
-		var a_ = this.Tobacco_Cessation_Counseling_Given();
-		var b_ = context.Operators.Exists<object>(a_);
-		var c_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered();
-		var d_ = context.Operators.Exists<MedicationRequest>(c_);
-		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation();
-		var g_ = context.Operators.Exists<MedicationRequest>(f_);
-		var h_ = context.Operators.Or(e_, g_);
+		IEnumerable<object> a_ = this.Tobacco_Cessation_Counseling_Given();
+		bool? b_ = context.Operators.Exists<object>(a_);
+		IEnumerable<MedicationRequest> c_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered();
+		bool? d_ = context.Operators.Exists<MedicationRequest>(c_);
+		bool? e_ = context.Operators.Or(b_, d_);
+		IEnumerable<MedicationRequest> f_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation();
+		bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+		bool? h_ = context.Operators.Or(e_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Numerator_2_Value"/>
     [CqlDeclaration("Numerator 2")]
 	public bool? Numerator_2() => 
 		__Numerator_2.Value;
 
+    /// <seealso cref="Numerator_3"/>
 	private bool? Numerator_3_Value()
 	{
-		var a_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User();
-		var b_ = context.Operators.Not((bool?)(a_ is null));
-		var c_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User();
-		var d_ = context.Operators.Not((bool?)(c_ is null));
-		var e_ = this.Tobacco_Cessation_Counseling_Given();
-		var f_ = context.Operators.Exists<object>(e_);
-		var g_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered();
-		var h_ = context.Operators.Exists<MedicationRequest>(g_);
-		var i_ = context.Operators.Or(f_, h_);
-		var j_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation();
-		var k_ = context.Operators.Exists<MedicationRequest>(j_);
-		var l_ = context.Operators.Or(i_, k_);
-		var m_ = context.Operators.And(d_, l_);
-		var n_ = context.Operators.Or(b_, m_);
+		Observation a_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User();
+		bool? b_ = context.Operators.Not((bool?)(a_ is null));
+		Observation c_ = this.Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User();
+		bool? d_ = context.Operators.Not((bool?)(c_ is null));
+		IEnumerable<object> e_ = this.Tobacco_Cessation_Counseling_Given();
+		bool? f_ = context.Operators.Exists<object>(e_);
+		IEnumerable<MedicationRequest> g_ = this.Tobacco_Cessation_Pharmacotherapy_Ordered();
+		bool? h_ = context.Operators.Exists<MedicationRequest>(g_);
+		bool? i_ = context.Operators.Or(f_, h_);
+		IEnumerable<MedicationRequest> j_ = this.Active_Pharmacotherapy_for_Tobacco_Cessation();
+		bool? k_ = context.Operators.Exists<MedicationRequest>(j_);
+		bool? l_ = context.Operators.Or(i_, k_);
+		bool? m_ = context.Operators.And(d_, l_);
+		bool? n_ = context.Operators.Or(b_, m_);
 
 		return n_;
 	}
 
+    /// <seealso cref="Numerator_3_Value"/>
     [CqlDeclaration("Numerator 3")]
 	public bool? Numerator_3() => 
 		__Numerator_3.Value;
 
+    /// <seealso cref="Denominator_Exclusion"/>
 	private bool? Denominator_Exclusion_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Exclusion_Value"/>
     [CqlDeclaration("Denominator Exclusion")]
 	public bool? Denominator_Exclusion() => 
 		__Denominator_Exclusion.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
+++ b/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
@@ -84,278 +84,326 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 
     #endregion
 
+    /// <seealso cref="Clinical_Oral_Evaluation"/>
 	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", null);
 
+    /// <seealso cref="Clinical_Oral_Evaluation_Value"/>
     [CqlDeclaration("Clinical Oral Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
 	public CqlValueSet Clinical_Oral_Evaluation() => 
 		__Clinical_Oral_Evaluation.Value;
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
 	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
+    /// <seealso cref="Discharged_to_Home_for_Hosice_Care"/>
 	private CqlValueSet Discharged_to_Home_for_Hosice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
+    /// <seealso cref="Discharged_to_Home_for_Hosice_Care_Value"/>
     [CqlDeclaration("Discharged to Home for Hosice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
 	public CqlValueSet Discharged_to_Home_for_Hosice_Care() => 
 		__Discharged_to_Home_for_Hosice_Care.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Fluoride_Varnish_Application_for_Children"/>
 	private CqlValueSet Fluoride_Varnish_Application_for_Children_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", null);
 
+    /// <seealso cref="Fluoride_Varnish_Application_for_Children_Value"/>
     [CqlDeclaration("Fluoride Varnish Application for Children")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002")]
 	public CqlValueSet Fluoride_Varnish_Application_for_Children() => 
 		__Fluoride_Varnish_Application_for_Children.Value;
 
+    /// <seealso cref="Hospice_care_ambulatory"/>
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
 
+    /// <seealso cref="Hospice_care_ambulatory_Value"/>
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
 	public CqlValueSet Hospice_care_ambulatory() => 
 		__Hospice_care_ambulatory.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Clinical_Oral_Evaluation();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = Status_1_6_000.isEncounterPerformed(b_);
+		CqlValueSet a_ = this.Clinical_Oral_Evaluation();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter ValidEncounter)
 		{
-			var f_ = this.Measurement_Period();
-			var g_ = ValidEncounter?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			Period g_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
 
 			return i_;
 		};
-		var e_ = context.Operators.Where<Encounter>(c_, d_);
+		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(1, 20, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var i_ = this.Qualifying_Encounters();
-		var j_ = context.Operators.Exists<Encounter>(i_);
-		var k_ = context.Operators.And(h_, j_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
+		bool? l_ = context.Operators.Exists<Encounter>(k_);
+		bool? m_ = context.Operators.And(j_, l_);
 
-		return k_;
+		return m_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Fluoride_Varnish_Application_for_Children();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.isProcedurePerformed(b_);
+		CqlValueSet a_ = this.Fluoride_Varnish_Application_for_Children();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		bool? d_(Procedure FluorideApplication)
 		{
-			var j_ = FluorideApplication?.Performed;
-			var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-			var l_ = QICoreCommon_2_0_000.toInterval(k_);
-			var m_ = context.Operators.End(l_);
-			var n_ = this.Measurement_Period();
-			var o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
+			DataType j_ = FluorideApplication?.Performed;
+			object k_ = FHIRHelpers_4_3_000.ToValue(j_);
+			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
+			CqlDateTime m_ = context.Operators.End(l_);
+			CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
+			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
 
 			return o_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 		CqlDate f_(Procedure FluorideApplication)
 		{
-			var p_ = FluorideApplication?.Performed;
-			var q_ = FHIRHelpers_4_3_000.ToValue(p_);
-			var r_ = QICoreCommon_2_0_000.toInterval(q_);
-			var s_ = context.Operators.End(r_);
-			var t_ = context.Operators.DateFrom(s_);
+			DataType p_ = FluorideApplication?.Performed;
+			object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+			CqlInterval<CqlDateTime> r_ = QICoreCommon_2_0_000.toInterval(q_);
+			CqlDateTime s_ = context.Operators.End(r_);
+			CqlDate t_ = context.Operators.DateFrom(s_);
 
 			return t_;
 		};
-		var g_ = context.Operators.Select<Procedure, CqlDate>(e_, f_);
-		var h_ = context.Operators.Count<CqlDate>(g_);
-		var i_ = context.Operators.GreaterOrEqual(h_, 2);
+		IEnumerable<CqlDate> g_ = context.Operators.Select<Procedure, CqlDate>(e_, f_);
+		int? h_ = context.Operators.Count<CqlDate>(g_);
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 2);
 
 		return i_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Stratification_1"/>
 	private bool? Stratification_1_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(1, 5, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(1, 5, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Stratification_1_Value"/>
     [CqlDeclaration("Stratification 1")]
 	public bool? Stratification_1() => 
 		__Stratification_1.Value;
 
+    /// <seealso cref="Stratification_2"/>
 	private bool? Stratification_2_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(6, 12, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(6, 12, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Stratification_2_Value"/>
     [CqlDeclaration("Stratification 2")]
 	public bool? Stratification_2() => 
 		__Stratification_2.Value;
 
+    /// <seealso cref="Stratification_3"/>
 	private bool? Stratification_3_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.Start(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(13, 20, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(13, 20, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Stratification_3_Value"/>
     [CqlDeclaration("Stratification 3")]
 	public bool? Stratification_3() => 
 		__Stratification_3.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
@@ -108,106 +108,133 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 
     #endregion
 
+    /// <seealso cref="Bone_Scan"/>
 	private CqlValueSet Bone_Scan_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320", null);
 
+    /// <seealso cref="Bone_Scan_Value"/>
     [CqlDeclaration("Bone Scan")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320")]
 	public CqlValueSet Bone_Scan() => 
 		__Bone_Scan.Value;
 
+    /// <seealso cref="Pain_Warranting_Further_Investigation_for_Prostate_Cancer"/>
 	private CqlValueSet Pain_Warranting_Further_Investigation_for_Prostate_Cancer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451", null);
 
+    /// <seealso cref="Pain_Warranting_Further_Investigation_for_Prostate_Cancer_Value"/>
     [CqlDeclaration("Pain Warranting Further Investigation for Prostate Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451")]
 	public CqlValueSet Pain_Warranting_Further_Investigation_for_Prostate_Cancer() => 
 		__Pain_Warranting_Further_Investigation_for_Prostate_Cancer.Value;
 
+    /// <seealso cref="Prostate_Cancer"/>
 	private CqlValueSet Prostate_Cancer_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319", null);
 
+    /// <seealso cref="Prostate_Cancer_Value"/>
     [CqlDeclaration("Prostate Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319")]
 	public CqlValueSet Prostate_Cancer() => 
 		__Prostate_Cancer.Value;
 
+    /// <seealso cref="Prostate_Cancer_Treatment"/>
 	private CqlValueSet Prostate_Cancer_Treatment_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398", null);
 
+    /// <seealso cref="Prostate_Cancer_Treatment_Value"/>
     [CqlDeclaration("Prostate Cancer Treatment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398")]
 	public CqlValueSet Prostate_Cancer_Treatment() => 
 		__Prostate_Cancer_Treatment.Value;
 
+    /// <seealso cref="Prostate_Specific_Antigen_Test"/>
 	private CqlValueSet Prostate_Specific_Antigen_Test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401", null);
 
+    /// <seealso cref="Prostate_Specific_Antigen_Test_Value"/>
     [CqlDeclaration("Prostate Specific Antigen Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401")]
 	public CqlValueSet Prostate_Specific_Antigen_Test() => 
 		__Prostate_Specific_Antigen_Test.Value;
 
+    /// <seealso cref="Salvage_Therapy"/>
 	private CqlValueSet Salvage_Therapy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399", null);
 
+    /// <seealso cref="Salvage_Therapy_Value"/>
     [CqlDeclaration("Salvage Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399")]
 	public CqlValueSet Salvage_Therapy() => 
 		__Salvage_Therapy.Value;
 
+    /// <seealso cref="Gleason_score_in_Specimen_Qualitative"/>
 	private CqlCode Gleason_score_in_Specimen_Qualitative_Value() => 
 		new CqlCode("35266-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Gleason_score_in_Specimen_Qualitative_Value"/>
     [CqlDeclaration("Gleason score in Specimen Qualitative")]
 	public CqlCode Gleason_score_in_Specimen_Qualitative() => 
 		__Gleason_score_in_Specimen_Qualitative.Value;
 
+    /// <seealso cref="Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_"/>
 	private CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding__Value() => 
 		new CqlCode("433351000124101", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding__Value"/>
     [CqlDeclaration("Neoplasm of prostate primary tumor staging category T1c: Tumor identified by needle biopsy (finding)")]
 	public CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_() => 
 		__Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_.Value;
 
+    /// <seealso cref="Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_"/>
 	private CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding__Value() => 
 		new CqlCode("433361000124104", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding__Value"/>
     [CqlDeclaration("Neoplasm of prostate primary tumor staging category T2a: Involves one-half of one lobe or less (finding)")]
 	public CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_() => 
 		__Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_.Value;
 
+    /// <seealso cref="Procedure_reason_record__record_artifact_"/>
 	private CqlCode Procedure_reason_record__record_artifact__Value() => 
 		new CqlCode("433611000124109", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Procedure_reason_record__record_artifact__Value"/>
     [CqlDeclaration("Procedure reason record (record artifact)")]
 	public CqlCode Procedure_reason_record__record_artifact_() => 
 		__Procedure_reason_record__record_artifact_.Value;
 
+    /// <seealso cref="T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_"/>
 	private CqlCode T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding__Value() => 
 		new CqlCode("369833007", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding__Value"/>
     [CqlDeclaration("T1a: Prostate tumor incidental histologic finding in 5 percent or less of tissue resected (finding)")]
 	public CqlCode T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_() => 
 		__T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_.Value;
 
+    /// <seealso cref="T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_"/>
 	private CqlCode T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding__Value() => 
 		new CqlCode("369834001", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding__Value"/>
     [CqlDeclaration("T1b: Prostate tumor incidental histologic finding in greater than 5 percent of tissue resected (finding)")]
 	public CqlCode T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_() => 
 		__T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_.Value;
 
+    /// <seealso cref="Tumor_staging__tumor_staging_"/>
 	private CqlCode Tumor_staging__tumor_staging__Value() => 
 		new CqlCode("254292007", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Tumor_staging__tumor_staging__Value"/>
     [CqlDeclaration("Tumor staging (tumor staging)")]
 	public CqlCode Tumor_staging__tumor_staging_() => 
 		__Tumor_staging__tumor_staging_.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("35266-6", "http://loinc.org", null, null),
 		};
@@ -215,13 +242,15 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("433351000124101", "http://snomed.info/sct", null, null),
 			new CqlCode("433361000124104", "http://snomed.info/sct", null, null),
@@ -234,509 +263,545 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Prostate_Cancer_Diagnosis"/>
 	private IEnumerable<Condition> Prostate_Cancer_Diagnosis_Value()
 	{
-		var a_ = this.Prostate_Cancer();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Prostate_Cancer();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition ProstateCancer)
 		{
-			var e_ = QICoreCommon_2_0_000.prevalenceInterval(ProstateCancer);
-			var f_ = this.Measurement_Period();
-			var g_ = context.Operators.Overlaps(e_, f_, "day");
-			var h_ = QICoreCommon_2_0_000.isProblemListItem(ProstateCancer);
-			var i_ = QICoreCommon_2_0_000.isHealthConcern(ProstateCancer);
-			var j_ = context.Operators.Or(h_, i_);
-			var k_ = context.Operators.And(g_, j_);
-			var l_ = QICoreCommon_2_0_000.isActive(ProstateCancer);
-			var m_ = context.Operators.And(k_, l_);
+			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.prevalenceInterval(ProstateCancer);
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			bool? g_ = context.Operators.Overlaps(e_, f_, "day");
+			bool? h_ = QICoreCommon_2_0_000.isProblemListItem(ProstateCancer);
+			bool? i_ = QICoreCommon_2_0_000.isHealthConcern(ProstateCancer);
+			bool? j_ = context.Operators.Or(h_, i_);
+			bool? k_ = context.Operators.And(g_, j_);
+			bool? l_ = QICoreCommon_2_0_000.isActive(ProstateCancer);
+			bool? m_ = context.Operators.And(k_, l_);
 
 			return m_;
 		};
-		var d_ = context.Operators.Where<Condition>(b_, c_);
+		IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Prostate_Cancer_Diagnosis_Value"/>
     [CqlDeclaration("Prostate Cancer Diagnosis")]
 	public IEnumerable<Condition> Prostate_Cancer_Diagnosis() => 
 		__Prostate_Cancer_Diagnosis.Value;
 
+    /// <seealso cref="Has_Diagnosis_of_Pain_related_to_Prostate_Cancer"/>
 	private bool? Has_Diagnosis_of_Pain_related_to_Prostate_Cancer_Value()
 	{
-		var a_ = this.Pain_Warranting_Further_Investigation_for_Prostate_Cancer();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Pain_Warranting_Further_Investigation_for_Prostate_Cancer();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		IEnumerable<Condition> c_(Condition ProstateCancerPain)
 		{
-			var f_ = this.Prostate_Cancer_Diagnosis();
+			IEnumerable<Condition> f_ = this.Prostate_Cancer_Diagnosis();
 			bool? g_(Condition ActiveProstateCancer)
 			{
-				var k_ = QICoreCommon_2_0_000.prevalenceInterval(ProstateCancerPain);
-				var l_ = context.Operators.Start(k_);
-				var m_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
-				var n_ = context.Operators.Start(m_);
-				var o_ = context.Operators.After(l_, n_, null);
-				var p_ = QICoreCommon_2_0_000.isProblemListItem(ProstateCancerPain);
-				var q_ = QICoreCommon_2_0_000.isHealthConcern(ProstateCancerPain);
-				var r_ = context.Operators.Or(p_, q_);
-				var s_ = context.Operators.And(o_, r_);
-				var t_ = QICoreCommon_2_0_000.isActive(ProstateCancerPain);
-				var u_ = context.Operators.And(s_, t_);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.prevalenceInterval(ProstateCancerPain);
+				CqlDateTime l_ = context.Operators.Start(k_);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				bool? o_ = context.Operators.After(l_, n_, null);
+				bool? p_ = QICoreCommon_2_0_000.isProblemListItem(ProstateCancerPain);
+				bool? q_ = QICoreCommon_2_0_000.isHealthConcern(ProstateCancerPain);
+				bool? r_ = context.Operators.Or(p_, q_);
+				bool? s_ = context.Operators.And(o_, r_);
+				bool? t_ = QICoreCommon_2_0_000.isActive(ProstateCancerPain);
+				bool? u_ = context.Operators.And(s_, t_);
 
 				return u_;
 			};
-			var h_ = context.Operators.Where<Condition>(f_, g_);
+			IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
 			Condition i_(Condition ActiveProstateCancer) => 
 				ProstateCancerPain;
-			var j_ = context.Operators.Select<Condition, Condition>(h_, i_);
+			IEnumerable<Condition> j_ = context.Operators.Select<Condition, Condition>(h_, i_);
 
 			return j_;
 		};
-		var d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
-		var e_ = context.Operators.Exists<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+		bool? e_ = context.Operators.Exists<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Diagnosis_of_Pain_related_to_Prostate_Cancer_Value"/>
     [CqlDeclaration("Has Diagnosis of Pain related to Prostate Cancer")]
 	public bool? Has_Diagnosis_of_Pain_related_to_Prostate_Cancer() => 
 		__Has_Diagnosis_of_Pain_related_to_Prostate_Cancer.Value;
 
+    /// <seealso cref="Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis"/>
 	private bool? Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis_Value()
 	{
-		var a_ = this.Salvage_Therapy();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		CqlValueSet a_ = this.Salvage_Therapy();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		IEnumerable<Procedure> c_(Procedure SalvageTherapy)
 		{
-			var f_ = this.Prostate_Cancer_Diagnosis();
+			IEnumerable<Condition> f_ = this.Prostate_Cancer_Diagnosis();
 			bool? g_(Condition ActiveProstateCancer)
 			{
-				var k_ = SalvageTherapy?.Performed;
-				var l_ = FHIRHelpers_4_3_000.ToValue(k_);
-				var m_ = QICoreCommon_2_0_000.toInterval(l_);
-				var n_ = context.Operators.Start(m_);
-				var o_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
-				var p_ = context.Operators.Start(o_);
-				var q_ = context.Operators.After(n_, p_, null);
-				var r_ = SalvageTherapy?.StatusElement;
-				var s_ = r_?.Value;
-				var t_ = context.Operators.Convert<string>(s_);
-				var u_ = context.Operators.Equal(t_, "completed");
-				var v_ = context.Operators.And(q_, u_);
+				DataType k_ = SalvageTherapy?.Performed;
+				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.toInterval(l_);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				bool? q_ = context.Operators.After(n_, p_, null);
+				Code<EventStatus> r_ = SalvageTherapy?.StatusElement;
+				EventStatus? s_ = r_?.Value;
+				string t_ = context.Operators.Convert<string>(s_);
+				bool? u_ = context.Operators.Equal(t_, "completed");
+				bool? v_ = context.Operators.And(q_, u_);
 
 				return v_;
 			};
-			var h_ = context.Operators.Where<Condition>(f_, g_);
+			IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
 			Procedure i_(Condition ActiveProstateCancer) => 
 				SalvageTherapy;
-			var j_ = context.Operators.Select<Condition, Procedure>(h_, i_);
+			IEnumerable<Procedure> j_ = context.Operators.Select<Condition, Procedure>(h_, i_);
 
 			return j_;
 		};
-		var d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
-		var e_ = context.Operators.Exists<Procedure>(d_);
+		IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+		bool? e_ = context.Operators.Exists<Procedure>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis_Value"/>
     [CqlDeclaration("Has Salvage Therapy Performed after Prostate Cancer Diagnosis")]
 	public bool? Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis() => 
 		__Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis.Value;
 
+    /// <seealso cref="Bone_Scan_Study_Performed"/>
 	private IEnumerable<Observation> Bone_Scan_Study_Performed_Value()
 	{
-		var a_ = this.Bone_Scan();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.Bone_Scan();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		IEnumerable<Observation> c_(Observation BoneScan)
 		{
-			var e_ = this.Prostate_Cancer_Diagnosis();
+			IEnumerable<Condition> e_ = this.Prostate_Cancer_Diagnosis();
 			bool? f_(Condition ActiveProstateCancer)
 			{
-				var j_ = BoneScan?.Effective;
-				var k_ = FHIRHelpers_4_3_000.ToValue(j_);
-				var l_ = QICoreCommon_2_0_000.toInterval(k_);
-				var m_ = context.Operators.Start(l_);
-				var n_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
-				var o_ = context.Operators.Start(n_);
-				var p_ = context.Operators.After(m_, o_, null);
+				DataType j_ = BoneScan?.Effective;
+				object k_ = FHIRHelpers_4_3_000.ToValue(j_);
+				CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
+				CqlDateTime m_ = context.Operators.Start(l_);
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
+				CqlDateTime o_ = context.Operators.Start(n_);
+				bool? p_ = context.Operators.After(m_, o_, null);
 
 				return p_;
 			};
-			var g_ = context.Operators.Where<Condition>(e_, f_);
+			IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
 			Observation h_(Condition ActiveProstateCancer) => 
 				BoneScan;
-			var i_ = context.Operators.Select<Condition, Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Select<Condition, Observation>(g_, h_);
 
 			return i_;
 		};
-		var d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Bone_Scan_Study_Performed_Value"/>
     [CqlDeclaration("Bone Scan Study Performed")]
 	public IEnumerable<Observation> Bone_Scan_Study_Performed() => 
 		__Bone_Scan_Study_Performed.Value;
 
+    /// <seealso cref="Has_Bone_Scan_Study_Performed_with_Documented_Reason"/>
 	private bool? Has_Bone_Scan_Study_Performed_with_Documented_Reason_Value()
 	{
-		var a_ = this.Bone_Scan_Study_Performed();
+		IEnumerable<Observation> a_ = this.Bone_Scan_Study_Performed();
 		bool? b_(Observation BoneScanAfterDiagnosis)
 		{
-			var e_ = BoneScanAfterDiagnosis?.Value;
-			var f_ = FHIRHelpers_4_3_000.ToValue(e_);
-			var g_ = this.Procedure_reason_record__record_artifact_();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent((f_ as CqlConcept), h_);
+			DataType e_ = BoneScanAfterDiagnosis?.Value;
+			object f_ = FHIRHelpers_4_3_000.ToValue(e_);
+			CqlCode g_ = this.Procedure_reason_record__record_artifact_();
+			CqlConcept h_ = context.Operators.ConvertCodeToConcept(g_);
+			bool? i_ = context.Operators.Equivalent((f_ as CqlConcept), h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.Where<Observation>(a_, b_);
-		var d_ = context.Operators.Exists<Observation>(c_);
+		IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
+		bool? d_ = context.Operators.Exists<Observation>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Has_Bone_Scan_Study_Performed_with_Documented_Reason_Value"/>
     [CqlDeclaration("Has Bone Scan Study Performed with Documented Reason")]
 	public bool? Has_Bone_Scan_Study_Performed_with_Documented_Reason() => 
 		__Has_Bone_Scan_Study_Performed_with_Documented_Reason.Value;
 
+    /// <seealso cref="Denominator_Exceptions"/>
 	private bool? Denominator_Exceptions_Value()
 	{
-		var a_ = this.Has_Diagnosis_of_Pain_related_to_Prostate_Cancer();
-		var b_ = this.Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis();
-		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_Bone_Scan_Study_Performed_with_Documented_Reason();
-		var e_ = context.Operators.Or(c_, d_);
+		bool? a_ = this.Has_Diagnosis_of_Pain_related_to_Prostate_Cancer();
+		bool? b_ = this.Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis();
+		bool? c_ = context.Operators.Or(a_, b_);
+		bool? d_ = this.Has_Bone_Scan_Study_Performed_with_Documented_Reason();
+		bool? e_ = context.Operators.Or(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Denominator_Exceptions_Value"/>
     [CqlDeclaration("Denominator Exceptions")]
 	public bool? Denominator_Exceptions() => 
 		__Denominator_Exceptions.Value;
 
+    /// <seealso cref="First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period"/>
 	private Procedure First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period_Value()
 	{
-		var a_ = this.Prostate_Cancer_Treatment();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		CqlValueSet a_ = this.Prostate_Cancer_Treatment();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure ProstateCancerTreatment)
 		{
-			var h_ = ProstateCancerTreatment?.Performed;
-			var i_ = FHIRHelpers_4_3_000.ToValue(h_);
-			var j_ = QICoreCommon_2_0_000.toInterval(i_);
-			var k_ = context.Operators.End(j_);
-			var l_ = this.Measurement_Period();
-			var m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
-			var n_ = ProstateCancerTreatment?.StatusElement;
-			var o_ = n_?.Value;
-			var p_ = context.Operators.Convert<string>(o_);
-			var q_ = context.Operators.Equal(p_, "completed");
-			var r_ = context.Operators.And(m_, q_);
+			DataType h_ = ProstateCancerTreatment?.Performed;
+			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
+			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.toInterval(i_);
+			CqlDateTime k_ = context.Operators.End(j_);
+			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
+			bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
+			Code<EventStatus> n_ = ProstateCancerTreatment?.StatusElement;
+			EventStatus? o_ = n_?.Value;
+			string p_ = context.Operators.Convert<string>(o_);
+			bool? q_ = context.Operators.Equal(p_, "completed");
+			bool? r_ = context.Operators.And(m_, q_);
 
 			return r_;
 		};
-		var d_ = context.Operators.Where<Procedure>(b_, c_);
+		IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
 		object e_(Procedure @this)
 		{
-			var s_ = @this?.Performed;
-			var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-			var u_ = QICoreCommon_2_0_000.toInterval(t_);
-			var v_ = context.Operators.Start(u_);
+			DataType s_ = @this?.Performed;
+			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
+			CqlDateTime v_ = context.Operators.Start(u_);
 
 			return v_;
 		};
-		var f_ = context.Operators.SortBy<Procedure>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-		var g_ = context.Operators.First<Procedure>(f_);
+		IEnumerable<Procedure> f_ = context.Operators.SortBy<Procedure>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		Procedure g_ = context.Operators.First<Procedure>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period_Value"/>
     [CqlDeclaration("First Prostate Cancer Treatment during day of Measurement Period")]
 	public Procedure First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period() => 
 		__First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Prostate_Cancer_Diagnosis();
-		var b_ = context.Operators.Exists<Condition>(a_);
+		IEnumerable<Condition> a_ = this.Prostate_Cancer_Diagnosis();
+		bool? b_ = context.Operators.Exists<Condition>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Most_Recent_Gleason_Score_is_Low"/>
 	private bool? Most_Recent_Gleason_Score_is_Low_Value()
 	{
-		var a_ = this.Gleason_score_in_Specimen_Qualitative();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.Gleason_score_in_Specimen_Qualitative();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		IEnumerable<Observation> d_(Observation GleasonScore)
 		{
-			var m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
-			var n_ = new Procedure[]
+			Procedure m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
+			Procedure[] n_ = new Procedure[]
 			{
 				m_,
 			};
 			bool? o_(Procedure FirstProstateCancerTreatment)
 			{
-				var s_ = GleasonScore?.Effective;
-				var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-				var u_ = QICoreCommon_2_0_000.toInterval(t_);
-				var v_ = context.Operators.Start(u_);
-				var w_ = FirstProstateCancerTreatment?.Performed;
-				var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-				var y_ = QICoreCommon_2_0_000.toInterval(x_);
-				var z_ = context.Operators.Start(y_);
-				var aa_ = context.Operators.Before(v_, z_, null);
-				var ab_ = GleasonScore?.StatusElement;
-				var ac_ = ab_?.Value;
-				var ad_ = context.Operators.Convert<Code<ObservationStatus>>(ac_);
-				var ae_ = context.Operators.Convert<string>(ad_);
-				var af_ = new string[]
+				DataType s_ = GleasonScore?.Effective;
+				object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
+				CqlDateTime v_ = context.Operators.Start(u_);
+				DataType w_ = FirstProstateCancerTreatment?.Performed;
+				object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
+				CqlDateTime z_ = context.Operators.Start(y_);
+				bool? aa_ = context.Operators.Before(v_, z_, null);
+				Code<ObservationStatus> ab_ = GleasonScore?.StatusElement;
+				ObservationStatus? ac_ = ab_?.Value;
+				Code<ObservationStatus> ad_ = context.Operators.Convert<Code<ObservationStatus>>(ac_);
+				string ae_ = context.Operators.Convert<string>(ad_);
+				string[] af_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ag_ = context.Operators.In<string>(ae_, (af_ as IEnumerable<string>));
-				var ah_ = context.Operators.And(aa_, ag_);
+				bool? ag_ = context.Operators.In<string>(ae_, (af_ as IEnumerable<string>));
+				bool? ah_ = context.Operators.And(aa_, ag_);
 
 				return ah_;
 			};
-			var p_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)n_, o_);
+			IEnumerable<Procedure> p_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)n_, o_);
 			Observation q_(Procedure FirstProstateCancerTreatment) => 
 				GleasonScore;
-			var r_ = context.Operators.Select<Procedure, Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Select<Procedure, Observation>(p_, q_);
 
 			return r_;
 		};
-		var e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			var ai_ = @this?.Effective;
-			var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-			var ak_ = QICoreCommon_2_0_000.toInterval(aj_);
-			var al_ = context.Operators.Start(ak_);
+			DataType ai_ = @this?.Effective;
+			object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.toInterval(aj_);
+			CqlDateTime al_ = context.Operators.Start(ak_);
 
 			return al_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = new Observation[]
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		Observation[] i_ = new Observation[]
 		{
 			h_,
 		};
 		bool? j_(Observation LastGleasonScore)
 		{
-			var am_ = LastGleasonScore?.Value;
-			var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-			var ao_ = context.Operators.LessOrEqual((int?)an_, 6);
+			DataType am_ = LastGleasonScore?.Value;
+			object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+			bool? ao_ = context.Operators.LessOrEqual((int?)an_, 6);
 
 			return ao_;
 		};
-		var k_ = context.Operators.Select<Observation, bool?>((IEnumerable<Observation>)i_, j_);
-		var l_ = context.Operators.SingletonFrom<bool?>(k_);
+		IEnumerable<bool?> k_ = context.Operators.Select<Observation, bool?>((IEnumerable<Observation>)i_, j_);
+		bool? l_ = context.Operators.SingletonFrom<bool?>(k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Most_Recent_Gleason_Score_is_Low_Value"/>
     [CqlDeclaration("Most Recent Gleason Score is Low")]
 	public bool? Most_Recent_Gleason_Score_is_Low() => 
 		__Most_Recent_Gleason_Score_is_Low.Value;
 
+    /// <seealso cref="Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a"/>
 	private Observation Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a_Value()
 	{
-		var a_ = this.Tumor_staging__tumor_staging_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.Tumor_staging__tumor_staging_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		IEnumerable<Observation> d_(Observation ProstateCancerStaging)
 		{
-			var m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
-			var n_ = new Procedure[]
+			Procedure m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
+			Procedure[] n_ = new Procedure[]
 			{
 				m_,
 			};
 			bool? o_(Procedure FirstProstateCancerTreatment)
 			{
-				var s_ = ProstateCancerStaging?.Effective;
-				var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-				var u_ = QICoreCommon_2_0_000.toInterval(t_);
-				var v_ = context.Operators.Start(u_);
-				var w_ = FirstProstateCancerTreatment?.Performed;
-				var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-				var y_ = QICoreCommon_2_0_000.toInterval(x_);
-				var z_ = context.Operators.Start(y_);
-				var aa_ = context.Operators.Before(v_, z_, null);
-				var ab_ = ProstateCancerStaging?.StatusElement;
-				var ac_ = ab_?.Value;
-				var ad_ = context.Operators.Convert<Code<ObservationStatus>>(ac_);
-				var ae_ = context.Operators.Convert<string>(ad_);
-				var af_ = new string[]
+				DataType s_ = ProstateCancerStaging?.Effective;
+				object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
+				CqlDateTime v_ = context.Operators.Start(u_);
+				DataType w_ = FirstProstateCancerTreatment?.Performed;
+				object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
+				CqlDateTime z_ = context.Operators.Start(y_);
+				bool? aa_ = context.Operators.Before(v_, z_, null);
+				Code<ObservationStatus> ab_ = ProstateCancerStaging?.StatusElement;
+				ObservationStatus? ac_ = ab_?.Value;
+				Code<ObservationStatus> ad_ = context.Operators.Convert<Code<ObservationStatus>>(ac_);
+				string ae_ = context.Operators.Convert<string>(ad_);
+				string[] af_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ag_ = context.Operators.In<string>(ae_, (af_ as IEnumerable<string>));
-				var ah_ = context.Operators.And(aa_, ag_);
+				bool? ag_ = context.Operators.In<string>(ae_, (af_ as IEnumerable<string>));
+				bool? ah_ = context.Operators.And(aa_, ag_);
 
 				return ah_;
 			};
-			var p_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)n_, o_);
+			IEnumerable<Procedure> p_ = context.Operators.Where<Procedure>((IEnumerable<Procedure>)n_, o_);
 			Observation q_(Procedure FirstProstateCancerTreatment) => 
 				ProstateCancerStaging;
-			var r_ = context.Operators.Select<Procedure, Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Select<Procedure, Observation>(p_, q_);
 
 			return r_;
 		};
-		var e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
 		object f_(Observation @this)
 		{
-			var ai_ = @this?.Effective;
-			var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-			var ak_ = QICoreCommon_2_0_000.toInterval(aj_);
-			var al_ = context.Operators.Start(ak_);
+			DataType ai_ = @this?.Effective;
+			object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.toInterval(aj_);
+			CqlDateTime al_ = context.Operators.Start(ak_);
 
 			return al_;
 		};
-		var g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.Last<Observation>(g_);
-		var i_ = new Observation[]
+		IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation h_ = context.Operators.Last<Observation>(g_);
+		Observation[] i_ = new Observation[]
 		{
 			h_,
 		};
 		bool? j_(Observation LastProstateCancerStaging)
 		{
-			var am_ = LastProstateCancerStaging?.Value;
-			var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-			var ao_ = this.T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_();
-			var ap_ = context.Operators.ConvertCodeToConcept(ao_);
-			var aq_ = context.Operators.Equivalent((an_ as CqlConcept), ap_);
-			var as_ = FHIRHelpers_4_3_000.ToValue(am_);
-			var at_ = this.T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_();
-			var au_ = context.Operators.ConvertCodeToConcept(at_);
-			var av_ = context.Operators.Equivalent((as_ as CqlConcept), au_);
-			var aw_ = context.Operators.Or(aq_, av_);
-			var ay_ = FHIRHelpers_4_3_000.ToValue(am_);
-			var az_ = this.Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_();
-			var ba_ = context.Operators.ConvertCodeToConcept(az_);
-			var bb_ = context.Operators.Equivalent((ay_ as CqlConcept), ba_);
-			var bc_ = context.Operators.Or(aw_, bb_);
-			var be_ = FHIRHelpers_4_3_000.ToValue(am_);
-			var bf_ = this.Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_();
-			var bg_ = context.Operators.ConvertCodeToConcept(bf_);
-			var bh_ = context.Operators.Equivalent((be_ as CqlConcept), bg_);
-			var bi_ = context.Operators.Or(bc_, bh_);
+			DataType am_ = LastProstateCancerStaging?.Value;
+			object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+			CqlCode ao_ = this.T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_();
+			CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+			bool? aq_ = context.Operators.Equivalent((an_ as CqlConcept), ap_);
+			object as_ = FHIRHelpers_4_3_000.ToValue(am_);
+			CqlCode at_ = this.T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_();
+			CqlConcept au_ = context.Operators.ConvertCodeToConcept(at_);
+			bool? av_ = context.Operators.Equivalent((as_ as CqlConcept), au_);
+			bool? aw_ = context.Operators.Or(aq_, av_);
+			object ay_ = FHIRHelpers_4_3_000.ToValue(am_);
+			CqlCode az_ = this.Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_();
+			CqlConcept ba_ = context.Operators.ConvertCodeToConcept(az_);
+			bool? bb_ = context.Operators.Equivalent((ay_ as CqlConcept), ba_);
+			bool? bc_ = context.Operators.Or(aw_, bb_);
+			object be_ = FHIRHelpers_4_3_000.ToValue(am_);
+			CqlCode bf_ = this.Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_();
+			CqlConcept bg_ = context.Operators.ConvertCodeToConcept(bf_);
+			bool? bh_ = context.Operators.Equivalent((be_ as CqlConcept), bg_);
+			bool? bi_ = context.Operators.Or(bc_, bh_);
 
 			return bi_;
 		};
-		var k_ = context.Operators.Where<Observation>((IEnumerable<Observation>)i_, j_);
-		var l_ = context.Operators.SingletonFrom<Observation>(k_);
+		IEnumerable<Observation> k_ = context.Operators.Where<Observation>((IEnumerable<Observation>)i_, j_);
+		Observation l_ = context.Operators.SingletonFrom<Observation>(k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a_Value"/>
     [CqlDeclaration("Most Recent Prostate Cancer Staging Tumor Size T1a to T2a")]
 	public Observation Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a() => 
 		__Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Bone_Scan_Study_Performed();
-		var b_ = context.Operators.Exists<Observation>(a_);
-		var c_ = context.Operators.Not(b_);
+		IEnumerable<Observation> a_ = this.Bone_Scan_Study_Performed();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
+		bool? c_ = context.Operators.Not(b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Most_Recent_PSA_Test_Result_is_Low"/>
 	private bool? Most_Recent_PSA_Test_Result_is_Low_Value()
 	{
-		var a_ = this.Prostate_Specific_Antigen_Test();
-		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		CqlValueSet a_ = this.Prostate_Specific_Antigen_Test();
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		IEnumerable<Observation> c_(Observation PSATest)
 		{
-			var l_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a();
-			var m_ = new Observation[]
+			Observation l_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a();
+			Observation[] m_ = new Observation[]
 			{
 				l_,
 			};
@@ -746,10 +811,10 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				{
 					bool ad_()
 					{
-						var ae_ = PSATest?.Effective;
-						var af_ = FHIRHelpers_4_3_000.ToValue(ae_);
-						var ag_ = QICoreCommon_2_0_000.toInterval(af_);
-						var ah_ = context.Operators.Start(ag_);
+						DataType ae_ = PSATest?.Effective;
+						object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
+						CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.toInterval(af_);
+						CqlDateTime ah_ = context.Operators.Start(ag_);
 
 						return (ah_ is null);
 					};
@@ -759,96 +824,99 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 					}
 					else
 					{
-						var ai_ = PSATest?.Effective;
-						var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
-						var ak_ = QICoreCommon_2_0_000.toInterval(aj_);
-						var al_ = context.Operators.Start(ak_);
-						var an_ = FHIRHelpers_4_3_000.ToValue(ai_);
-						var ao_ = QICoreCommon_2_0_000.toInterval(an_);
-						var ap_ = context.Operators.Start(ao_);
-						var aq_ = context.Operators.Interval(al_, ap_, true, true);
+						DataType ai_ = PSATest?.Effective;
+						object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+						CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.toInterval(aj_);
+						CqlDateTime al_ = context.Operators.Start(ak_);
+						object an_ = FHIRHelpers_4_3_000.ToValue(ai_);
+						CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_0_000.toInterval(an_);
+						CqlDateTime ap_ = context.Operators.Start(ao_);
+						CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(al_, ap_, true, true);
 
 						return aq_;
 					}
 				};
-				var s_ = MostRecentProstateCancerStaging?.Effective;
-				var t_ = FHIRHelpers_4_3_000.ToValue(s_);
-				var u_ = QICoreCommon_2_0_000.toInterval(t_);
-				var v_ = context.Operators.Before(r_(), u_, null);
-				var w_ = PSATest?.StatusElement;
-				var x_ = w_?.Value;
-				var y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
-				var z_ = context.Operators.Convert<string>(y_);
-				var aa_ = new string[]
+				DataType s_ = MostRecentProstateCancerStaging?.Effective;
+				object t_ = FHIRHelpers_4_3_000.ToValue(s_);
+				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
+				bool? v_ = context.Operators.Before(r_(), u_, null);
+				Code<ObservationStatus> w_ = PSATest?.StatusElement;
+				ObservationStatus? x_ = w_?.Value;
+				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
+				string z_ = context.Operators.Convert<string>(y_);
+				string[] aa_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
-				var ac_ = context.Operators.And(v_, ab_);
+				bool? ab_ = context.Operators.In<string>(z_, (aa_ as IEnumerable<string>));
+				bool? ac_ = context.Operators.And(v_, ab_);
 
 				return ac_;
 			};
-			var o_ = context.Operators.Where<Observation>((IEnumerable<Observation>)m_, n_);
+			IEnumerable<Observation> o_ = context.Operators.Where<Observation>((IEnumerable<Observation>)m_, n_);
 			Observation p_(Observation MostRecentProstateCancerStaging) => 
 				PSATest;
-			var q_ = context.Operators.Select<Observation, Observation>(o_, p_);
+			IEnumerable<Observation> q_ = context.Operators.Select<Observation, Observation>(o_, p_);
 
 			return q_;
 		};
-		var d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.SelectMany<Observation, Observation>(b_, c_);
 		object e_(Observation @this)
 		{
-			var ar_ = @this?.Effective;
-			var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
-			var at_ = QICoreCommon_2_0_000.toInterval(as_);
-			var au_ = context.Operators.Start(at_);
+			DataType ar_ = @this?.Effective;
+			object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+			CqlInterval<CqlDateTime> at_ = QICoreCommon_2_0_000.toInterval(as_);
+			CqlDateTime au_ = context.Operators.Start(at_);
 
 			return au_;
 		};
-		var f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-		var g_ = context.Operators.Last<Observation>(f_);
-		var h_ = new Observation[]
+		IEnumerable<Observation> f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		Observation g_ = context.Operators.Last<Observation>(f_);
+		Observation[] h_ = new Observation[]
 		{
 			g_,
 		};
 		bool? i_(Observation LastPSATest)
 		{
-			var av_ = LastPSATest?.Value;
-			var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-			var ax_ = context.Operators.Quantity(10m, "ng/mL");
-			var ay_ = context.Operators.Less((aw_ as CqlQuantity), ax_);
+			DataType av_ = LastPSATest?.Value;
+			object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+			CqlQuantity ax_ = context.Operators.Quantity(10m, "ng/mL");
+			bool? ay_ = context.Operators.Less((aw_ as CqlQuantity), ax_);
 
 			return ay_;
 		};
-		var j_ = context.Operators.Select<Observation, bool?>((IEnumerable<Observation>)h_, i_);
-		var k_ = context.Operators.SingletonFrom<bool?>(j_);
+		IEnumerable<bool?> j_ = context.Operators.Select<Observation, bool?>((IEnumerable<Observation>)h_, i_);
+		bool? k_ = context.Operators.SingletonFrom<bool?>(j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Most_Recent_PSA_Test_Result_is_Low_Value"/>
     [CqlDeclaration("Most Recent PSA Test Result is Low")]
 	public bool? Most_Recent_PSA_Test_Result_is_Low() => 
 		__Most_Recent_PSA_Test_Result_is_Low.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
-		var b_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
-		var c_ = context.Operators.Not((bool?)(b_ is null));
-		var d_ = context.Operators.And(a_, c_);
-		var e_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a();
-		var f_ = context.Operators.Not((bool?)(e_ is null));
-		var g_ = context.Operators.And(d_, f_);
-		var h_ = this.Most_Recent_PSA_Test_Result_is_Low();
-		var i_ = context.Operators.And(g_, h_);
-		var j_ = this.Most_Recent_Gleason_Score_is_Low();
-		var k_ = context.Operators.And(i_, j_);
+		bool? a_ = this.Initial_Population();
+		Procedure b_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
+		bool? c_ = context.Operators.Not((bool?)(b_ is null));
+		bool? d_ = context.Operators.And(a_, c_);
+		Observation e_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a();
+		bool? f_ = context.Operators.Not((bool?)(e_ is null));
+		bool? g_ = context.Operators.And(d_, f_);
+		bool? h_ = this.Most_Recent_PSA_Test_Result_is_Low();
+		bool? i_ = context.Operators.And(g_, h_);
+		bool? j_ = this.Most_Recent_Gleason_Score_is_Low();
+		bool? k_ = context.Operators.And(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;

--- a/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
@@ -184,415 +184,532 @@ public class QICoreCommon_2_0_000
 
     #endregion
 
+    /// <seealso cref="Birthdate"/>
 	private CqlCode Birthdate_Value() => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Birthdate_Value"/>
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
+    /// <seealso cref="Dead"/>
 	private CqlCode Dead_Value() => 
 		new CqlCode("419099009", "http://snomed.info/sct", null, null);
 
+    /// <seealso cref="Dead_Value"/>
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
 		__Dead.Value;
 
+    /// <seealso cref="ER"/>
 	private CqlCode ER_Value() => 
 		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
 
+    /// <seealso cref="ER_Value"/>
     [CqlDeclaration("ER")]
 	public CqlCode ER() => 
 		__ER.Value;
 
+    /// <seealso cref="ICU"/>
 	private CqlCode ICU_Value() => 
 		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
 
+    /// <seealso cref="ICU_Value"/>
     [CqlDeclaration("ICU")]
 	public CqlCode ICU() => 
 		__ICU.Value;
 
+    /// <seealso cref="Billing"/>
 	private CqlCode Billing_Value() => 
 		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
 
+    /// <seealso cref="Billing_Value"/>
     [CqlDeclaration("Billing")]
 	public CqlCode Billing() => 
 		__Billing.Value;
 
+    /// <seealso cref="ambulatory"/>
 	private CqlCode ambulatory_Value() => 
 		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="ambulatory_Value"/>
     [CqlDeclaration("ambulatory")]
 	public CqlCode ambulatory() => 
 		__ambulatory.Value;
 
+    /// <seealso cref="emergency"/>
 	private CqlCode emergency_Value() => 
 		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="emergency_Value"/>
     [CqlDeclaration("emergency")]
 	public CqlCode emergency() => 
 		__emergency.Value;
 
+    /// <seealso cref="field"/>
 	private CqlCode field_Value() => 
 		new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="field_Value"/>
     [CqlDeclaration("field")]
 	public CqlCode field() => 
 		__field.Value;
 
+    /// <seealso cref="home_health"/>
 	private CqlCode home_health_Value() => 
 		new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="home_health_Value"/>
     [CqlDeclaration("home health")]
 	public CqlCode home_health() => 
 		__home_health.Value;
 
+    /// <seealso cref="inpatient_encounter"/>
 	private CqlCode inpatient_encounter_Value() => 
 		new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="inpatient_encounter_Value"/>
     [CqlDeclaration("inpatient encounter")]
 	public CqlCode inpatient_encounter() => 
 		__inpatient_encounter.Value;
 
+    /// <seealso cref="inpatient_acute"/>
 	private CqlCode inpatient_acute_Value() => 
 		new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="inpatient_acute_Value"/>
     [CqlDeclaration("inpatient acute")]
 	public CqlCode inpatient_acute() => 
 		__inpatient_acute.Value;
 
+    /// <seealso cref="inpatient_non_acute"/>
 	private CqlCode inpatient_non_acute_Value() => 
 		new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="inpatient_non_acute_Value"/>
     [CqlDeclaration("inpatient non-acute")]
 	public CqlCode inpatient_non_acute() => 
 		__inpatient_non_acute.Value;
 
+    /// <seealso cref="observation_encounter"/>
 	private CqlCode observation_encounter_Value() => 
 		new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="observation_encounter_Value"/>
     [CqlDeclaration("observation encounter")]
 	public CqlCode observation_encounter() => 
 		__observation_encounter.Value;
 
+    /// <seealso cref="pre_admission"/>
 	private CqlCode pre_admission_Value() => 
 		new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="pre_admission_Value"/>
     [CqlDeclaration("pre-admission")]
 	public CqlCode pre_admission() => 
 		__pre_admission.Value;
 
+    /// <seealso cref="short_stay"/>
 	private CqlCode short_stay_Value() => 
 		new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="short_stay_Value"/>
     [CqlDeclaration("short stay")]
 	public CqlCode short_stay() => 
 		__short_stay.Value;
 
+    /// <seealso cref="@virtual"/>
 	private CqlCode @virtual_Value() => 
 		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="@virtual_Value"/>
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
+    /// <seealso cref="problem_list_item"/>
 	private CqlCode problem_list_item_Value() => 
 		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
 
+    /// <seealso cref="problem_list_item_Value"/>
     [CqlDeclaration("problem-list-item")]
 	public CqlCode problem_list_item() => 
 		__problem_list_item.Value;
 
+    /// <seealso cref="encounter_diagnosis"/>
 	private CqlCode encounter_diagnosis_Value() => 
 		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
 
+    /// <seealso cref="encounter_diagnosis_Value"/>
     [CqlDeclaration("encounter-diagnosis")]
 	public CqlCode encounter_diagnosis() => 
 		__encounter_diagnosis.Value;
 
+    /// <seealso cref="health_concern"/>
 	private CqlCode health_concern_Value() => 
 		new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", null, null);
 
+    /// <seealso cref="health_concern_Value"/>
     [CqlDeclaration("health-concern")]
 	public CqlCode health_concern() => 
 		__health_concern.Value;
 
+    /// <seealso cref="active"/>
 	private CqlCode active_Value() => 
 		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
+    /// <seealso cref="active_Value"/>
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
+    /// <seealso cref="recurrence"/>
 	private CqlCode recurrence_Value() => 
 		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
+    /// <seealso cref="recurrence_Value"/>
     [CqlDeclaration("recurrence")]
 	public CqlCode recurrence() => 
 		__recurrence.Value;
 
+    /// <seealso cref="relapse"/>
 	private CqlCode relapse_Value() => 
 		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
+    /// <seealso cref="relapse_Value"/>
     [CqlDeclaration("relapse")]
 	public CqlCode relapse() => 
 		__relapse.Value;
 
+    /// <seealso cref="inactive"/>
 	private CqlCode inactive_Value() => 
 		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
+    /// <seealso cref="inactive_Value"/>
     [CqlDeclaration("inactive")]
 	public CqlCode inactive() => 
 		__inactive.Value;
 
+    /// <seealso cref="remission"/>
 	private CqlCode remission_Value() => 
 		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
+    /// <seealso cref="remission_Value"/>
     [CqlDeclaration("remission")]
 	public CqlCode remission() => 
 		__remission.Value;
 
+    /// <seealso cref="resolved"/>
 	private CqlCode resolved_Value() => 
 		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
+    /// <seealso cref="resolved_Value"/>
     [CqlDeclaration("resolved")]
 	public CqlCode resolved() => 
 		__resolved.Value;
 
+    /// <seealso cref="unconfirmed"/>
 	private CqlCode unconfirmed_Value() => 
 		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
+    /// <seealso cref="unconfirmed_Value"/>
     [CqlDeclaration("unconfirmed")]
 	public CqlCode unconfirmed() => 
 		__unconfirmed.Value;
 
+    /// <seealso cref="provisional"/>
 	private CqlCode provisional_Value() => 
 		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
+    /// <seealso cref="provisional_Value"/>
     [CqlDeclaration("provisional")]
 	public CqlCode provisional() => 
 		__provisional.Value;
 
+    /// <seealso cref="differential"/>
 	private CqlCode differential_Value() => 
 		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
+    /// <seealso cref="differential_Value"/>
     [CqlDeclaration("differential")]
 	public CqlCode differential() => 
 		__differential.Value;
 
+    /// <seealso cref="confirmed"/>
 	private CqlCode confirmed_Value() => 
 		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
+    /// <seealso cref="confirmed_Value"/>
     [CqlDeclaration("confirmed")]
 	public CqlCode confirmed() => 
 		__confirmed.Value;
 
+    /// <seealso cref="refuted"/>
 	private CqlCode refuted_Value() => 
 		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
+    /// <seealso cref="refuted_Value"/>
     [CqlDeclaration("refuted")]
 	public CqlCode refuted() => 
 		__refuted.Value;
 
+    /// <seealso cref="entered_in_error"/>
 	private CqlCode entered_in_error_Value() => 
 		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
+    /// <seealso cref="entered_in_error_Value"/>
     [CqlDeclaration("entered-in-error")]
 	public CqlCode entered_in_error() => 
 		__entered_in_error.Value;
 
+    /// <seealso cref="allergy_active"/>
 	private CqlCode allergy_active_Value() => 
 		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
 
+    /// <seealso cref="allergy_active_Value"/>
     [CqlDeclaration("allergy-active")]
 	public CqlCode allergy_active() => 
 		__allergy_active.Value;
 
+    /// <seealso cref="allergy_inactive"/>
 	private CqlCode allergy_inactive_Value() => 
 		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
 
+    /// <seealso cref="allergy_inactive_Value"/>
     [CqlDeclaration("allergy-inactive")]
 	public CqlCode allergy_inactive() => 
 		__allergy_inactive.Value;
 
+    /// <seealso cref="allergy_resolved"/>
 	private CqlCode allergy_resolved_Value() => 
 		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
 
+    /// <seealso cref="allergy_resolved_Value"/>
     [CqlDeclaration("allergy-resolved")]
 	public CqlCode allergy_resolved() => 
 		__allergy_resolved.Value;
 
+    /// <seealso cref="allergy_unconfirmed"/>
 	private CqlCode allergy_unconfirmed_Value() => 
 		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
+    /// <seealso cref="allergy_unconfirmed_Value"/>
     [CqlDeclaration("allergy-unconfirmed")]
 	public CqlCode allergy_unconfirmed() => 
 		__allergy_unconfirmed.Value;
 
+    /// <seealso cref="allergy_confirmed"/>
 	private CqlCode allergy_confirmed_Value() => 
 		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
+    /// <seealso cref="allergy_confirmed_Value"/>
     [CqlDeclaration("allergy-confirmed")]
 	public CqlCode allergy_confirmed() => 
 		__allergy_confirmed.Value;
 
+    /// <seealso cref="allergy_refuted"/>
 	private CqlCode allergy_refuted_Value() => 
 		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
+    /// <seealso cref="allergy_refuted_Value"/>
     [CqlDeclaration("allergy-refuted")]
 	public CqlCode allergy_refuted() => 
 		__allergy_refuted.Value;
 
+    /// <seealso cref="Inpatient"/>
 	private CqlCode Inpatient_Value() => 
 		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
+    /// <seealso cref="Inpatient_Value"/>
     [CqlDeclaration("Inpatient")]
 	public CqlCode Inpatient() => 
 		__Inpatient.Value;
 
+    /// <seealso cref="Outpatient"/>
 	private CqlCode Outpatient_Value() => 
 		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
+    /// <seealso cref="Outpatient_Value"/>
     [CqlDeclaration("Outpatient")]
 	public CqlCode Outpatient() => 
 		__Outpatient.Value;
 
+    /// <seealso cref="Community"/>
 	private CqlCode Community_Value() => 
 		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
+    /// <seealso cref="Community_Value"/>
     [CqlDeclaration("Community")]
 	public CqlCode Community() => 
 		__Community.Value;
 
+    /// <seealso cref="Discharge"/>
 	private CqlCode Discharge_Value() => 
 		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
+    /// <seealso cref="Discharge_Value"/>
     [CqlDeclaration("Discharge")]
 	public CqlCode Discharge() => 
 		__Discharge.Value;
 
+    /// <seealso cref="AD"/>
 	private CqlCode AD_Value() => 
 		new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
 
+    /// <seealso cref="AD_Value"/>
     [CqlDeclaration("AD")]
 	public CqlCode AD() => 
 		__AD.Value;
 
+    /// <seealso cref="DD"/>
 	private CqlCode DD_Value() => 
 		new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
 
+    /// <seealso cref="DD_Value"/>
     [CqlDeclaration("DD")]
 	public CqlCode DD() => 
 		__DD.Value;
 
+    /// <seealso cref="CC"/>
 	private CqlCode CC_Value() => 
 		new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
 
+    /// <seealso cref="CC_Value"/>
     [CqlDeclaration("CC")]
 	public CqlCode CC() => 
 		__CC.Value;
 
+    /// <seealso cref="CM"/>
 	private CqlCode CM_Value() => 
 		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
 
+    /// <seealso cref="CM_Value"/>
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
+    /// <seealso cref="pre_op"/>
 	private CqlCode pre_op_Value() => 
 		new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
 
+    /// <seealso cref="pre_op_Value"/>
     [CqlDeclaration("pre-op")]
 	public CqlCode pre_op() => 
 		__pre_op.Value;
 
+    /// <seealso cref="post_op"/>
 	private CqlCode post_op_Value() => 
 		new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
 
+    /// <seealso cref="post_op_Value"/>
     [CqlDeclaration("post-op")]
 	public CqlCode post_op() => 
 		__post_op.Value;
 
+    /// <seealso cref="billing"/>
 	private CqlCode billing_Value() => 
 		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
 
+    /// <seealso cref="billing_Value"/>
     [CqlDeclaration("billing")]
 	public CqlCode billing() => 
 		__billing.Value;
 
+    /// <seealso cref="social_history"/>
 	private CqlCode social_history_Value() => 
 		new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="social_history_Value"/>
     [CqlDeclaration("social-history")]
 	public CqlCode social_history() => 
 		__social_history.Value;
 
+    /// <seealso cref="vital_signs"/>
 	private CqlCode vital_signs_Value() => 
 		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="vital_signs_Value"/>
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
+    /// <seealso cref="imaging"/>
 	private CqlCode imaging_Value() => 
 		new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="imaging_Value"/>
     [CqlDeclaration("imaging")]
 	public CqlCode imaging() => 
 		__imaging.Value;
 
+    /// <seealso cref="laboratory"/>
 	private CqlCode laboratory_Value() => 
 		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="laboratory_Value"/>
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
+    /// <seealso cref="procedure"/>
 	private CqlCode procedure_Value() => 
 		new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="procedure_Value"/>
     [CqlDeclaration("procedure")]
 	public CqlCode procedure() => 
 		__procedure.Value;
 
+    /// <seealso cref="survey"/>
 	private CqlCode survey_Value() => 
 		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="survey_Value"/>
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
+    /// <seealso cref="exam"/>
 	private CqlCode exam_Value() => 
 		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="exam_Value"/>
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
+    /// <seealso cref="therapy"/>
 	private CqlCode therapy_Value() => 
 		new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="therapy_Value"/>
     [CqlDeclaration("therapy")]
 	public CqlCode therapy() => 
 		__therapy.Value;
 
+    /// <seealso cref="activity"/>
 	private CqlCode activity_Value() => 
 		new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="activity_Value"/>
     [CqlDeclaration("activity")]
 	public CqlCode activity() => 
 		__activity.Value;
 
+    /// <seealso cref="clinical_test"/>
 	private CqlCode clinical_test_Value() => 
 		new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", null, null);
 
+    /// <seealso cref="clinical_test_Value"/>
     [CqlDeclaration("clinical-test")]
 	public CqlCode clinical_test() => 
 		__clinical_test.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("21112-8", "http://loinc.org", null, null),
 		};
@@ -600,13 +717,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("419099009", "http://snomed.info/sct", null, null),
 		};
@@ -614,13 +733,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
@@ -638,13 +759,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="RoleCode"/>
 	private CqlCode[] RoleCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
 			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
@@ -653,13 +776,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="RoleCode_Value"/>
     [CqlDeclaration("RoleCode")]
 	public CqlCode[] RoleCode() => 
 		__RoleCode.Value;
 
+    /// <seealso cref="Diagnosis_Role"/>
 	private CqlCode[] Diagnosis_Role_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
 			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
@@ -674,25 +799,29 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="Diagnosis_Role_Value"/>
     [CqlDeclaration("Diagnosis Role")]
 	public CqlCode[] Diagnosis_Role() => 
 		__Diagnosis_Role.Value;
 
+    /// <seealso cref="RequestIntent"/>
 	private CqlCode[] RequestIntent_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="RequestIntent_Value"/>
     [CqlDeclaration("RequestIntent")]
 	public CqlCode[] RequestIntent() => 
 		__RequestIntent.Value;
 
+    /// <seealso cref="MedicationRequestCategory"/>
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
 			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
@@ -703,13 +832,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="MedicationRequestCategory_Value"/>
     [CqlDeclaration("MedicationRequestCategory")]
 	public CqlCode[] MedicationRequestCategory() => 
 		__MedicationRequestCategory.Value;
 
+    /// <seealso cref="ConditionClinicalStatusCodes"/>
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
 			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
@@ -722,13 +853,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="ConditionClinicalStatusCodes_Value"/>
     [CqlDeclaration("ConditionClinicalStatusCodes")]
 	public CqlCode[] ConditionClinicalStatusCodes() => 
 		__ConditionClinicalStatusCodes.Value;
 
+    /// <seealso cref="ConditionVerificationStatusCodes"/>
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
 			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
@@ -741,13 +874,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="ConditionVerificationStatusCodes_Value"/>
     [CqlDeclaration("ConditionVerificationStatusCodes")]
 	public CqlCode[] ConditionVerificationStatusCodes() => 
 		__ConditionVerificationStatusCodes.Value;
 
+    /// <seealso cref="AllergyIntoleranceClinicalStatusCodes"/>
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
 			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
@@ -757,13 +892,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="AllergyIntoleranceClinicalStatusCodes_Value"/>
     [CqlDeclaration("AllergyIntoleranceClinicalStatusCodes")]
 	public CqlCode[] AllergyIntoleranceClinicalStatusCodes() => 
 		__AllergyIntoleranceClinicalStatusCodes.Value;
 
+    /// <seealso cref="AllergyIntoleranceVerificationStatusCodes"/>
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
 			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
@@ -773,13 +910,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="AllergyIntoleranceVerificationStatusCodes_Value"/>
     [CqlDeclaration("AllergyIntoleranceVerificationStatusCodes")]
 	public CqlCode[] AllergyIntoleranceVerificationStatusCodes() => 
 		__AllergyIntoleranceVerificationStatusCodes.Value;
 
+    /// <seealso cref="ObservationCategoryCodes"/>
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
 			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
@@ -795,13 +934,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="ObservationCategoryCodes_Value"/>
     [CqlDeclaration("ObservationCategoryCodes")]
 	public CqlCode[] ObservationCategoryCodes() => 
 		__ObservationCategoryCodes.Value;
 
+    /// <seealso cref="USCoreObservationCategoryExtensionCodes"/>
 	private CqlCode[] USCoreObservationCategoryExtensionCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", null, null),
 		};
@@ -809,13 +950,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="USCoreObservationCategoryExtensionCodes_Value"/>
     [CqlDeclaration("USCoreObservationCategoryExtensionCodes")]
 	public CqlCode[] USCoreObservationCategoryExtensionCodes() => 
 		__USCoreObservationCategoryExtensionCodes.Value;
 
+    /// <seealso cref="ConditionCategory"/>
 	private CqlCode[] ConditionCategory_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
 			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
@@ -824,13 +967,15 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="ConditionCategory_Value"/>
     [CqlDeclaration("ConditionCategory")]
 	public CqlCode[] ConditionCategory() => 
 		__ConditionCategory.Value;
 
+    /// <seealso cref="USCoreConditionCategoryExtensionCodes"/>
 	private CqlCode[] USCoreConditionCategoryExtensionCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", null, null),
 		};
@@ -838,18 +983,21 @@ public class QICoreCommon_2_0_000
 		return a_;
 	}
 
+    /// <seealso cref="USCoreConditionCategoryExtensionCodes_Value"/>
     [CqlDeclaration("USCoreConditionCategoryExtensionCodes")]
 	public CqlCode[] USCoreConditionCategoryExtensionCodes() => 
 		__USCoreConditionCategoryExtensionCodes.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
@@ -858,443 +1006,463 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Returns true if the given condition has a clinical status of active, recurrence, or relapse")]
 	public bool? isActive(Condition condition)
 	{
-		var a_ = FHIRHelpers_4_3_000.ToConcept(condition?.ClinicalStatus);
-		var b_ = this.active();
-		var c_ = context.Operators.ConvertCodeToConcept(b_);
-		var d_ = context.Operators.Equivalent(a_, c_);
-		var f_ = this.recurrence();
-		var g_ = context.Operators.ConvertCodeToConcept(f_);
-		var h_ = context.Operators.Equivalent(a_, g_);
-		var i_ = context.Operators.Or(d_, h_);
-		var k_ = this.relapse();
-		var l_ = context.Operators.ConvertCodeToConcept(k_);
-		var m_ = context.Operators.Equivalent(a_, l_);
-		var n_ = context.Operators.Or(i_, m_);
+		CodeableConcept a_ = condition?.ClinicalStatus;
+		CqlConcept b_ = FHIRHelpers_4_3_000.ToConcept(a_);
+		CqlCode c_ = this.active();
+		CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+		bool? e_ = context.Operators.Equivalent(b_, d_);
+		CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(a_);
+		CqlCode h_ = this.recurrence();
+		CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+		bool? j_ = context.Operators.Equivalent(g_, i_);
+		bool? k_ = context.Operators.Or(e_, j_);
+		CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(a_);
+		CqlCode n_ = this.relapse();
+		CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+		bool? p_ = context.Operators.Equivalent(m_, o_);
+		bool? q_ = context.Operators.Or(k_, p_);
 
-		return n_;
+		return q_;
 	}
 
     [CqlDeclaration("hasCategory")]
     [CqlTag("description", "Returns true if the given condition has the given category")]
 	public bool? hasCategory(Condition condition, CqlCode category)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = condition?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)condition?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = context.Operators.ConvertCodeToConcept(category);
-			var h_ = context.Operators.Equivalent(C, g_);
+			CqlConcept h_ = context.Operators.ConvertCodeToConcept(category);
+			bool? i_ = context.Operators.Equivalent(C, h_);
 
-			return h_;
+			return i_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("hasCategory")]
     [CqlTag("description", "Returns true if the given observation has the given category")]
 	public bool? hasCategory(Observation observation, CqlCode category)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = context.Operators.ConvertCodeToConcept(category);
-			var h_ = context.Operators.Equivalent(C, g_);
+			CqlConcept h_ = context.Operators.ConvertCodeToConcept(category);
+			bool? i_ = context.Operators.Equivalent(C, h_);
 
-			return h_;
+			return i_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isProblemListItem")]
     [CqlTag("description", "Returns true if the given condition is a problem list item.")]
 	public bool? isProblemListItem(Condition condition)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = condition?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)condition?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.problem_list_item();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.problem_list_item();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isEncounterDiagnosis")]
     [CqlTag("description", "Returns true if the given condition is an encounter diagnosis")]
 	public bool? isEncounterDiagnosis(Condition condition)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = condition?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)condition?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.encounter_diagnosis();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.encounter_diagnosis();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isHealthConcern")]
     [CqlTag("description", "Returns true if the given condition is a health concern")]
 	public bool? isHealthConcern(Condition condition)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = condition?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)condition?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.health_concern();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.health_concern();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isSocialHistory")]
     [CqlTag("description", "Returns true if the given observation is a social history observation")]
 	public bool? isSocialHistory(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.social_history();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.social_history();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isVitalSign")]
     [CqlTag("description", "Returns true if the given observation is a vital sign")]
 	public bool? isVitalSign(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.vital_signs();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.vital_signs();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isImaging")]
     [CqlTag("description", "Returns true if the given observation is an imaging observation")]
 	public bool? isImaging(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.imaging();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.imaging();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isLaboratory")]
     [CqlTag("description", "Returns true if the given observation is a laboratory observation")]
 	public bool? isLaboratory(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.laboratory();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.laboratory();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isProcedure")]
     [CqlTag("description", "REturns true if the given observation is a procedure observation")]
 	public bool? isProcedure(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.procedure();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.procedure();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isSurvey")]
     [CqlTag("description", "Returns true if the given observation is a survey observation")]
 	public bool? isSurvey(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.survey();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.survey();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isExam")]
     [CqlTag("description", "Returns true if the given observation is an exam observation")]
 	public bool? isExam(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.exam();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.exam();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isTherapy")]
     [CqlTag("description", "Returns true if the given observation is a therapy observation")]
 	public bool? isTherapy(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.therapy();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.therapy();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isActivity")]
     [CqlTag("description", "Returns true if the given observation is an activity observation")]
 	public bool? isActivity(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.activity();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.activity();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isClinicalTest")]
     [CqlTag("description", "Returns true if the given observation is a clinical test result")]
 	public bool? isClinicalTest(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.clinical_test();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.clinical_test();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isCommunity")]
     [CqlTag("description", "Returns true if the given MedicationRequest has a category of Community")]
 	public bool? isCommunity(MedicationRequest medicationRequest)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = medicationRequest?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)medicationRequest?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.Community();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.Community();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isDischarge")]
     [CqlTag("description", "Returns true if the given MedicationRequest has a category of Discharge")]
 	public bool? isDischarge(MedicationRequest medicationRequest)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = medicationRequest?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)medicationRequest?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.Discharge();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.Discharge();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("doNotPerform")]
@@ -1303,24 +1471,24 @@ public class QICoreCommon_2_0_000
 	{
 		bool? a_(Extension E)
 		{
-			var f_ = E?.Url;
-			var g_ = context.Operators.LateBoundProperty<string>(f_, "value");
-			var h_ = context.Operators.Equal(g_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerform");
+			string f_ = E?.Url;
+			string g_ = context.Operators.LateBoundProperty<string>(f_, "value");
+			bool? h_ = context.Operators.Equal(g_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerform");
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Extension>(((deviceRequest is DomainResource)
+		IEnumerable<Extension> b_ = context.Operators.Where<Extension>(((deviceRequest is DomainResource)
 				? ((IEnumerable<Extension>)(deviceRequest as DomainResource).ModifierExtension)
 				: null), a_);
 		bool? c_(Extension E)
 		{
-			var i_ = E?.Value;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			DataType i_ = E?.Value;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 
 			return (bool?)j_;
 		};
-		var d_ = context.Operators.Select<Extension, bool?>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<bool?>(d_);
+		IEnumerable<bool?> d_ = context.Operators.Select<Extension, bool?>(b_, c_);
+		bool? e_ = context.Operators.SingletonFrom<bool?>(d_);
 
 		return e_;
 	}
@@ -1335,7 +1503,7 @@ public class QICoreCommon_2_0_000
 		{
 			if (choice is CqlDateTime)
 			{
-				var b_ = context.Operators.Interval((choice as CqlDateTime), (choice as CqlDateTime), true, true);
+				CqlInterval<CqlDateTime> b_ = context.Operators.Interval((choice as CqlDateTime), (choice as CqlDateTime), true, true);
 
 				return b_;
 			}
@@ -1345,117 +1513,117 @@ public class QICoreCommon_2_0_000
 			}
 			else if (choice is CqlQuantity)
 			{
-				var c_ = this.Patient();
-				var d_ = c_?.BirthDateElement;
-				var e_ = d_?.Value;
-				var f_ = context.Operators.ConvertStringToDate(e_);
-				var g_ = context.Operators.Add(f_, (choice as CqlQuantity));
-				var i_ = c_?.BirthDateElement;
-				var j_ = i_?.Value;
-				var k_ = context.Operators.ConvertStringToDate(j_);
-				var l_ = context.Operators.Add(k_, (choice as CqlQuantity));
-				var m_ = context.Operators.Quantity(1m, "year");
-				var n_ = context.Operators.Add(l_, m_);
-				var o_ = context.Operators.Interval(g_, n_, true, false);
-				var p_ = o_?.low;
-				var q_ = context.Operators.ConvertDateToDateTime(p_);
-				var s_ = c_?.BirthDateElement;
-				var t_ = s_?.Value;
-				var u_ = context.Operators.ConvertStringToDate(t_);
-				var v_ = context.Operators.Add(u_, (choice as CqlQuantity));
-				var x_ = c_?.BirthDateElement;
-				var y_ = x_?.Value;
-				var z_ = context.Operators.ConvertStringToDate(y_);
-				var aa_ = context.Operators.Add(z_, (choice as CqlQuantity));
-				var ac_ = context.Operators.Add(aa_, m_);
-				var ad_ = context.Operators.Interval(v_, ac_, true, false);
-				var ae_ = ad_?.high;
-				var af_ = context.Operators.ConvertDateToDateTime(ae_);
-				var ah_ = c_?.BirthDateElement;
-				var ai_ = ah_?.Value;
-				var aj_ = context.Operators.ConvertStringToDate(ai_);
-				var ak_ = context.Operators.Add(aj_, (choice as CqlQuantity));
-				var am_ = c_?.BirthDateElement;
-				var an_ = am_?.Value;
-				var ao_ = context.Operators.ConvertStringToDate(an_);
-				var ap_ = context.Operators.Add(ao_, (choice as CqlQuantity));
-				var ar_ = context.Operators.Add(ap_, m_);
-				var as_ = context.Operators.Interval(ak_, ar_, true, false);
-				var at_ = as_?.lowClosed;
-				var av_ = c_?.BirthDateElement;
-				var aw_ = av_?.Value;
-				var ax_ = context.Operators.ConvertStringToDate(aw_);
-				var ay_ = context.Operators.Add(ax_, (choice as CqlQuantity));
-				var ba_ = c_?.BirthDateElement;
-				var bb_ = ba_?.Value;
-				var bc_ = context.Operators.ConvertStringToDate(bb_);
-				var bd_ = context.Operators.Add(bc_, (choice as CqlQuantity));
-				var bf_ = context.Operators.Add(bd_, m_);
-				var bg_ = context.Operators.Interval(ay_, bf_, true, false);
-				var bh_ = bg_?.highClosed;
-				var bi_ = context.Operators.Interval(q_, af_, at_, bh_);
+				Patient c_ = this.Patient();
+				Date d_ = c_?.BirthDateElement;
+				string e_ = d_?.Value;
+				CqlDate f_ = context.Operators.ConvertStringToDate(e_);
+				CqlDate g_ = context.Operators.Add(f_, (choice as CqlQuantity));
+				Date i_ = c_?.BirthDateElement;
+				string j_ = i_?.Value;
+				CqlDate k_ = context.Operators.ConvertStringToDate(j_);
+				CqlDate l_ = context.Operators.Add(k_, (choice as CqlQuantity));
+				CqlQuantity m_ = context.Operators.Quantity(1m, "year");
+				CqlDate n_ = context.Operators.Add(l_, m_);
+				CqlInterval<CqlDate> o_ = context.Operators.Interval(g_, n_, true, false);
+				CqlDate p_ = o_?.low;
+				CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+				Date s_ = c_?.BirthDateElement;
+				string t_ = s_?.Value;
+				CqlDate u_ = context.Operators.ConvertStringToDate(t_);
+				CqlDate v_ = context.Operators.Add(u_, (choice as CqlQuantity));
+				Date x_ = c_?.BirthDateElement;
+				string y_ = x_?.Value;
+				CqlDate z_ = context.Operators.ConvertStringToDate(y_);
+				CqlDate aa_ = context.Operators.Add(z_, (choice as CqlQuantity));
+				CqlDate ac_ = context.Operators.Add(aa_, m_);
+				CqlInterval<CqlDate> ad_ = context.Operators.Interval(v_, ac_, true, false);
+				CqlDate ae_ = ad_?.high;
+				CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
+				Date ah_ = c_?.BirthDateElement;
+				string ai_ = ah_?.Value;
+				CqlDate aj_ = context.Operators.ConvertStringToDate(ai_);
+				CqlDate ak_ = context.Operators.Add(aj_, (choice as CqlQuantity));
+				Date am_ = c_?.BirthDateElement;
+				string an_ = am_?.Value;
+				CqlDate ao_ = context.Operators.ConvertStringToDate(an_);
+				CqlDate ap_ = context.Operators.Add(ao_, (choice as CqlQuantity));
+				CqlDate ar_ = context.Operators.Add(ap_, m_);
+				CqlInterval<CqlDate> as_ = context.Operators.Interval(ak_, ar_, true, false);
+				bool? at_ = as_?.lowClosed;
+				Date av_ = c_?.BirthDateElement;
+				string aw_ = av_?.Value;
+				CqlDate ax_ = context.Operators.ConvertStringToDate(aw_);
+				CqlDate ay_ = context.Operators.Add(ax_, (choice as CqlQuantity));
+				Date ba_ = c_?.BirthDateElement;
+				string bb_ = ba_?.Value;
+				CqlDate bc_ = context.Operators.ConvertStringToDate(bb_);
+				CqlDate bd_ = context.Operators.Add(bc_, (choice as CqlQuantity));
+				CqlDate bf_ = context.Operators.Add(bd_, m_);
+				CqlInterval<CqlDate> bg_ = context.Operators.Interval(ay_, bf_, true, false);
+				bool? bh_ = bg_?.highClosed;
+				CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(q_, af_, at_, bh_);
 
 				return bi_;
 			}
 			else if (choice is CqlInterval<CqlQuantity>)
 			{
-				var bj_ = this.Patient();
-				var bk_ = bj_?.BirthDateElement;
-				var bl_ = bk_?.Value;
-				var bm_ = context.Operators.ConvertStringToDate(bl_);
-				var bn_ = context.Operators.LateBoundProperty<object>(choice, "low");
-				var bo_ = context.Operators.Add(bm_, (bn_ as CqlQuantity));
-				var bq_ = bj_?.BirthDateElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.ConvertStringToDate(br_);
-				var bt_ = context.Operators.LateBoundProperty<object>(choice, "high");
-				var bu_ = context.Operators.Add(bs_, (bt_ as CqlQuantity));
-				var bv_ = context.Operators.Quantity(1m, "year");
-				var bw_ = context.Operators.Add(bu_, bv_);
-				var bx_ = context.Operators.Interval(bo_, bw_, true, false);
-				var by_ = bx_?.low;
-				var bz_ = context.Operators.ConvertDateToDateTime(by_);
-				var cb_ = bj_?.BirthDateElement;
-				var cc_ = cb_?.Value;
-				var cd_ = context.Operators.ConvertStringToDate(cc_);
-				var cf_ = context.Operators.Add(cd_, (bn_ as CqlQuantity));
-				var ch_ = bj_?.BirthDateElement;
-				var ci_ = ch_?.Value;
-				var cj_ = context.Operators.ConvertStringToDate(ci_);
-				var cl_ = context.Operators.Add(cj_, (bt_ as CqlQuantity));
-				var cn_ = context.Operators.Add(cl_, bv_);
-				var co_ = context.Operators.Interval(cf_, cn_, true, false);
-				var cp_ = co_?.high;
-				var cq_ = context.Operators.ConvertDateToDateTime(cp_);
-				var cs_ = bj_?.BirthDateElement;
-				var ct_ = cs_?.Value;
-				var cu_ = context.Operators.ConvertStringToDate(ct_);
-				var cw_ = context.Operators.Add(cu_, (bn_ as CqlQuantity));
-				var cy_ = bj_?.BirthDateElement;
-				var cz_ = cy_?.Value;
-				var da_ = context.Operators.ConvertStringToDate(cz_);
-				var dc_ = context.Operators.Add(da_, (bt_ as CqlQuantity));
-				var de_ = context.Operators.Add(dc_, bv_);
-				var df_ = context.Operators.Interval(cw_, de_, true, false);
-				var dg_ = df_?.lowClosed;
-				var di_ = bj_?.BirthDateElement;
-				var dj_ = di_?.Value;
-				var dk_ = context.Operators.ConvertStringToDate(dj_);
-				var dm_ = context.Operators.Add(dk_, (bn_ as CqlQuantity));
-				var do_ = bj_?.BirthDateElement;
-				var dp_ = do_?.Value;
-				var dq_ = context.Operators.ConvertStringToDate(dp_);
-				var ds_ = context.Operators.Add(dq_, (bt_ as CqlQuantity));
-				var du_ = context.Operators.Add(ds_, bv_);
-				var dv_ = context.Operators.Interval(dm_, du_, true, false);
-				var dw_ = dv_?.highClosed;
-				var dx_ = context.Operators.Interval(bz_, cq_, dg_, dw_);
+				Patient bj_ = this.Patient();
+				Date bk_ = bj_?.BirthDateElement;
+				string bl_ = bk_?.Value;
+				CqlDate bm_ = context.Operators.ConvertStringToDate(bl_);
+				object bn_ = context.Operators.LateBoundProperty<object>(choice, "low");
+				CqlDate bo_ = context.Operators.Add(bm_, (bn_ as CqlQuantity));
+				Date bq_ = bj_?.BirthDateElement;
+				string br_ = bq_?.Value;
+				CqlDate bs_ = context.Operators.ConvertStringToDate(br_);
+				object bt_ = context.Operators.LateBoundProperty<object>(choice, "high");
+				CqlDate bu_ = context.Operators.Add(bs_, (bt_ as CqlQuantity));
+				CqlQuantity bv_ = context.Operators.Quantity(1m, "year");
+				CqlDate bw_ = context.Operators.Add(bu_, bv_);
+				CqlInterval<CqlDate> bx_ = context.Operators.Interval(bo_, bw_, true, false);
+				CqlDate by_ = bx_?.low;
+				CqlDateTime bz_ = context.Operators.ConvertDateToDateTime(by_);
+				Date cb_ = bj_?.BirthDateElement;
+				string cc_ = cb_?.Value;
+				CqlDate cd_ = context.Operators.ConvertStringToDate(cc_);
+				CqlDate cf_ = context.Operators.Add(cd_, (bn_ as CqlQuantity));
+				Date ch_ = bj_?.BirthDateElement;
+				string ci_ = ch_?.Value;
+				CqlDate cj_ = context.Operators.ConvertStringToDate(ci_);
+				CqlDate cl_ = context.Operators.Add(cj_, (bt_ as CqlQuantity));
+				CqlDate cn_ = context.Operators.Add(cl_, bv_);
+				CqlInterval<CqlDate> co_ = context.Operators.Interval(cf_, cn_, true, false);
+				CqlDate cp_ = co_?.high;
+				CqlDateTime cq_ = context.Operators.ConvertDateToDateTime(cp_);
+				Date cs_ = bj_?.BirthDateElement;
+				string ct_ = cs_?.Value;
+				CqlDate cu_ = context.Operators.ConvertStringToDate(ct_);
+				CqlDate cw_ = context.Operators.Add(cu_, (bn_ as CqlQuantity));
+				Date cy_ = bj_?.BirthDateElement;
+				string cz_ = cy_?.Value;
+				CqlDate da_ = context.Operators.ConvertStringToDate(cz_);
+				CqlDate dc_ = context.Operators.Add(da_, (bt_ as CqlQuantity));
+				CqlDate de_ = context.Operators.Add(dc_, bv_);
+				CqlInterval<CqlDate> df_ = context.Operators.Interval(cw_, de_, true, false);
+				bool? dg_ = df_?.lowClosed;
+				Date di_ = bj_?.BirthDateElement;
+				string dj_ = di_?.Value;
+				CqlDate dk_ = context.Operators.ConvertStringToDate(dj_);
+				CqlDate dm_ = context.Operators.Add(dk_, (bn_ as CqlQuantity));
+				Date do_ = bj_?.BirthDateElement;
+				string dp_ = do_?.Value;
+				CqlDate dq_ = context.Operators.ConvertStringToDate(dp_);
+				CqlDate ds_ = context.Operators.Add(dq_, (bt_ as CqlQuantity));
+				CqlDate du_ = context.Operators.Add(ds_, bv_);
+				CqlInterval<CqlDate> dv_ = context.Operators.Interval(dm_, du_, true, false);
+				bool? dw_ = dv_?.highClosed;
+				CqlInterval<CqlDateTime> dx_ = context.Operators.Interval(bz_, cq_, dg_, dw_);
 
 				return dx_;
 			}
 			else if (choice is Timing)
 			{
-				var dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
+				object dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
 
 				return (dy_ as CqlInterval<CqlDateTime>);
 			}
@@ -1477,7 +1645,7 @@ public class QICoreCommon_2_0_000
 		{
 			if (choice is CqlDateTime)
 			{
-				var b_ = context.Operators.Interval((choice as CqlDateTime), (choice as CqlDateTime), true, true);
+				CqlInterval<CqlDateTime> b_ = context.Operators.Interval((choice as CqlDateTime), (choice as CqlDateTime), true, true);
 
 				return b_;
 			}
@@ -1487,117 +1655,117 @@ public class QICoreCommon_2_0_000
 			}
 			else if (choice is CqlQuantity)
 			{
-				var c_ = this.Patient();
-				var d_ = c_?.BirthDateElement;
-				var e_ = d_?.Value;
-				var f_ = context.Operators.ConvertStringToDate(e_);
-				var g_ = context.Operators.Add(f_, (choice as CqlQuantity));
-				var i_ = c_?.BirthDateElement;
-				var j_ = i_?.Value;
-				var k_ = context.Operators.ConvertStringToDate(j_);
-				var l_ = context.Operators.Add(k_, (choice as CqlQuantity));
-				var m_ = context.Operators.Quantity(1m, "year");
-				var n_ = context.Operators.Add(l_, m_);
-				var o_ = context.Operators.Interval(g_, n_, true, false);
-				var p_ = o_?.low;
-				var q_ = context.Operators.ConvertDateToDateTime(p_);
-				var s_ = c_?.BirthDateElement;
-				var t_ = s_?.Value;
-				var u_ = context.Operators.ConvertStringToDate(t_);
-				var v_ = context.Operators.Add(u_, (choice as CqlQuantity));
-				var x_ = c_?.BirthDateElement;
-				var y_ = x_?.Value;
-				var z_ = context.Operators.ConvertStringToDate(y_);
-				var aa_ = context.Operators.Add(z_, (choice as CqlQuantity));
-				var ac_ = context.Operators.Add(aa_, m_);
-				var ad_ = context.Operators.Interval(v_, ac_, true, false);
-				var ae_ = ad_?.high;
-				var af_ = context.Operators.ConvertDateToDateTime(ae_);
-				var ah_ = c_?.BirthDateElement;
-				var ai_ = ah_?.Value;
-				var aj_ = context.Operators.ConvertStringToDate(ai_);
-				var ak_ = context.Operators.Add(aj_, (choice as CqlQuantity));
-				var am_ = c_?.BirthDateElement;
-				var an_ = am_?.Value;
-				var ao_ = context.Operators.ConvertStringToDate(an_);
-				var ap_ = context.Operators.Add(ao_, (choice as CqlQuantity));
-				var ar_ = context.Operators.Add(ap_, m_);
-				var as_ = context.Operators.Interval(ak_, ar_, true, false);
-				var at_ = as_?.lowClosed;
-				var av_ = c_?.BirthDateElement;
-				var aw_ = av_?.Value;
-				var ax_ = context.Operators.ConvertStringToDate(aw_);
-				var ay_ = context.Operators.Add(ax_, (choice as CqlQuantity));
-				var ba_ = c_?.BirthDateElement;
-				var bb_ = ba_?.Value;
-				var bc_ = context.Operators.ConvertStringToDate(bb_);
-				var bd_ = context.Operators.Add(bc_, (choice as CqlQuantity));
-				var bf_ = context.Operators.Add(bd_, m_);
-				var bg_ = context.Operators.Interval(ay_, bf_, true, false);
-				var bh_ = bg_?.highClosed;
-				var bi_ = context.Operators.Interval(q_, af_, at_, bh_);
+				Patient c_ = this.Patient();
+				Date d_ = c_?.BirthDateElement;
+				string e_ = d_?.Value;
+				CqlDate f_ = context.Operators.ConvertStringToDate(e_);
+				CqlDate g_ = context.Operators.Add(f_, (choice as CqlQuantity));
+				Date i_ = c_?.BirthDateElement;
+				string j_ = i_?.Value;
+				CqlDate k_ = context.Operators.ConvertStringToDate(j_);
+				CqlDate l_ = context.Operators.Add(k_, (choice as CqlQuantity));
+				CqlQuantity m_ = context.Operators.Quantity(1m, "year");
+				CqlDate n_ = context.Operators.Add(l_, m_);
+				CqlInterval<CqlDate> o_ = context.Operators.Interval(g_, n_, true, false);
+				CqlDate p_ = o_?.low;
+				CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+				Date s_ = c_?.BirthDateElement;
+				string t_ = s_?.Value;
+				CqlDate u_ = context.Operators.ConvertStringToDate(t_);
+				CqlDate v_ = context.Operators.Add(u_, (choice as CqlQuantity));
+				Date x_ = c_?.BirthDateElement;
+				string y_ = x_?.Value;
+				CqlDate z_ = context.Operators.ConvertStringToDate(y_);
+				CqlDate aa_ = context.Operators.Add(z_, (choice as CqlQuantity));
+				CqlDate ac_ = context.Operators.Add(aa_, m_);
+				CqlInterval<CqlDate> ad_ = context.Operators.Interval(v_, ac_, true, false);
+				CqlDate ae_ = ad_?.high;
+				CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
+				Date ah_ = c_?.BirthDateElement;
+				string ai_ = ah_?.Value;
+				CqlDate aj_ = context.Operators.ConvertStringToDate(ai_);
+				CqlDate ak_ = context.Operators.Add(aj_, (choice as CqlQuantity));
+				Date am_ = c_?.BirthDateElement;
+				string an_ = am_?.Value;
+				CqlDate ao_ = context.Operators.ConvertStringToDate(an_);
+				CqlDate ap_ = context.Operators.Add(ao_, (choice as CqlQuantity));
+				CqlDate ar_ = context.Operators.Add(ap_, m_);
+				CqlInterval<CqlDate> as_ = context.Operators.Interval(ak_, ar_, true, false);
+				bool? at_ = as_?.lowClosed;
+				Date av_ = c_?.BirthDateElement;
+				string aw_ = av_?.Value;
+				CqlDate ax_ = context.Operators.ConvertStringToDate(aw_);
+				CqlDate ay_ = context.Operators.Add(ax_, (choice as CqlQuantity));
+				Date ba_ = c_?.BirthDateElement;
+				string bb_ = ba_?.Value;
+				CqlDate bc_ = context.Operators.ConvertStringToDate(bb_);
+				CqlDate bd_ = context.Operators.Add(bc_, (choice as CqlQuantity));
+				CqlDate bf_ = context.Operators.Add(bd_, m_);
+				CqlInterval<CqlDate> bg_ = context.Operators.Interval(ay_, bf_, true, false);
+				bool? bh_ = bg_?.highClosed;
+				CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(q_, af_, at_, bh_);
 
 				return bi_;
 			}
 			else if (choice is CqlInterval<CqlQuantity>)
 			{
-				var bj_ = this.Patient();
-				var bk_ = bj_?.BirthDateElement;
-				var bl_ = bk_?.Value;
-				var bm_ = context.Operators.ConvertStringToDate(bl_);
-				var bn_ = context.Operators.LateBoundProperty<object>(choice, "low");
-				var bo_ = context.Operators.Add(bm_, (bn_ as CqlQuantity));
-				var bq_ = bj_?.BirthDateElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.ConvertStringToDate(br_);
-				var bt_ = context.Operators.LateBoundProperty<object>(choice, "high");
-				var bu_ = context.Operators.Add(bs_, (bt_ as CqlQuantity));
-				var bv_ = context.Operators.Quantity(1m, "year");
-				var bw_ = context.Operators.Add(bu_, bv_);
-				var bx_ = context.Operators.Interval(bo_, bw_, true, false);
-				var by_ = bx_?.low;
-				var bz_ = context.Operators.ConvertDateToDateTime(by_);
-				var cb_ = bj_?.BirthDateElement;
-				var cc_ = cb_?.Value;
-				var cd_ = context.Operators.ConvertStringToDate(cc_);
-				var cf_ = context.Operators.Add(cd_, (bn_ as CqlQuantity));
-				var ch_ = bj_?.BirthDateElement;
-				var ci_ = ch_?.Value;
-				var cj_ = context.Operators.ConvertStringToDate(ci_);
-				var cl_ = context.Operators.Add(cj_, (bt_ as CqlQuantity));
-				var cn_ = context.Operators.Add(cl_, bv_);
-				var co_ = context.Operators.Interval(cf_, cn_, true, false);
-				var cp_ = co_?.high;
-				var cq_ = context.Operators.ConvertDateToDateTime(cp_);
-				var cs_ = bj_?.BirthDateElement;
-				var ct_ = cs_?.Value;
-				var cu_ = context.Operators.ConvertStringToDate(ct_);
-				var cw_ = context.Operators.Add(cu_, (bn_ as CqlQuantity));
-				var cy_ = bj_?.BirthDateElement;
-				var cz_ = cy_?.Value;
-				var da_ = context.Operators.ConvertStringToDate(cz_);
-				var dc_ = context.Operators.Add(da_, (bt_ as CqlQuantity));
-				var de_ = context.Operators.Add(dc_, bv_);
-				var df_ = context.Operators.Interval(cw_, de_, true, false);
-				var dg_ = df_?.lowClosed;
-				var di_ = bj_?.BirthDateElement;
-				var dj_ = di_?.Value;
-				var dk_ = context.Operators.ConvertStringToDate(dj_);
-				var dm_ = context.Operators.Add(dk_, (bn_ as CqlQuantity));
-				var do_ = bj_?.BirthDateElement;
-				var dp_ = do_?.Value;
-				var dq_ = context.Operators.ConvertStringToDate(dp_);
-				var ds_ = context.Operators.Add(dq_, (bt_ as CqlQuantity));
-				var du_ = context.Operators.Add(ds_, bv_);
-				var dv_ = context.Operators.Interval(dm_, du_, true, false);
-				var dw_ = dv_?.highClosed;
-				var dx_ = context.Operators.Interval(bz_, cq_, dg_, dw_);
+				Patient bj_ = this.Patient();
+				Date bk_ = bj_?.BirthDateElement;
+				string bl_ = bk_?.Value;
+				CqlDate bm_ = context.Operators.ConvertStringToDate(bl_);
+				object bn_ = context.Operators.LateBoundProperty<object>(choice, "low");
+				CqlDate bo_ = context.Operators.Add(bm_, (bn_ as CqlQuantity));
+				Date bq_ = bj_?.BirthDateElement;
+				string br_ = bq_?.Value;
+				CqlDate bs_ = context.Operators.ConvertStringToDate(br_);
+				object bt_ = context.Operators.LateBoundProperty<object>(choice, "high");
+				CqlDate bu_ = context.Operators.Add(bs_, (bt_ as CqlQuantity));
+				CqlQuantity bv_ = context.Operators.Quantity(1m, "year");
+				CqlDate bw_ = context.Operators.Add(bu_, bv_);
+				CqlInterval<CqlDate> bx_ = context.Operators.Interval(bo_, bw_, true, false);
+				CqlDate by_ = bx_?.low;
+				CqlDateTime bz_ = context.Operators.ConvertDateToDateTime(by_);
+				Date cb_ = bj_?.BirthDateElement;
+				string cc_ = cb_?.Value;
+				CqlDate cd_ = context.Operators.ConvertStringToDate(cc_);
+				CqlDate cf_ = context.Operators.Add(cd_, (bn_ as CqlQuantity));
+				Date ch_ = bj_?.BirthDateElement;
+				string ci_ = ch_?.Value;
+				CqlDate cj_ = context.Operators.ConvertStringToDate(ci_);
+				CqlDate cl_ = context.Operators.Add(cj_, (bt_ as CqlQuantity));
+				CqlDate cn_ = context.Operators.Add(cl_, bv_);
+				CqlInterval<CqlDate> co_ = context.Operators.Interval(cf_, cn_, true, false);
+				CqlDate cp_ = co_?.high;
+				CqlDateTime cq_ = context.Operators.ConvertDateToDateTime(cp_);
+				Date cs_ = bj_?.BirthDateElement;
+				string ct_ = cs_?.Value;
+				CqlDate cu_ = context.Operators.ConvertStringToDate(ct_);
+				CqlDate cw_ = context.Operators.Add(cu_, (bn_ as CqlQuantity));
+				Date cy_ = bj_?.BirthDateElement;
+				string cz_ = cy_?.Value;
+				CqlDate da_ = context.Operators.ConvertStringToDate(cz_);
+				CqlDate dc_ = context.Operators.Add(da_, (bt_ as CqlQuantity));
+				CqlDate de_ = context.Operators.Add(dc_, bv_);
+				CqlInterval<CqlDate> df_ = context.Operators.Interval(cw_, de_, true, false);
+				bool? dg_ = df_?.lowClosed;
+				Date di_ = bj_?.BirthDateElement;
+				string dj_ = di_?.Value;
+				CqlDate dk_ = context.Operators.ConvertStringToDate(dj_);
+				CqlDate dm_ = context.Operators.Add(dk_, (bn_ as CqlQuantity));
+				Date do_ = bj_?.BirthDateElement;
+				string dp_ = do_?.Value;
+				CqlDate dq_ = context.Operators.ConvertStringToDate(dp_);
+				CqlDate ds_ = context.Operators.Add(dq_, (bt_ as CqlQuantity));
+				CqlDate du_ = context.Operators.Add(ds_, bv_);
+				CqlInterval<CqlDate> dv_ = context.Operators.Interval(dm_, du_, true, false);
+				bool? dw_ = dv_?.highClosed;
+				CqlInterval<CqlDateTime> dx_ = context.Operators.Interval(bz_, cq_, dg_, dw_);
 
 				return dx_;
 			}
 			else if (choice is Timing)
 			{
-				var dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
+				object dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
 
 				return (dy_ as CqlInterval<CqlDateTime>);
 			}
@@ -1620,187 +1788,187 @@ public class QICoreCommon_2_0_000
 		{
 			bool b_()
 			{
-				var f_ = condition?.Abatement;
-				var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-				var h_ = g_ is CqlDateTime;
+				DataType f_ = condition?.Abatement;
+				object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+				bool h_ = g_ is CqlDateTime;
 
 				return h_;
 			};
 			bool c_()
 			{
-				var i_ = condition?.Abatement;
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = j_ is CqlQuantity;
+				DataType i_ = condition?.Abatement;
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				bool k_ = j_ is CqlQuantity;
 
 				return k_;
 			};
 			bool d_()
 			{
-				var l_ = condition?.Abatement;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = m_ is CqlInterval<CqlQuantity>;
+				DataType l_ = condition?.Abatement;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				bool n_ = m_ is CqlInterval<CqlQuantity>;
 
 				return n_;
 			};
 			bool e_()
 			{
-				var o_ = condition?.Abatement;
-				var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-				var q_ = p_ is CqlInterval<CqlDateTime>;
+				DataType o_ = condition?.Abatement;
+				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+				bool q_ = p_ is CqlInterval<CqlDateTime>;
 
 				return q_;
 			};
 			if (b_())
 			{
-				var r_ = condition?.Abatement;
-				var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var u_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var v_ = context.Operators.Interval((s_ as CqlDateTime), (u_ as CqlDateTime), true, true);
+				DataType r_ = condition?.Abatement;
+				object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+				object u_ = FHIRHelpers_4_3_000.ToValue(r_);
+				CqlInterval<CqlDateTime> v_ = context.Operators.Interval((s_ as CqlDateTime), (u_ as CqlDateTime), true, true);
 
 				return v_;
 			}
 			else if (c_())
 			{
-				var w_ = this.Patient();
-				var x_ = w_?.BirthDateElement;
-				var y_ = x_?.Value;
-				var z_ = context.Operators.ConvertStringToDate(y_);
-				var aa_ = condition?.Abatement;
-				var ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var ac_ = context.Operators.Add(z_, (ab_ as CqlQuantity));
-				var ae_ = w_?.BirthDateElement;
-				var af_ = ae_?.Value;
-				var ag_ = context.Operators.ConvertStringToDate(af_);
-				var ai_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var aj_ = context.Operators.Add(ag_, (ai_ as CqlQuantity));
-				var ak_ = context.Operators.Quantity(1m, "year");
-				var al_ = context.Operators.Add(aj_, ak_);
-				var am_ = context.Operators.Interval(ac_, al_, true, false);
-				var an_ = am_?.low;
-				var ao_ = context.Operators.ConvertDateToDateTime(an_);
-				var aq_ = w_?.BirthDateElement;
-				var ar_ = aq_?.Value;
-				var as_ = context.Operators.ConvertStringToDate(ar_);
-				var au_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var av_ = context.Operators.Add(as_, (au_ as CqlQuantity));
-				var ax_ = w_?.BirthDateElement;
-				var ay_ = ax_?.Value;
-				var az_ = context.Operators.ConvertStringToDate(ay_);
-				var bb_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bc_ = context.Operators.Add(az_, (bb_ as CqlQuantity));
-				var be_ = context.Operators.Add(bc_, ak_);
-				var bf_ = context.Operators.Interval(av_, be_, true, false);
-				var bg_ = bf_?.high;
-				var bh_ = context.Operators.ConvertDateToDateTime(bg_);
-				var bj_ = w_?.BirthDateElement;
-				var bk_ = bj_?.Value;
-				var bl_ = context.Operators.ConvertStringToDate(bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bo_ = context.Operators.Add(bl_, (bn_ as CqlQuantity));
-				var bq_ = w_?.BirthDateElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.ConvertStringToDate(br_);
-				var bu_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bv_ = context.Operators.Add(bs_, (bu_ as CqlQuantity));
-				var bx_ = context.Operators.Add(bv_, ak_);
-				var by_ = context.Operators.Interval(bo_, bx_, true, false);
-				var bz_ = by_?.lowClosed;
-				var cb_ = w_?.BirthDateElement;
-				var cc_ = cb_?.Value;
-				var cd_ = context.Operators.ConvertStringToDate(cc_);
-				var cf_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var cg_ = context.Operators.Add(cd_, (cf_ as CqlQuantity));
-				var ci_ = w_?.BirthDateElement;
-				var cj_ = ci_?.Value;
-				var ck_ = context.Operators.ConvertStringToDate(cj_);
-				var cm_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var cn_ = context.Operators.Add(ck_, (cm_ as CqlQuantity));
-				var cp_ = context.Operators.Add(cn_, ak_);
-				var cq_ = context.Operators.Interval(cg_, cp_, true, false);
-				var cr_ = cq_?.highClosed;
-				var cs_ = context.Operators.Interval(ao_, bh_, bz_, cr_);
+				Patient w_ = this.Patient();
+				Date x_ = w_?.BirthDateElement;
+				string y_ = x_?.Value;
+				CqlDate z_ = context.Operators.ConvertStringToDate(y_);
+				DataType aa_ = condition?.Abatement;
+				object ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate ac_ = context.Operators.Add(z_, (ab_ as CqlQuantity));
+				Date ae_ = w_?.BirthDateElement;
+				string af_ = ae_?.Value;
+				CqlDate ag_ = context.Operators.ConvertStringToDate(af_);
+				object ai_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate aj_ = context.Operators.Add(ag_, (ai_ as CqlQuantity));
+				CqlQuantity ak_ = context.Operators.Quantity(1m, "year");
+				CqlDate al_ = context.Operators.Add(aj_, ak_);
+				CqlInterval<CqlDate> am_ = context.Operators.Interval(ac_, al_, true, false);
+				CqlDate an_ = am_?.low;
+				CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
+				Date aq_ = w_?.BirthDateElement;
+				string ar_ = aq_?.Value;
+				CqlDate as_ = context.Operators.ConvertStringToDate(ar_);
+				object au_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate av_ = context.Operators.Add(as_, (au_ as CqlQuantity));
+				Date ax_ = w_?.BirthDateElement;
+				string ay_ = ax_?.Value;
+				CqlDate az_ = context.Operators.ConvertStringToDate(ay_);
+				object bb_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bc_ = context.Operators.Add(az_, (bb_ as CqlQuantity));
+				CqlDate be_ = context.Operators.Add(bc_, ak_);
+				CqlInterval<CqlDate> bf_ = context.Operators.Interval(av_, be_, true, false);
+				CqlDate bg_ = bf_?.high;
+				CqlDateTime bh_ = context.Operators.ConvertDateToDateTime(bg_);
+				Date bj_ = w_?.BirthDateElement;
+				string bk_ = bj_?.Value;
+				CqlDate bl_ = context.Operators.ConvertStringToDate(bk_);
+				object bn_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bo_ = context.Operators.Add(bl_, (bn_ as CqlQuantity));
+				Date bq_ = w_?.BirthDateElement;
+				string br_ = bq_?.Value;
+				CqlDate bs_ = context.Operators.ConvertStringToDate(br_);
+				object bu_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bv_ = context.Operators.Add(bs_, (bu_ as CqlQuantity));
+				CqlDate bx_ = context.Operators.Add(bv_, ak_);
+				CqlInterval<CqlDate> by_ = context.Operators.Interval(bo_, bx_, true, false);
+				bool? bz_ = by_?.lowClosed;
+				Date cb_ = w_?.BirthDateElement;
+				string cc_ = cb_?.Value;
+				CqlDate cd_ = context.Operators.ConvertStringToDate(cc_);
+				object cf_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate cg_ = context.Operators.Add(cd_, (cf_ as CqlQuantity));
+				Date ci_ = w_?.BirthDateElement;
+				string cj_ = ci_?.Value;
+				CqlDate ck_ = context.Operators.ConvertStringToDate(cj_);
+				object cm_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate cn_ = context.Operators.Add(ck_, (cm_ as CqlQuantity));
+				CqlDate cp_ = context.Operators.Add(cn_, ak_);
+				CqlInterval<CqlDate> cq_ = context.Operators.Interval(cg_, cp_, true, false);
+				bool? cr_ = cq_?.highClosed;
+				CqlInterval<CqlDateTime> cs_ = context.Operators.Interval(ao_, bh_, bz_, cr_);
 
 				return cs_;
 			}
 			else if (d_())
 			{
-				var ct_ = this.Patient();
-				var cu_ = ct_?.BirthDateElement;
-				var cv_ = cu_?.Value;
-				var cw_ = context.Operators.ConvertStringToDate(cv_);
-				var cx_ = condition?.Abatement;
-				var cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var cz_ = context.Operators.LateBoundProperty<object>(cy_, "low");
-				var da_ = context.Operators.Add(cw_, (cz_ as CqlQuantity));
-				var dc_ = ct_?.BirthDateElement;
-				var dd_ = dc_?.Value;
-				var de_ = context.Operators.ConvertStringToDate(dd_);
-				var dg_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var dh_ = context.Operators.LateBoundProperty<object>(dg_, "high");
-				var di_ = context.Operators.Add(de_, (dh_ as CqlQuantity));
-				var dj_ = context.Operators.Quantity(1m, "year");
-				var dk_ = context.Operators.Add(di_, dj_);
-				var dl_ = context.Operators.Interval(da_, dk_, true, false);
-				var dm_ = dl_?.low;
-				var dn_ = context.Operators.ConvertDateToDateTime(dm_);
-				var dp_ = ct_?.BirthDateElement;
-				var dq_ = dp_?.Value;
-				var dr_ = context.Operators.ConvertStringToDate(dq_);
-				var dt_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var du_ = context.Operators.LateBoundProperty<object>(dt_, "low");
-				var dv_ = context.Operators.Add(dr_, (du_ as CqlQuantity));
-				var dx_ = ct_?.BirthDateElement;
-				var dy_ = dx_?.Value;
-				var dz_ = context.Operators.ConvertStringToDate(dy_);
-				var eb_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ec_ = context.Operators.LateBoundProperty<object>(eb_, "high");
-				var ed_ = context.Operators.Add(dz_, (ec_ as CqlQuantity));
-				var ef_ = context.Operators.Add(ed_, dj_);
-				var eg_ = context.Operators.Interval(dv_, ef_, true, false);
-				var eh_ = eg_?.high;
-				var ei_ = context.Operators.ConvertDateToDateTime(eh_);
-				var ek_ = ct_?.BirthDateElement;
-				var el_ = ek_?.Value;
-				var em_ = context.Operators.ConvertStringToDate(el_);
-				var eo_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ep_ = context.Operators.LateBoundProperty<object>(eo_, "low");
-				var eq_ = context.Operators.Add(em_, (ep_ as CqlQuantity));
-				var es_ = ct_?.BirthDateElement;
-				var et_ = es_?.Value;
-				var eu_ = context.Operators.ConvertStringToDate(et_);
-				var ew_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ex_ = context.Operators.LateBoundProperty<object>(ew_, "high");
-				var ey_ = context.Operators.Add(eu_, (ex_ as CqlQuantity));
-				var fa_ = context.Operators.Add(ey_, dj_);
-				var fb_ = context.Operators.Interval(eq_, fa_, true, false);
-				var fc_ = fb_?.lowClosed;
-				var fe_ = ct_?.BirthDateElement;
-				var ff_ = fe_?.Value;
-				var fg_ = context.Operators.ConvertStringToDate(ff_);
-				var fi_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var fj_ = context.Operators.LateBoundProperty<object>(fi_, "low");
-				var fk_ = context.Operators.Add(fg_, (fj_ as CqlQuantity));
-				var fm_ = ct_?.BirthDateElement;
-				var fn_ = fm_?.Value;
-				var fo_ = context.Operators.ConvertStringToDate(fn_);
-				var fq_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var fr_ = context.Operators.LateBoundProperty<object>(fq_, "high");
-				var fs_ = context.Operators.Add(fo_, (fr_ as CqlQuantity));
-				var fu_ = context.Operators.Add(fs_, dj_);
-				var fv_ = context.Operators.Interval(fk_, fu_, true, false);
-				var fw_ = fv_?.highClosed;
-				var fx_ = context.Operators.Interval(dn_, ei_, fc_, fw_);
+				Patient ct_ = this.Patient();
+				Date cu_ = ct_?.BirthDateElement;
+				string cv_ = cu_?.Value;
+				CqlDate cw_ = context.Operators.ConvertStringToDate(cv_);
+				DataType cx_ = condition?.Abatement;
+				object cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object cz_ = context.Operators.LateBoundProperty<object>(cy_, "low");
+				CqlDate da_ = context.Operators.Add(cw_, (cz_ as CqlQuantity));
+				Date dc_ = ct_?.BirthDateElement;
+				string dd_ = dc_?.Value;
+				CqlDate de_ = context.Operators.ConvertStringToDate(dd_);
+				object dg_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object dh_ = context.Operators.LateBoundProperty<object>(dg_, "high");
+				CqlDate di_ = context.Operators.Add(de_, (dh_ as CqlQuantity));
+				CqlQuantity dj_ = context.Operators.Quantity(1m, "year");
+				CqlDate dk_ = context.Operators.Add(di_, dj_);
+				CqlInterval<CqlDate> dl_ = context.Operators.Interval(da_, dk_, true, false);
+				CqlDate dm_ = dl_?.low;
+				CqlDateTime dn_ = context.Operators.ConvertDateToDateTime(dm_);
+				Date dp_ = ct_?.BirthDateElement;
+				string dq_ = dp_?.Value;
+				CqlDate dr_ = context.Operators.ConvertStringToDate(dq_);
+				object dt_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object du_ = context.Operators.LateBoundProperty<object>(dt_, "low");
+				CqlDate dv_ = context.Operators.Add(dr_, (du_ as CqlQuantity));
+				Date dx_ = ct_?.BirthDateElement;
+				string dy_ = dx_?.Value;
+				CqlDate dz_ = context.Operators.ConvertStringToDate(dy_);
+				object eb_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ec_ = context.Operators.LateBoundProperty<object>(eb_, "high");
+				CqlDate ed_ = context.Operators.Add(dz_, (ec_ as CqlQuantity));
+				CqlDate ef_ = context.Operators.Add(ed_, dj_);
+				CqlInterval<CqlDate> eg_ = context.Operators.Interval(dv_, ef_, true, false);
+				CqlDate eh_ = eg_?.high;
+				CqlDateTime ei_ = context.Operators.ConvertDateToDateTime(eh_);
+				Date ek_ = ct_?.BirthDateElement;
+				string el_ = ek_?.Value;
+				CqlDate em_ = context.Operators.ConvertStringToDate(el_);
+				object eo_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ep_ = context.Operators.LateBoundProperty<object>(eo_, "low");
+				CqlDate eq_ = context.Operators.Add(em_, (ep_ as CqlQuantity));
+				Date es_ = ct_?.BirthDateElement;
+				string et_ = es_?.Value;
+				CqlDate eu_ = context.Operators.ConvertStringToDate(et_);
+				object ew_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ex_ = context.Operators.LateBoundProperty<object>(ew_, "high");
+				CqlDate ey_ = context.Operators.Add(eu_, (ex_ as CqlQuantity));
+				CqlDate fa_ = context.Operators.Add(ey_, dj_);
+				CqlInterval<CqlDate> fb_ = context.Operators.Interval(eq_, fa_, true, false);
+				bool? fc_ = fb_?.lowClosed;
+				Date fe_ = ct_?.BirthDateElement;
+				string ff_ = fe_?.Value;
+				CqlDate fg_ = context.Operators.ConvertStringToDate(ff_);
+				object fi_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object fj_ = context.Operators.LateBoundProperty<object>(fi_, "low");
+				CqlDate fk_ = context.Operators.Add(fg_, (fj_ as CqlQuantity));
+				Date fm_ = ct_?.BirthDateElement;
+				string fn_ = fm_?.Value;
+				CqlDate fo_ = context.Operators.ConvertStringToDate(fn_);
+				object fq_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object fr_ = context.Operators.LateBoundProperty<object>(fq_, "high");
+				CqlDate fs_ = context.Operators.Add(fo_, (fr_ as CqlQuantity));
+				CqlDate fu_ = context.Operators.Add(fs_, dj_);
+				CqlInterval<CqlDate> fv_ = context.Operators.Interval(fk_, fu_, true, false);
+				bool? fw_ = fv_?.highClosed;
+				CqlInterval<CqlDateTime> fx_ = context.Operators.Interval(dn_, ei_, fc_, fw_);
 
 				return fx_;
 			}
 			else if (e_())
 			{
-				var fy_ = condition?.Abatement;
-				var fz_ = FHIRHelpers_4_3_000.ToValue(fy_);
-				var ga_ = context.Operators.LateBoundProperty<object>(fz_, "low");
-				var gc_ = FHIRHelpers_4_3_000.ToValue(fy_);
-				var gd_ = context.Operators.LateBoundProperty<object>(gc_, "high");
-				var ge_ = context.Operators.Interval((ga_ as CqlDateTime), (gd_ as CqlDateTime), true, false);
+				DataType fy_ = condition?.Abatement;
+				object fz_ = FHIRHelpers_4_3_000.ToValue(fy_);
+				object ga_ = context.Operators.LateBoundProperty<object>(fz_, "low");
+				object gc_ = FHIRHelpers_4_3_000.ToValue(fy_);
+				object gd_ = context.Operators.LateBoundProperty<object>(gc_, "high");
+				CqlInterval<CqlDateTime> ge_ = context.Operators.Interval((ga_ as CqlDateTime), (gd_ as CqlDateTime), true, false);
 
 				return ge_;
 			}
@@ -1822,187 +1990,187 @@ public class QICoreCommon_2_0_000
 		{
 			bool b_()
 			{
-				var f_ = condition?.Abatement;
-				var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-				var h_ = g_ is CqlDateTime;
+				DataType f_ = condition?.Abatement;
+				object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+				bool h_ = g_ is CqlDateTime;
 
 				return h_;
 			};
 			bool c_()
 			{
-				var i_ = condition?.Abatement;
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = j_ is CqlQuantity;
+				DataType i_ = condition?.Abatement;
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				bool k_ = j_ is CqlQuantity;
 
 				return k_;
 			};
 			bool d_()
 			{
-				var l_ = condition?.Abatement;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = m_ is CqlInterval<CqlQuantity>;
+				DataType l_ = condition?.Abatement;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				bool n_ = m_ is CqlInterval<CqlQuantity>;
 
 				return n_;
 			};
 			bool e_()
 			{
-				var o_ = condition?.Abatement;
-				var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-				var q_ = p_ is CqlInterval<CqlDateTime>;
+				DataType o_ = condition?.Abatement;
+				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+				bool q_ = p_ is CqlInterval<CqlDateTime>;
 
 				return q_;
 			};
 			if (b_())
 			{
-				var r_ = condition?.Abatement;
-				var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var u_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var v_ = context.Operators.Interval((s_ as CqlDateTime), (u_ as CqlDateTime), true, true);
+				DataType r_ = condition?.Abatement;
+				object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+				object u_ = FHIRHelpers_4_3_000.ToValue(r_);
+				CqlInterval<CqlDateTime> v_ = context.Operators.Interval((s_ as CqlDateTime), (u_ as CqlDateTime), true, true);
 
 				return v_;
 			}
 			else if (c_())
 			{
-				var w_ = this.Patient();
-				var x_ = w_?.BirthDateElement;
-				var y_ = x_?.Value;
-				var z_ = context.Operators.ConvertStringToDate(y_);
-				var aa_ = condition?.Abatement;
-				var ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var ac_ = context.Operators.Add(z_, (ab_ as CqlQuantity));
-				var ae_ = w_?.BirthDateElement;
-				var af_ = ae_?.Value;
-				var ag_ = context.Operators.ConvertStringToDate(af_);
-				var ai_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var aj_ = context.Operators.Add(ag_, (ai_ as CqlQuantity));
-				var ak_ = context.Operators.Quantity(1m, "year");
-				var al_ = context.Operators.Add(aj_, ak_);
-				var am_ = context.Operators.Interval(ac_, al_, true, false);
-				var an_ = am_?.low;
-				var ao_ = context.Operators.ConvertDateToDateTime(an_);
-				var aq_ = w_?.BirthDateElement;
-				var ar_ = aq_?.Value;
-				var as_ = context.Operators.ConvertStringToDate(ar_);
-				var au_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var av_ = context.Operators.Add(as_, (au_ as CqlQuantity));
-				var ax_ = w_?.BirthDateElement;
-				var ay_ = ax_?.Value;
-				var az_ = context.Operators.ConvertStringToDate(ay_);
-				var bb_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bc_ = context.Operators.Add(az_, (bb_ as CqlQuantity));
-				var be_ = context.Operators.Add(bc_, ak_);
-				var bf_ = context.Operators.Interval(av_, be_, true, false);
-				var bg_ = bf_?.high;
-				var bh_ = context.Operators.ConvertDateToDateTime(bg_);
-				var bj_ = w_?.BirthDateElement;
-				var bk_ = bj_?.Value;
-				var bl_ = context.Operators.ConvertStringToDate(bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bo_ = context.Operators.Add(bl_, (bn_ as CqlQuantity));
-				var bq_ = w_?.BirthDateElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.ConvertStringToDate(br_);
-				var bu_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bv_ = context.Operators.Add(bs_, (bu_ as CqlQuantity));
-				var bx_ = context.Operators.Add(bv_, ak_);
-				var by_ = context.Operators.Interval(bo_, bx_, true, false);
-				var bz_ = by_?.lowClosed;
-				var cb_ = w_?.BirthDateElement;
-				var cc_ = cb_?.Value;
-				var cd_ = context.Operators.ConvertStringToDate(cc_);
-				var cf_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var cg_ = context.Operators.Add(cd_, (cf_ as CqlQuantity));
-				var ci_ = w_?.BirthDateElement;
-				var cj_ = ci_?.Value;
-				var ck_ = context.Operators.ConvertStringToDate(cj_);
-				var cm_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var cn_ = context.Operators.Add(ck_, (cm_ as CqlQuantity));
-				var cp_ = context.Operators.Add(cn_, ak_);
-				var cq_ = context.Operators.Interval(cg_, cp_, true, false);
-				var cr_ = cq_?.highClosed;
-				var cs_ = context.Operators.Interval(ao_, bh_, bz_, cr_);
+				Patient w_ = this.Patient();
+				Date x_ = w_?.BirthDateElement;
+				string y_ = x_?.Value;
+				CqlDate z_ = context.Operators.ConvertStringToDate(y_);
+				DataType aa_ = condition?.Abatement;
+				object ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate ac_ = context.Operators.Add(z_, (ab_ as CqlQuantity));
+				Date ae_ = w_?.BirthDateElement;
+				string af_ = ae_?.Value;
+				CqlDate ag_ = context.Operators.ConvertStringToDate(af_);
+				object ai_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate aj_ = context.Operators.Add(ag_, (ai_ as CqlQuantity));
+				CqlQuantity ak_ = context.Operators.Quantity(1m, "year");
+				CqlDate al_ = context.Operators.Add(aj_, ak_);
+				CqlInterval<CqlDate> am_ = context.Operators.Interval(ac_, al_, true, false);
+				CqlDate an_ = am_?.low;
+				CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
+				Date aq_ = w_?.BirthDateElement;
+				string ar_ = aq_?.Value;
+				CqlDate as_ = context.Operators.ConvertStringToDate(ar_);
+				object au_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate av_ = context.Operators.Add(as_, (au_ as CqlQuantity));
+				Date ax_ = w_?.BirthDateElement;
+				string ay_ = ax_?.Value;
+				CqlDate az_ = context.Operators.ConvertStringToDate(ay_);
+				object bb_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bc_ = context.Operators.Add(az_, (bb_ as CqlQuantity));
+				CqlDate be_ = context.Operators.Add(bc_, ak_);
+				CqlInterval<CqlDate> bf_ = context.Operators.Interval(av_, be_, true, false);
+				CqlDate bg_ = bf_?.high;
+				CqlDateTime bh_ = context.Operators.ConvertDateToDateTime(bg_);
+				Date bj_ = w_?.BirthDateElement;
+				string bk_ = bj_?.Value;
+				CqlDate bl_ = context.Operators.ConvertStringToDate(bk_);
+				object bn_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bo_ = context.Operators.Add(bl_, (bn_ as CqlQuantity));
+				Date bq_ = w_?.BirthDateElement;
+				string br_ = bq_?.Value;
+				CqlDate bs_ = context.Operators.ConvertStringToDate(br_);
+				object bu_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bv_ = context.Operators.Add(bs_, (bu_ as CqlQuantity));
+				CqlDate bx_ = context.Operators.Add(bv_, ak_);
+				CqlInterval<CqlDate> by_ = context.Operators.Interval(bo_, bx_, true, false);
+				bool? bz_ = by_?.lowClosed;
+				Date cb_ = w_?.BirthDateElement;
+				string cc_ = cb_?.Value;
+				CqlDate cd_ = context.Operators.ConvertStringToDate(cc_);
+				object cf_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate cg_ = context.Operators.Add(cd_, (cf_ as CqlQuantity));
+				Date ci_ = w_?.BirthDateElement;
+				string cj_ = ci_?.Value;
+				CqlDate ck_ = context.Operators.ConvertStringToDate(cj_);
+				object cm_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate cn_ = context.Operators.Add(ck_, (cm_ as CqlQuantity));
+				CqlDate cp_ = context.Operators.Add(cn_, ak_);
+				CqlInterval<CqlDate> cq_ = context.Operators.Interval(cg_, cp_, true, false);
+				bool? cr_ = cq_?.highClosed;
+				CqlInterval<CqlDateTime> cs_ = context.Operators.Interval(ao_, bh_, bz_, cr_);
 
 				return cs_;
 			}
 			else if (d_())
 			{
-				var ct_ = this.Patient();
-				var cu_ = ct_?.BirthDateElement;
-				var cv_ = cu_?.Value;
-				var cw_ = context.Operators.ConvertStringToDate(cv_);
-				var cx_ = condition?.Abatement;
-				var cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var cz_ = context.Operators.LateBoundProperty<object>(cy_, "low");
-				var da_ = context.Operators.Add(cw_, (cz_ as CqlQuantity));
-				var dc_ = ct_?.BirthDateElement;
-				var dd_ = dc_?.Value;
-				var de_ = context.Operators.ConvertStringToDate(dd_);
-				var dg_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var dh_ = context.Operators.LateBoundProperty<object>(dg_, "high");
-				var di_ = context.Operators.Add(de_, (dh_ as CqlQuantity));
-				var dj_ = context.Operators.Quantity(1m, "year");
-				var dk_ = context.Operators.Add(di_, dj_);
-				var dl_ = context.Operators.Interval(da_, dk_, true, false);
-				var dm_ = dl_?.low;
-				var dn_ = context.Operators.ConvertDateToDateTime(dm_);
-				var dp_ = ct_?.BirthDateElement;
-				var dq_ = dp_?.Value;
-				var dr_ = context.Operators.ConvertStringToDate(dq_);
-				var dt_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var du_ = context.Operators.LateBoundProperty<object>(dt_, "low");
-				var dv_ = context.Operators.Add(dr_, (du_ as CqlQuantity));
-				var dx_ = ct_?.BirthDateElement;
-				var dy_ = dx_?.Value;
-				var dz_ = context.Operators.ConvertStringToDate(dy_);
-				var eb_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ec_ = context.Operators.LateBoundProperty<object>(eb_, "high");
-				var ed_ = context.Operators.Add(dz_, (ec_ as CqlQuantity));
-				var ef_ = context.Operators.Add(ed_, dj_);
-				var eg_ = context.Operators.Interval(dv_, ef_, true, false);
-				var eh_ = eg_?.high;
-				var ei_ = context.Operators.ConvertDateToDateTime(eh_);
-				var ek_ = ct_?.BirthDateElement;
-				var el_ = ek_?.Value;
-				var em_ = context.Operators.ConvertStringToDate(el_);
-				var eo_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ep_ = context.Operators.LateBoundProperty<object>(eo_, "low");
-				var eq_ = context.Operators.Add(em_, (ep_ as CqlQuantity));
-				var es_ = ct_?.BirthDateElement;
-				var et_ = es_?.Value;
-				var eu_ = context.Operators.ConvertStringToDate(et_);
-				var ew_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ex_ = context.Operators.LateBoundProperty<object>(ew_, "high");
-				var ey_ = context.Operators.Add(eu_, (ex_ as CqlQuantity));
-				var fa_ = context.Operators.Add(ey_, dj_);
-				var fb_ = context.Operators.Interval(eq_, fa_, true, false);
-				var fc_ = fb_?.lowClosed;
-				var fe_ = ct_?.BirthDateElement;
-				var ff_ = fe_?.Value;
-				var fg_ = context.Operators.ConvertStringToDate(ff_);
-				var fi_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var fj_ = context.Operators.LateBoundProperty<object>(fi_, "low");
-				var fk_ = context.Operators.Add(fg_, (fj_ as CqlQuantity));
-				var fm_ = ct_?.BirthDateElement;
-				var fn_ = fm_?.Value;
-				var fo_ = context.Operators.ConvertStringToDate(fn_);
-				var fq_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var fr_ = context.Operators.LateBoundProperty<object>(fq_, "high");
-				var fs_ = context.Operators.Add(fo_, (fr_ as CqlQuantity));
-				var fu_ = context.Operators.Add(fs_, dj_);
-				var fv_ = context.Operators.Interval(fk_, fu_, true, false);
-				var fw_ = fv_?.highClosed;
-				var fx_ = context.Operators.Interval(dn_, ei_, fc_, fw_);
+				Patient ct_ = this.Patient();
+				Date cu_ = ct_?.BirthDateElement;
+				string cv_ = cu_?.Value;
+				CqlDate cw_ = context.Operators.ConvertStringToDate(cv_);
+				DataType cx_ = condition?.Abatement;
+				object cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object cz_ = context.Operators.LateBoundProperty<object>(cy_, "low");
+				CqlDate da_ = context.Operators.Add(cw_, (cz_ as CqlQuantity));
+				Date dc_ = ct_?.BirthDateElement;
+				string dd_ = dc_?.Value;
+				CqlDate de_ = context.Operators.ConvertStringToDate(dd_);
+				object dg_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object dh_ = context.Operators.LateBoundProperty<object>(dg_, "high");
+				CqlDate di_ = context.Operators.Add(de_, (dh_ as CqlQuantity));
+				CqlQuantity dj_ = context.Operators.Quantity(1m, "year");
+				CqlDate dk_ = context.Operators.Add(di_, dj_);
+				CqlInterval<CqlDate> dl_ = context.Operators.Interval(da_, dk_, true, false);
+				CqlDate dm_ = dl_?.low;
+				CqlDateTime dn_ = context.Operators.ConvertDateToDateTime(dm_);
+				Date dp_ = ct_?.BirthDateElement;
+				string dq_ = dp_?.Value;
+				CqlDate dr_ = context.Operators.ConvertStringToDate(dq_);
+				object dt_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object du_ = context.Operators.LateBoundProperty<object>(dt_, "low");
+				CqlDate dv_ = context.Operators.Add(dr_, (du_ as CqlQuantity));
+				Date dx_ = ct_?.BirthDateElement;
+				string dy_ = dx_?.Value;
+				CqlDate dz_ = context.Operators.ConvertStringToDate(dy_);
+				object eb_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ec_ = context.Operators.LateBoundProperty<object>(eb_, "high");
+				CqlDate ed_ = context.Operators.Add(dz_, (ec_ as CqlQuantity));
+				CqlDate ef_ = context.Operators.Add(ed_, dj_);
+				CqlInterval<CqlDate> eg_ = context.Operators.Interval(dv_, ef_, true, false);
+				CqlDate eh_ = eg_?.high;
+				CqlDateTime ei_ = context.Operators.ConvertDateToDateTime(eh_);
+				Date ek_ = ct_?.BirthDateElement;
+				string el_ = ek_?.Value;
+				CqlDate em_ = context.Operators.ConvertStringToDate(el_);
+				object eo_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ep_ = context.Operators.LateBoundProperty<object>(eo_, "low");
+				CqlDate eq_ = context.Operators.Add(em_, (ep_ as CqlQuantity));
+				Date es_ = ct_?.BirthDateElement;
+				string et_ = es_?.Value;
+				CqlDate eu_ = context.Operators.ConvertStringToDate(et_);
+				object ew_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ex_ = context.Operators.LateBoundProperty<object>(ew_, "high");
+				CqlDate ey_ = context.Operators.Add(eu_, (ex_ as CqlQuantity));
+				CqlDate fa_ = context.Operators.Add(ey_, dj_);
+				CqlInterval<CqlDate> fb_ = context.Operators.Interval(eq_, fa_, true, false);
+				bool? fc_ = fb_?.lowClosed;
+				Date fe_ = ct_?.BirthDateElement;
+				string ff_ = fe_?.Value;
+				CqlDate fg_ = context.Operators.ConvertStringToDate(ff_);
+				object fi_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object fj_ = context.Operators.LateBoundProperty<object>(fi_, "low");
+				CqlDate fk_ = context.Operators.Add(fg_, (fj_ as CqlQuantity));
+				Date fm_ = ct_?.BirthDateElement;
+				string fn_ = fm_?.Value;
+				CqlDate fo_ = context.Operators.ConvertStringToDate(fn_);
+				object fq_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object fr_ = context.Operators.LateBoundProperty<object>(fq_, "high");
+				CqlDate fs_ = context.Operators.Add(fo_, (fr_ as CqlQuantity));
+				CqlDate fu_ = context.Operators.Add(fs_, dj_);
+				CqlInterval<CqlDate> fv_ = context.Operators.Interval(fk_, fu_, true, false);
+				bool? fw_ = fv_?.highClosed;
+				CqlInterval<CqlDateTime> fx_ = context.Operators.Interval(dn_, ei_, fc_, fw_);
 
 				return fx_;
 			}
 			else if (e_())
 			{
-				var fy_ = condition?.Abatement;
-				var fz_ = FHIRHelpers_4_3_000.ToValue(fy_);
-				var ga_ = context.Operators.LateBoundProperty<object>(fz_, "low");
-				var gc_ = FHIRHelpers_4_3_000.ToValue(fy_);
-				var gd_ = context.Operators.LateBoundProperty<object>(gc_, "high");
-				var ge_ = context.Operators.Interval((ga_ as CqlDateTime), (gd_ as CqlDateTime), true, false);
+				DataType fy_ = condition?.Abatement;
+				object fz_ = FHIRHelpers_4_3_000.ToValue(fy_);
+				object ga_ = context.Operators.LateBoundProperty<object>(fz_, "low");
+				object gc_ = FHIRHelpers_4_3_000.ToValue(fy_);
+				object gd_ = context.Operators.LateBoundProperty<object>(gc_, "high");
+				CqlInterval<CqlDateTime> ge_ = context.Operators.Interval((ga_ as CqlDateTime), (gd_ as CqlDateTime), true, false);
 
 				return ge_;
 			}
@@ -2025,41 +2193,41 @@ public class QICoreCommon_2_0_000
 		{
 			bool b_()
 			{
-				var c_ = condition?.ClinicalStatus;
-				var d_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var e_ = this.active();
-				var f_ = context.Operators.ConvertCodeToConcept(e_);
-				var g_ = context.Operators.Equivalent(d_, f_);
-				var i_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var j_ = this.recurrence();
-				var k_ = context.Operators.ConvertCodeToConcept(j_);
-				var l_ = context.Operators.Equivalent(i_, k_);
-				var m_ = context.Operators.Or(g_, l_);
-				var o_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var p_ = this.relapse();
-				var q_ = context.Operators.ConvertCodeToConcept(p_);
-				var r_ = context.Operators.Equivalent(o_, q_);
-				var s_ = context.Operators.Or(m_, r_);
+				CodeableConcept c_ = condition?.ClinicalStatus;
+				CqlConcept d_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode e_ = this.active();
+				CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+				bool? g_ = context.Operators.Equivalent(d_, f_);
+				CqlConcept i_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode j_ = this.recurrence();
+				CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+				bool? l_ = context.Operators.Equivalent(i_, k_);
+				bool? m_ = context.Operators.Or(g_, l_);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode p_ = this.relapse();
+				CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+				bool? r_ = context.Operators.Equivalent(o_, q_);
+				bool? s_ = context.Operators.Or(m_, r_);
 
 				return (s_ ?? false);
 			};
 			if (b_())
 			{
-				var t_ = condition?.Onset;
-				var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-				var v_ = this.ToInterval(u_);
-				var w_ = context.Operators.Start(v_);
-				var x_ = this.ToAbatementInterval(condition);
-				var y_ = context.Operators.End(x_);
-				var z_ = context.Operators.Interval(w_, y_, true, true);
+				DataType t_ = condition?.Onset;
+				object u_ = FHIRHelpers_4_3_000.ToValue(t_);
+				CqlInterval<CqlDateTime> v_ = this.ToInterval(u_);
+				CqlDateTime w_ = context.Operators.Start(v_);
+				CqlInterval<CqlDateTime> x_ = this.ToAbatementInterval(condition);
+				CqlDateTime y_ = context.Operators.End(x_);
+				CqlInterval<CqlDateTime> z_ = context.Operators.Interval(w_, y_, true, true);
 
 				return z_;
 			}
 			else
 			{
-				var aa_ = this.ToAbatementInterval(condition);
-				var ab_ = context.Operators.End(aa_);
-				var ac_ = new CqlDateTime[]
+				CqlInterval<CqlDateTime> aa_ = this.ToAbatementInterval(condition);
+				CqlDateTime ab_ = context.Operators.End(aa_);
+				CqlDateTime[] ac_ = new CqlDateTime[]
 				{
 					ab_,
 				};
@@ -2069,21 +2237,21 @@ public class QICoreCommon_2_0_000
 					{
 						if ((abatementDate is null))
 						{
-							var ah_ = condition?.Onset;
-							var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-							var aj_ = this.ToInterval(ai_);
-							var ak_ = context.Operators.Start(aj_);
-							var al_ = context.Operators.Interval(ak_, abatementDate, true, false);
+							DataType ah_ = condition?.Onset;
+							object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+							CqlInterval<CqlDateTime> aj_ = this.ToInterval(ai_);
+							CqlDateTime ak_ = context.Operators.Start(aj_);
+							CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ak_, abatementDate, true, false);
 
 							return al_;
 						}
 						else
 						{
-							var am_ = condition?.Onset;
-							var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-							var ao_ = this.ToInterval(an_);
-							var ap_ = context.Operators.Start(ao_);
-							var aq_ = context.Operators.Interval(ap_, abatementDate, true, true);
+							DataType am_ = condition?.Onset;
+							object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+							CqlInterval<CqlDateTime> ao_ = this.ToInterval(an_);
+							CqlDateTime ap_ = context.Operators.Start(ao_);
+							CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ap_, abatementDate, true, true);
 
 							return aq_;
 						}
@@ -2091,8 +2259,8 @@ public class QICoreCommon_2_0_000
 
 					return ag_();
 				};
-				var ae_ = context.Operators.Select<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)ac_, ad_);
-				var af_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ae_);
+				IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.Select<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)ac_, ad_);
+				CqlInterval<CqlDateTime> af_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ae_);
 
 				return af_;
 			}
@@ -2110,41 +2278,41 @@ public class QICoreCommon_2_0_000
 		{
 			bool b_()
 			{
-				var c_ = condition?.ClinicalStatus;
-				var d_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var e_ = this.active();
-				var f_ = context.Operators.ConvertCodeToConcept(e_);
-				var g_ = context.Operators.Equivalent(d_, f_);
-				var i_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var j_ = this.recurrence();
-				var k_ = context.Operators.ConvertCodeToConcept(j_);
-				var l_ = context.Operators.Equivalent(i_, k_);
-				var m_ = context.Operators.Or(g_, l_);
-				var o_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var p_ = this.relapse();
-				var q_ = context.Operators.ConvertCodeToConcept(p_);
-				var r_ = context.Operators.Equivalent(o_, q_);
-				var s_ = context.Operators.Or(m_, r_);
+				CodeableConcept c_ = condition?.ClinicalStatus;
+				CqlConcept d_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode e_ = this.active();
+				CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+				bool? g_ = context.Operators.Equivalent(d_, f_);
+				CqlConcept i_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode j_ = this.recurrence();
+				CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+				bool? l_ = context.Operators.Equivalent(i_, k_);
+				bool? m_ = context.Operators.Or(g_, l_);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode p_ = this.relapse();
+				CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+				bool? r_ = context.Operators.Equivalent(o_, q_);
+				bool? s_ = context.Operators.Or(m_, r_);
 
 				return (s_ ?? false);
 			};
 			if (b_())
 			{
-				var t_ = condition?.Onset;
-				var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-				var v_ = this.toInterval(u_);
-				var w_ = context.Operators.Start(v_);
-				var x_ = this.abatementInterval(condition);
-				var y_ = context.Operators.End(x_);
-				var z_ = context.Operators.Interval(w_, y_, true, true);
+				DataType t_ = condition?.Onset;
+				object u_ = FHIRHelpers_4_3_000.ToValue(t_);
+				CqlInterval<CqlDateTime> v_ = this.toInterval(u_);
+				CqlDateTime w_ = context.Operators.Start(v_);
+				CqlInterval<CqlDateTime> x_ = this.abatementInterval(condition);
+				CqlDateTime y_ = context.Operators.End(x_);
+				CqlInterval<CqlDateTime> z_ = context.Operators.Interval(w_, y_, true, true);
 
 				return z_;
 			}
 			else
 			{
-				var aa_ = this.ToAbatementInterval(condition);
-				var ab_ = context.Operators.End(aa_);
-				var ac_ = new CqlDateTime[]
+				CqlInterval<CqlDateTime> aa_ = this.ToAbatementInterval(condition);
+				CqlDateTime ab_ = context.Operators.End(aa_);
+				CqlDateTime[] ac_ = new CqlDateTime[]
 				{
 					ab_,
 				};
@@ -2154,21 +2322,21 @@ public class QICoreCommon_2_0_000
 					{
 						if ((abatementDate is null))
 						{
-							var ah_ = condition?.Onset;
-							var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-							var aj_ = this.ToInterval(ai_);
-							var ak_ = context.Operators.Start(aj_);
-							var al_ = context.Operators.Interval(ak_, abatementDate, true, false);
+							DataType ah_ = condition?.Onset;
+							object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+							CqlInterval<CqlDateTime> aj_ = this.ToInterval(ai_);
+							CqlDateTime ak_ = context.Operators.Start(aj_);
+							CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ak_, abatementDate, true, false);
 
 							return al_;
 						}
 						else
 						{
-							var am_ = condition?.Onset;
-							var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-							var ao_ = this.ToInterval(an_);
-							var ap_ = context.Operators.Start(ao_);
-							var aq_ = context.Operators.Interval(ap_, abatementDate, true, true);
+							DataType am_ = condition?.Onset;
+							object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+							CqlInterval<CqlDateTime> ao_ = this.ToInterval(an_);
+							CqlDateTime ap_ = context.Operators.Start(ao_);
+							CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ap_, abatementDate, true, true);
 
 							return aq_;
 						}
@@ -2176,8 +2344,8 @@ public class QICoreCommon_2_0_000
 
 					return ag_();
 				};
-				var ae_ = context.Operators.Select<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)ac_, ad_);
-				var af_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ae_);
+				IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.Select<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)ac_, ad_);
+				CqlInterval<CqlDateTime> af_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ae_);
 
 				return af_;
 			}
@@ -2192,8 +2360,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getId()` instead")]
 	public string GetId(string uri)
 	{
-		var a_ = context.Operators.Split(uri, "/");
-		var b_ = context.Operators.Last<string>(a_);
+		IEnumerable<string> a_ = context.Operators.Split(uri, "/");
+		string b_ = context.Operators.Last<string>(a_);
 
 		return b_;
 	}
@@ -2203,8 +2371,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("comment", "This function can be used to determine the logical id of a given resource. It can be used in a single-server environment to trace references. However, this function does not attempt to resolve or distinguish the base of the given url, and so cannot be used safely in multi-server environments.")]
 	public string getId(string uri)
 	{
-		var a_ = context.Operators.Split(uri, "/");
-		var b_ = context.Operators.Last<string>(a_);
+		IEnumerable<string> a_ = context.Operators.Split(uri, "/");
+		string b_ = context.Operators.Last<string>(a_);
 
 		return b_;
 	}
@@ -2214,11 +2382,11 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Uee the fluent function `hasStart()` instead")]
 	public bool? HasStart(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.Start(period);
-		var c_ = context.Operators.MinValue<CqlDateTime>();
-		var d_ = context.Operators.Equal(a_, c_);
-		var e_ = context.Operators.Or((bool?)(a_ is null), d_);
-		var f_ = context.Operators.Not(e_);
+		CqlDateTime a_ = context.Operators.Start(period);
+		CqlDateTime c_ = context.Operators.MinValue<CqlDateTime>();
+		bool? d_ = context.Operators.Equal(a_, c_);
+		bool? e_ = context.Operators.Or((bool?)(a_ is null), d_);
+		bool? f_ = context.Operators.Not(e_);
 
 		return f_;
 	}
@@ -2227,11 +2395,11 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Given an interval, return true if the interval has a starting boundary specified (i.e. the start of the interval is not null and not the minimum DateTime value)")]
 	public bool? hasStart(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.Start(period);
-		var c_ = context.Operators.MinValue<CqlDateTime>();
-		var d_ = context.Operators.Equal(a_, c_);
-		var e_ = context.Operators.Or((bool?)(a_ is null), d_);
-		var f_ = context.Operators.Not(e_);
+		CqlDateTime a_ = context.Operators.Start(period);
+		CqlDateTime c_ = context.Operators.MinValue<CqlDateTime>();
+		bool? d_ = context.Operators.Equal(a_, c_);
+		bool? e_ = context.Operators.Or((bool?)(a_ is null), d_);
+		bool? f_ = context.Operators.Not(e_);
 
 		return f_;
 	}
@@ -2241,11 +2409,11 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hasEnd()` instead")]
 	public bool? HasEnd(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.End(period);
-		var c_ = context.Operators.MaxValue<CqlDateTime>();
-		var d_ = context.Operators.Equal(a_, c_);
-		var e_ = context.Operators.Or((bool?)(a_ is null), d_);
-		var f_ = context.Operators.Not(e_);
+		CqlDateTime a_ = context.Operators.End(period);
+		CqlDateTime c_ = context.Operators.MaxValue<CqlDateTime>();
+		bool? d_ = context.Operators.Equal(a_, c_);
+		bool? e_ = context.Operators.Or((bool?)(a_ is null), d_);
+		bool? f_ = context.Operators.Not(e_);
 
 		return f_;
 	}
@@ -2254,11 +2422,11 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Given an interval, returns true if the interval has an ending boundary specified (i.e. the end of the interval is not null and not the maximum DateTime value)")]
 	public bool? hasEnd(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.End(period);
-		var c_ = context.Operators.MaxValue<CqlDateTime>();
-		var d_ = context.Operators.Equal(a_, c_);
-		var e_ = context.Operators.Or((bool?)(a_ is null), d_);
-		var f_ = context.Operators.Not(e_);
+		CqlDateTime a_ = context.Operators.End(period);
+		CqlDateTime c_ = context.Operators.MaxValue<CqlDateTime>();
+		bool? d_ = context.Operators.Equal(a_, c_);
+		bool? e_ = context.Operators.Or((bool?)(a_ is null), d_);
+		bool? f_ = context.Operators.Not(e_);
 
 		return f_;
 	}
@@ -2268,8 +2436,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `latest()` instead")]
 	public CqlDateTime Latest(object choice)
 	{
-		var a_ = this.toInterval(choice);
-		var b_ = new CqlInterval<CqlDateTime>[]
+		CqlInterval<CqlDateTime> a_ = this.toInterval(choice);
+		CqlInterval<CqlDateTime>[] b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
 		};
@@ -2279,13 +2447,13 @@ public class QICoreCommon_2_0_000
 			{
 				if ((this.HasEnd(period) ?? false))
 				{
-					var g_ = context.Operators.End(period);
+					CqlDateTime g_ = context.Operators.End(period);
 
 					return g_;
 				}
 				else
 				{
-					var h_ = context.Operators.Start(period);
+					CqlDateTime h_ = context.Operators.Start(period);
 
 					return h_;
 				}
@@ -2293,8 +2461,8 @@ public class QICoreCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
+		IEnumerable<CqlDateTime> d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
+		CqlDateTime e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
 
 		return e_;
 	}
@@ -2303,8 +2471,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Given an interval, returns the ending point if the interval has an ending boundary specified, otherwise, returns the starting point")]
 	public CqlDateTime latest(object choice)
 	{
-		var a_ = this.toInterval(choice);
-		var b_ = new CqlInterval<CqlDateTime>[]
+		CqlInterval<CqlDateTime> a_ = this.toInterval(choice);
+		CqlInterval<CqlDateTime>[] b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
 		};
@@ -2314,13 +2482,13 @@ public class QICoreCommon_2_0_000
 			{
 				if ((this.hasEnd(period) ?? false))
 				{
-					var g_ = context.Operators.End(period);
+					CqlDateTime g_ = context.Operators.End(period);
 
 					return g_;
 				}
 				else
 				{
-					var h_ = context.Operators.Start(period);
+					CqlDateTime h_ = context.Operators.Start(period);
 
 					return h_;
 				}
@@ -2328,8 +2496,8 @@ public class QICoreCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
+		IEnumerable<CqlDateTime> d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
+		CqlDateTime e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
 
 		return e_;
 	}
@@ -2339,8 +2507,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `earliest()` instead")]
 	public CqlDateTime Earliest(object choice)
 	{
-		var a_ = this.toInterval(choice);
-		var b_ = new CqlInterval<CqlDateTime>[]
+		CqlInterval<CqlDateTime> a_ = this.toInterval(choice);
+		CqlInterval<CqlDateTime>[] b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
 		};
@@ -2350,13 +2518,13 @@ public class QICoreCommon_2_0_000
 			{
 				if ((this.HasStart(period) ?? false))
 				{
-					var g_ = context.Operators.Start(period);
+					CqlDateTime g_ = context.Operators.Start(period);
 
 					return g_;
 				}
 				else
 				{
-					var h_ = context.Operators.End(period);
+					CqlDateTime h_ = context.Operators.End(period);
 
 					return h_;
 				}
@@ -2364,8 +2532,8 @@ public class QICoreCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
+		IEnumerable<CqlDateTime> d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
+		CqlDateTime e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
 
 		return e_;
 	}
@@ -2374,8 +2542,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Given an interval, return the starting point if the interval has a starting boundary specified, otherwise, return the ending point")]
 	public CqlDateTime earliest(object choice)
 	{
-		var a_ = this.toInterval(choice);
-		var b_ = new CqlInterval<CqlDateTime>[]
+		CqlInterval<CqlDateTime> a_ = this.toInterval(choice);
+		CqlInterval<CqlDateTime>[] b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
 		};
@@ -2385,13 +2553,13 @@ public class QICoreCommon_2_0_000
 			{
 				if ((this.hasStart(period) ?? false))
 				{
-					var g_ = context.Operators.Start(period);
+					CqlDateTime g_ = context.Operators.Start(period);
 
 					return g_;
 				}
 				else
 				{
-					var h_ = context.Operators.End(period);
+					CqlDateTime h_ = context.Operators.End(period);
 
 					return h_;
 				}
@@ -2399,8 +2567,8 @@ public class QICoreCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
+		IEnumerable<CqlDateTime> d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
+		CqlDateTime e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
 
 		return e_;
 	}
@@ -2410,22 +2578,22 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `toDayNumbers()` instead")]
 	public IEnumerable<int?> Interval_To_Day_Numbers(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = context.Operators.Start(Period);
-		var b_ = context.Operators.End(Period);
-		var c_ = context.Operators.DurationBetween(a_, b_, "day");
-		var d_ = context.Operators.Interval(1, c_, true, true);
-		var e_ = new CqlInterval<int?>[]
+		CqlDateTime a_ = context.Operators.Start(Period);
+		CqlDateTime b_ = context.Operators.End(Period);
+		int? c_ = context.Operators.DurationBetween(a_, b_, "day");
+		CqlInterval<int?> d_ = context.Operators.Interval(1, c_, true, true);
+		CqlInterval<int?>[] e_ = new CqlInterval<int?>[]
 		{
 			d_,
 		};
-		var f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
 		int? g_(CqlInterval<int?> DayNumber)
 		{
-			var i_ = context.Operators.End(DayNumber);
+			int? i_ = context.Operators.End(DayNumber);
 
 			return i_;
 		};
-		var h_ = context.Operators.Select<CqlInterval<int?>, int?>(f_, g_);
+		IEnumerable<int?> h_ = context.Operators.Select<CqlInterval<int?>, int?>(f_, g_);
 
 		return h_;
 	}
@@ -2434,22 +2602,22 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Creates a list of integers from 1 to how many days are in the interval. Note, this wont create an index for the final day if it is less than 24 hours. This also includes the first 24 hour period.")]
 	public IEnumerable<int?> toDayNumbers(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = context.Operators.Start(Period);
-		var b_ = context.Operators.End(Period);
-		var c_ = context.Operators.DurationBetween(a_, b_, "day");
-		var d_ = context.Operators.Interval(1, c_, true, true);
-		var e_ = new CqlInterval<int?>[]
+		CqlDateTime a_ = context.Operators.Start(Period);
+		CqlDateTime b_ = context.Operators.End(Period);
+		int? c_ = context.Operators.DurationBetween(a_, b_, "day");
+		CqlInterval<int?> d_ = context.Operators.Interval(1, c_, true, true);
+		CqlInterval<int?>[] e_ = new CqlInterval<int?>[]
 		{
 			d_,
 		};
-		var f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
 		int? g_(CqlInterval<int?> DayNumber)
 		{
-			var i_ = context.Operators.End(DayNumber);
+			int? i_ = context.Operators.End(DayNumber);
 
 			return i_;
 		};
-		var h_ = context.Operators.Select<CqlInterval<int?>, int?>(f_, g_);
+		IEnumerable<int?> h_ = context.Operators.Select<CqlInterval<int?>, int?>(f_, g_);
 
 		return h_;
 	}
@@ -2459,55 +2627,55 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `daysInPeriod()` instead")]
 	public IEnumerable<Tuple_ddJhZGNHefSCOAJJFEIEcXie> Days_In_Period(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = this.Interval_To_Day_Numbers(Period);
+		IEnumerable<int?> a_ = this.Interval_To_Day_Numbers(Period);
 		Tuple_ddJhZGNHefSCOAJJFEIEcXie b_(int? DayIndex)
 		{
-			var d_ = context.Operators.Start(Period);
-			var e_ = context.Operators.Quantity(24m, "hours");
-			var f_ = context.Operators.Subtract(DayIndex, 1);
-			var g_ = context.Operators.ConvertIntegerToQuantity(f_);
-			var h_ = context.Operators.Multiply(e_, g_);
-			var i_ = context.Operators.Add(d_, h_);
+			CqlDateTime d_ = context.Operators.Start(Period);
+			CqlQuantity e_ = context.Operators.Quantity(24m, "hours");
+			int? f_ = context.Operators.Subtract(DayIndex, 1);
+			CqlQuantity g_ = context.Operators.ConvertIntegerToQuantity(f_);
+			CqlQuantity h_ = context.Operators.Multiply(e_, g_);
+			CqlDateTime i_ = context.Operators.Add(d_, h_);
 			CqlDateTime j_()
 			{
 				bool m_()
 				{
-					var n_ = context.Operators.Start(Period);
-					var o_ = context.Operators.Quantity(24m, "hours");
-					var p_ = context.Operators.Subtract(DayIndex, 1);
-					var q_ = context.Operators.ConvertIntegerToQuantity(p_);
-					var r_ = context.Operators.Multiply(o_, q_);
-					var s_ = context.Operators.Add(n_, r_);
-					var t_ = context.Operators.End(Period);
-					var u_ = context.Operators.DurationBetween(s_, t_, "hour");
-					var v_ = context.Operators.Less(u_, 24);
+					CqlDateTime n_ = context.Operators.Start(Period);
+					CqlQuantity o_ = context.Operators.Quantity(24m, "hours");
+					int? p_ = context.Operators.Subtract(DayIndex, 1);
+					CqlQuantity q_ = context.Operators.ConvertIntegerToQuantity(p_);
+					CqlQuantity r_ = context.Operators.Multiply(o_, q_);
+					CqlDateTime s_ = context.Operators.Add(n_, r_);
+					CqlDateTime t_ = context.Operators.End(Period);
+					int? u_ = context.Operators.DurationBetween(s_, t_, "hour");
+					bool? v_ = context.Operators.Less(u_, 24);
 
 					return (v_ ?? false);
 				};
 				if (m_())
 				{
-					var w_ = context.Operators.Start(Period);
-					var x_ = context.Operators.Quantity(24m, "hours");
-					var y_ = context.Operators.Subtract(DayIndex, 1);
-					var z_ = context.Operators.ConvertIntegerToQuantity(y_);
-					var aa_ = context.Operators.Multiply(x_, z_);
-					var ab_ = context.Operators.Add(w_, aa_);
+					CqlDateTime w_ = context.Operators.Start(Period);
+					CqlQuantity x_ = context.Operators.Quantity(24m, "hours");
+					int? y_ = context.Operators.Subtract(DayIndex, 1);
+					CqlQuantity z_ = context.Operators.ConvertIntegerToQuantity(y_);
+					CqlQuantity aa_ = context.Operators.Multiply(x_, z_);
+					CqlDateTime ab_ = context.Operators.Add(w_, aa_);
 
 					return ab_;
 				}
 				else
 				{
-					var ac_ = context.Operators.Start(Period);
-					var ad_ = context.Operators.Quantity(24m, "hours");
-					var ae_ = context.Operators.ConvertIntegerToQuantity(DayIndex);
-					var af_ = context.Operators.Multiply(ad_, ae_);
-					var ag_ = context.Operators.Add(ac_, af_);
+					CqlDateTime ac_ = context.Operators.Start(Period);
+					CqlQuantity ad_ = context.Operators.Quantity(24m, "hours");
+					CqlQuantity ae_ = context.Operators.ConvertIntegerToQuantity(DayIndex);
+					CqlQuantity af_ = context.Operators.Multiply(ad_, ae_);
+					CqlDateTime ag_ = context.Operators.Add(ac_, af_);
 
 					return ag_;
 				}
 			};
-			var k_ = context.Operators.Interval(i_, j_(), true, false);
-			var l_ = new Tuple_ddJhZGNHefSCOAJJFEIEcXie
+			CqlInterval<CqlDateTime> k_ = context.Operators.Interval(i_, j_(), true, false);
+			Tuple_ddJhZGNHefSCOAJJFEIEcXie l_ = new Tuple_ddJhZGNHefSCOAJJFEIEcXie
 			{
 				dayIndex = DayIndex,
 				dayPeriod = k_,
@@ -2515,7 +2683,7 @@ public class QICoreCommon_2_0_000
 
 			return l_;
 		};
-		var c_ = context.Operators.Select<int?, Tuple_ddJhZGNHefSCOAJJFEIEcXie>(a_, b_);
+		IEnumerable<Tuple_ddJhZGNHefSCOAJJFEIEcXie> c_ = context.Operators.Select<int?, Tuple_ddJhZGNHefSCOAJJFEIEcXie>(a_, b_);
 
 		return c_;
 	}
@@ -2524,55 +2692,55 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Creates a list of 24 hour long intervals in an interval paired with the index (1 indexed) to which 24 hour interval it is. Note that the result will include intervals that are closed at the beginning and open at the end")]
 	public IEnumerable<Tuple_ddJhZGNHefSCOAJJFEIEcXie> daysInPeriod(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = this.Interval_To_Day_Numbers(Period);
+		IEnumerable<int?> a_ = this.Interval_To_Day_Numbers(Period);
 		Tuple_ddJhZGNHefSCOAJJFEIEcXie b_(int? DayIndex)
 		{
-			var d_ = context.Operators.Start(Period);
-			var e_ = context.Operators.Quantity(24m, "hours");
-			var f_ = context.Operators.Subtract(DayIndex, 1);
-			var g_ = context.Operators.ConvertIntegerToQuantity(f_);
-			var h_ = context.Operators.Multiply(e_, g_);
-			var i_ = context.Operators.Add(d_, h_);
+			CqlDateTime d_ = context.Operators.Start(Period);
+			CqlQuantity e_ = context.Operators.Quantity(24m, "hours");
+			int? f_ = context.Operators.Subtract(DayIndex, 1);
+			CqlQuantity g_ = context.Operators.ConvertIntegerToQuantity(f_);
+			CqlQuantity h_ = context.Operators.Multiply(e_, g_);
+			CqlDateTime i_ = context.Operators.Add(d_, h_);
 			CqlDateTime j_()
 			{
 				bool m_()
 				{
-					var n_ = context.Operators.Start(Period);
-					var o_ = context.Operators.Quantity(24m, "hours");
-					var p_ = context.Operators.Subtract(DayIndex, 1);
-					var q_ = context.Operators.ConvertIntegerToQuantity(p_);
-					var r_ = context.Operators.Multiply(o_, q_);
-					var s_ = context.Operators.Add(n_, r_);
-					var t_ = context.Operators.End(Period);
-					var u_ = context.Operators.DurationBetween(s_, t_, "hour");
-					var v_ = context.Operators.Less(u_, 24);
+					CqlDateTime n_ = context.Operators.Start(Period);
+					CqlQuantity o_ = context.Operators.Quantity(24m, "hours");
+					int? p_ = context.Operators.Subtract(DayIndex, 1);
+					CqlQuantity q_ = context.Operators.ConvertIntegerToQuantity(p_);
+					CqlQuantity r_ = context.Operators.Multiply(o_, q_);
+					CqlDateTime s_ = context.Operators.Add(n_, r_);
+					CqlDateTime t_ = context.Operators.End(Period);
+					int? u_ = context.Operators.DurationBetween(s_, t_, "hour");
+					bool? v_ = context.Operators.Less(u_, 24);
 
 					return (v_ ?? false);
 				};
 				if (m_())
 				{
-					var w_ = context.Operators.Start(Period);
-					var x_ = context.Operators.Quantity(24m, "hours");
-					var y_ = context.Operators.Subtract(DayIndex, 1);
-					var z_ = context.Operators.ConvertIntegerToQuantity(y_);
-					var aa_ = context.Operators.Multiply(x_, z_);
-					var ab_ = context.Operators.Add(w_, aa_);
+					CqlDateTime w_ = context.Operators.Start(Period);
+					CqlQuantity x_ = context.Operators.Quantity(24m, "hours");
+					int? y_ = context.Operators.Subtract(DayIndex, 1);
+					CqlQuantity z_ = context.Operators.ConvertIntegerToQuantity(y_);
+					CqlQuantity aa_ = context.Operators.Multiply(x_, z_);
+					CqlDateTime ab_ = context.Operators.Add(w_, aa_);
 
 					return ab_;
 				}
 				else
 				{
-					var ac_ = context.Operators.Start(Period);
-					var ad_ = context.Operators.Quantity(24m, "hours");
-					var ae_ = context.Operators.ConvertIntegerToQuantity(DayIndex);
-					var af_ = context.Operators.Multiply(ad_, ae_);
-					var ag_ = context.Operators.Add(ac_, af_);
+					CqlDateTime ac_ = context.Operators.Start(Period);
+					CqlQuantity ad_ = context.Operators.Quantity(24m, "hours");
+					CqlQuantity ae_ = context.Operators.ConvertIntegerToQuantity(DayIndex);
+					CqlQuantity af_ = context.Operators.Multiply(ad_, ae_);
+					CqlDateTime ag_ = context.Operators.Add(ac_, af_);
 
 					return ag_;
 				}
 			};
-			var k_ = context.Operators.Interval(i_, j_(), true, false);
-			var l_ = new Tuple_ddJhZGNHefSCOAJJFEIEcXie
+			CqlInterval<CqlDateTime> k_ = context.Operators.Interval(i_, j_(), true, false);
+			Tuple_ddJhZGNHefSCOAJJFEIEcXie l_ = new Tuple_ddJhZGNHefSCOAJJFEIEcXie
 			{
 				dayIndex = DayIndex,
 				dayPeriod = k_,
@@ -2580,7 +2748,7 @@ public class QICoreCommon_2_0_000
 
 			return l_;
 		};
-		var c_ = context.Operators.Select<int?, Tuple_ddJhZGNHefSCOAJJFEIEcXie>(a_, b_);
+		IEnumerable<Tuple_ddJhZGNHefSCOAJJFEIEcXie> c_ = context.Operators.Select<int?, Tuple_ddJhZGNHefSCOAJJFEIEcXie>(a_, b_);
 
 		return c_;
 	}

--- a/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
@@ -254,383 +254,478 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="_20_to_42_Plus_Weeks_Gestation"/>
 	private CqlValueSet _20_to_42_Plus_Weeks_Gestation_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67", null);
 
+    /// <seealso cref="_20_to_42_Plus_Weeks_Gestation_Value"/>
     [CqlDeclaration("20 to 42 Plus Weeks Gestation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67")]
 	public CqlValueSet _20_to_42_Plus_Weeks_Gestation() => 
 		___20_to_42_Plus_Weeks_Gestation.Value;
 
+    /// <seealso cref="Acute_or_Persistent_Asthma"/>
 	private CqlValueSet Acute_or_Persistent_Asthma_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271", null);
 
+    /// <seealso cref="Acute_or_Persistent_Asthma_Value"/>
     [CqlDeclaration("Acute or Persistent Asthma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271")]
 	public CqlValueSet Acute_or_Persistent_Asthma() => 
 		__Acute_or_Persistent_Asthma.Value;
 
+    /// <seealso cref="Anemia"/>
 	private CqlValueSet Anemia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323", null);
 
+    /// <seealso cref="Anemia_Value"/>
     [CqlDeclaration("Anemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323")]
 	public CqlValueSet Anemia() => 
 		__Anemia.Value;
 
+    /// <seealso cref="Autoimmune_Disease"/>
 	private CqlValueSet Autoimmune_Disease_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311", null);
 
+    /// <seealso cref="Autoimmune_Disease_Value"/>
     [CqlDeclaration("Autoimmune Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311")]
 	public CqlValueSet Autoimmune_Disease() => 
 		__Autoimmune_Disease.Value;
 
+    /// <seealso cref="Bariatric_Surgery"/>
 	private CqlValueSet Bariatric_Surgery_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317", null);
 
+    /// <seealso cref="Bariatric_Surgery_Value"/>
     [CqlDeclaration("Bariatric Surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317")]
 	public CqlValueSet Bariatric_Surgery() => 
 		__Bariatric_Surgery.Value;
 
+    /// <seealso cref="Bleeding_Disorder"/>
 	private CqlValueSet Bleeding_Disorder_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287", null);
 
+    /// <seealso cref="Bleeding_Disorder_Value"/>
     [CqlDeclaration("Bleeding Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287")]
 	public CqlValueSet Bleeding_Disorder() => 
 		__Bleeding_Disorder.Value;
 
+    /// <seealso cref="Blood_Transfusion"/>
 	private CqlValueSet Blood_Transfusion_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213", null);
 
+    /// <seealso cref="Blood_Transfusion_Value"/>
     [CqlDeclaration("Blood Transfusion")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213")]
 	public CqlValueSet Blood_Transfusion() => 
 		__Blood_Transfusion.Value;
 
+    /// <seealso cref="Cardiac_Disease"/>
 	private CqlValueSet Cardiac_Disease_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341", null);
 
+    /// <seealso cref="Cardiac_Disease_Value"/>
     [CqlDeclaration("Cardiac Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341")]
 	public CqlValueSet Cardiac_Disease() => 
 		__Cardiac_Disease.Value;
 
+    /// <seealso cref="COVID_19_Confirmed"/>
 	private CqlValueSet COVID_19_Confirmed_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373", null);
 
+    /// <seealso cref="COVID_19_Confirmed_Value"/>
     [CqlDeclaration("COVID 19 Confirmed")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373")]
 	public CqlValueSet COVID_19_Confirmed() => 
 		__COVID_19_Confirmed.Value;
 
+    /// <seealso cref="Delivery_Procedures"/>
 	private CqlValueSet Delivery_Procedures_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", null);
 
+    /// <seealso cref="Delivery_Procedures_Value"/>
     [CqlDeclaration("Delivery Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
 	public CqlValueSet Delivery_Procedures() => 
 		__Delivery_Procedures.Value;
 
+    /// <seealso cref="Economic_Housing_Instability"/>
 	private CqlValueSet Economic_Housing_Instability_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292", null);
 
+    /// <seealso cref="Economic_Housing_Instability_Value"/>
     [CqlDeclaration("Economic Housing Instability")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292")]
 	public CqlValueSet Economic_Housing_Instability() => 
 		__Economic_Housing_Instability.Value;
 
+    /// <seealso cref="ED_Visit_and_OB_Triage"/>
 	private CqlValueSet ED_Visit_and_OB_Triage_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", null);
 
+    /// <seealso cref="ED_Visit_and_OB_Triage_Value"/>
     [CqlDeclaration("ED Visit and OB Triage")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369")]
 	public CqlValueSet ED_Visit_and_OB_Triage() => 
 		__ED_Visit_and_OB_Triage.Value;
 
+    /// <seealso cref="Emergency_Department_Visit"/>
 	private CqlValueSet Emergency_Department_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
+    /// <seealso cref="Emergency_Department_Visit_Value"/>
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
 	public CqlValueSet Emergency_Department_Visit() => 
 		__Emergency_Department_Visit.Value;
 
+    /// <seealso cref="Gastrointestinal_Disease"/>
 	private CqlValueSet Gastrointestinal_Disease_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338", null);
 
+    /// <seealso cref="Gastrointestinal_Disease_Value"/>
     [CqlDeclaration("Gastrointestinal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338")]
 	public CqlValueSet Gastrointestinal_Disease() => 
 		__Gastrointestinal_Disease.Value;
 
+    /// <seealso cref="Gestational_Diabetes"/>
 	private CqlValueSet Gestational_Diabetes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269", null);
 
+    /// <seealso cref="Gestational_Diabetes_Value"/>
     [CqlDeclaration("Gestational Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269")]
 	public CqlValueSet Gestational_Diabetes() => 
 		__Gestational_Diabetes.Value;
 
+    /// <seealso cref="Hematocrit_lab_test"/>
 	private CqlValueSet Hematocrit_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
 
+    /// <seealso cref="Hematocrit_lab_test_Value"/>
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
 	public CqlValueSet Hematocrit_lab_test() => 
 		__Hematocrit_lab_test.Value;
 
+    /// <seealso cref="HIV_in_Pregnancy_Childbirth_and_Puerperium"/>
 	private CqlValueSet HIV_in_Pregnancy_Childbirth_and_Puerperium_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272", null);
 
+    /// <seealso cref="HIV_in_Pregnancy_Childbirth_and_Puerperium_Value"/>
     [CqlDeclaration("HIV in Pregnancy Childbirth and Puerperium")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272")]
 	public CqlValueSet HIV_in_Pregnancy_Childbirth_and_Puerperium() => 
 		__HIV_in_Pregnancy_Childbirth_and_Puerperium.Value;
 
+    /// <seealso cref="Hypertension"/>
 	private CqlValueSet Hypertension_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332", null);
 
+    /// <seealso cref="Hypertension_Value"/>
     [CqlDeclaration("Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332")]
 	public CqlValueSet Hypertension() => 
 		__Hypertension.Value;
 
+    /// <seealso cref="Long_Term_Anticoagulant_Use"/>
 	private CqlValueSet Long_Term_Anticoagulant_Use_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366", null);
 
+    /// <seealso cref="Long_Term_Anticoagulant_Use_Value"/>
     [CqlDeclaration("Long Term Anticoagulant Use")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366")]
 	public CqlValueSet Long_Term_Anticoagulant_Use() => 
 		__Long_Term_Anticoagulant_Use.Value;
 
+    /// <seealso cref="Mental_Health_Disorder"/>
 	private CqlValueSet Mental_Health_Disorder_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314", null);
 
+    /// <seealso cref="Mental_Health_Disorder_Value"/>
     [CqlDeclaration("Mental Health Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314")]
 	public CqlValueSet Mental_Health_Disorder() => 
 		__Mental_Health_Disorder.Value;
 
+    /// <seealso cref="Mild_or_Moderate_Preeclampsia"/>
 	private CqlValueSet Mild_or_Moderate_Preeclampsia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329", null);
 
+    /// <seealso cref="Mild_or_Moderate_Preeclampsia_Value"/>
     [CqlDeclaration("Mild or Moderate Preeclampsia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329")]
 	public CqlValueSet Mild_or_Moderate_Preeclampsia() => 
 		__Mild_or_Moderate_Preeclampsia.Value;
 
+    /// <seealso cref="Morbid_or_Severe_Obesity"/>
 	private CqlValueSet Morbid_or_Severe_Obesity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290", null);
 
+    /// <seealso cref="Morbid_or_Severe_Obesity_Value"/>
     [CqlDeclaration("Morbid or Severe Obesity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290")]
 	public CqlValueSet Morbid_or_Severe_Obesity() => 
 		__Morbid_or_Severe_Obesity.Value;
 
+    /// <seealso cref="Multiple_Pregnancy"/>
 	private CqlValueSet Multiple_Pregnancy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284", null);
 
+    /// <seealso cref="Multiple_Pregnancy_Value"/>
     [CqlDeclaration("Multiple Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284")]
 	public CqlValueSet Multiple_Pregnancy() => 
 		__Multiple_Pregnancy.Value;
 
+    /// <seealso cref="Neuromuscular_Disease"/>
 	private CqlValueSet Neuromuscular_Disease_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308", null);
 
+    /// <seealso cref="Neuromuscular_Disease_Value"/>
     [CqlDeclaration("Neuromuscular Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308")]
 	public CqlValueSet Neuromuscular_Disease() => 
 		__Neuromuscular_Disease.Value;
 
+    /// <seealso cref="Observation_Services"/>
 	private CqlValueSet Observation_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
+    /// <seealso cref="Observation_Services_Value"/>
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
 	public CqlValueSet Observation_Services() => 
 		__Observation_Services.Value;
 
+    /// <seealso cref="Patient_Expired"/>
 	private CqlValueSet Patient_Expired_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
 
+    /// <seealso cref="Patient_Expired_Value"/>
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
 	public CqlValueSet Patient_Expired() => 
 		__Patient_Expired.Value;
 
+    /// <seealso cref="Placenta_Previa"/>
 	private CqlValueSet Placenta_Previa_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35", null);
 
+    /// <seealso cref="Placenta_Previa_Value"/>
     [CqlDeclaration("Placenta Previa")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35")]
 	public CqlValueSet Placenta_Previa() => 
 		__Placenta_Previa.Value;
 
+    /// <seealso cref="Placental_Abruption"/>
 	private CqlValueSet Placental_Abruption_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305", null);
 
+    /// <seealso cref="Placental_Abruption_Value"/>
     [CqlDeclaration("Placental Abruption")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305")]
 	public CqlValueSet Placental_Abruption() => 
 		__Placental_Abruption.Value;
 
+    /// <seealso cref="Placental_Accreta_Spectrum"/>
 	private CqlValueSet Placental_Accreta_Spectrum_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302", null);
 
+    /// <seealso cref="Placental_Accreta_Spectrum_Value"/>
     [CqlDeclaration("Placental Accreta Spectrum")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302")]
 	public CqlValueSet Placental_Accreta_Spectrum() => 
 		__Placental_Accreta_Spectrum.Value;
 
+    /// <seealso cref="Preexisting_Diabetes"/>
 	private CqlValueSet Preexisting_Diabetes_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275", null);
 
+    /// <seealso cref="Preexisting_Diabetes_Value"/>
     [CqlDeclaration("Preexisting Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275")]
 	public CqlValueSet Preexisting_Diabetes() => 
 		__Preexisting_Diabetes.Value;
 
+    /// <seealso cref="Present_on_Admission_is_No_or_Unable_To_Determine"/>
 	private CqlValueSet Present_on_Admission_is_No_or_Unable_To_Determine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370", null);
 
+    /// <seealso cref="Present_on_Admission_is_No_or_Unable_To_Determine_Value"/>
     [CqlDeclaration("Present on Admission is No or Unable To Determine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370")]
 	public CqlValueSet Present_on_Admission_is_No_or_Unable_To_Determine() => 
 		__Present_on_Admission_is_No_or_Unable_To_Determine.Value;
 
+    /// <seealso cref="Present_On_Admission_is_Yes_or_Exempt"/>
 	private CqlValueSet Present_On_Admission_is_Yes_or_Exempt_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63", null);
 
+    /// <seealso cref="Present_On_Admission_is_Yes_or_Exempt_Value"/>
     [CqlDeclaration("Present On Admission is Yes or Exempt")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63")]
 	public CqlValueSet Present_On_Admission_is_Yes_or_Exempt() => 
 		__Present_On_Admission_is_Yes_or_Exempt.Value;
 
+    /// <seealso cref="Preterm_Birth"/>
 	private CqlValueSet Preterm_Birth_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299", null);
 
+    /// <seealso cref="Preterm_Birth_Value"/>
     [CqlDeclaration("Preterm Birth")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299")]
 	public CqlValueSet Preterm_Birth() => 
 		__Preterm_Birth.Value;
 
+    /// <seealso cref="Previous_Cesarean"/>
 	private CqlValueSet Previous_Cesarean_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278", null);
 
+    /// <seealso cref="Previous_Cesarean_Value"/>
     [CqlDeclaration("Previous Cesarean")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278")]
 	public CqlValueSet Previous_Cesarean() => 
 		__Previous_Cesarean.Value;
 
+    /// <seealso cref="Pulmonary_Hypertension"/>
 	private CqlValueSet Pulmonary_Hypertension_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281", null);
 
+    /// <seealso cref="Pulmonary_Hypertension_Value"/>
     [CqlDeclaration("Pulmonary Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281")]
 	public CqlValueSet Pulmonary_Hypertension() => 
 		__Pulmonary_Hypertension.Value;
 
+    /// <seealso cref="Renal_Disease"/>
 	private CqlValueSet Renal_Disease_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335", null);
 
+    /// <seealso cref="Renal_Disease_Value"/>
     [CqlDeclaration("Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335")]
 	public CqlValueSet Renal_Disease() => 
 		__Renal_Disease.Value;
 
+    /// <seealso cref="Respiratory_Conditions_Related_to_COVID_19"/>
 	private CqlValueSet Respiratory_Conditions_Related_to_COVID_19_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376", null);
 
+    /// <seealso cref="Respiratory_Conditions_Related_to_COVID_19_Value"/>
     [CqlDeclaration("Respiratory Conditions Related to COVID 19")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376")]
 	public CqlValueSet Respiratory_Conditions_Related_to_COVID_19() => 
 		__Respiratory_Conditions_Related_to_COVID_19.Value;
 
+    /// <seealso cref="Respiratory_Support_Procedures_Related_to_COVID_19"/>
 	private CqlValueSet Respiratory_Support_Procedures_Related_to_COVID_19_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379", null);
 
+    /// <seealso cref="Respiratory_Support_Procedures_Related_to_COVID_19_Value"/>
     [CqlDeclaration("Respiratory Support Procedures Related to COVID 19")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379")]
 	public CqlValueSet Respiratory_Support_Procedures_Related_to_COVID_19() => 
 		__Respiratory_Support_Procedures_Related_to_COVID_19.Value;
 
+    /// <seealso cref="Severe_Maternal_Morbidity_Diagnoses"/>
 	private CqlValueSet Severe_Maternal_Morbidity_Diagnoses_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255", null);
 
+    /// <seealso cref="Severe_Maternal_Morbidity_Diagnoses_Value"/>
     [CqlDeclaration("Severe Maternal Morbidity Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255")]
 	public CqlValueSet Severe_Maternal_Morbidity_Diagnoses() => 
 		__Severe_Maternal_Morbidity_Diagnoses.Value;
 
+    /// <seealso cref="Severe_Maternal_Morbidity_Procedures"/>
 	private CqlValueSet Severe_Maternal_Morbidity_Procedures_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256", null);
 
+    /// <seealso cref="Severe_Maternal_Morbidity_Procedures_Value"/>
     [CqlDeclaration("Severe Maternal Morbidity Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256")]
 	public CqlValueSet Severe_Maternal_Morbidity_Procedures() => 
 		__Severe_Maternal_Morbidity_Procedures.Value;
 
+    /// <seealso cref="Severe_Preeclampsia"/>
 	private CqlValueSet Severe_Preeclampsia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327", null);
 
+    /// <seealso cref="Severe_Preeclampsia_Value"/>
     [CqlDeclaration("Severe Preeclampsia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327")]
 	public CqlValueSet Severe_Preeclampsia() => 
 		__Severe_Preeclampsia.Value;
 
+    /// <seealso cref="Substance_Abuse"/>
 	private CqlValueSet Substance_Abuse_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320", null);
 
+    /// <seealso cref="Substance_Abuse_Value"/>
     [CqlDeclaration("Substance Abuse")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320")]
 	public CqlValueSet Substance_Abuse() => 
 		__Substance_Abuse.Value;
 
+    /// <seealso cref="Thyrotoxicosis"/>
 	private CqlValueSet Thyrotoxicosis_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296", null);
 
+    /// <seealso cref="Thyrotoxicosis_Value"/>
     [CqlDeclaration("Thyrotoxicosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296")]
 	public CqlValueSet Thyrotoxicosis() => 
 		__Thyrotoxicosis.Value;
 
+    /// <seealso cref="Venous_Thromboembolism_in_Pregnancy"/>
 	private CqlValueSet Venous_Thromboembolism_in_Pregnancy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363", null);
 
+    /// <seealso cref="Venous_Thromboembolism_in_Pregnancy_Value"/>
     [CqlDeclaration("Venous Thromboembolism in Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363")]
 	public CqlValueSet Venous_Thromboembolism_in_Pregnancy() => 
 		__Venous_Thromboembolism_in_Pregnancy.Value;
 
+    /// <seealso cref="White_blood_cells_count_lab_test"/>
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
 
+    /// <seealso cref="White_blood_cells_count_lab_test_Value"/>
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
 	public CqlValueSet White_blood_cells_count_lab_test() => 
 		__White_blood_cells_count_lab_test.Value;
 
+    /// <seealso cref="Heart_rate"/>
 	private CqlCode Heart_rate_Value() => 
 		new CqlCode("8867-4", "http://loinc.org", null, null);
 
+    /// <seealso cref="Heart_rate_Value"/>
     [CqlDeclaration("Heart rate")]
 	public CqlCode Heart_rate() => 
 		__Heart_rate.Value;
 
+    /// <seealso cref="Systolic_blood_pressure"/>
 	private CqlCode Systolic_blood_pressure_Value() => 
 		new CqlCode("8480-6", "http://loinc.org", null, null);
 
+    /// <seealso cref="Systolic_blood_pressure_Value"/>
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
 		__Systolic_blood_pressure.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("8867-4", "http://loinc.org", null, null),
 			new CqlCode("8480-6", "http://loinc.org", null, null),
@@ -639,486 +734,535 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="SNOMEDCT"/>
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
 	}
 
+    /// <seealso cref="SNOMEDCT_Value"/>
     [CqlDeclaration("SNOMEDCT")]
 	public CqlCode[] SNOMEDCT() => 
 		__SNOMEDCT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("SevereObstetricComplicationsFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("SevereObstetricComplicationsFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks"/>
 	private IEnumerable<Encounter> Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 		bool? b_(Encounter DeliveryEncounter)
 		{
-			var d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
-			var e_ = context.Operators.GreaterOrEqual(d_, 20);
+			int? d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			bool? e_ = context.Operators.GreaterOrEqual(d_, 20);
 
 			return e_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Value"/>
     [CqlDeclaration("Delivery Encounters with Calculated Gestational Age Greater than or Equal to 20 Weeks")]
 	public IEnumerable<Encounter> Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks() => 
 		__Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks.Value;
 
+    /// <seealso cref="Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks"/>
 	private IEnumerable<Encounter> Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 		bool? b_(Encounter DeliveryEncounter)
 		{
-			var d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
-			var e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
-			var f_ = context.Operators.Quantity(20m, "weeks");
-			var g_ = context.Operators.GreaterOrEqual(e_, f_);
-			var h_ = context.Operators.And((bool?)(d_ is null), g_);
+			int? d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			CqlQuantity e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			CqlQuantity f_ = context.Operators.Quantity(20m, "weeks");
+			bool? g_ = context.Operators.GreaterOrEqual(e_, f_);
+			bool? h_ = context.Operators.And((bool?)(d_ is null), g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks_Value"/>
     [CqlDeclaration("Delivery Encounters with Estimated Gestational Age Assessment Greater than or Equal to 20 Weeks")]
 	public IEnumerable<Encounter> Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks() => 
 		__Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks.Value;
 
+    /// <seealso cref="Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding"/>
 	private IEnumerable<Encounter> Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 		bool? b_(Encounter DeliveryEncounter)
 		{
-			var d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
-			var e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
-			var f_ = context.Operators.And((bool?)(d_ is null), (bool?)(e_ is null));
-			var g_ = CQMCommon_2_0_000.encounterDiagnosis(DeliveryEncounter);
+			int? d_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			CqlQuantity e_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			bool? f_ = context.Operators.And((bool?)(d_ is null), (bool?)(e_ is null));
+			IEnumerable<Condition> g_ = CQMCommon_2_0_000.encounterDiagnosis(DeliveryEncounter);
 			bool? h_(Condition EncounterDiagnosis)
 			{
-				var l_ = EncounterDiagnosis?.Code;
-				var m_ = FHIRHelpers_4_3_000.ToConcept(l_);
-				var n_ = this._20_to_42_Plus_Weeks_Gestation();
-				var o_ = context.Operators.ConceptInValueSet(m_, n_);
+				CodeableConcept l_ = EncounterDiagnosis?.Code;
+				CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
+				CqlValueSet n_ = this._20_to_42_Plus_Weeks_Gestation();
+				bool? o_ = context.Operators.ConceptInValueSet(m_, n_);
 
 				return o_;
 			};
-			var i_ = context.Operators.Where<Condition>(g_, h_);
-			var j_ = context.Operators.Exists<Condition>(i_);
-			var k_ = context.Operators.And(f_, j_);
+			IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
+			bool? j_ = context.Operators.Exists<Condition>(i_);
+			bool? k_ = context.Operators.And(f_, j_);
 
 			return k_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding_Value"/>
     [CqlDeclaration("Delivery Encounters with Gestational Age Greater than or Equal to 20 Weeks Based on Coding")]
 	public IEnumerable<Encounter> Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding() => 
 		__Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding.Value;
 
+    /// <seealso cref="Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation"/>
 	private IEnumerable<Encounter> Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation_Value()
 	{
-		var a_ = this.Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks();
-		var b_ = this.Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
-		var d_ = this.Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding();
-		var e_ = context.Operators.Union<Encounter>(c_, d_);
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_with_Calculated_Gestational_Age_Greater_than_or_Equal_to_20_Weeks();
+		IEnumerable<Encounter> b_ = this.Delivery_Encounters_with_Estimated_Gestational_Age_Assessment_Greater_than_or_Equal_to_20_Weeks();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.Delivery_Encounters_with_Gestational_Age_Greater_than_or_Equal_to_20_Weeks_Based_on_Coding();
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation_Value"/>
     [CqlDeclaration("Delivery Encounters At Greater than or Equal to 20 Weeks Gestation")]
 	public IEnumerable<Encounter> Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation() => 
 		__Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation.Value;
 
+    /// <seealso cref="Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion"/>
 	private IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = TwentyWeeksPlusEncounter?.Diagnosis;
+			List<Encounter.DiagnosisComponent> d_ = TwentyWeeksPlusEncounter?.Diagnosis;
 			bool? e_(Encounter.DiagnosisComponent EncounterDiagnoses)
 			{
-				var n_ = EncounterDiagnoses?.Condition;
-				var o_ = CQMCommon_2_0_000.getCondition(n_);
-				var p_ = o_?.Code;
-				var q_ = FHIRHelpers_4_3_000.ToConcept(p_);
-				var r_ = this.Severe_Maternal_Morbidity_Diagnoses();
-				var s_ = context.Operators.ConceptInValueSet(q_, r_);
+				ResourceReference n_ = EncounterDiagnoses?.Condition;
+				Condition o_ = CQMCommon_2_0_000.getCondition(n_);
+				CodeableConcept p_ = o_?.Code;
+				CqlConcept q_ = FHIRHelpers_4_3_000.ToConcept(p_);
+				CqlValueSet r_ = this.Severe_Maternal_Morbidity_Diagnoses();
+				bool? s_ = context.Operators.ConceptInValueSet(q_, r_);
 				bool? t_(Extension @this)
 				{
-					var ad_ = @this?.Url;
-					var ae_ = context.Operators.Convert<FhirUri>(ad_);
-					var af_ = FHIRHelpers_4_3_000.ToString(ae_);
-					var ag_ = context.Operators.Equal(af_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+					string ad_ = @this?.Url;
+					FhirUri ae_ = context.Operators.Convert<FhirUri>(ad_);
+					string af_ = FHIRHelpers_4_3_000.ToString(ae_);
+					bool? ag_ = context.Operators.Equal(af_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
 
 					return ag_;
 				};
-				var u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
+				IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
 						? ((EncounterDiagnoses as Element).Extension)
 						: null), t_);
 				DataType v_(Extension @this)
 				{
-					var ah_ = @this?.Value;
+					DataType ah_ = @this?.Value;
 
 					return ah_;
 				};
-				var w_ = context.Operators.Select<Extension, DataType>(u_, v_);
-				var x_ = context.Operators.SingletonFrom<DataType>(w_);
-				var y_ = context.Operators.Convert<CodeableConcept>(x_);
-				var z_ = FHIRHelpers_4_3_000.ToConcept(y_);
-				var aa_ = this.Present_on_Admission_is_No_or_Unable_To_Determine();
-				var ab_ = context.Operators.ConceptInValueSet(z_, aa_);
-				var ac_ = context.Operators.And(s_, ab_);
+				IEnumerable<DataType> w_ = context.Operators.Select<Extension, DataType>(u_, v_);
+				DataType x_ = context.Operators.SingletonFrom<DataType>(w_);
+				CodeableConcept y_ = context.Operators.Convert<CodeableConcept>(x_);
+				CqlConcept z_ = FHIRHelpers_4_3_000.ToConcept(y_);
+				CqlValueSet aa_ = this.Present_on_Admission_is_No_or_Unable_To_Determine();
+				bool? ab_ = context.Operators.ConceptInValueSet(z_, aa_);
+				bool? ac_ = context.Operators.And(s_, ab_);
 
 				return ac_;
 			};
-			var f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
-			var g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
-			var h_ = this.Severe_Maternal_Morbidity_Procedures();
-			var i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+			IEnumerable<Encounter.DiagnosisComponent> f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
+			bool? g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
+			CqlValueSet h_ = this.Severe_Maternal_Morbidity_Procedures();
+			IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
 			bool? j_(Procedure EncounterSMMProcedures)
 			{
-				var ai_ = EncounterSMMProcedures?.StatusElement;
-				var aj_ = ai_?.Value;
-				var ak_ = context.Operators.Convert<string>(aj_);
-				var al_ = context.Operators.Equal(ak_, "completed");
-				var am_ = EncounterSMMProcedures?.Performed;
-				var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-				var ao_ = QICoreCommon_2_0_000.toInterval(an_);
-				var ap_ = context.Operators.Start(ao_);
-				var aq_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, "day");
-				var as_ = context.Operators.And(al_, ar_);
+				Code<EventStatus> ai_ = EncounterSMMProcedures?.StatusElement;
+				EventStatus? aj_ = ai_?.Value;
+				string ak_ = context.Operators.Convert<string>(aj_);
+				bool? al_ = context.Operators.Equal(ak_, "completed");
+				DataType am_ = EncounterSMMProcedures?.Performed;
+				object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+				CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_0_000.toInterval(an_);
+				CqlDateTime ap_ = context.Operators.Start(ao_);
+				CqlInterval<CqlDateTime> aq_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				bool? ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, "day");
+				bool? as_ = context.Operators.And(al_, ar_);
 
 				return as_;
 			};
-			var k_ = context.Operators.Where<Procedure>(i_, j_);
-			var l_ = context.Operators.Exists<Procedure>(k_);
-			var m_ = context.Operators.Or(g_, l_);
+			IEnumerable<Procedure> k_ = context.Operators.Where<Procedure>(i_, j_);
+			bool? l_ = context.Operators.Exists<Procedure>(k_);
+			bool? m_ = context.Operators.Or(g_, l_);
 
 			return m_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion_Value"/>
     [CqlDeclaration("Delivery Encounters with Severe Obstetric Complications Diagnosis or Procedure Excluding Blood Transfusion")]
 	public IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion() => 
 		__Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion.Value;
 
+    /// <seealso cref="Delivery_Encounters_with_Expiration"/>
 	private IEnumerable<Encounter> Delivery_Encounters_with_Expiration_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = TwentyWeeksPlusEncounter?.Hospitalization;
-			var e_ = d_?.DischargeDisposition;
-			var f_ = FHIRHelpers_4_3_000.ToConcept(e_);
-			var g_ = this.Patient_Expired();
-			var h_ = context.Operators.ConceptInValueSet(f_, g_);
+			Encounter.HospitalizationComponent d_ = TwentyWeeksPlusEncounter?.Hospitalization;
+			CodeableConcept e_ = d_?.DischargeDisposition;
+			CqlConcept f_ = FHIRHelpers_4_3_000.ToConcept(e_);
+			CqlValueSet g_ = this.Patient_Expired();
+			bool? h_ = context.Operators.ConceptInValueSet(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_with_Expiration_Value"/>
     [CqlDeclaration("Delivery Encounters with Expiration")]
 	public IEnumerable<Encounter> Delivery_Encounters_with_Expiration() => 
 		__Delivery_Encounters_with_Expiration.Value;
 
+    /// <seealso cref="Delivery_Encounters_with_Blood_Transfusion"/>
 	private IEnumerable<Encounter> Delivery_Encounters_with_Blood_Transfusion_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		IEnumerable<Encounter> b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.Blood_Transfusion();
-			var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			CqlValueSet d_ = this.Blood_Transfusion();
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
 			bool? f_(Procedure BloodTransfusion)
 			{
-				var j_ = BloodTransfusion?.StatusElement;
-				var k_ = j_?.Value;
-				var l_ = context.Operators.Convert<string>(k_);
-				var m_ = context.Operators.Equal(l_, "completed");
-				var n_ = BloodTransfusion?.Performed;
-				var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-				var p_ = QICoreCommon_2_0_000.toInterval(o_);
-				var q_ = context.Operators.Start(p_);
-				var r_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
-				var t_ = context.Operators.And(m_, s_);
+				Code<EventStatus> j_ = BloodTransfusion?.StatusElement;
+				EventStatus? k_ = j_?.Value;
+				string l_ = context.Operators.Convert<string>(k_);
+				bool? m_ = context.Operators.Equal(l_, "completed");
+				DataType n_ = BloodTransfusion?.Performed;
+				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
+				CqlDateTime q_ = context.Operators.Start(p_);
+				CqlInterval<CqlDateTime> r_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
+				bool? t_ = context.Operators.And(m_, s_);
 
 				return t_;
 			};
-			var g_ = context.Operators.Where<Procedure>(e_, f_);
+			IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
 			Encounter h_(Procedure BloodTransfusion) => 
 				TwentyWeeksPlusEncounter;
-			var i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
 
 			return i_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_with_Blood_Transfusion_Value"/>
     [CqlDeclaration("Delivery Encounters with Blood Transfusion")]
 	public IEnumerable<Encounter> Delivery_Encounters_with_Blood_Transfusion() => 
 		__Delivery_Encounters_with_Blood_Transfusion.Value;
 
+    /// <seealso cref="Delivery_Encounters_with_Severe_Obstetric_Complications"/>
 	private IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Value()
 	{
-		var a_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion();
-		var b_ = this.Delivery_Encounters_with_Expiration();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
-		var d_ = this.Delivery_Encounters_with_Blood_Transfusion();
-		var e_ = context.Operators.Union<Encounter>(c_, d_);
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion();
+		IEnumerable<Encounter> b_ = this.Delivery_Encounters_with_Expiration();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.Delivery_Encounters_with_Blood_Transfusion();
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_with_Severe_Obstetric_Complications_Value"/>
     [CqlDeclaration("Delivery Encounters with Severe Obstetric Complications")]
 	public IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications() => 
 		__Delivery_Encounters_with_Severe_Obstetric_Complications.Value;
 
+    /// <seealso cref="Numerator"/>
 	private IEnumerable<Encounter> Numerator_Value()
 	{
-		var a_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications();
 
 		return a_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public IEnumerable<Encounter> Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure"/>
 	private IEnumerable<Encounter> Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = CQMCommon_2_0_000.encounterDiagnosis(TwentyWeeksPlusEncounter);
+			IEnumerable<Condition> d_ = CQMCommon_2_0_000.encounterDiagnosis(TwentyWeeksPlusEncounter);
 			bool? e_(Condition EncounterDiagnosis)
 			{
-				var s_ = EncounterDiagnosis?.Code;
-				var t_ = FHIRHelpers_4_3_000.ToConcept(s_);
-				var u_ = this.COVID_19_Confirmed();
-				var v_ = context.Operators.ConceptInValueSet(t_, u_);
+				CodeableConcept s_ = EncounterDiagnosis?.Code;
+				CqlConcept t_ = FHIRHelpers_4_3_000.ToConcept(s_);
+				CqlValueSet u_ = this.COVID_19_Confirmed();
+				bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
 
 				return v_;
 			};
-			var f_ = context.Operators.Where<Condition>(d_, e_);
-			var g_ = context.Operators.Exists<Condition>(f_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+			bool? g_ = context.Operators.Exists<Condition>(f_);
 			bool? i_(Condition EncounterDiagnosis)
 			{
-				var w_ = EncounterDiagnosis?.Code;
-				var x_ = FHIRHelpers_4_3_000.ToConcept(w_);
-				var y_ = this.Respiratory_Conditions_Related_to_COVID_19();
-				var z_ = context.Operators.ConceptInValueSet(x_, y_);
+				CodeableConcept w_ = EncounterDiagnosis?.Code;
+				CqlConcept x_ = FHIRHelpers_4_3_000.ToConcept(w_);
+				CqlValueSet y_ = this.Respiratory_Conditions_Related_to_COVID_19();
+				bool? z_ = context.Operators.ConceptInValueSet(x_, y_);
 
 				return z_;
 			};
-			var j_ = context.Operators.Where<Condition>(d_, i_);
-			var k_ = context.Operators.Exists<Condition>(j_);
-			var l_ = this.Respiratory_Support_Procedures_Related_to_COVID_19();
-			var m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, null);
+			IEnumerable<Condition> j_ = context.Operators.Where<Condition>(d_, i_);
+			bool? k_ = context.Operators.Exists<Condition>(j_);
+			CqlValueSet l_ = this.Respiratory_Support_Procedures_Related_to_COVID_19();
+			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, null);
 			bool? n_(Procedure COVIDRespiratoryProcedure)
 			{
-				var aa_ = COVIDRespiratoryProcedure?.StatusElement;
-				var ab_ = aa_?.Value;
-				var ac_ = context.Operators.Convert<string>(ab_);
-				var ad_ = context.Operators.Equal(ac_, "completed");
-				var ae_ = COVIDRespiratoryProcedure?.Performed;
-				var af_ = FHIRHelpers_4_3_000.ToValue(ae_);
-				var ag_ = QICoreCommon_2_0_000.toInterval(af_);
-				var ah_ = context.Operators.Start(ag_);
-				var ai_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, "day");
-				var ak_ = context.Operators.And(ad_, aj_);
+				Code<EventStatus> aa_ = COVIDRespiratoryProcedure?.StatusElement;
+				EventStatus? ab_ = aa_?.Value;
+				string ac_ = context.Operators.Convert<string>(ab_);
+				bool? ad_ = context.Operators.Equal(ac_, "completed");
+				DataType ae_ = COVIDRespiratoryProcedure?.Performed;
+				object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
+				CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.toInterval(af_);
+				CqlDateTime ah_ = context.Operators.Start(ag_);
+				CqlInterval<CqlDateTime> ai_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				bool? aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, "day");
+				bool? ak_ = context.Operators.And(ad_, aj_);
 
 				return ak_;
 			};
-			var o_ = context.Operators.Where<Procedure>(m_, n_);
-			var p_ = context.Operators.Exists<Procedure>(o_);
-			var q_ = context.Operators.Or(k_, p_);
-			var r_ = context.Operators.And(g_, q_);
+			IEnumerable<Procedure> o_ = context.Operators.Where<Procedure>(m_, n_);
+			bool? p_ = context.Operators.Exists<Procedure>(o_);
+			bool? q_ = context.Operators.Or(k_, p_);
+			bool? r_ = context.Operators.And(g_, q_);
 
 			return r_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure_Value"/>
     [CqlDeclaration("Delivery Encounters with COVID and Respiratory Condition or Procedure")]
 	public IEnumerable<Encounter> Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure() => 
 		__Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure.Value;
 
+    /// <seealso cref="Denominator_Exclusion"/>
 	private IEnumerable<Encounter> Denominator_Exclusion_Value()
 	{
-		var a_ = this.Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_with_COVID_and_Respiratory_Condition_or_Procedure();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Exclusion_Value"/>
     [CqlDeclaration("Denominator Exclusion")]
 	public IEnumerable<Encounter> Denominator_Exclusion() => 
 		__Denominator_Exclusion.Value;
 
+    /// <seealso cref="Stratification_Encounter"/>
 	private IEnumerable<Encounter> Stratification_Encounter_Value()
 	{
-		var a_ = this.Numerator();
-		var b_ = this.Denominator_Exclusion();
-		var c_ = context.Operators.Except<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Numerator();
+		IEnumerable<Encounter> b_ = this.Denominator_Exclusion();
+		IEnumerable<Encounter> c_ = context.Operators.Except<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Stratification_Encounter_Value"/>
     [CqlDeclaration("Stratification Encounter")]
 	public IEnumerable<Encounter> Stratification_Encounter() => 
 		__Stratification_Encounter.Value;
 
+    /// <seealso cref="Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions"/>
 	private IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions_Value()
 	{
-		var a_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion();
-		var b_ = this.Delivery_Encounters_with_Expiration();
-		var c_ = context.Operators.Union<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications_Diagnosis_or_Procedure_Excluding_Blood_Transfusion();
+		IEnumerable<Encounter> b_ = this.Delivery_Encounters_with_Expiration();
+		IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions_Value"/>
     [CqlDeclaration("Delivery Encounters with Severe Obstetric Complications Excluding Blood Transfusions")]
 	public IEnumerable<Encounter> Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions() => 
 		__Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions.Value;
 
+    /// <seealso cref="Stratum_1"/>
 	private IEnumerable<Encounter> Stratum_1_Value()
 	{
-		var a_ = this.Stratification_Encounter();
-		var b_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions();
-		var c_ = context.Operators.Intersect<Encounter>(a_, b_);
+		IEnumerable<Encounter> a_ = this.Stratification_Encounter();
+		IEnumerable<Encounter> b_ = this.Delivery_Encounters_with_Severe_Obstetric_Complications_Excluding_Blood_Transfusions();
+		IEnumerable<Encounter> c_ = context.Operators.Intersect<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Stratum_1_Value"/>
     [CqlDeclaration("Stratum 1")]
 	public IEnumerable<Encounter> Stratum_1() => 
 		__Stratum_1.Value;
 
+    /// <seealso cref="Variable_Calculated_Gestational_Age"/>
 	private IEnumerable<Tuple_QRZgNJCaGQEYIeOSBhjLZNSO> Variable_Calculated_Gestational_Age_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Variable_Calculated_Gestational_Age();
+		IEnumerable<Tuple_QRZgNJCaGQEYIeOSBhjLZNSO> a_ = PCMaternal_5_16_000.Variable_Calculated_Gestational_Age();
 
 		return a_;
 	}
 
+    /// <seealso cref="Variable_Calculated_Gestational_Age_Value"/>
     [CqlDeclaration("Variable Calculated Gestational Age")]
 	public IEnumerable<Tuple_QRZgNJCaGQEYIeOSBhjLZNSO> Variable_Calculated_Gestational_Age() => 
 		__Variable_Calculated_Gestational_Age.Value;
 
+    /// <seealso cref="Denominator"/>
 	private IEnumerable<Encounter> Denominator_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public IEnumerable<Encounter> Denominator() => 
 		__Denominator.Value;
@@ -1126,752 +1270,812 @@ public class SevereObstetricComplicationsFHIR_0_1_000
     [CqlDeclaration("pOAIsYesOrExempt")]
 	public IEnumerable<CqlConcept> pOAIsYesOrExempt(Encounter TheEncounter)
 	{
-		bool? a_(Encounter.DiagnosisComponent EncounterDiagnoses)
+		List<Encounter.DiagnosisComponent> a_ = TheEncounter?.Diagnosis;
+		bool? b_(Encounter.DiagnosisComponent EncounterDiagnoses)
 		{
-			bool? e_(Extension @this)
+			bool? f_(Extension @this)
 			{
-				var n_ = @this?.Url;
-				var o_ = context.Operators.Convert<FhirUri>(n_);
-				var p_ = FHIRHelpers_4_3_000.ToString(o_);
-				var q_ = context.Operators.Equal(p_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
-
-				return q_;
-			};
-			var f_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
-					? ((EncounterDiagnoses as Element).Extension)
-					: null), e_);
-			DataType g_(Extension @this)
-			{
-				var r_ = @this?.Value;
+				string o_ = @this?.Url;
+				FhirUri p_ = context.Operators.Convert<FhirUri>(o_);
+				string q_ = FHIRHelpers_4_3_000.ToString(p_);
+				bool? r_ = context.Operators.Equal(q_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
 
 				return r_;
 			};
-			var h_ = context.Operators.Select<Extension, DataType>(f_, g_);
-			var i_ = context.Operators.SingletonFrom<DataType>(h_);
-			var j_ = context.Operators.Convert<CodeableConcept>(i_);
-			var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
-			var l_ = this.Present_On_Admission_is_Yes_or_Exempt();
-			var m_ = context.Operators.ConceptInValueSet(k_, l_);
+			IEnumerable<Extension> g_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
+					? ((EncounterDiagnoses as Element).Extension)
+					: null), f_);
+			DataType h_(Extension @this)
+			{
+				DataType s_ = @this?.Value;
 
-			return m_;
+				return s_;
+			};
+			IEnumerable<DataType> i_ = context.Operators.Select<Extension, DataType>(g_, h_);
+			DataType j_ = context.Operators.SingletonFrom<DataType>(i_);
+			CodeableConcept k_ = context.Operators.Convert<CodeableConcept>(j_);
+			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlValueSet m_ = this.Present_On_Admission_is_Yes_or_Exempt();
+			bool? n_ = context.Operators.ConceptInValueSet(l_, m_);
+
+			return n_;
 		};
-		var b_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)TheEncounter?.Diagnosis, a_);
-		CqlConcept c_(Encounter.DiagnosisComponent EncounterDiagnoses)
+		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
+		CqlConcept d_(Encounter.DiagnosisComponent EncounterDiagnoses)
 		{
-			var s_ = EncounterDiagnoses?.Condition;
-			var t_ = CQMCommon_2_0_000.getCondition(s_);
-			var u_ = t_?.Code;
-			var v_ = FHIRHelpers_4_3_000.ToConcept(u_);
+			ResourceReference t_ = EncounterDiagnoses?.Condition;
+			Condition u_ = CQMCommon_2_0_000.getCondition(t_);
+			CodeableConcept v_ = u_?.Code;
+			CqlConcept w_ = FHIRHelpers_4_3_000.ToConcept(v_);
 
-			return v_;
+			return w_;
 		};
-		var d_ = context.Operators.Select<Encounter.DiagnosisComponent, CqlConcept>(b_, c_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Select<Encounter.DiagnosisComponent, CqlConcept>(c_, d_);
 
-		return d_;
+		return e_;
 	}
 
+    /// <seealso cref="Risk_Variable_Anemia"/>
 	private IEnumerable<Encounter> Risk_Variable_Anemia_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Anemia();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Anemia();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Anemia_Value"/>
     [CqlDeclaration("Risk Variable Anemia")]
 	public IEnumerable<Encounter> Risk_Variable_Anemia() => 
 		__Risk_Variable_Anemia.Value;
 
+    /// <seealso cref="Risk_Variable_Asthma"/>
 	private IEnumerable<Encounter> Risk_Variable_Asthma_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Acute_or_Persistent_Asthma();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Acute_or_Persistent_Asthma();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Asthma_Value"/>
     [CqlDeclaration("Risk Variable Asthma")]
 	public IEnumerable<Encounter> Risk_Variable_Asthma() => 
 		__Risk_Variable_Asthma.Value;
 
+    /// <seealso cref="Risk_Variable_Autoimmune_Disease"/>
 	private IEnumerable<Encounter> Risk_Variable_Autoimmune_Disease_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Autoimmune_Disease();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Autoimmune_Disease();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Autoimmune_Disease_Value"/>
     [CqlDeclaration("Risk Variable Autoimmune Disease")]
 	public IEnumerable<Encounter> Risk_Variable_Autoimmune_Disease() => 
 		__Risk_Variable_Autoimmune_Disease.Value;
 
+    /// <seealso cref="Risk_Variable_Bariatric_Surgery"/>
 	private IEnumerable<Encounter> Risk_Variable_Bariatric_Surgery_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Bariatric_Surgery();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Bariatric_Surgery();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Bariatric_Surgery_Value"/>
     [CqlDeclaration("Risk Variable Bariatric Surgery")]
 	public IEnumerable<Encounter> Risk_Variable_Bariatric_Surgery() => 
 		__Risk_Variable_Bariatric_Surgery.Value;
 
+    /// <seealso cref="Risk_Variable_Bleeding_Disorder"/>
 	private IEnumerable<Encounter> Risk_Variable_Bleeding_Disorder_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Bleeding_Disorder();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Bleeding_Disorder();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Bleeding_Disorder_Value"/>
     [CqlDeclaration("Risk Variable Bleeding Disorder")]
 	public IEnumerable<Encounter> Risk_Variable_Bleeding_Disorder() => 
 		__Risk_Variable_Bleeding_Disorder.Value;
 
+    /// <seealso cref="Risk_Variable_Morbid_Obesity"/>
 	private IEnumerable<Encounter> Risk_Variable_Morbid_Obesity_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Morbid_or_Severe_Obesity();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Morbid_or_Severe_Obesity();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Morbid_Obesity_Value"/>
     [CqlDeclaration("Risk Variable Morbid Obesity")]
 	public IEnumerable<Encounter> Risk_Variable_Morbid_Obesity() => 
 		__Risk_Variable_Morbid_Obesity.Value;
 
+    /// <seealso cref="Risk_Variable_Cardiac_Disease"/>
 	private IEnumerable<Encounter> Risk_Variable_Cardiac_Disease_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Cardiac_Disease();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Cardiac_Disease();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Cardiac_Disease_Value"/>
     [CqlDeclaration("Risk Variable Cardiac Disease")]
 	public IEnumerable<Encounter> Risk_Variable_Cardiac_Disease() => 
 		__Risk_Variable_Cardiac_Disease.Value;
 
+    /// <seealso cref="Risk_Variable_Economic_Housing_Instability"/>
 	private IEnumerable<Encounter> Risk_Variable_Economic_Housing_Instability_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Economic_Housing_Instability();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Economic_Housing_Instability();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Economic_Housing_Instability_Value"/>
     [CqlDeclaration("Risk Variable Economic Housing Instability")]
 	public IEnumerable<Encounter> Risk_Variable_Economic_Housing_Instability() => 
 		__Risk_Variable_Economic_Housing_Instability.Value;
 
+    /// <seealso cref="Risk_Variable_Gastrointestinal_Disease"/>
 	private IEnumerable<Encounter> Risk_Variable_Gastrointestinal_Disease_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Gastrointestinal_Disease();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Gastrointestinal_Disease();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Gastrointestinal_Disease_Value"/>
     [CqlDeclaration("Risk Variable Gastrointestinal Disease")]
 	public IEnumerable<Encounter> Risk_Variable_Gastrointestinal_Disease() => 
 		__Risk_Variable_Gastrointestinal_Disease.Value;
 
+    /// <seealso cref="Risk_Variable_Gestational_Diabetes"/>
 	private IEnumerable<Encounter> Risk_Variable_Gestational_Diabetes_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Gestational_Diabetes();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Gestational_Diabetes();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Gestational_Diabetes_Value"/>
     [CqlDeclaration("Risk Variable Gestational Diabetes")]
 	public IEnumerable<Encounter> Risk_Variable_Gestational_Diabetes() => 
 		__Risk_Variable_Gestational_Diabetes.Value;
 
+    /// <seealso cref="Risk_Variable_HIV"/>
 	private IEnumerable<Encounter> Risk_Variable_HIV_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.HIV_in_Pregnancy_Childbirth_and_Puerperium();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.HIV_in_Pregnancy_Childbirth_and_Puerperium();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_HIV_Value"/>
     [CqlDeclaration("Risk Variable HIV")]
 	public IEnumerable<Encounter> Risk_Variable_HIV() => 
 		__Risk_Variable_HIV.Value;
 
+    /// <seealso cref="Risk_Variable_Hypertension"/>
 	private IEnumerable<Encounter> Risk_Variable_Hypertension_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Hypertension();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Hypertension();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Hypertension_Value"/>
     [CqlDeclaration("Risk Variable Hypertension")]
 	public IEnumerable<Encounter> Risk_Variable_Hypertension() => 
 		__Risk_Variable_Hypertension.Value;
 
+    /// <seealso cref="Risk_Variable_Long_Term_Anticoagulant_Use"/>
 	private IEnumerable<Encounter> Risk_Variable_Long_Term_Anticoagulant_Use_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Long_Term_Anticoagulant_Use();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Long_Term_Anticoagulant_Use();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Long_Term_Anticoagulant_Use_Value"/>
     [CqlDeclaration("Risk Variable Long Term Anticoagulant Use")]
 	public IEnumerable<Encounter> Risk_Variable_Long_Term_Anticoagulant_Use() => 
 		__Risk_Variable_Long_Term_Anticoagulant_Use.Value;
 
+    /// <seealso cref="Risk_Variable_Mental_Health_Disorder"/>
 	private IEnumerable<Encounter> Risk_Variable_Mental_Health_Disorder_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Mental_Health_Disorder();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Mental_Health_Disorder();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Mental_Health_Disorder_Value"/>
     [CqlDeclaration("Risk Variable Mental Health Disorder")]
 	public IEnumerable<Encounter> Risk_Variable_Mental_Health_Disorder() => 
 		__Risk_Variable_Mental_Health_Disorder.Value;
 
+    /// <seealso cref="Risk_Variable_Multiple_Pregnancy"/>
 	private IEnumerable<Encounter> Risk_Variable_Multiple_Pregnancy_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Multiple_Pregnancy();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Multiple_Pregnancy();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Multiple_Pregnancy_Value"/>
     [CqlDeclaration("Risk Variable Multiple Pregnancy")]
 	public IEnumerable<Encounter> Risk_Variable_Multiple_Pregnancy() => 
 		__Risk_Variable_Multiple_Pregnancy.Value;
 
+    /// <seealso cref="Risk_Variable_Neuromuscular"/>
 	private IEnumerable<Encounter> Risk_Variable_Neuromuscular_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Neuromuscular_Disease();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Neuromuscular_Disease();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Neuromuscular_Value"/>
     [CqlDeclaration("Risk Variable Neuromuscular")]
 	public IEnumerable<Encounter> Risk_Variable_Neuromuscular() => 
 		__Risk_Variable_Neuromuscular.Value;
 
+    /// <seealso cref="Risk_Variable_Obstetrical_VTE"/>
 	private IEnumerable<Encounter> Risk_Variable_Obstetrical_VTE_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Venous_Thromboembolism_in_Pregnancy();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Venous_Thromboembolism_in_Pregnancy();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Obstetrical_VTE_Value"/>
     [CqlDeclaration("Risk Variable Obstetrical VTE")]
 	public IEnumerable<Encounter> Risk_Variable_Obstetrical_VTE() => 
 		__Risk_Variable_Obstetrical_VTE.Value;
 
+    /// <seealso cref="Risk_Variable_Placenta_Previa"/>
 	private IEnumerable<Encounter> Risk_Variable_Placenta_Previa_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Placenta_Previa();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Placenta_Previa();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Placenta_Previa_Value"/>
     [CqlDeclaration("Risk Variable Placenta Previa")]
 	public IEnumerable<Encounter> Risk_Variable_Placenta_Previa() => 
 		__Risk_Variable_Placenta_Previa.Value;
 
+    /// <seealso cref="Risk_Variable_Placental_Abruption"/>
 	private IEnumerable<Encounter> Risk_Variable_Placental_Abruption_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Placental_Abruption();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Placental_Abruption();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Placental_Abruption_Value"/>
     [CqlDeclaration("Risk Variable Placental Abruption")]
 	public IEnumerable<Encounter> Risk_Variable_Placental_Abruption() => 
 		__Risk_Variable_Placental_Abruption.Value;
 
+    /// <seealso cref="Risk_Variable_Placental_Accreta_Spectrum"/>
 	private IEnumerable<Encounter> Risk_Variable_Placental_Accreta_Spectrum_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Placental_Accreta_Spectrum();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Placental_Accreta_Spectrum();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Placental_Accreta_Spectrum_Value"/>
     [CqlDeclaration("Risk Variable Placental Accreta Spectrum")]
 	public IEnumerable<Encounter> Risk_Variable_Placental_Accreta_Spectrum() => 
 		__Risk_Variable_Placental_Accreta_Spectrum.Value;
 
+    /// <seealso cref="Risk_Variable_Preexisting_Diabetes"/>
 	private IEnumerable<Encounter> Risk_Variable_Preexisting_Diabetes_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Preexisting_Diabetes();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Preexisting_Diabetes();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Preexisting_Diabetes_Value"/>
     [CqlDeclaration("Risk Variable Preexisting Diabetes")]
 	public IEnumerable<Encounter> Risk_Variable_Preexisting_Diabetes() => 
 		__Risk_Variable_Preexisting_Diabetes.Value;
 
+    /// <seealso cref="Risk_Variable_Previous_Cesarean"/>
 	private IEnumerable<Encounter> Risk_Variable_Previous_Cesarean_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Previous_Cesarean();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Previous_Cesarean();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Previous_Cesarean_Value"/>
     [CqlDeclaration("Risk Variable Previous Cesarean")]
 	public IEnumerable<Encounter> Risk_Variable_Previous_Cesarean() => 
 		__Risk_Variable_Previous_Cesarean.Value;
 
+    /// <seealso cref="Risk_Variable_Pulmonary_Hypertension"/>
 	private IEnumerable<Encounter> Risk_Variable_Pulmonary_Hypertension_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Pulmonary_Hypertension();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Pulmonary_Hypertension();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Pulmonary_Hypertension_Value"/>
     [CqlDeclaration("Risk Variable Pulmonary Hypertension")]
 	public IEnumerable<Encounter> Risk_Variable_Pulmonary_Hypertension() => 
 		__Risk_Variable_Pulmonary_Hypertension.Value;
 
+    /// <seealso cref="Risk_Variable_Renal_Disease"/>
 	private IEnumerable<Encounter> Risk_Variable_Renal_Disease_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Renal_Disease();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Renal_Disease();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Renal_Disease_Value"/>
     [CqlDeclaration("Risk Variable Renal Disease")]
 	public IEnumerable<Encounter> Risk_Variable_Renal_Disease() => 
 		__Risk_Variable_Renal_Disease.Value;
 
+    /// <seealso cref="Risk_Variable_Severe_Preeclampsia"/>
 	private IEnumerable<Encounter> Risk_Variable_Severe_Preeclampsia_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Severe_Preeclampsia();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Severe_Preeclampsia();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Severe_Preeclampsia_Value"/>
     [CqlDeclaration("Risk Variable Severe Preeclampsia")]
 	public IEnumerable<Encounter> Risk_Variable_Severe_Preeclampsia() => 
 		__Risk_Variable_Severe_Preeclampsia.Value;
 
+    /// <seealso cref="Risk_Variable_Substance_Abuse"/>
 	private IEnumerable<Encounter> Risk_Variable_Substance_Abuse_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Substance_Abuse();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Substance_Abuse();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Substance_Abuse_Value"/>
     [CqlDeclaration("Risk Variable Substance Abuse")]
 	public IEnumerable<Encounter> Risk_Variable_Substance_Abuse() => 
 		__Risk_Variable_Substance_Abuse.Value;
 
+    /// <seealso cref="Risk_Variable_Thyrotoxicosis"/>
 	private IEnumerable<Encounter> Risk_Variable_Thyrotoxicosis_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Thyrotoxicosis();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Thyrotoxicosis();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Thyrotoxicosis_Value"/>
     [CqlDeclaration("Risk Variable Thyrotoxicosis")]
 	public IEnumerable<Encounter> Risk_Variable_Thyrotoxicosis() => 
 		__Risk_Variable_Thyrotoxicosis.Value;
 
+    /// <seealso cref="Risk_Variable_Other_Preeclampsia"/>
 	private IEnumerable<Encounter> Risk_Variable_Other_Preeclampsia_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		bool? b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
-			var e_ = this.Mild_or_Moderate_Preeclampsia();
-			var f_ = context.Operators.ConceptsInValueSet(d_, e_);
+			IEnumerable<CqlConcept> d_ = this.pOAIsYesOrExempt(TwentyWeeksPlusEncounter);
+			CqlValueSet e_ = this.Mild_or_Moderate_Preeclampsia();
+			bool? f_ = context.Operators.ConceptsInValueSet(d_, e_);
 
 			return f_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Other_Preeclampsia_Value"/>
     [CqlDeclaration("Risk Variable Other Preeclampsia")]
 	public IEnumerable<Encounter> Risk_Variable_Other_Preeclampsia() => 
 		__Risk_Variable_Other_Preeclampsia.Value;
 
+    /// <seealso cref="Risk_Variable_Preterm_Birth"/>
 	private IEnumerable<Encounter> Risk_Variable_Preterm_Birth_Value()
 	{
-		var a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
+		IEnumerable<Encounter> a_ = PCMaternal_5_16_000.Delivery_Encounter_with_Age_Range();
 		bool? b_(Encounter DeliveryEncounter)
 		{
-			var h_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
-			var i_ = context.Operators.Interval(20, 36, true, true);
-			var j_ = context.Operators.In<int?>(h_, i_, null);
-			var l_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
-			var m_ = context.Operators.Quantity(20m, "weeks");
-			var n_ = context.Operators.GreaterOrEqual(l_, m_);
-			var p_ = context.Operators.Quantity(36m, "weeks");
-			var q_ = context.Operators.LessOrEqual(l_, p_);
-			var r_ = context.Operators.And(n_, q_);
-			var s_ = context.Operators.And((bool?)(h_ is null), r_);
-			var t_ = context.Operators.Or(j_, s_);
+			int? h_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			CqlInterval<int?> i_ = context.Operators.Interval(20, 36, true, true);
+			bool? j_ = context.Operators.In<int?>(h_, i_, null);
+			CqlQuantity l_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			CqlQuantity m_ = context.Operators.Quantity(20m, "weeks");
+			bool? n_ = context.Operators.GreaterOrEqual(l_, m_);
+			CqlQuantity p_ = context.Operators.Quantity(36m, "weeks");
+			bool? q_ = context.Operators.LessOrEqual(l_, p_);
+			bool? r_ = context.Operators.And(n_, q_);
+			bool? s_ = context.Operators.And((bool?)(h_ is null), r_);
+			bool? t_ = context.Operators.Or(j_, s_);
 
 			return t_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 		bool? e_(Encounter DeliveryEncounter)
 		{
-			var u_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
-			var v_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
-			var w_ = context.Operators.And((bool?)(u_ is null), (bool?)(v_ is null));
-			var x_ = this.pOAIsYesOrExempt(DeliveryEncounter);
-			var y_ = this.Preterm_Birth();
-			var z_ = context.Operators.ConceptsInValueSet(x_, y_);
-			var aa_ = context.Operators.And(w_, z_);
+			int? u_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
+			CqlQuantity v_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
+			bool? w_ = context.Operators.And((bool?)(u_ is null), (bool?)(v_ is null));
+			IEnumerable<CqlConcept> x_ = this.pOAIsYesOrExempt(DeliveryEncounter);
+			CqlValueSet y_ = this.Preterm_Birth();
+			bool? z_ = context.Operators.ConceptsInValueSet(x_, y_);
+			bool? aa_ = context.Operators.And(w_, z_);
 
 			return aa_;
 		};
-		var f_ = context.Operators.Where<Encounter>(a_, e_);
-		var g_ = context.Operators.Union<Encounter>(c_, f_);
+		IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(a_, e_);
+		IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Risk_Variable_Preterm_Birth_Value"/>
     [CqlDeclaration("Risk Variable Preterm Birth")]
 	public IEnumerable<Encounter> Risk_Variable_Preterm_Birth() => 
 		__Risk_Variable_Preterm_Birth.Value;
 
+    /// <seealso cref="Risk_Variable_First_Hematocrit_Lab_Test"/>
 	private IEnumerable<Tuple_DIHdhbAJeJTdiAVUAELUHRNdS> Risk_Variable_First_Hematocrit_Lab_Test_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		Tuple_DIHdhbAJeJTdiAVUAELUHRNdS b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = TwentyWeeksPlusEncounter?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.Hematocrit_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.Hematocrit_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation Hematocrit)
 			{
-				var z_ = Hematocrit?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var ad_ = context.Operators.Start(ac_);
-				var ae_ = context.Operators.Quantity(1440m, "minutes");
-				var af_ = context.Operators.Subtract(ad_, ae_);
-				var ag_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
-				var ah_ = context.Operators.Interval(af_, ag_, true, false);
-				var ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, null);
-				var aj_ = Hematocrit?.StatusElement;
-				var ak_ = aj_?.Value;
-				var al_ = context.Operators.Convert<string>(ak_);
-				var am_ = new string[]
+				Instant z_ = Hematocrit?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlInterval<CqlDateTime> ac_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				CqlDateTime ad_ = context.Operators.Start(ac_);
+				CqlQuantity ae_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
+				CqlDateTime ag_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(af_, ag_, true, false);
+				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, null);
+				Code<ObservationStatus> aj_ = Hematocrit?.StatusElement;
+				ObservationStatus? ak_ = aj_?.Value;
+				string al_ = context.Operators.Convert<string>(ak_);
+				string[] am_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var an_ = context.Operators.In<string>(al_, (am_ as IEnumerable<string>));
-				var ao_ = context.Operators.And(ai_, an_);
-				var ap_ = Hematocrit?.Value;
-				var aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
-				var ar_ = context.Operators.Not((bool?)(aq_ is null));
-				var as_ = context.Operators.And(ao_, ar_);
+				bool? an_ = context.Operators.In<string>(al_, (am_ as IEnumerable<string>));
+				bool? ao_ = context.Operators.And(ai_, an_);
+				DataType ap_ = Hematocrit?.Value;
+				object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+				bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
+				bool? as_ = context.Operators.And(ao_, ar_);
 
 				return as_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var at_ = @this?.IssuedElement;
-				var au_ = at_?.Value;
-				var av_ = context.Operators.Convert<CqlDateTime>(au_);
-				var aw_ = QICoreCommon_2_0_000.earliest((av_ as object));
+				Instant at_ = @this?.IssuedElement;
+				DateTimeOffset? au_ = at_?.Value;
+				CqlDateTime av_ = context.Operators.Convert<CqlDateTime>(au_);
+				CqlDateTime aw_ = QICoreCommon_2_0_000.earliest((av_ as object));
 
 				return aw_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation Hematocrit)
 			{
-				var ax_ = Hematocrit?.IssuedElement;
-				var ay_ = ax_?.Value;
-				var az_ = context.Operators.Convert<CqlDateTime>(ay_);
-				var ba_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var bb_ = context.Operators.Start(ba_);
-				var bc_ = context.Operators.Quantity(1440m, "minutes");
-				var bd_ = context.Operators.Subtract(bb_, bc_);
-				var be_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
-				var bf_ = context.Operators.Interval(bd_, be_, true, false);
-				var bg_ = context.Operators.In<CqlDateTime>(az_, bf_, null);
-				var bh_ = Hematocrit?.StatusElement;
-				var bi_ = bh_?.Value;
-				var bj_ = context.Operators.Convert<string>(bi_);
-				var bk_ = new string[]
+				Instant ax_ = Hematocrit?.IssuedElement;
+				DateTimeOffset? ay_ = ax_?.Value;
+				CqlDateTime az_ = context.Operators.Convert<CqlDateTime>(ay_);
+				CqlInterval<CqlDateTime> ba_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				CqlDateTime bb_ = context.Operators.Start(ba_);
+				CqlQuantity bc_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bd_ = context.Operators.Subtract(bb_, bc_);
+				CqlDateTime be_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(bd_, be_, true, false);
+				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, null);
+				Code<ObservationStatus> bh_ = Hematocrit?.StatusElement;
+				ObservationStatus? bi_ = bh_?.Value;
+				string bj_ = context.Operators.Convert<string>(bi_);
+				string[] bk_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bl_ = context.Operators.In<string>(bj_, (bk_ as IEnumerable<string>));
-				var bm_ = context.Operators.And(bg_, bl_);
-				var bn_ = Hematocrit?.Value;
-				var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
-				var bp_ = context.Operators.Not((bool?)(bo_ is null));
-				var bq_ = context.Operators.And(bm_, bp_);
+				bool? bl_ = context.Operators.In<string>(bj_, (bk_ as IEnumerable<string>));
+				bool? bm_ = context.Operators.And(bg_, bl_);
+				DataType bn_ = Hematocrit?.Value;
+				object bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+				bool? bp_ = context.Operators.Not((bool?)(bo_ is null));
+				bool? bq_ = context.Operators.And(bm_, bp_);
 
 				return bq_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var br_ = @this?.IssuedElement;
-				var bs_ = br_?.Value;
-				var bt_ = context.Operators.Convert<CqlDateTime>(bs_);
-				var bu_ = QICoreCommon_2_0_000.earliest((bt_ as object));
+				Instant br_ = @this?.IssuedElement;
+				DateTimeOffset? bs_ = br_?.Value;
+				CqlDateTime bt_ = context.Operators.Convert<CqlDateTime>(bs_);
+				CqlDateTime bu_ = QICoreCommon_2_0_000.earliest((bt_ as object));
 
 				return bu_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_DIHdhbAJeJTdiAVUAELUHRNdS
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_DIHdhbAJeJTdiAVUAELUHRNdS y_ = new Tuple_DIHdhbAJeJTdiAVUAELUHRNdS
 			{
 				EncounterId = e_,
 				FirstHematocritResult = (n_ as CqlQuantity),
@@ -1880,115 +2084,117 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_DIHdhbAJeJTdiAVUAELUHRNdS>(a_, b_);
+		IEnumerable<Tuple_DIHdhbAJeJTdiAVUAELUHRNdS> c_ = context.Operators.Select<Encounter, Tuple_DIHdhbAJeJTdiAVUAELUHRNdS>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_First_Hematocrit_Lab_Test_Value"/>
     [CqlDeclaration("Risk Variable First Hematocrit Lab Test")]
 	public IEnumerable<Tuple_DIHdhbAJeJTdiAVUAELUHRNdS> Risk_Variable_First_Hematocrit_Lab_Test() => 
 		__Risk_Variable_First_Hematocrit_Lab_Test.Value;
 
+    /// <seealso cref="Risk_Variable_First_White_Blood_Cell_Count_Lab_Test"/>
 	private IEnumerable<Tuple_ESFBYaBAeYMhOBFMjVCbeLhQA> Risk_Variable_First_White_Blood_Cell_Count_Lab_Test_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		Tuple_ESFBYaBAeYMhOBFMjVCbeLhQA b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = TwentyWeeksPlusEncounter?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = this.White_blood_cells_count_lab_test();
-			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
+			string e_ = d_?.Value;
+			CqlValueSet f_ = this.White_blood_cells_count_lab_test();
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation WBC)
 			{
-				var z_ = WBC?.IssuedElement;
-				var aa_ = z_?.Value;
-				var ab_ = context.Operators.Convert<CqlDateTime>(aa_);
-				var ac_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var ad_ = context.Operators.Start(ac_);
-				var ae_ = context.Operators.Quantity(1440m, "minutes");
-				var af_ = context.Operators.Subtract(ad_, ae_);
-				var ag_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
-				var ah_ = context.Operators.Interval(af_, ag_, true, false);
-				var ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, null);
-				var aj_ = WBC?.StatusElement;
-				var ak_ = aj_?.Value;
-				var al_ = context.Operators.Convert<string>(ak_);
-				var am_ = new string[]
+				Instant z_ = WBC?.IssuedElement;
+				DateTimeOffset? aa_ = z_?.Value;
+				CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
+				CqlInterval<CqlDateTime> ac_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				CqlDateTime ad_ = context.Operators.Start(ac_);
+				CqlQuantity ae_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
+				CqlDateTime ag_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(af_, ag_, true, false);
+				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, null);
+				Code<ObservationStatus> aj_ = WBC?.StatusElement;
+				ObservationStatus? ak_ = aj_?.Value;
+				string al_ = context.Operators.Convert<string>(ak_);
+				string[] am_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var an_ = context.Operators.In<string>(al_, (am_ as IEnumerable<string>));
-				var ao_ = context.Operators.And(ai_, an_);
-				var ap_ = WBC?.Value;
-				var aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
-				var ar_ = context.Operators.Not((bool?)(aq_ is null));
-				var as_ = context.Operators.And(ao_, ar_);
+				bool? an_ = context.Operators.In<string>(al_, (am_ as IEnumerable<string>));
+				bool? ao_ = context.Operators.And(ai_, an_);
+				DataType ap_ = WBC?.Value;
+				object aq_ = FHIRHelpers_4_3_000.ToValue(ap_);
+				bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
+				bool? as_ = context.Operators.And(ao_, ar_);
 
 				return as_;
 			};
-			var i_ = context.Operators.Where<Observation>(g_, h_);
+			IEnumerable<Observation> i_ = context.Operators.Where<Observation>(g_, h_);
 			object j_(Observation @this)
 			{
-				var at_ = @this?.IssuedElement;
-				var au_ = at_?.Value;
-				var av_ = context.Operators.Convert<CqlDateTime>(au_);
-				var aw_ = QICoreCommon_2_0_000.earliest((av_ as object));
+				Instant at_ = @this?.IssuedElement;
+				DateTimeOffset? au_ = at_?.Value;
+				CqlDateTime av_ = context.Operators.Convert<CqlDateTime>(au_);
+				CqlDateTime aw_ = QICoreCommon_2_0_000.earliest((av_ as object));
 
 				return aw_;
 			};
-			var k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
-			var l_ = context.Operators.First<Observation>(k_);
-			var m_ = l_?.Value;
-			var n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			var p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> k_ = context.Operators.SortBy<Observation>(i_, j_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation l_ = context.Operators.First<Observation>(k_);
+			DataType m_ = l_?.Value;
+			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? q_(Observation WBC)
 			{
-				var ax_ = WBC?.IssuedElement;
-				var ay_ = ax_?.Value;
-				var az_ = context.Operators.Convert<CqlDateTime>(ay_);
-				var ba_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var bb_ = context.Operators.Start(ba_);
-				var bc_ = context.Operators.Quantity(1440m, "minutes");
-				var bd_ = context.Operators.Subtract(bb_, bc_);
-				var be_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
-				var bf_ = context.Operators.Interval(bd_, be_, true, false);
-				var bg_ = context.Operators.In<CqlDateTime>(az_, bf_, null);
-				var bh_ = WBC?.StatusElement;
-				var bi_ = bh_?.Value;
-				var bj_ = context.Operators.Convert<string>(bi_);
-				var bk_ = new string[]
+				Instant ax_ = WBC?.IssuedElement;
+				DateTimeOffset? ay_ = ax_?.Value;
+				CqlDateTime az_ = context.Operators.Convert<CqlDateTime>(ay_);
+				CqlInterval<CqlDateTime> ba_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				CqlDateTime bb_ = context.Operators.Start(ba_);
+				CqlQuantity bc_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bd_ = context.Operators.Subtract(bb_, bc_);
+				CqlDateTime be_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(bd_, be_, true, false);
+				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, null);
+				Code<ObservationStatus> bh_ = WBC?.StatusElement;
+				ObservationStatus? bi_ = bh_?.Value;
+				string bj_ = context.Operators.Convert<string>(bi_);
+				string[] bk_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bl_ = context.Operators.In<string>(bj_, (bk_ as IEnumerable<string>));
-				var bm_ = context.Operators.And(bg_, bl_);
-				var bn_ = WBC?.Value;
-				var bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
-				var bp_ = context.Operators.Not((bool?)(bo_ is null));
-				var bq_ = context.Operators.And(bm_, bp_);
+				bool? bl_ = context.Operators.In<string>(bj_, (bk_ as IEnumerable<string>));
+				bool? bm_ = context.Operators.And(bg_, bl_);
+				DataType bn_ = WBC?.Value;
+				object bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
+				bool? bp_ = context.Operators.Not((bool?)(bo_ is null));
+				bool? bq_ = context.Operators.And(bm_, bp_);
 
 				return bq_;
 			};
-			var r_ = context.Operators.Where<Observation>(p_, q_);
+			IEnumerable<Observation> r_ = context.Operators.Where<Observation>(p_, q_);
 			object s_(Observation @this)
 			{
-				var br_ = @this?.IssuedElement;
-				var bs_ = br_?.Value;
-				var bt_ = context.Operators.Convert<CqlDateTime>(bs_);
-				var bu_ = QICoreCommon_2_0_000.earliest((bt_ as object));
+				Instant br_ = @this?.IssuedElement;
+				DateTimeOffset? bs_ = br_?.Value;
+				CqlDateTime bt_ = context.Operators.Convert<CqlDateTime>(bs_);
+				CqlDateTime bu_ = QICoreCommon_2_0_000.earliest((bt_ as object));
 
 				return bu_;
 			};
-			var t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.First<Observation>(t_);
-			var v_ = u_?.IssuedElement;
-			var w_ = v_?.Value;
-			var x_ = context.Operators.Convert<CqlDateTime>(w_);
-			var y_ = new Tuple_ESFBYaBAeYMhOBFMjVCbeLhQA
+			IEnumerable<Observation> t_ = context.Operators.SortBy<Observation>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation u_ = context.Operators.First<Observation>(t_);
+			Instant v_ = u_?.IssuedElement;
+			DateTimeOffset? w_ = v_?.Value;
+			CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+			Tuple_ESFBYaBAeYMhOBFMjVCbeLhQA y_ = new Tuple_ESFBYaBAeYMhOBFMjVCbeLhQA
 			{
 				EncounterId = e_,
 				FirstWBCResult = (n_ as CqlQuantity),
@@ -1997,104 +2203,106 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 
 			return y_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_ESFBYaBAeYMhOBFMjVCbeLhQA>(a_, b_);
+		IEnumerable<Tuple_ESFBYaBAeYMhOBFMjVCbeLhQA> c_ = context.Operators.Select<Encounter, Tuple_ESFBYaBAeYMhOBFMjVCbeLhQA>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_First_White_Blood_Cell_Count_Lab_Test_Value"/>
     [CqlDeclaration("Risk Variable First White Blood Cell Count Lab Test")]
 	public IEnumerable<Tuple_ESFBYaBAeYMhOBFMjVCbeLhQA> Risk_Variable_First_White_Blood_Cell_Count_Lab_Test() => 
 		__Risk_Variable_First_White_Blood_Cell_Count_Lab_Test.Value;
 
+    /// <seealso cref="Risk_Variable_Heart_Rate"/>
 	private IEnumerable<Tuple_HOiMaDjifIOTXXFShNKiWLBLV> Risk_Variable_Heart_Rate_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		Tuple_HOiMaDjifIOTXXFShNKiWLBLV b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = TwentyWeeksPlusEncounter?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
+			string e_ = d_?.Value;
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? g_(Observation HeartRate)
 			{
-				var y_ = HeartRate?.Effective;
-				var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-				var aa_ = QICoreCommon_2_0_000.earliest(z_);
-				var ab_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var ac_ = context.Operators.Start(ab_);
-				var ad_ = context.Operators.Quantity(1440m, "minutes");
-				var ae_ = context.Operators.Subtract(ac_, ad_);
-				var af_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
-				var ag_ = context.Operators.Interval(ae_, af_, true, false);
-				var ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, null);
-				var ai_ = HeartRate?.StatusElement;
-				var aj_ = ai_?.Value;
-				var ak_ = context.Operators.Convert<string>(aj_);
-				var al_ = new string[]
+				DataType y_ = HeartRate?.Effective;
+				object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+				CqlDateTime aa_ = QICoreCommon_2_0_000.earliest(z_);
+				CqlInterval<CqlDateTime> ab_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				CqlDateTime ac_ = context.Operators.Start(ab_);
+				CqlQuantity ad_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ae_ = context.Operators.Subtract(ac_, ad_);
+				CqlDateTime af_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ae_, af_, true, false);
+				bool? ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, null);
+				Code<ObservationStatus> ai_ = HeartRate?.StatusElement;
+				ObservationStatus? aj_ = ai_?.Value;
+				string ak_ = context.Operators.Convert<string>(aj_);
+				string[] al_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var am_ = context.Operators.In<string>(ak_, (al_ as IEnumerable<string>));
-				var an_ = context.Operators.And(ah_, am_);
+				bool? am_ = context.Operators.In<string>(ak_, (al_ as IEnumerable<string>));
+				bool? an_ = context.Operators.And(ah_, am_);
 
 				return an_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			object i_(Observation @this)
 			{
-				var ao_ = @this?.Effective;
-				var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-				var aq_ = QICoreCommon_2_0_000.earliest(ap_);
+				DataType ao_ = @this?.Effective;
+				object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+				CqlDateTime aq_ = QICoreCommon_2_0_000.earliest(ap_);
 
 				return aq_;
 			};
-			var j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.First<Observation>(j_);
-			var l_ = k_?.Value;
-			var m_ = context.Operators.Convert<Quantity>(l_);
-			var n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
+			IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation k_ = context.Operators.First<Observation>(j_);
+			DataType l_ = k_?.Value;
+			Quantity m_ = context.Operators.Convert<Quantity>(l_);
+			CqlQuantity n_ = FHIRHelpers_4_3_000.ToQuantity(m_);
 			bool? p_(Observation HeartRate)
 			{
-				var ar_ = HeartRate?.Effective;
-				var as_ = FHIRHelpers_4_3_000.ToValue(ar_);
-				var at_ = QICoreCommon_2_0_000.earliest(as_);
-				var au_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var av_ = context.Operators.Start(au_);
-				var aw_ = context.Operators.Quantity(1440m, "minutes");
-				var ax_ = context.Operators.Subtract(av_, aw_);
-				var ay_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
-				var az_ = context.Operators.Interval(ax_, ay_, true, false);
-				var ba_ = context.Operators.In<CqlDateTime>(at_, az_, null);
-				var bb_ = HeartRate?.StatusElement;
-				var bc_ = bb_?.Value;
-				var bd_ = context.Operators.Convert<string>(bc_);
-				var be_ = new string[]
+				DataType ar_ = HeartRate?.Effective;
+				object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
+				CqlDateTime at_ = QICoreCommon_2_0_000.earliest(as_);
+				CqlInterval<CqlDateTime> au_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				CqlDateTime av_ = context.Operators.Start(au_);
+				CqlQuantity aw_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ax_ = context.Operators.Subtract(av_, aw_);
+				CqlDateTime ay_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				CqlInterval<CqlDateTime> az_ = context.Operators.Interval(ax_, ay_, true, false);
+				bool? ba_ = context.Operators.In<CqlDateTime>(at_, az_, null);
+				Code<ObservationStatus> bb_ = HeartRate?.StatusElement;
+				ObservationStatus? bc_ = bb_?.Value;
+				string bd_ = context.Operators.Convert<string>(bc_);
+				string[] be_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bf_ = context.Operators.In<string>(bd_, (be_ as IEnumerable<string>));
-				var bg_ = context.Operators.And(ba_, bf_);
+				bool? bf_ = context.Operators.In<string>(bd_, (be_ as IEnumerable<string>));
+				bool? bg_ = context.Operators.And(ba_, bf_);
 
 				return bg_;
 			};
-			var q_ = context.Operators.Where<Observation>(f_, p_);
+			IEnumerable<Observation> q_ = context.Operators.Where<Observation>(f_, p_);
 			object r_(Observation @this)
 			{
-				var bh_ = @this?.Effective;
-				var bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
-				var bj_ = QICoreCommon_2_0_000.earliest(bi_);
+				DataType bh_ = @this?.Effective;
+				object bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
+				CqlDateTime bj_ = QICoreCommon_2_0_000.earliest(bi_);
 
 				return bj_;
 			};
-			var s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
-			var t_ = context.Operators.First<Observation>(s_);
-			var u_ = t_?.Effective;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = QICoreCommon_2_0_000.earliest(v_);
-			var x_ = new Tuple_HOiMaDjifIOTXXFShNKiWLBLV
+			IEnumerable<Observation> s_ = context.Operators.SortBy<Observation>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation t_ = context.Operators.First<Observation>(s_);
+			DataType u_ = t_?.Effective;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			CqlDateTime w_ = QICoreCommon_2_0_000.earliest(v_);
+			Tuple_HOiMaDjifIOTXXFShNKiWLBLV x_ = new Tuple_HOiMaDjifIOTXXFShNKiWLBLV
 			{
 				EncounterId = e_,
 				FirstHRResult = n_,
@@ -2103,121 +2311,123 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 
 			return x_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_HOiMaDjifIOTXXFShNKiWLBLV>(a_, b_);
+		IEnumerable<Tuple_HOiMaDjifIOTXXFShNKiWLBLV> c_ = context.Operators.Select<Encounter, Tuple_HOiMaDjifIOTXXFShNKiWLBLV>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Heart_Rate_Value"/>
     [CqlDeclaration("Risk Variable Heart Rate")]
 	public IEnumerable<Tuple_HOiMaDjifIOTXXFShNKiWLBLV> Risk_Variable_Heart_Rate() => 
 		__Risk_Variable_Heart_Rate.Value;
 
+    /// <seealso cref="Risk_Variable_Systolic_Blood_Pressure"/>
 	private IEnumerable<Tuple_FjSKXeIESORPNbRGajibMfUaK> Risk_Variable_Systolic_Blood_Pressure_Value()
 	{
-		var a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
+		IEnumerable<Encounter> a_ = this.Delivery_Encounters_At_Greater_than_or_Equal_to_20_Weeks_Gestation();
 		Tuple_FjSKXeIESORPNbRGajibMfUaK b_(Encounter TwentyWeeksPlusEncounter)
 		{
-			var d_ = TwentyWeeksPlusEncounter?.IdElement;
-			var e_ = d_?.Value;
-			var f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
+			string e_ = d_?.Value;
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 			bool? g_(Observation BP)
 			{
-				var aa_ = BP?.Effective;
-				var ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var ac_ = QICoreCommon_2_0_000.earliest(ab_);
-				var ad_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var ae_ = context.Operators.Start(ad_);
-				var af_ = context.Operators.Quantity(1440m, "minutes");
-				var ag_ = context.Operators.Subtract(ae_, af_);
-				var ah_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
-				var ai_ = context.Operators.Interval(ag_, ah_, true, false);
-				var aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, null);
-				var ak_ = BP?.StatusElement;
-				var al_ = ak_?.Value;
-				var am_ = context.Operators.Convert<string>(al_);
-				var an_ = new string[]
+				DataType aa_ = BP?.Effective;
+				object ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDateTime ac_ = QICoreCommon_2_0_000.earliest(ab_);
+				CqlInterval<CqlDateTime> ad_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				CqlDateTime ae_ = context.Operators.Start(ad_);
+				CqlQuantity af_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
+				CqlDateTime ah_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ag_, ah_, true, false);
+				bool? aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, null);
+				Code<ObservationStatus> ak_ = BP?.StatusElement;
+				ObservationStatus? al_ = ak_?.Value;
+				string am_ = context.Operators.Convert<string>(al_);
+				string[] an_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var ao_ = context.Operators.In<string>(am_, (an_ as IEnumerable<string>));
-				var ap_ = context.Operators.And(aj_, ao_);
+				bool? ao_ = context.Operators.In<string>(am_, (an_ as IEnumerable<string>));
+				bool? ap_ = context.Operators.And(aj_, ao_);
 
 				return ap_;
 			};
-			var h_ = context.Operators.Where<Observation>(f_, g_);
+			IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
 			object i_(Observation @this)
 			{
-				var aq_ = @this?.Effective;
-				var ar_ = FHIRHelpers_4_3_000.ToValue(aq_);
-				var as_ = QICoreCommon_2_0_000.earliest(ar_);
+				DataType aq_ = @this?.Effective;
+				object ar_ = FHIRHelpers_4_3_000.ToValue(aq_);
+				CqlDateTime as_ = QICoreCommon_2_0_000.earliest(ar_);
 
 				return as_;
 			};
-			var j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.First<Observation>(j_);
-			var l_ = k_?.Component;
+			IEnumerable<Observation> j_ = context.Operators.SortBy<Observation>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation k_ = context.Operators.First<Observation>(j_);
+			List<Observation.ComponentComponent> l_ = k_?.Component;
 			bool? m_(Observation.ComponentComponent C)
 			{
-				var at_ = C?.Code;
-				var au_ = FHIRHelpers_4_3_000.ToConcept(at_);
-				var av_ = this.Systolic_blood_pressure();
-				var aw_ = context.Operators.ConvertCodeToConcept(av_);
-				var ax_ = context.Operators.Equivalent(au_, aw_);
+				CodeableConcept at_ = C?.Code;
+				CqlConcept au_ = FHIRHelpers_4_3_000.ToConcept(at_);
+				CqlCode av_ = this.Systolic_blood_pressure();
+				CqlConcept aw_ = context.Operators.ConvertCodeToConcept(av_);
+				bool? ax_ = context.Operators.Equivalent(au_, aw_);
 
 				return ax_;
 			};
-			var n_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)l_, m_);
+			IEnumerable<Observation.ComponentComponent> n_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)l_, m_);
 			CqlQuantity o_(Observation.ComponentComponent C)
 			{
-				var ay_ = C?.Value;
-				var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+				DataType ay_ = C?.Value;
+				object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
 
 				return (az_ as CqlQuantity);
 			};
-			var p_ = context.Operators.Select<Observation.ComponentComponent, CqlQuantity>(n_, o_);
+			IEnumerable<CqlQuantity> p_ = context.Operators.Select<Observation.ComponentComponent, CqlQuantity>(n_, o_);
 			bool? r_(Observation BP)
 			{
-				var ba_ = BP?.Effective;
-				var bb_ = FHIRHelpers_4_3_000.ToValue(ba_);
-				var bc_ = QICoreCommon_2_0_000.earliest(bb_);
-				var bd_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				var be_ = context.Operators.Start(bd_);
-				var bf_ = context.Operators.Quantity(1440m, "minutes");
-				var bg_ = context.Operators.Subtract(be_, bf_);
-				var bh_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
-				var bi_ = context.Operators.Interval(bg_, bh_, true, false);
-				var bj_ = context.Operators.In<CqlDateTime>(bc_, bi_, null);
-				var bk_ = BP?.StatusElement;
-				var bl_ = bk_?.Value;
-				var bm_ = context.Operators.Convert<string>(bl_);
-				var bn_ = new string[]
+				DataType ba_ = BP?.Effective;
+				object bb_ = FHIRHelpers_4_3_000.ToValue(ba_);
+				CqlDateTime bc_ = QICoreCommon_2_0_000.earliest(bb_);
+				CqlInterval<CqlDateTime> bd_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
+				CqlDateTime be_ = context.Operators.Start(bd_);
+				CqlQuantity bf_ = context.Operators.Quantity(1440m, "minutes");
+				CqlDateTime bg_ = context.Operators.Subtract(be_, bf_);
+				CqlDateTime bh_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
+				CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(bg_, bh_, true, false);
+				bool? bj_ = context.Operators.In<CqlDateTime>(bc_, bi_, null);
+				Code<ObservationStatus> bk_ = BP?.StatusElement;
+				ObservationStatus? bl_ = bk_?.Value;
+				string bm_ = context.Operators.Convert<string>(bl_);
+				string[] bn_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var bo_ = context.Operators.In<string>(bm_, (bn_ as IEnumerable<string>));
-				var bp_ = context.Operators.And(bj_, bo_);
+				bool? bo_ = context.Operators.In<string>(bm_, (bn_ as IEnumerable<string>));
+				bool? bp_ = context.Operators.And(bj_, bo_);
 
 				return bp_;
 			};
-			var s_ = context.Operators.Where<Observation>(f_, r_);
+			IEnumerable<Observation> s_ = context.Operators.Where<Observation>(f_, r_);
 			object t_(Observation @this)
 			{
-				var bq_ = @this?.Effective;
-				var br_ = FHIRHelpers_4_3_000.ToValue(bq_);
-				var bs_ = QICoreCommon_2_0_000.earliest(br_);
+				DataType bq_ = @this?.Effective;
+				object br_ = FHIRHelpers_4_3_000.ToValue(bq_);
+				CqlDateTime bs_ = QICoreCommon_2_0_000.earliest(br_);
 
 				return bs_;
 			};
-			var u_ = context.Operators.SortBy<Observation>(s_, t_, System.ComponentModel.ListSortDirection.Ascending);
-			var v_ = context.Operators.First<Observation>(u_);
-			var w_ = v_?.Effective;
-			var x_ = FHIRHelpers_4_3_000.ToValue(w_);
-			var y_ = QICoreCommon_2_0_000.earliest(x_);
-			var z_ = new Tuple_FjSKXeIESORPNbRGajibMfUaK
+			IEnumerable<Observation> u_ = context.Operators.SortBy<Observation>(s_, t_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation v_ = context.Operators.First<Observation>(u_);
+			DataType w_ = v_?.Effective;
+			object x_ = FHIRHelpers_4_3_000.ToValue(w_);
+			CqlDateTime y_ = QICoreCommon_2_0_000.earliest(x_);
+			Tuple_FjSKXeIESORPNbRGajibMfUaK z_ = new Tuple_FjSKXeIESORPNbRGajibMfUaK
 			{
 				EncounterId = e_,
 				FirstSBPResult = p_,
@@ -2226,11 +2436,12 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 
 			return z_;
 		};
-		var c_ = context.Operators.Select<Encounter, Tuple_FjSKXeIESORPNbRGajibMfUaK>(a_, b_);
+		IEnumerable<Tuple_FjSKXeIESORPNbRGajibMfUaK> c_ = context.Operators.Select<Encounter, Tuple_FjSKXeIESORPNbRGajibMfUaK>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Risk_Variable_Systolic_Blood_Pressure_Value"/>
     [CqlDeclaration("Risk Variable Systolic Blood Pressure")]
 	public IEnumerable<Tuple_FjSKXeIESORPNbRGajibMfUaK> Risk_Variable_Systolic_Blood_Pressure() => 
 		__Risk_Variable_Systolic_Blood_Pressure.Value;
@@ -2238,48 +2449,49 @@ public class SevereObstetricComplicationsFHIR_0_1_000
     [CqlDeclaration("pOAIsNoOrUTD")]
 	public IEnumerable<CqlConcept> pOAIsNoOrUTD(Encounter TheEncounter)
 	{
-		bool? a_(Encounter.DiagnosisComponent EncounterDiagnoses)
+		List<Encounter.DiagnosisComponent> a_ = TheEncounter?.Diagnosis;
+		bool? b_(Encounter.DiagnosisComponent EncounterDiagnoses)
 		{
-			bool? e_(Extension @this)
+			bool? f_(Extension @this)
 			{
-				var n_ = @this?.Url;
-				var o_ = context.Operators.Convert<FhirUri>(n_);
-				var p_ = FHIRHelpers_4_3_000.ToString(o_);
-				var q_ = context.Operators.Equal(p_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
-
-				return q_;
-			};
-			var f_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
-					? ((EncounterDiagnoses as Element).Extension)
-					: null), e_);
-			DataType g_(Extension @this)
-			{
-				var r_ = @this?.Value;
+				string o_ = @this?.Url;
+				FhirUri p_ = context.Operators.Convert<FhirUri>(o_);
+				string q_ = FHIRHelpers_4_3_000.ToString(p_);
+				bool? r_ = context.Operators.Equal(q_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
 
 				return r_;
 			};
-			var h_ = context.Operators.Select<Extension, DataType>(f_, g_);
-			var i_ = context.Operators.SingletonFrom<DataType>(h_);
-			var j_ = context.Operators.Convert<CodeableConcept>(i_);
-			var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
-			var l_ = this.Present_on_Admission_is_No_or_Unable_To_Determine();
-			var m_ = context.Operators.ConceptInValueSet(k_, l_);
+			IEnumerable<Extension> g_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
+					? ((EncounterDiagnoses as Element).Extension)
+					: null), f_);
+			DataType h_(Extension @this)
+			{
+				DataType s_ = @this?.Value;
 
-			return m_;
+				return s_;
+			};
+			IEnumerable<DataType> i_ = context.Operators.Select<Extension, DataType>(g_, h_);
+			DataType j_ = context.Operators.SingletonFrom<DataType>(i_);
+			CodeableConcept k_ = context.Operators.Convert<CodeableConcept>(j_);
+			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlValueSet m_ = this.Present_on_Admission_is_No_or_Unable_To_Determine();
+			bool? n_ = context.Operators.ConceptInValueSet(l_, m_);
+
+			return n_;
 		};
-		var b_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)TheEncounter?.Diagnosis, a_);
-		CqlConcept c_(Encounter.DiagnosisComponent EncounterDiagnoses)
+		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
+		CqlConcept d_(Encounter.DiagnosisComponent EncounterDiagnoses)
 		{
-			var s_ = EncounterDiagnoses?.Condition;
-			var t_ = CQMCommon_2_0_000.getCondition(s_);
-			var u_ = t_?.Code;
-			var v_ = FHIRHelpers_4_3_000.ToConcept(u_);
+			ResourceReference t_ = EncounterDiagnoses?.Condition;
+			Condition u_ = CQMCommon_2_0_000.getCondition(t_);
+			CodeableConcept v_ = u_?.Code;
+			CqlConcept w_ = FHIRHelpers_4_3_000.ToConcept(v_);
 
-			return v_;
+			return w_;
 		};
-		var d_ = context.Operators.Select<Encounter.DiagnosisComponent, CqlConcept>(b_, c_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Select<Encounter.DiagnosisComponent, CqlConcept>(c_, d_);
 
-		return d_;
+		return e_;
 	}
 
 }

--- a/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
@@ -52,44 +52,55 @@ public class Status_1_6_000
 
     #endregion
 
+    /// <seealso cref="laboratory"/>
 	private CqlCode laboratory_Value() => 
 		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="laboratory_Value"/>
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
+    /// <seealso cref="exam"/>
 	private CqlCode exam_Value() => 
 		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="exam_Value"/>
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
+    /// <seealso cref="survey"/>
 	private CqlCode survey_Value() => 
 		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="survey_Value"/>
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
+    /// <seealso cref="vital_signs"/>
 	private CqlCode vital_signs_Value() => 
 		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="vital_signs_Value"/>
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
+    /// <seealso cref="active"/>
 	private CqlCode active_Value() => 
 		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
+    /// <seealso cref="active_Value"/>
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
+    /// <seealso cref="ObservationCategoryCodes"/>
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
 			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
@@ -100,13 +111,15 @@ public class Status_1_6_000
 		return a_;
 	}
 
+    /// <seealso cref="ObservationCategoryCodes_Value"/>
     [CqlDeclaration("ObservationCategoryCodes")]
 	public CqlCode[] ObservationCategoryCodes() => 
 		__ObservationCategoryCodes.Value;
 
+    /// <seealso cref="ConditionClinicalStatusCodes"/>
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
 		};
@@ -114,18 +127,21 @@ public class Status_1_6_000
 		return a_;
 	}
 
+    /// <seealso cref="ConditionClinicalStatusCodes_Value"/>
     [CqlDeclaration("ConditionClinicalStatusCodes")]
 	public CqlCode[] ConditionClinicalStatusCodes() => 
 		__ConditionClinicalStatusCodes.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
@@ -135,40 +151,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.survey();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.survey();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -178,40 +194,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.survey();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.survey();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -221,15 +237,15 @@ public class Status_1_6_000
 	{
 		bool? a_(Condition C)
 		{
-			var c_ = C?.ClinicalStatus;
-			var d_ = FHIRHelpers_4_3_000.ToConcept(c_);
-			var e_ = this.active();
-			var f_ = context.Operators.ConvertCodeToConcept(e_);
-			var g_ = context.Operators.Equivalent(d_, f_);
+			CodeableConcept c_ = C?.ClinicalStatus;
+			CqlConcept d_ = FHIRHelpers_4_3_000.ToConcept(c_);
+			CqlCode e_ = this.active();
+			CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+			bool? g_ = context.Operators.Equivalent(d_, f_);
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Condition>(Condition, a_);
+		IEnumerable<Condition> b_ = context.Operators.Where<Condition>(Condition, a_);
 
 		return b_;
 	}
@@ -239,15 +255,15 @@ public class Status_1_6_000
 	{
 		bool? a_(Condition C)
 		{
-			var c_ = C?.ClinicalStatus;
-			var d_ = FHIRHelpers_4_3_000.ToConcept(c_);
-			var e_ = this.active();
-			var f_ = context.Operators.ConvertCodeToConcept(e_);
-			var g_ = context.Operators.Equivalent(d_, f_);
+			CodeableConcept c_ = C?.ClinicalStatus;
+			CqlConcept d_ = FHIRHelpers_4_3_000.ToConcept(c_);
+			CqlCode e_ = this.active();
+			CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+			bool? g_ = context.Operators.Equivalent(d_, f_);
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Condition>(Condition, a_);
+		IEnumerable<Condition> b_ = context.Operators.Where<Condition>(Condition, a_);
 
 		return b_;
 	}
@@ -257,25 +273,25 @@ public class Status_1_6_000
 	{
 		bool? a_(DeviceRequest D)
 		{
-			var c_ = D?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = D?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = D?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = D?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<DeviceRequest>(DeviceRequest, a_);
+		IEnumerable<DeviceRequest> b_ = context.Operators.Where<DeviceRequest>(DeviceRequest, a_);
 
 		return b_;
 	}
@@ -285,25 +301,25 @@ public class Status_1_6_000
 	{
 		bool? a_(DeviceRequest D)
 		{
-			var c_ = D?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = D?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = D?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = D?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<DeviceRequest>(DeviceRequest, a_);
+		IEnumerable<DeviceRequest> b_ = context.Operators.Where<DeviceRequest>(DeviceRequest, a_);
 
 		return b_;
 	}
@@ -313,25 +329,25 @@ public class Status_1_6_000
 	{
 		bool? a_(ServiceRequest S)
 		{
-			var c_ = S?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = S?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = S?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = S?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
+		IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
 
 		return b_;
 	}
@@ -341,25 +357,25 @@ public class Status_1_6_000
 	{
 		bool? a_(ServiceRequest S)
 		{
-			var c_ = S?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = S?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = S?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = S?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
+		IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
 
 		return b_;
 	}
@@ -369,25 +385,25 @@ public class Status_1_6_000
 	{
 		bool? a_(ServiceRequest S)
 		{
-			var c_ = S?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = S?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = S?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = S?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
+		IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
 
 		return b_;
 	}
@@ -397,25 +413,25 @@ public class Status_1_6_000
 	{
 		bool? a_(ServiceRequest S)
 		{
-			var c_ = S?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = S?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = S?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = S?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
+		IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
 
 		return b_;
 	}
@@ -425,21 +441,21 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -449,21 +465,21 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -473,11 +489,11 @@ public class Status_1_6_000
 	{
 		bool? a_(Encounter E)
 		{
-			var c_ = E?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<Encounter.EncounterStatus> c_ = E?.StatusElement;
+			Encounter.EncounterStatus? d_ = c_?.Value;
+			Code<Encounter.EncounterStatus> e_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"finished",
 				"arrived",
@@ -485,11 +501,11 @@ public class Status_1_6_000
 				"in-progress",
 				"onleave",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Encounter>(Enc, a_);
+		IEnumerable<Encounter> b_ = context.Operators.Where<Encounter>(Enc, a_);
 
 		return b_;
 	}
@@ -499,11 +515,11 @@ public class Status_1_6_000
 	{
 		bool? a_(Encounter E)
 		{
-			var c_ = E?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<Encounter.EncounterStatus> c_ = E?.StatusElement;
+			Encounter.EncounterStatus? d_ = c_?.Value;
+			Code<Encounter.EncounterStatus> e_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"finished",
 				"arrived",
@@ -511,11 +527,11 @@ public class Status_1_6_000
 				"in-progress",
 				"onleave",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Encounter>(Enc, a_);
+		IEnumerable<Encounter> b_ = context.Operators.Where<Encounter>(Enc, a_);
 
 		return b_;
 	}
@@ -525,14 +541,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Immunization I)
 		{
-			var c_ = I?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<Immunization.ImmunizationStatusCodes> c_ = I?.StatusElement;
+			Immunization.ImmunizationStatusCodes? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Immunization>(Immunization, a_);
+		IEnumerable<Immunization> b_ = context.Operators.Where<Immunization>(Immunization, a_);
 
 		return b_;
 	}
@@ -542,14 +558,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Immunization I)
 		{
-			var c_ = I?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<Immunization.ImmunizationStatusCodes> c_ = I?.StatusElement;
+			Immunization.ImmunizationStatusCodes? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Immunization>(Immunization, a_);
+		IEnumerable<Immunization> b_ = context.Operators.Where<Immunization>(Immunization, a_);
 
 		return b_;
 	}
@@ -559,14 +575,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Procedure P)
 		{
-			var c_ = P?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<EventStatus> c_ = P?.StatusElement;
+			EventStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Procedure>(Proc, a_);
+		IEnumerable<Procedure> b_ = context.Operators.Where<Procedure>(Proc, a_);
 
 		return b_;
 	}
@@ -576,14 +592,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Procedure P)
 		{
-			var c_ = P?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<EventStatus> c_ = P?.StatusElement;
+			EventStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Procedure>(Proc, a_);
+		IEnumerable<Procedure> b_ = context.Operators.Where<Procedure>(Proc, a_);
 
 		return b_;
 	}
@@ -593,14 +609,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Procedure P)
 		{
-			var c_ = P?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<EventStatus> c_ = P?.StatusElement;
+			EventStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Procedure>(Proc, a_);
+		IEnumerable<Procedure> b_ = context.Operators.Where<Procedure>(Proc, a_);
 
 		return b_;
 	}
@@ -610,40 +626,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.laboratory();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.laboratory();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -653,40 +669,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.laboratory();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.laboratory();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -696,19 +712,19 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationRequest M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equal(e_, "active");
-			var g_ = M?.IntentElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<string>(h_);
-			var j_ = context.Operators.Equal(i_, "order");
-			var k_ = context.Operators.And(f_, j_);
+			Code<MedicationRequest.MedicationrequestStatus> c_ = M?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equal(e_, "active");
+			Code<MedicationRequest.MedicationRequestIntent> g_ = M?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? h_ = g_?.Value;
+			string i_ = context.Operators.Convert<string>(h_);
+			bool? j_ = context.Operators.Equal(i_, "order");
+			bool? k_ = context.Operators.And(f_, j_);
 
 			return k_;
 		};
-		var b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
+		IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
 
 		return b_;
 	}
@@ -718,19 +734,19 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationRequest M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equal(e_, "active");
-			var g_ = M?.IntentElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<string>(h_);
-			var j_ = context.Operators.Equal(i_, "order");
-			var k_ = context.Operators.And(f_, j_);
+			Code<MedicationRequest.MedicationrequestStatus> c_ = M?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equal(e_, "active");
+			Code<MedicationRequest.MedicationRequestIntent> g_ = M?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? h_ = g_?.Value;
+			string i_ = context.Operators.Convert<string>(h_);
+			bool? j_ = context.Operators.Equal(i_, "order");
+			bool? k_ = context.Operators.And(f_, j_);
 
 			return k_;
 		};
-		var b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
+		IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
 
 		return b_;
 	}
@@ -740,21 +756,21 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationDispense M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<MedicationDispense.MedicationDispenseStatusCodes>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<MedicationDispense.MedicationDispenseStatusCodes> c_ = M?.StatusElement;
+			MedicationDispense.MedicationDispenseStatusCodes? d_ = c_?.Value;
+			Code<MedicationDispense.MedicationDispenseStatusCodes> e_ = context.Operators.Convert<Code<MedicationDispense.MedicationDispenseStatusCodes>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"completed",
 				"in-progress",
 				"on-hold",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<MedicationDispense>(Med, a_);
+		IEnumerable<MedicationDispense> b_ = context.Operators.Where<MedicationDispense>(Med, a_);
 
 		return b_;
 	}
@@ -764,21 +780,21 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationDispense M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<MedicationDispense.MedicationDispenseStatusCodes>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<MedicationDispense.MedicationDispenseStatusCodes> c_ = M?.StatusElement;
+			MedicationDispense.MedicationDispenseStatusCodes? d_ = c_?.Value;
+			Code<MedicationDispense.MedicationDispenseStatusCodes> e_ = context.Operators.Convert<Code<MedicationDispense.MedicationDispenseStatusCodes>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"completed",
 				"in-progress",
 				"on-hold",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<MedicationDispense>(Med, a_);
+		IEnumerable<MedicationDispense> b_ = context.Operators.Where<MedicationDispense>(Med, a_);
 
 		return b_;
 	}
@@ -788,24 +804,24 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationRequest M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<MedicationRequest.MedicationrequestStatus> c_ = M?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
-			var h_ = M?.IntentElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<string>(i_);
-			var k_ = context.Operators.Equal(j_, "order");
-			var l_ = context.Operators.And(g_, k_);
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
+			string j_ = context.Operators.Convert<string>(i_);
+			bool? k_ = context.Operators.Equal(j_, "order");
+			bool? l_ = context.Operators.And(g_, k_);
 
 			return l_;
 		};
-		var b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
+		IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
 
 		return b_;
 	}
@@ -815,24 +831,24 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationRequest M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<MedicationRequest.MedicationrequestStatus> c_ = M?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
-			var h_ = M?.IntentElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<string>(i_);
-			var k_ = context.Operators.Equal(j_, "order");
-			var l_ = context.Operators.And(g_, k_);
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
+			string j_ = context.Operators.Convert<string>(i_);
+			bool? k_ = context.Operators.Equal(j_, "order");
+			bool? l_ = context.Operators.And(g_, k_);
 
 			return l_;
 		};
-		var b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
+		IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
 
 		return b_;
 	}
@@ -842,40 +858,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.exam();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.exam();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -885,40 +901,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.exam();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.exam();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -928,20 +944,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -951,20 +967,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -974,20 +990,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -997,20 +1013,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1020,20 +1036,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1043,20 +1059,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1066,20 +1082,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1089,20 +1105,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1112,22 +1128,22 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"preliminary",
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1137,22 +1153,22 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"preliminary",
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}

--- a/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -54,64 +54,75 @@ public class SupplementalDataElements_3_4_000
 
     #endregion
 
+    /// <seealso cref="Ethnicity"/>
 	private CqlValueSet Ethnicity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
 
+    /// <seealso cref="Ethnicity_Value"/>
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
 	public CqlValueSet Ethnicity() => 
 		__Ethnicity.Value;
 
+    /// <seealso cref="ONC_Administrative_Sex"/>
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
 
+    /// <seealso cref="ONC_Administrative_Sex_Value"/>
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
 	public CqlValueSet ONC_Administrative_Sex() => 
 		__ONC_Administrative_Sex.Value;
 
+    /// <seealso cref="Payer_Type"/>
 	private CqlValueSet Payer_Type_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
 
+    /// <seealso cref="Payer_Type_Value"/>
     [CqlDeclaration("Payer Type")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
 	public CqlValueSet Payer_Type() => 
 		__Payer_Type.Value;
 
+    /// <seealso cref="Race"/>
 	private CqlValueSet Race_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
 
+    /// <seealso cref="Race_Value"/>
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
 	public CqlValueSet Race() => 
 		__Race.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
 		List<Extension> a_()
 		{
 			bool i_()
 			{
-				var j_ = this.Patient();
-				var k_ = j_ is DomainResource;
+				Patient j_ = this.Patient();
+				bool k_ = j_ is DomainResource;
 
 				return k_;
 			};
 			if (i_())
 			{
-				var l_ = this.Patient();
+				Patient l_ = this.Patient();
 
 				return (l_ as DomainResource).Extension;
 			}
@@ -122,16 +133,16 @@ public class SupplementalDataElements_3_4_000
 		};
 		bool? b_(Extension @this)
 		{
-			var m_ = @this?.Url;
-			var n_ = context.Operators.Convert<FhirUri>(m_);
-			var o_ = FHIRHelpers_4_3_000.ToString(n_);
-			var p_ = context.Operators.Equal(o_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
+			string m_ = @this?.Url;
+			FhirUri n_ = context.Operators.Convert<FhirUri>(m_);
+			string o_ = FHIRHelpers_4_3_000.ToString(n_);
+			bool? p_ = context.Operators.Equal(o_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity");
 
 			return p_;
 		};
-		var c_ = context.Operators.Where<Extension>((IEnumerable<Extension>)a_(), b_);
-		var d_ = context.Operators.SingletonFrom<Extension>(c_);
-		var e_ = new Extension[]
+		IEnumerable<Extension> c_ = context.Operators.Where<Extension>((IEnumerable<Extension>)a_(), b_);
+		Extension d_ = context.Operators.SingletonFrom<Extension>(c_);
+		Extension[] e_ = new Extension[]
 		{
 			d_,
 		};
@@ -139,80 +150,80 @@ public class SupplementalDataElements_3_4_000
 		{
 			bool? q_(Extension @this)
 			{
-				var am_ = @this?.Url;
-				var an_ = context.Operators.Convert<FhirUri>(am_);
-				var ao_ = FHIRHelpers_4_3_000.ToString(an_);
-				var ap_ = context.Operators.Equal(ao_, "ombCategory");
+				string am_ = @this?.Url;
+				FhirUri an_ = context.Operators.Convert<FhirUri>(am_);
+				string ao_ = FHIRHelpers_4_3_000.ToString(an_);
+				bool? ap_ = context.Operators.Equal(ao_, "ombCategory");
 
 				return ap_;
 			};
-			var r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
+			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
 					: null), q_);
 			DataType s_(Extension @this)
 			{
-				var aq_ = @this?.Value;
+				DataType aq_ = @this?.Value;
 
 				return aq_;
 			};
-			var t_ = context.Operators.Select<Extension, DataType>(r_, s_);
-			var u_ = context.Operators.SingletonFrom<DataType>(t_);
-			var v_ = context.Operators.Convert<Coding>(u_);
-			var w_ = FHIRHelpers_4_3_000.ToCode(v_);
-			var x_ = new CqlCode[]
+			IEnumerable<DataType> t_ = context.Operators.Select<Extension, DataType>(r_, s_);
+			DataType u_ = context.Operators.SingletonFrom<DataType>(t_);
+			Coding v_ = context.Operators.Convert<Coding>(u_);
+			CqlCode w_ = FHIRHelpers_4_3_000.ToCode(v_);
+			CqlCode[] x_ = new CqlCode[]
 			{
 				w_,
 			};
 			bool? y_(Extension @this)
 			{
-				var ar_ = @this?.Url;
-				var as_ = context.Operators.Convert<FhirUri>(ar_);
-				var at_ = FHIRHelpers_4_3_000.ToString(as_);
-				var au_ = context.Operators.Equal(at_, "detailed");
+				string ar_ = @this?.Url;
+				FhirUri as_ = context.Operators.Convert<FhirUri>(ar_);
+				string at_ = FHIRHelpers_4_3_000.ToString(as_);
+				bool? au_ = context.Operators.Equal(at_, "detailed");
 
 				return au_;
 			};
-			var z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
+			IEnumerable<Extension> z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
 					: null), y_);
 			DataType aa_(Extension @this)
 			{
-				var av_ = @this?.Value;
+				DataType av_ = @this?.Value;
 
 				return av_;
 			};
-			var ab_ = context.Operators.Select<Extension, DataType>(z_, aa_);
+			IEnumerable<DataType> ab_ = context.Operators.Select<Extension, DataType>(z_, aa_);
 			CqlCode ac_(DataType @this)
 			{
-				var aw_ = context.Operators.Convert<Coding>(@this);
-				var ax_ = FHIRHelpers_4_3_000.ToCode(aw_);
+				Coding aw_ = context.Operators.Convert<Coding>(@this);
+				CqlCode ax_ = FHIRHelpers_4_3_000.ToCode(aw_);
 
 				return ax_;
 			};
-			var ad_ = context.Operators.Select<DataType, CqlCode>(ab_, ac_);
-			var ae_ = context.Operators.Union<CqlCode>((x_ as IEnumerable<CqlCode>), ad_);
+			IEnumerable<CqlCode> ad_ = context.Operators.Select<DataType, CqlCode>(ab_, ac_);
+			IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>((x_ as IEnumerable<CqlCode>), ad_);
 			bool? af_(Extension @this)
 			{
-				var ay_ = @this?.Url;
-				var az_ = context.Operators.Convert<FhirUri>(ay_);
-				var ba_ = FHIRHelpers_4_3_000.ToString(az_);
-				var bb_ = context.Operators.Equal(ba_, "text");
+				string ay_ = @this?.Url;
+				FhirUri az_ = context.Operators.Convert<FhirUri>(ay_);
+				string ba_ = FHIRHelpers_4_3_000.ToString(az_);
+				bool? bb_ = context.Operators.Equal(ba_, "text");
 
 				return bb_;
 			};
-			var ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
+			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
 					: null), af_);
 			DataType ah_(Extension @this)
 			{
-				var bc_ = @this?.Value;
+				DataType bc_ = @this?.Value;
 
 				return bc_;
 			};
-			var ai_ = context.Operators.Select<Extension, DataType>(ag_, ah_);
-			var aj_ = context.Operators.SingletonFrom<DataType>(ai_);
-			var ak_ = context.Operators.Convert<string>(aj_);
-			var al_ = new Tuple_HPcCiDPXQfZTXIORThMLfTQDR
+			IEnumerable<DataType> ai_ = context.Operators.Select<Extension, DataType>(ag_, ah_);
+			DataType aj_ = context.Operators.SingletonFrom<DataType>(ai_);
+			string ak_ = context.Operators.Convert<string>(aj_);
+			Tuple_HPcCiDPXQfZTXIORThMLfTQDR al_ = new Tuple_HPcCiDPXQfZTXIORThMLfTQDR
 			{
 				codes = ae_,
 				display = ak_,
@@ -220,27 +231,29 @@ public class SupplementalDataElements_3_4_000
 
 			return al_;
 		};
-		var g_ = context.Operators.Select<Extension, Tuple_HPcCiDPXQfZTXIORThMLfTQDR>((IEnumerable<Extension>)e_, f_);
-		var h_ = context.Operators.SingletonFrom<Tuple_HPcCiDPXQfZTXIORThMLfTQDR>(g_);
+		IEnumerable<Tuple_HPcCiDPXQfZTXIORThMLfTQDR> g_ = context.Operators.Select<Extension, Tuple_HPcCiDPXQfZTXIORThMLfTQDR>((IEnumerable<Extension>)e_, f_);
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR h_ = context.Operators.SingletonFrom<Tuple_HPcCiDPXQfZTXIORThMLfTQDR>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = this.Payer_Type();
-		var b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, null);
+		CqlValueSet a_ = this.Payer_Type();
+		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, null);
 		Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ c_(Coverage Payer)
 		{
-			var e_ = Payer?.Type;
-			var f_ = FHIRHelpers_4_3_000.ToConcept(e_);
-			var g_ = Payer?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = new Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ
+			CodeableConcept e_ = Payer?.Type;
+			CqlConcept f_ = FHIRHelpers_4_3_000.ToConcept(e_);
+			Period g_ = Payer?.Period;
+			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+			Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ i_ = new Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ
 			{
 				code = f_,
 				period = h_,
@@ -248,29 +261,31 @@ public class SupplementalDataElements_3_4_000
 
 			return i_;
 		};
-		var d_ = context.Operators.Select<Coverage, Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ>(b_, c_);
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> d_ = context.Operators.Select<Coverage, Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
 		List<Extension> a_()
 		{
 			bool i_()
 			{
-				var j_ = this.Patient();
-				var k_ = j_ is DomainResource;
+				Patient j_ = this.Patient();
+				bool k_ = j_ is DomainResource;
 
 				return k_;
 			};
 			if (i_())
 			{
-				var l_ = this.Patient();
+				Patient l_ = this.Patient();
 
 				return (l_ as DomainResource).Extension;
 			}
@@ -281,16 +296,16 @@ public class SupplementalDataElements_3_4_000
 		};
 		bool? b_(Extension @this)
 		{
-			var m_ = @this?.Url;
-			var n_ = context.Operators.Convert<FhirUri>(m_);
-			var o_ = FHIRHelpers_4_3_000.ToString(n_);
-			var p_ = context.Operators.Equal(o_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race");
+			string m_ = @this?.Url;
+			FhirUri n_ = context.Operators.Convert<FhirUri>(m_);
+			string o_ = FHIRHelpers_4_3_000.ToString(n_);
+			bool? p_ = context.Operators.Equal(o_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race");
 
 			return p_;
 		};
-		var c_ = context.Operators.Where<Extension>((IEnumerable<Extension>)a_(), b_);
-		var d_ = context.Operators.SingletonFrom<Extension>(c_);
-		var e_ = new Extension[]
+		IEnumerable<Extension> c_ = context.Operators.Where<Extension>((IEnumerable<Extension>)a_(), b_);
+		Extension d_ = context.Operators.SingletonFrom<Extension>(c_);
+		Extension[] e_ = new Extension[]
 		{
 			d_,
 		};
@@ -298,81 +313,81 @@ public class SupplementalDataElements_3_4_000
 		{
 			bool? q_(Extension @this)
 			{
-				var ak_ = @this?.Url;
-				var al_ = context.Operators.Convert<FhirUri>(ak_);
-				var am_ = FHIRHelpers_4_3_000.ToString(al_);
-				var an_ = context.Operators.Equal(am_, "ombCategory");
+				string ak_ = @this?.Url;
+				FhirUri al_ = context.Operators.Convert<FhirUri>(ak_);
+				string am_ = FHIRHelpers_4_3_000.ToString(al_);
+				bool? an_ = context.Operators.Equal(am_, "ombCategory");
 
 				return an_;
 			};
-			var r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
+			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
 					: null), q_);
 			DataType s_(Extension @this)
 			{
-				var ao_ = @this?.Value;
+				DataType ao_ = @this?.Value;
 
 				return ao_;
 			};
-			var t_ = context.Operators.Select<Extension, DataType>(r_, s_);
+			IEnumerable<DataType> t_ = context.Operators.Select<Extension, DataType>(r_, s_);
 			CqlCode u_(DataType @this)
 			{
-				var ap_ = context.Operators.Convert<Coding>(@this);
-				var aq_ = FHIRHelpers_4_3_000.ToCode(ap_);
+				Coding ap_ = context.Operators.Convert<Coding>(@this);
+				CqlCode aq_ = FHIRHelpers_4_3_000.ToCode(ap_);
 
 				return aq_;
 			};
-			var v_ = context.Operators.Select<DataType, CqlCode>(t_, u_);
+			IEnumerable<CqlCode> v_ = context.Operators.Select<DataType, CqlCode>(t_, u_);
 			bool? w_(Extension @this)
 			{
-				var ar_ = @this?.Url;
-				var as_ = context.Operators.Convert<FhirUri>(ar_);
-				var at_ = FHIRHelpers_4_3_000.ToString(as_);
-				var au_ = context.Operators.Equal(at_, "detailed");
+				string ar_ = @this?.Url;
+				FhirUri as_ = context.Operators.Convert<FhirUri>(ar_);
+				string at_ = FHIRHelpers_4_3_000.ToString(as_);
+				bool? au_ = context.Operators.Equal(at_, "detailed");
 
 				return au_;
 			};
-			var x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
+			IEnumerable<Extension> x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
 					: null), w_);
 			DataType y_(Extension @this)
 			{
-				var av_ = @this?.Value;
+				DataType av_ = @this?.Value;
 
 				return av_;
 			};
-			var z_ = context.Operators.Select<Extension, DataType>(x_, y_);
+			IEnumerable<DataType> z_ = context.Operators.Select<Extension, DataType>(x_, y_);
 			CqlCode aa_(DataType @this)
 			{
-				var aw_ = context.Operators.Convert<Coding>(@this);
-				var ax_ = FHIRHelpers_4_3_000.ToCode(aw_);
+				Coding aw_ = context.Operators.Convert<Coding>(@this);
+				CqlCode ax_ = FHIRHelpers_4_3_000.ToCode(aw_);
 
 				return ax_;
 			};
-			var ab_ = context.Operators.Select<DataType, CqlCode>(z_, aa_);
-			var ac_ = context.Operators.Union<CqlCode>(v_, ab_);
+			IEnumerable<CqlCode> ab_ = context.Operators.Select<DataType, CqlCode>(z_, aa_);
+			IEnumerable<CqlCode> ac_ = context.Operators.Union<CqlCode>(v_, ab_);
 			bool? ad_(Extension @this)
 			{
-				var ay_ = @this?.Url;
-				var az_ = context.Operators.Convert<FhirUri>(ay_);
-				var ba_ = FHIRHelpers_4_3_000.ToString(az_);
-				var bb_ = context.Operators.Equal(ba_, "text");
+				string ay_ = @this?.Url;
+				FhirUri az_ = context.Operators.Convert<FhirUri>(ay_);
+				string ba_ = FHIRHelpers_4_3_000.ToString(az_);
+				bool? bb_ = context.Operators.Equal(ba_, "text");
 
 				return bb_;
 			};
-			var ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
+			IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
 					: null), ad_);
 			DataType af_(Extension @this)
 			{
-				var bc_ = @this?.Value;
+				DataType bc_ = @this?.Value;
 
 				return bc_;
 			};
-			var ag_ = context.Operators.Select<Extension, DataType>(ae_, af_);
-			var ah_ = context.Operators.SingletonFrom<DataType>(ag_);
-			var ai_ = context.Operators.Convert<string>(ah_);
-			var aj_ = new Tuple_HPcCiDPXQfZTXIORThMLfTQDR
+			IEnumerable<DataType> ag_ = context.Operators.Select<Extension, DataType>(ae_, af_);
+			DataType ah_ = context.Operators.SingletonFrom<DataType>(ag_);
+			string ai_ = context.Operators.Convert<string>(ah_);
+			Tuple_HPcCiDPXQfZTXIORThMLfTQDR aj_ = new Tuple_HPcCiDPXQfZTXIORThMLfTQDR
 			{
 				codes = ac_,
 				display = ai_,
@@ -380,37 +395,39 @@ public class SupplementalDataElements_3_4_000
 
 			return aj_;
 		};
-		var g_ = context.Operators.Select<Extension, Tuple_HPcCiDPXQfZTXIORThMLfTQDR>((IEnumerable<Extension>)e_, f_);
-		var h_ = context.Operators.SingletonFrom<Tuple_HPcCiDPXQfZTXIORThMLfTQDR>(g_);
+		IEnumerable<Tuple_HPcCiDPXQfZTXIORThMLfTQDR> g_ = context.Operators.Select<Extension, Tuple_HPcCiDPXQfZTXIORThMLfTQDR>((IEnumerable<Extension>)e_, f_);
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR h_ = context.Operators.SingletonFrom<Tuple_HPcCiDPXQfZTXIORThMLfTQDR>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
 		CqlCode a_()
 		{
 			bool b_()
 			{
-				var d_ = this.Patient();
-				var e_ = d_?.GenderElement;
-				var f_ = e_?.Value;
-				var g_ = context.Operators.Convert<string>(f_);
-				var h_ = context.Operators.Equal(g_, "male");
+				Patient d_ = this.Patient();
+				Code<AdministrativeGender> e_ = d_?.GenderElement;
+				AdministrativeGender? f_ = e_?.Value;
+				string g_ = context.Operators.Convert<string>(f_);
+				bool? h_ = context.Operators.Equal(g_, "male");
 
 				return (h_ ?? false);
 			};
 			bool c_()
 			{
-				var i_ = this.Patient();
-				var j_ = i_?.GenderElement;
-				var k_ = j_?.Value;
-				var l_ = context.Operators.Convert<string>(k_);
-				var m_ = context.Operators.Equal(l_, "female");
+				Patient i_ = this.Patient();
+				Code<AdministrativeGender> j_ = i_?.GenderElement;
+				AdministrativeGender? k_ = j_?.Value;
+				string l_ = context.Operators.Convert<string>(k_);
+				bool? m_ = context.Operators.Equal(l_, "female");
 
 				return (m_ ?? false);
 			};
@@ -431,6 +448,7 @@ public class SupplementalDataElements_3_4_000
 		return a_();
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
@@ -78,264 +78,297 @@ public class TJCOverall_8_11_000
 
     #endregion
 
+    /// <seealso cref="Comfort_Measures"/>
 	private CqlValueSet Comfort_Measures_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", null);
 
+    /// <seealso cref="Comfort_Measures_Value"/>
     [CqlDeclaration("Comfort Measures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45")]
 	public CqlValueSet Comfort_Measures() => 
 		__Comfort_Measures.Value;
 
+    /// <seealso cref="Discharge_To_Acute_Care_Facility"/>
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
 
+    /// <seealso cref="Discharge_To_Acute_Care_Facility_Value"/>
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
 	public CqlValueSet Discharge_To_Acute_Care_Facility() => 
 		__Discharge_To_Acute_Care_Facility.Value;
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
 	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
 	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
+    /// <seealso cref="Hemorrhagic_Stroke"/>
 	private CqlValueSet Hemorrhagic_Stroke_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", null);
 
+    /// <seealso cref="Hemorrhagic_Stroke_Value"/>
     [CqlDeclaration("Hemorrhagic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212")]
 	public CqlValueSet Hemorrhagic_Stroke() => 
 		__Hemorrhagic_Stroke.Value;
 
+    /// <seealso cref="Ischemic_Stroke"/>
 	private CqlValueSet Ischemic_Stroke_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", null);
 
+    /// <seealso cref="Ischemic_Stroke_Value"/>
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247")]
 	public CqlValueSet Ischemic_Stroke() => 
 		__Ischemic_Stroke.Value;
 
+    /// <seealso cref="Left_Against_Medical_Advice"/>
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
 
+    /// <seealso cref="Left_Against_Medical_Advice_Value"/>
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
 	public CqlValueSet Left_Against_Medical_Advice() => 
 		__Left_Against_Medical_Advice.Value;
 
+    /// <seealso cref="Nonelective_Inpatient_Encounter"/>
 	private CqlValueSet Nonelective_Inpatient_Encounter_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", null);
 
+    /// <seealso cref="Nonelective_Inpatient_Encounter_Value"/>
     [CqlDeclaration("Nonelective Inpatient Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424")]
 	public CqlValueSet Nonelective_Inpatient_Encounter() => 
 		__Nonelective_Inpatient_Encounter.Value;
 
+    /// <seealso cref="Patient_Expired"/>
 	private CqlValueSet Patient_Expired_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
 
+    /// <seealso cref="Patient_Expired_Value"/>
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
 	public CqlValueSet Patient_Expired() => 
 		__Patient_Expired.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.ResolveParameter("TJCOverall-8.11.000", "Measurement Period", null);
+		object a_ = context.ResolveParameter("TJCOverall-8.11.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Non_Elective_Inpatient_Encounter"/>
 	private IEnumerable<Encounter> Non_Elective_Inpatient_Encounter_Value()
 	{
-		var a_ = this.Nonelective_Inpatient_Encounter();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Nonelective_Inpatient_Encounter();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter NonElectiveEncounter)
 		{
-			var e_ = NonElectiveEncounter?.Period;
-			var f_ = FHIRHelpers_4_3_000.ToInterval(e_);
-			var g_ = context.Operators.End(f_);
-			var h_ = this.Measurement_Period();
-			var i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
+			Period e_ = NonElectiveEncounter?.Period;
+			CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+			CqlDateTime g_ = context.Operators.End(f_);
+			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
+			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
 
 			return i_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Non_Elective_Inpatient_Encounter_Value"/>
     [CqlDeclaration("Non Elective Inpatient Encounter")]
 	public IEnumerable<Encounter> Non_Elective_Inpatient_Encounter() => 
 		__Non_Elective_Inpatient_Encounter.Value;
 
+    /// <seealso cref="All_Stroke_Encounter"/>
 	private IEnumerable<Encounter> All_Stroke_Encounter_Value()
 	{
-		var a_ = this.Non_Elective_Inpatient_Encounter();
+		IEnumerable<Encounter> a_ = this.Non_Elective_Inpatient_Encounter();
 		bool? b_(Encounter NonElectiveEncounter)
 		{
-			var d_ = CQMCommon_2_0_000.principalDiagnosis(NonElectiveEncounter);
-			var e_ = d_?.Code;
-			var f_ = FHIRHelpers_4_3_000.ToConcept(e_);
-			var g_ = this.Hemorrhagic_Stroke();
-			var h_ = context.Operators.ConceptInValueSet(f_, g_);
-			var j_ = d_?.Code;
-			var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
-			var l_ = this.Ischemic_Stroke();
-			var m_ = context.Operators.ConceptInValueSet(k_, l_);
-			var n_ = context.Operators.Or(h_, m_);
+			Condition d_ = CQMCommon_2_0_000.principalDiagnosis(NonElectiveEncounter);
+			CodeableConcept e_ = d_?.Code;
+			CqlConcept f_ = FHIRHelpers_4_3_000.ToConcept(e_);
+			CqlValueSet g_ = this.Hemorrhagic_Stroke();
+			bool? h_ = context.Operators.ConceptInValueSet(f_, g_);
+			CodeableConcept j_ = d_?.Code;
+			CqlConcept k_ = FHIRHelpers_4_3_000.ToConcept(j_);
+			CqlValueSet l_ = this.Ischemic_Stroke();
+			bool? m_ = context.Operators.ConceptInValueSet(k_, l_);
+			bool? n_ = context.Operators.Or(h_, m_);
 
 			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="All_Stroke_Encounter_Value"/>
     [CqlDeclaration("All Stroke Encounter")]
 	public IEnumerable<Encounter> All_Stroke_Encounter() => 
 		__All_Stroke_Encounter.Value;
 
+    /// <seealso cref="Encounter_with_Principal_Diagnosis_and_Age"/>
 	private IEnumerable<Encounter> Encounter_with_Principal_Diagnosis_and_Age_Value()
 	{
-		var a_ = this.All_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = this.All_Stroke_Encounter();
 		bool? b_(Encounter AllStrokeEncounter)
 		{
-			var d_ = this.Patient();
-			var e_ = d_?.BirthDateElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.Convert<CqlDate>(f_);
-			var h_ = AllStrokeEncounter?.Period;
-			var i_ = FHIRHelpers_4_3_000.ToInterval(h_);
-			var j_ = context.Operators.Start(i_);
-			var k_ = context.Operators.DateFrom(j_);
-			var l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
-			var m_ = context.Operators.GreaterOrEqual(l_, 18);
+			Patient d_ = this.Patient();
+			Date e_ = d_?.BirthDateElement;
+			string f_ = e_?.Value;
+			CqlDate g_ = context.Operators.Convert<CqlDate>(f_);
+			Period h_ = AllStrokeEncounter?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
+			CqlDate k_ = context.Operators.DateFrom(j_);
+			int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
+			bool? m_ = context.Operators.GreaterOrEqual(l_, 18);
 
 			return m_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Principal_Diagnosis_and_Age_Value"/>
     [CqlDeclaration("Encounter with Principal Diagnosis and Age")]
 	public IEnumerable<Encounter> Encounter_with_Principal_Diagnosis_and_Age() => 
 		__Encounter_with_Principal_Diagnosis_and_Age.Value;
 
+    /// <seealso cref="Ischemic_Stroke_Encounter"/>
 	private IEnumerable<Encounter> Ischemic_Stroke_Encounter_Value()
 	{
-		var a_ = this.Encounter_with_Principal_Diagnosis_and_Age();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Principal_Diagnosis_and_Age();
 		bool? b_(Encounter EncounterWithAge)
 		{
-			var d_ = CQMCommon_2_0_000.principalDiagnosis(EncounterWithAge);
-			var e_ = d_?.Code;
-			var f_ = FHIRHelpers_4_3_000.ToConcept(e_);
-			var g_ = this.Ischemic_Stroke();
-			var h_ = context.Operators.ConceptInValueSet(f_, g_);
+			Condition d_ = CQMCommon_2_0_000.principalDiagnosis(EncounterWithAge);
+			CodeableConcept e_ = d_?.Code;
+			CqlConcept f_ = FHIRHelpers_4_3_000.ToConcept(e_);
+			CqlValueSet g_ = this.Ischemic_Stroke();
+			bool? h_ = context.Operators.ConceptInValueSet(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Ischemic_Stroke_Encounter_Value"/>
     [CqlDeclaration("Ischemic Stroke Encounter")]
 	public IEnumerable<Encounter> Ischemic_Stroke_Encounter() => 
 		__Ischemic_Stroke_Encounter.Value;
 
+    /// <seealso cref="Ischemic_Stroke_Encounters_with_Discharge_Disposition"/>
 	private IEnumerable<Encounter> Ischemic_Stroke_Encounters_with_Discharge_Disposition_Value()
 	{
-		var a_ = this.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = this.Ischemic_Stroke_Encounter();
 		bool? b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = IschemicStrokeEncounter?.Hospitalization;
-			var e_ = d_?.DischargeDisposition;
-			var f_ = FHIRHelpers_4_3_000.ToConcept(e_);
-			var g_ = this.Discharge_To_Acute_Care_Facility();
-			var h_ = context.Operators.ConceptInValueSet(f_, g_);
-			var j_ = d_?.DischargeDisposition;
-			var k_ = FHIRHelpers_4_3_000.ToConcept(j_);
-			var l_ = this.Left_Against_Medical_Advice();
-			var m_ = context.Operators.ConceptInValueSet(k_, l_);
-			var n_ = context.Operators.Or(h_, m_);
-			var p_ = d_?.DischargeDisposition;
-			var q_ = FHIRHelpers_4_3_000.ToConcept(p_);
-			var r_ = this.Patient_Expired();
-			var s_ = context.Operators.ConceptInValueSet(q_, r_);
-			var t_ = context.Operators.Or(n_, s_);
-			var v_ = d_?.DischargeDisposition;
-			var w_ = FHIRHelpers_4_3_000.ToConcept(v_);
-			var x_ = this.Discharged_to_Home_for_Hospice_Care();
-			var y_ = context.Operators.ConceptInValueSet(w_, x_);
-			var z_ = context.Operators.Or(t_, y_);
-			var ab_ = d_?.DischargeDisposition;
-			var ac_ = FHIRHelpers_4_3_000.ToConcept(ab_);
-			var ad_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care();
-			var ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
-			var af_ = context.Operators.Or(z_, ae_);
+			Encounter.HospitalizationComponent d_ = IschemicStrokeEncounter?.Hospitalization;
+			CodeableConcept e_ = d_?.DischargeDisposition;
+			CqlConcept f_ = FHIRHelpers_4_3_000.ToConcept(e_);
+			CqlValueSet g_ = this.Discharge_To_Acute_Care_Facility();
+			bool? h_ = context.Operators.ConceptInValueSet(f_, g_);
+			CodeableConcept j_ = d_?.DischargeDisposition;
+			CqlConcept k_ = FHIRHelpers_4_3_000.ToConcept(j_);
+			CqlValueSet l_ = this.Left_Against_Medical_Advice();
+			bool? m_ = context.Operators.ConceptInValueSet(k_, l_);
+			bool? n_ = context.Operators.Or(h_, m_);
+			CodeableConcept p_ = d_?.DischargeDisposition;
+			CqlConcept q_ = FHIRHelpers_4_3_000.ToConcept(p_);
+			CqlValueSet r_ = this.Patient_Expired();
+			bool? s_ = context.Operators.ConceptInValueSet(q_, r_);
+			bool? t_ = context.Operators.Or(n_, s_);
+			CodeableConcept v_ = d_?.DischargeDisposition;
+			CqlConcept w_ = FHIRHelpers_4_3_000.ToConcept(v_);
+			CqlValueSet x_ = this.Discharged_to_Home_for_Hospice_Care();
+			bool? y_ = context.Operators.ConceptInValueSet(w_, x_);
+			bool? z_ = context.Operators.Or(t_, y_);
+			CodeableConcept ab_ = d_?.DischargeDisposition;
+			CqlConcept ac_ = FHIRHelpers_4_3_000.ToConcept(ab_);
+			CqlValueSet ad_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care();
+			bool? ae_ = context.Operators.ConceptInValueSet(ac_, ad_);
+			bool? af_ = context.Operators.Or(z_, ae_);
 
 			return af_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Ischemic_Stroke_Encounters_with_Discharge_Disposition_Value"/>
     [CqlDeclaration("Ischemic Stroke Encounters with Discharge Disposition")]
 	public IEnumerable<Encounter> Ischemic_Stroke_Encounters_with_Discharge_Disposition() => 
 		__Ischemic_Stroke_Encounters_with_Discharge_Disposition.Value;
 
+    /// <seealso cref="Intervention_Comfort_Measures"/>
 	private IEnumerable<object> Intervention_Comfort_Measures_Value()
 	{
-		var a_ = this.Comfort_Measures();
-		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		CqlValueSet a_ = this.Comfort_Measures();
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
 		bool? c_(ServiceRequest SR)
 		{
-			var j_ = SR?.StatusElement;
-			var k_ = j_?.Value;
-			var l_ = context.Operators.Convert<Code<RequestStatus>>(k_);
-			var m_ = context.Operators.Convert<string>(l_);
-			var n_ = new string[]
+			Code<RequestStatus> j_ = SR?.StatusElement;
+			RequestStatus? k_ = j_?.Value;
+			Code<RequestStatus> l_ = context.Operators.Convert<Code<RequestStatus>>(k_);
+			string m_ = context.Operators.Convert<string>(l_);
+			string[] n_ = new string[]
 			{
 				"active",
 				"completed",
 				"on-hold",
 			};
-			var o_ = context.Operators.In<string>(m_, (n_ as IEnumerable<string>));
-			var p_ = SR?.IntentElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<RequestIntent>>(q_);
-			var s_ = context.Operators.Convert<string>(r_);
-			var t_ = new string[]
+			bool? o_ = context.Operators.In<string>(m_, (n_ as IEnumerable<string>));
+			Code<RequestIntent> p_ = SR?.IntentElement;
+			RequestIntent? q_ = p_?.Value;
+			Code<RequestIntent> r_ = context.Operators.Convert<Code<RequestIntent>>(q_);
+			string s_ = context.Operators.Convert<string>(r_);
+			string[] t_ = new string[]
 			{
 				"order",
 				"original-order",
@@ -343,108 +376,113 @@ public class TJCOverall_8_11_000
 				"filler-order",
 				"instance-order",
 			};
-			var u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
-			var v_ = context.Operators.And(o_, u_);
-			var w_ = SR?.DoNotPerformElement;
-			var x_ = w_?.Value;
-			var y_ = context.Operators.IsTrue(x_);
-			var z_ = context.Operators.Not(y_);
-			var aa_ = context.Operators.And(v_, z_);
+			bool? u_ = context.Operators.In<string>(s_, (t_ as IEnumerable<string>));
+			bool? v_ = context.Operators.And(o_, u_);
+			FhirBoolean w_ = SR?.DoNotPerformElement;
+			bool? x_ = w_?.Value;
+			bool? y_ = context.Operators.IsTrue(x_);
+			bool? z_ = context.Operators.Not(y_);
+			bool? aa_ = context.Operators.And(v_, z_);
 
 			return aa_;
 		};
-		var d_ = context.Operators.Where<ServiceRequest>(b_, c_);
-		var f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
+		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? g_(Procedure InterventionPerformed)
 		{
-			var ab_ = InterventionPerformed?.StatusElement;
-			var ac_ = ab_?.Value;
-			var ad_ = context.Operators.Convert<string>(ac_);
-			var ae_ = new string[]
+			Code<EventStatus> ab_ = InterventionPerformed?.StatusElement;
+			EventStatus? ac_ = ab_?.Value;
+			string ad_ = context.Operators.Convert<string>(ac_);
+			string[] ae_ = new string[]
 			{
 				"completed",
 				"in-progress",
 			};
-			var af_ = context.Operators.In<string>(ad_, (ae_ as IEnumerable<string>));
+			bool? af_ = context.Operators.In<string>(ad_, (ae_ as IEnumerable<string>));
 
 			return af_;
 		};
-		var h_ = context.Operators.Where<Procedure>(f_, g_);
-		var i_ = context.Operators.Union<object>((d_ as IEnumerable<object>), (h_ as IEnumerable<object>));
+		IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
+		IEnumerable<object> i_ = context.Operators.Union<object>((d_ as IEnumerable<object>), (h_ as IEnumerable<object>));
 
 		return i_;
 	}
 
+    /// <seealso cref="Intervention_Comfort_Measures_Value"/>
     [CqlDeclaration("Intervention Comfort Measures")]
 	public IEnumerable<object> Intervention_Comfort_Measures() => 
 		__Intervention_Comfort_Measures.Value;
 
+    /// <seealso cref="Comfort_Measures_during_Hospitalization"/>
 	private IEnumerable<Encounter> Comfort_Measures_during_Hospitalization_Value()
 	{
-		var a_ = this.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = this.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Intervention_Comfort_Measures();
+			IEnumerable<object> d_ = this.Intervention_Comfort_Measures();
 			bool? e_(object ComfortMeasure)
 			{
-				var i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = QICoreCommon_2_0_000.toInterval(j_);
-				var l_ = context.Operators.Start(k_);
-				var m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
-				var n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
-				var o_ = CQMCommon_2_0_000.hospitalizationWithObservation(IschemicStrokeEncounter);
-				var p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
+				object i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
+				CqlDateTime l_ = context.Operators.Start(k_);
+				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
+				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(IschemicStrokeEncounter);
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
 
 				return p_;
 			};
-			var f_ = context.Operators.Where<object>(d_, e_);
+			IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
 			Encounter g_(object ComfortMeasure) => 
 				IschemicStrokeEncounter;
-			var h_ = context.Operators.Select<object, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Comfort_Measures_during_Hospitalization_Value"/>
     [CqlDeclaration("Comfort Measures during Hospitalization")]
 	public IEnumerable<Encounter> Comfort_Measures_during_Hospitalization() => 
 		__Comfort_Measures_during_Hospitalization.Value;
 
+    /// <seealso cref="Encounter_with_Comfort_Measures_during_Hospitalization"/>
 	private IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization_Value()
 	{
-		var a_ = this.Ischemic_Stroke_Encounter();
+		IEnumerable<Encounter> a_ = this.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Intervention_Comfort_Measures();
+			IEnumerable<object> d_ = this.Intervention_Comfort_Measures();
 			bool? e_(object ComfortMeasure)
 			{
-				var i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = QICoreCommon_2_0_000.toInterval(j_);
-				var l_ = context.Operators.Start(k_);
-				var m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
-				var n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
-				var o_ = CQMCommon_2_0_000.hospitalizationWithObservation(IschemicStrokeEncounter);
-				var p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
+				object i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
+				CqlDateTime l_ = context.Operators.Start(k_);
+				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
+				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
+				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(IschemicStrokeEncounter);
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
 
 				return p_;
 			};
-			var f_ = context.Operators.Where<object>(d_, e_);
+			IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
 			Encounter g_(object ComfortMeasure) => 
 				IschemicStrokeEncounter;
-			var h_ = context.Operators.Select<object, Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Encounter_with_Comfort_Measures_during_Hospitalization_Value"/>
     [CqlDeclaration("Encounter with Comfort Measures during Hospitalization")]
 	public IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization() => 
 		__Encounter_with_Comfort_Measures_during_Hospitalization.Value;
@@ -452,10 +490,10 @@ public class TJCOverall_8_11_000
     [CqlDeclaration("CalendarDayOfOrDayAfter")]
 	public CqlInterval<CqlDate> CalendarDayOfOrDayAfter(CqlDateTime StartValue)
 	{
-		var a_ = context.Operators.DateFrom(StartValue);
-		var c_ = context.Operators.Quantity(1m, "day");
-		var d_ = context.Operators.Add(a_, c_);
-		var e_ = context.Operators.Interval(a_, d_, true, true);
+		CqlDate a_ = context.Operators.DateFrom(StartValue);
+		CqlQuantity c_ = context.Operators.Quantity(1m, "day");
+		CqlDate d_ = context.Operators.Add(a_, c_);
+		CqlInterval<CqlDate> e_ = context.Operators.Interval(a_, d_, true, true);
 
 		return e_;
 	}

--- a/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
@@ -120,83 +120,104 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
     #endregion
 
+    /// <seealso cref="Hospital_Services_for_urology_care"/>
 	private CqlValueSet Hospital_Services_for_urology_care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.64", null);
 
+    /// <seealso cref="Hospital_Services_for_urology_care_Value"/>
     [CqlDeclaration("Hospital Services for urology care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.64")]
 	public CqlValueSet Hospital_Services_for_urology_care() => 
 		__Hospital_Services_for_urology_care.Value;
 
+    /// <seealso cref="Morbid_Obesity"/>
 	private CqlValueSet Morbid_Obesity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.67", null);
 
+    /// <seealso cref="Morbid_Obesity_Value"/>
     [CqlDeclaration("Morbid Obesity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.67")]
 	public CqlValueSet Morbid_Obesity() => 
 		__Morbid_Obesity.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Urinary_retention"/>
 	private CqlValueSet Urinary_retention_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.52", null);
 
+    /// <seealso cref="Urinary_retention_Value"/>
     [CqlDeclaration("Urinary retention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.52")]
 	public CqlValueSet Urinary_retention() => 
 		__Urinary_retention.Value;
 
+    /// <seealso cref="American_Urological_Association_Symptom_Index__AUASI_"/>
 	private CqlCode American_Urological_Association_Symptom_Index__AUASI__Value() => 
 		new CqlCode("80883-2", "http://loinc.org", null, null);
 
+    /// <seealso cref="American_Urological_Association_Symptom_Index__AUASI__Value"/>
     [CqlDeclaration("American Urological Association Symptom Index [AUASI]")]
 	public CqlCode American_Urological_Association_Symptom_Index__AUASI_() => 
 		__American_Urological_Association_Symptom_Index__AUASI_.Value;
 
+    /// <seealso cref="Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms"/>
 	private CqlCode Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms_Value() => 
 		new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
 
+    /// <seealso cref="Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms_Value"/>
     [CqlDeclaration("Benign prostatic hyperplasia with lower urinary tract symptoms")]
 	public CqlCode Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms() => 
 		__Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms.Value;
 
+    /// <seealso cref="If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_"/>
 	private CqlCode If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS__Value() => 
 		new CqlCode("81090-3", "http://loinc.org", null, null);
 
+    /// <seealso cref="If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS__Value"/>
     [CqlDeclaration("If you were to spend the rest of your life with your urinary condition just the way it is now, how would you feel about that [IPSS]")]
 	public CqlCode If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_() => 
 		__If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_.Value;
 
+    /// <seealso cref="International_Prostate_Symptom_Score__IPSS_"/>
 	private CqlCode International_Prostate_Symptom_Score__IPSS__Value() => 
 		new CqlCode("80976-4", "http://loinc.org", null, null);
 
+    /// <seealso cref="International_Prostate_Symptom_Score__IPSS__Value"/>
     [CqlDeclaration("International Prostate Symptom Score [IPSS]")]
 	public CqlCode International_Prostate_Symptom_Score__IPSS_() => 
 		__International_Prostate_Symptom_Score__IPSS_.Value;
 
+    /// <seealso cref="survey"/>
 	private CqlCode survey_Value() => 
 		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="survey_Value"/>
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
+    /// <seealso cref="@virtual"/>
 	private CqlCode @virtual_Value() => 
 		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
 
+    /// <seealso cref="@virtual_Value"/>
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("80883-2", "http://loinc.org", null, null),
 			new CqlCode("81090-3", "http://loinc.org", null, null),
@@ -206,13 +227,15 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="ICD10CM"/>
 	private CqlCode[] ICD10CM_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
 		};
@@ -220,13 +243,15 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		return a_;
 	}
 
+    /// <seealso cref="ICD10CM_Value"/>
     [CqlDeclaration("ICD10CM")]
 	public CqlCode[] ICD10CM() => 
 		__ICD10CM.Value;
 
+    /// <seealso cref="ObservationCategoryCodes"/>
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
 		};
@@ -234,13 +259,15 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		return a_;
 	}
 
+    /// <seealso cref="ObservationCategoryCodes_Value"/>
     [CqlDeclaration("ObservationCategoryCodes")]
 	public CqlCode[] ObservationCategoryCodes() => 
 		__ObservationCategoryCodes.Value;
 
+    /// <seealso cref="ActCode"/>
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 		};
@@ -248,79 +275,90 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		return a_;
 	}
 
+    /// <seealso cref="ActCode_Value"/>
     [CqlDeclaration("ActCode")]
 	public CqlCode[] ActCode() => 
 		__ActCode.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Patient_is_Male"/>
 	private bool? Patient_is_Male_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<string>(a_?.GenderElement?.Value);
-		var c_ = context.Operators.Equal(b_, "male");
-
-		return c_;
-	}
-
-    [CqlDeclaration("Patient is Male")]
-	public bool? Patient_is_Male() => 
-		__Patient_is_Male.Value;
-
-	private bool? Has_Qualifying_Encounter_Value()
-	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		bool? c_(Encounter ValidEncounter)
-		{
-			var f_ = this.Measurement_Period();
-			var g_ = ValidEncounter?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
-			var j_ = ValidEncounter?.Class;
-			var k_ = FHIRHelpers_4_3_000.ToCode(j_);
-			var l_ = this.@virtual();
-			var m_ = context.Operators.Equivalent(k_, l_);
-			var n_ = context.Operators.Not(m_);
-			var o_ = context.Operators.And(i_, n_);
-			var p_ = ValidEncounter?.StatusElement;
-			var q_ = p_?.Value;
-			var r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
-			var s_ = context.Operators.Equal(r_, "finished");
-			var t_ = context.Operators.And(o_, s_);
-
-			return t_;
-		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
-		var e_ = context.Operators.Exists<Encounter>(d_);
+		Patient a_ = this.Patient();
+		Code<AdministrativeGender> b_ = a_?.GenderElement;
+		AdministrativeGender? c_ = b_?.Value;
+		string d_ = context.Operators.Convert<string>(c_);
+		bool? e_ = context.Operators.Equal(d_, "male");
 
 		return e_;
 	}
 
+    /// <seealso cref="Patient_is_Male_Value"/>
+    [CqlDeclaration("Patient is Male")]
+	public bool? Patient_is_Male() => 
+		__Patient_is_Male.Value;
+
+    /// <seealso cref="Has_Qualifying_Encounter"/>
+	private bool? Has_Qualifying_Encounter_Value()
+	{
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		bool? c_(Encounter ValidEncounter)
+		{
+			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
+			Period g_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
+			Coding j_ = ValidEncounter?.Class;
+			CqlCode k_ = FHIRHelpers_4_3_000.ToCode(j_);
+			CqlCode l_ = this.@virtual();
+			bool? m_ = context.Operators.Equivalent(k_, l_);
+			bool? n_ = context.Operators.Not(m_);
+			bool? o_ = context.Operators.And(i_, n_);
+			Code<Encounter.EncounterStatus> p_ = ValidEncounter?.StatusElement;
+			Encounter.EncounterStatus? q_ = p_?.Value;
+			Code<Encounter.EncounterStatus> r_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(q_);
+			bool? s_ = context.Operators.Equal(r_, "finished");
+			bool? t_ = context.Operators.And(o_, s_);
+
+			return t_;
+		};
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
+		bool? e_ = context.Operators.Exists<Encounter>(d_);
+
+		return e_;
+	}
+
+    /// <seealso cref="Has_Qualifying_Encounter_Value"/>
     [CqlDeclaration("Has Qualifying Encounter")]
 	public bool? Has_Qualifying_Encounter() => 
 		__Has_Qualifying_Encounter.Value;
@@ -328,169 +366,174 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
     [CqlDeclaration("isConfirmedActiveDiagnosis")]
 	public bool? isConfirmedActiveDiagnosis(Condition Condition)
 	{
-		var a_ = new Condition[]
+		Condition[] a_ = new Condition[]
 		{
 			Condition,
 		};
 		bool? b_(Condition Diagnosis)
 		{
-			var f_ = Diagnosis?.ClinicalStatus;
-			var g_ = FHIRHelpers_4_3_000.ToConcept(f_);
-			var h_ = QICoreCommon_2_0_000.active();
-			var i_ = context.Operators.ConvertCodeToConcept(h_);
-			var j_ = context.Operators.Equivalent(g_, i_);
-			var k_ = Diagnosis?.VerificationStatus;
-			var l_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var m_ = QICoreCommon_2_0_000.unconfirmed();
-			var n_ = context.Operators.ConvertCodeToConcept(m_);
-			var o_ = context.Operators.Equivalent(l_, n_);
-			var q_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var r_ = QICoreCommon_2_0_000.refuted();
-			var s_ = context.Operators.ConvertCodeToConcept(r_);
-			var t_ = context.Operators.Equivalent(q_, s_);
-			var u_ = context.Operators.Or(o_, t_);
-			var w_ = FHIRHelpers_4_3_000.ToConcept(k_);
-			var x_ = QICoreCommon_2_0_000.entered_in_error();
-			var y_ = context.Operators.ConvertCodeToConcept(x_);
-			var z_ = context.Operators.Equivalent(w_, y_);
-			var aa_ = context.Operators.Or(u_, z_);
-			var ab_ = context.Operators.Not(aa_);
-			var ac_ = context.Operators.And(j_, ab_);
+			CodeableConcept f_ = Diagnosis?.ClinicalStatus;
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(f_);
+			CqlCode h_ = QICoreCommon_2_0_000.active();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(g_, i_);
+			CodeableConcept k_ = Diagnosis?.VerificationStatus;
+			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode m_ = QICoreCommon_2_0_000.unconfirmed();
+			CqlConcept n_ = context.Operators.ConvertCodeToConcept(m_);
+			bool? o_ = context.Operators.Equivalent(l_, n_);
+			CqlConcept q_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode r_ = QICoreCommon_2_0_000.refuted();
+			CqlConcept s_ = context.Operators.ConvertCodeToConcept(r_);
+			bool? t_ = context.Operators.Equivalent(q_, s_);
+			bool? u_ = context.Operators.Or(o_, t_);
+			CqlConcept w_ = FHIRHelpers_4_3_000.ToConcept(k_);
+			CqlCode x_ = QICoreCommon_2_0_000.entered_in_error();
+			CqlConcept y_ = context.Operators.ConvertCodeToConcept(x_);
+			bool? z_ = context.Operators.Equivalent(w_, y_);
+			bool? aa_ = context.Operators.Or(u_, z_);
+			bool? ab_ = context.Operators.Not(aa_);
+			bool? ac_ = context.Operators.And(j_, ab_);
 
 			return ac_;
 		};
-		var c_ = context.Operators.Where<Condition>((IEnumerable<Condition>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<Condition>(c_);
-		var e_ = context.Operators.Not((bool?)(d_ is null));
+		IEnumerable<Condition> c_ = context.Operators.Where<Condition>((IEnumerable<Condition>)a_, b_);
+		Condition d_ = context.Operators.SingletonFrom<Condition>(c_);
+		bool? e_ = context.Operators.Not((bool?)(d_ is null));
 
 		return e_;
 	}
 
+    /// <seealso cref="Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period"/>
 	private Condition Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period_Value()
 	{
-		var a_ = this.Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		CqlCode a_ = this.Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
 		bool? d_(Condition NewBPHDiagnosis)
 		{
-			var i_ = QICoreCommon_2_0_000.prevalenceInterval(NewBPHDiagnosis);
-			var j_ = context.Operators.Start(i_);
-			var k_ = this.Measurement_Period();
-			var l_ = context.Operators.Start(k_);
-			var m_ = context.Operators.Quantity(6m, "months");
-			var n_ = context.Operators.Subtract(l_, m_);
-			var p_ = context.Operators.End(k_);
-			var q_ = context.Operators.Interval(n_, p_, true, true);
-			var r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
-			var s_ = this.isConfirmedActiveDiagnosis(NewBPHDiagnosis);
-			var t_ = context.Operators.And(r_, s_);
+			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.prevalenceInterval(NewBPHDiagnosis);
+			CqlDateTime j_ = context.Operators.Start(i_);
+			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
+			CqlDateTime l_ = context.Operators.Start(k_);
+			CqlQuantity m_ = context.Operators.Quantity(6m, "months");
+			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
+			CqlDateTime p_ = context.Operators.End(k_);
+			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
+			bool? s_ = this.isConfirmedActiveDiagnosis(NewBPHDiagnosis);
+			bool? t_ = context.Operators.And(r_, s_);
 
 			return t_;
 		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
 		object f_(Condition @this)
 		{
-			var u_ = @this?.Onset;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = QICoreCommon_2_0_000.toInterval(v_);
-			var x_ = context.Operators.Start(w_);
+			DataType u_ = @this?.Onset;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			CqlInterval<CqlDateTime> w_ = QICoreCommon_2_0_000.toInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
 
 			return x_;
 		};
-		var g_ = context.Operators.SortBy<Condition>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
-		var h_ = context.Operators.First<Condition>(g_);
+		IEnumerable<Condition> g_ = context.Operators.SortBy<Condition>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+		Condition h_ = context.Operators.First<Condition>(g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period_Value"/>
     [CqlDeclaration("Initial BPH Diagnosis Starts Within 6 Months Before or After Start of Measurement Period")]
 	public Condition Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period() => 
 		__Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period.Value;
 
+    /// <seealso cref="Has_Qualifying_BPH_Diagnosis"/>
 	private bool? Has_Qualifying_BPH_Diagnosis_Value()
 	{
-		var a_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
-		var b_ = context.Operators.Not((bool?)(a_ is null));
+		Condition a_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
+		bool? b_ = context.Operators.Not((bool?)(a_ is null));
 
 		return b_;
 	}
 
+    /// <seealso cref="Has_Qualifying_BPH_Diagnosis_Value"/>
     [CqlDeclaration("Has Qualifying BPH Diagnosis")]
 	public bool? Has_Qualifying_BPH_Diagnosis() => 
 		__Has_Qualifying_BPH_Diagnosis.Value;
 
+    /// <seealso cref="Documented_IPSS_Assessment_Result"/>
 	private IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> Documented_IPSS_Assessment_Result_Value()
 	{
-		var a_ = this.International_Prostate_Symptom_Score__IPSS_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.International_Prostate_Symptom_Score__IPSS_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation IPSSAssessment)
 		{
-			var h_ = IPSSAssessment?.StatusElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<Code<ObservationStatus>>(i_);
-			var k_ = context.Operators.Convert<string>(j_);
-			var l_ = new string[]
+			Code<ObservationStatus> h_ = IPSSAssessment?.StatusElement;
+			ObservationStatus? i_ = h_?.Value;
+			Code<ObservationStatus> j_ = context.Operators.Convert<Code<ObservationStatus>>(i_);
+			string k_ = context.Operators.Convert<string>(j_);
+			string[] l_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var m_ = context.Operators.In<string>(k_, (l_ as IEnumerable<string>));
-			var n_ = IPSSAssessment?.Value;
-			var o_ = FHIRHelpers_4_3_000.ToValue(n_);
-			var p_ = context.Operators.Not((bool?)(o_ is null));
-			var q_ = context.Operators.And(m_, p_);
+			bool? m_ = context.Operators.In<string>(k_, (l_ as IEnumerable<string>));
+			DataType n_ = IPSSAssessment?.Value;
+			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
+			bool? p_ = context.Operators.Not((bool?)(o_ is null));
+			bool? q_ = context.Operators.And(m_, p_);
 
 			return q_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		Tuple_GNNDVIQPcTANSdLebhBKYIdga f_(Observation IPSSAssessment)
 		{
 			object r_()
 			{
 				bool w_()
 				{
-					var z_ = IPSSAssessment?.Effective;
-					var aa_ = FHIRHelpers_4_3_000.ToValue(z_);
-					var ab_ = aa_ is CqlDateTime;
+					DataType z_ = IPSSAssessment?.Effective;
+					object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
+					bool ab_ = aa_ is CqlDateTime;
 
 					return ab_;
 				};
 				bool x_()
 				{
-					var ac_ = IPSSAssessment?.Effective;
-					var ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
-					var ae_ = ad_ is CqlInterval<CqlDateTime>;
+					DataType ac_ = IPSSAssessment?.Effective;
+					object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
+					bool ae_ = ad_ is CqlInterval<CqlDateTime>;
 
 					return ae_;
 				};
 				bool y_()
 				{
-					var af_ = IPSSAssessment?.Effective;
-					var ag_ = FHIRHelpers_4_3_000.ToValue(af_);
-					var ah_ = ag_ is CqlDateTime;
+					DataType af_ = IPSSAssessment?.Effective;
+					object ag_ = FHIRHelpers_4_3_000.ToValue(af_);
+					bool ah_ = ag_ is CqlDateTime;
 
 					return ah_;
 				};
 				if (w_())
 				{
-					var ai_ = IPSSAssessment?.Effective;
-					var aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
+					DataType ai_ = IPSSAssessment?.Effective;
+					object aj_ = FHIRHelpers_4_3_000.ToValue(ai_);
 
 					return ((aj_ as CqlDateTime) as object);
 				}
 				else if (x_())
 				{
-					var ak_ = IPSSAssessment?.Effective;
-					var al_ = FHIRHelpers_4_3_000.ToValue(ak_);
+					DataType ak_ = IPSSAssessment?.Effective;
+					object al_ = FHIRHelpers_4_3_000.ToValue(ak_);
 
 					return ((al_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (y_())
 				{
-					var am_ = IPSSAssessment?.Effective;
-					var an_ = FHIRHelpers_4_3_000.ToValue(am_);
+					DataType am_ = IPSSAssessment?.Effective;
+					object an_ = FHIRHelpers_4_3_000.ToValue(am_);
 
 					return ((an_ as CqlDateTime) as object);
 				}
@@ -499,10 +542,10 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 					return null;
 				}
 			};
-			var s_ = QICoreCommon_2_0_000.earliest(r_());
-			var t_ = IPSSAssessment?.Value;
-			var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-			var v_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga
+			CqlDateTime s_ = QICoreCommon_2_0_000.earliest(r_());
+			DataType t_ = IPSSAssessment?.Value;
+			object u_ = FHIRHelpers_4_3_000.ToValue(t_);
+			Tuple_GNNDVIQPcTANSdLebhBKYIdga v_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga
 			{
 				effectiveDatetime = s_,
 				valueInteger = (int?)u_,
@@ -510,106 +553,108 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
 			return v_;
 		};
-		var g_ = context.Operators.Select<Observation, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(e_, f_);
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> g_ = context.Operators.Select<Observation, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Documented_IPSS_Assessment_Result_Value"/>
     [CqlDeclaration("Documented IPSS Assessment Result")]
 	public IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> Documented_IPSS_Assessment_Result() => 
 		__Documented_IPSS_Assessment_Result.Value;
 
+    /// <seealso cref="AUA_Symptom_Index_and_Quality_of_Life_Assessment_Result"/>
 	private IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> AUA_Symptom_Index_and_Quality_of_Life_Assessment_Result_Value()
 	{
-		var a_ = this.American_Urological_Association_Symptom_Index__AUASI_();
-		var b_ = context.Operators.ToList<CqlCode>(a_);
-		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		CqlCode a_ = this.American_Urological_Association_Symptom_Index__AUASI_();
+		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation AUASIAssessment)
 		{
-			var h_ = AUASIAssessment?.Category;
+			List<CodeableConcept> h_ = AUASIAssessment?.Category;
 			CqlConcept i_(CodeableConcept @this)
 			{
-				var y_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept y_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return y_;
 			};
-			var j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
+			IEnumerable<CqlConcept> j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
 			bool? k_(CqlConcept AUASIAssessmentCategory)
 			{
-				var z_ = this.survey();
-				var aa_ = context.Operators.ConvertCodeToConcept(z_);
-				var ab_ = context.Operators.Equivalent(AUASIAssessmentCategory, aa_);
+				CqlCode z_ = this.survey();
+				CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
+				bool? ab_ = context.Operators.Equivalent(AUASIAssessmentCategory, aa_);
 
 				return ab_;
 			};
-			var l_ = context.Operators.Where<CqlConcept>(j_, k_);
-			var m_ = context.Operators.Exists<CqlConcept>(l_);
-			var n_ = AUASIAssessment?.StatusElement;
-			var o_ = n_?.Value;
-			var p_ = context.Operators.Convert<Code<ObservationStatus>>(o_);
-			var q_ = context.Operators.Convert<string>(p_);
-			var r_ = new string[]
+			IEnumerable<CqlConcept> l_ = context.Operators.Where<CqlConcept>(j_, k_);
+			bool? m_ = context.Operators.Exists<CqlConcept>(l_);
+			Code<ObservationStatus> n_ = AUASIAssessment?.StatusElement;
+			ObservationStatus? o_ = n_?.Value;
+			Code<ObservationStatus> p_ = context.Operators.Convert<Code<ObservationStatus>>(o_);
+			string q_ = context.Operators.Convert<string>(p_);
+			string[] r_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var s_ = context.Operators.In<string>(q_, (r_ as IEnumerable<string>));
-			var t_ = context.Operators.And(m_, s_);
-			var u_ = AUASIAssessment?.Value;
-			var v_ = FHIRHelpers_4_3_000.ToValue(u_);
-			var w_ = context.Operators.Not((bool?)(v_ is null));
-			var x_ = context.Operators.And(t_, w_);
+			bool? s_ = context.Operators.In<string>(q_, (r_ as IEnumerable<string>));
+			bool? t_ = context.Operators.And(m_, s_);
+			DataType u_ = AUASIAssessment?.Value;
+			object v_ = FHIRHelpers_4_3_000.ToValue(u_);
+			bool? w_ = context.Operators.Not((bool?)(v_ is null));
+			bool? x_ = context.Operators.And(t_, w_);
 
 			return x_;
 		};
-		var e_ = context.Operators.Where<Observation>(c_, d_);
+		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		Tuple_GNNDVIQPcTANSdLebhBKYIdga f_(Observation AUASIAssessment)
 		{
 			object ac_()
 			{
 				bool as_()
 				{
-					var av_ = AUASIAssessment?.Effective;
-					var aw_ = FHIRHelpers_4_3_000.ToValue(av_);
-					var ax_ = aw_ is CqlDateTime;
+					DataType av_ = AUASIAssessment?.Effective;
+					object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
+					bool ax_ = aw_ is CqlDateTime;
 
 					return ax_;
 				};
 				bool at_()
 				{
-					var ay_ = AUASIAssessment?.Effective;
-					var az_ = FHIRHelpers_4_3_000.ToValue(ay_);
-					var ba_ = az_ is CqlInterval<CqlDateTime>;
+					DataType ay_ = AUASIAssessment?.Effective;
+					object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
+					bool ba_ = az_ is CqlInterval<CqlDateTime>;
 
 					return ba_;
 				};
 				bool au_()
 				{
-					var bb_ = AUASIAssessment?.Effective;
-					var bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
-					var bd_ = bc_ is CqlDateTime;
+					DataType bb_ = AUASIAssessment?.Effective;
+					object bc_ = FHIRHelpers_4_3_000.ToValue(bb_);
+					bool bd_ = bc_ is CqlDateTime;
 
 					return bd_;
 				};
 				if (as_())
 				{
-					var be_ = AUASIAssessment?.Effective;
-					var bf_ = FHIRHelpers_4_3_000.ToValue(be_);
+					DataType be_ = AUASIAssessment?.Effective;
+					object bf_ = FHIRHelpers_4_3_000.ToValue(be_);
 
 					return ((bf_ as CqlDateTime) as object);
 				}
 				else if (at_())
 				{
-					var bg_ = AUASIAssessment?.Effective;
-					var bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
+					DataType bg_ = AUASIAssessment?.Effective;
+					object bh_ = FHIRHelpers_4_3_000.ToValue(bg_);
 
 					return ((bh_ as CqlInterval<CqlDateTime>) as object);
 				}
 				else if (au_())
 				{
-					var bi_ = AUASIAssessment?.Effective;
-					var bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
+					DataType bi_ = AUASIAssessment?.Effective;
+					object bj_ = FHIRHelpers_4_3_000.ToValue(bi_);
 
 					return ((bj_ as CqlDateTime) as object);
 				}
@@ -618,58 +663,58 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 					return null;
 				}
 			};
-			var ad_ = QICoreCommon_2_0_000.earliest(ac_());
-			var ae_ = AUASIAssessment?.Value;
-			var af_ = FHIRHelpers_4_3_000.ToValue(ae_);
-			var ag_ = this.If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_();
-			var ah_ = context.Operators.ToList<CqlCode>(ag_);
-			var ai_ = context.Operators.RetrieveByCodes<Observation>(ah_, null);
+			CqlDateTime ad_ = QICoreCommon_2_0_000.earliest(ac_());
+			DataType ae_ = AUASIAssessment?.Value;
+			object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
+			CqlCode ag_ = this.If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_();
+			IEnumerable<CqlCode> ah_ = context.Operators.ToList<CqlCode>(ag_);
+			IEnumerable<Observation> ai_ = context.Operators.RetrieveByCodes<Observation>(ah_, null);
 			bool? aj_(Observation QOLAssessment)
 			{
 				object bk_()
 				{
 					bool ch_()
 					{
-						var ck_ = QOLAssessment?.Effective;
-						var cl_ = FHIRHelpers_4_3_000.ToValue(ck_);
-						var cm_ = cl_ is CqlDateTime;
+						DataType ck_ = QOLAssessment?.Effective;
+						object cl_ = FHIRHelpers_4_3_000.ToValue(ck_);
+						bool cm_ = cl_ is CqlDateTime;
 
 						return cm_;
 					};
 					bool ci_()
 					{
-						var cn_ = QOLAssessment?.Effective;
-						var co_ = FHIRHelpers_4_3_000.ToValue(cn_);
-						var cp_ = co_ is CqlInterval<CqlDateTime>;
+						DataType cn_ = QOLAssessment?.Effective;
+						object co_ = FHIRHelpers_4_3_000.ToValue(cn_);
+						bool cp_ = co_ is CqlInterval<CqlDateTime>;
 
 						return cp_;
 					};
 					bool cj_()
 					{
-						var cq_ = QOLAssessment?.Effective;
-						var cr_ = FHIRHelpers_4_3_000.ToValue(cq_);
-						var cs_ = cr_ is CqlDateTime;
+						DataType cq_ = QOLAssessment?.Effective;
+						object cr_ = FHIRHelpers_4_3_000.ToValue(cq_);
+						bool cs_ = cr_ is CqlDateTime;
 
 						return cs_;
 					};
 					if (ch_())
 					{
-						var ct_ = QOLAssessment?.Effective;
-						var cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
+						DataType ct_ = QOLAssessment?.Effective;
+						object cu_ = FHIRHelpers_4_3_000.ToValue(ct_);
 
 						return ((cu_ as CqlDateTime) as object);
 					}
 					else if (ci_())
 					{
-						var cv_ = QOLAssessment?.Effective;
-						var cw_ = FHIRHelpers_4_3_000.ToValue(cv_);
+						DataType cv_ = QOLAssessment?.Effective;
+						object cw_ = FHIRHelpers_4_3_000.ToValue(cv_);
 
 						return ((cw_ as CqlInterval<CqlDateTime>) as object);
 					}
 					else if (cj_())
 					{
-						var cx_ = QOLAssessment?.Effective;
-						var cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
+						DataType cx_ = QOLAssessment?.Effective;
+						object cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
 
 						return ((cy_ as CqlDateTime) as object);
 					}
@@ -678,51 +723,51 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 						return null;
 					}
 				};
-				var bl_ = QICoreCommon_2_0_000.earliest(bk_());
+				CqlDateTime bl_ = QICoreCommon_2_0_000.earliest(bk_());
 				object bm_()
 				{
 					bool cz_()
 					{
-						var dc_ = QOLAssessment?.Effective;
-						var dd_ = FHIRHelpers_4_3_000.ToValue(dc_);
-						var de_ = dd_ is CqlDateTime;
+						DataType dc_ = QOLAssessment?.Effective;
+						object dd_ = FHIRHelpers_4_3_000.ToValue(dc_);
+						bool de_ = dd_ is CqlDateTime;
 
 						return de_;
 					};
 					bool da_()
 					{
-						var df_ = QOLAssessment?.Effective;
-						var dg_ = FHIRHelpers_4_3_000.ToValue(df_);
-						var dh_ = dg_ is CqlInterval<CqlDateTime>;
+						DataType df_ = QOLAssessment?.Effective;
+						object dg_ = FHIRHelpers_4_3_000.ToValue(df_);
+						bool dh_ = dg_ is CqlInterval<CqlDateTime>;
 
 						return dh_;
 					};
 					bool db_()
 					{
-						var di_ = QOLAssessment?.Effective;
-						var dj_ = FHIRHelpers_4_3_000.ToValue(di_);
-						var dk_ = dj_ is CqlDateTime;
+						DataType di_ = QOLAssessment?.Effective;
+						object dj_ = FHIRHelpers_4_3_000.ToValue(di_);
+						bool dk_ = dj_ is CqlDateTime;
 
 						return dk_;
 					};
 					if (cz_())
 					{
-						var dl_ = QOLAssessment?.Effective;
-						var dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
+						DataType dl_ = QOLAssessment?.Effective;
+						object dm_ = FHIRHelpers_4_3_000.ToValue(dl_);
 
 						return ((dm_ as CqlDateTime) as object);
 					}
 					else if (da_())
 					{
-						var dn_ = QOLAssessment?.Effective;
-						var do_ = FHIRHelpers_4_3_000.ToValue(dn_);
+						DataType dn_ = QOLAssessment?.Effective;
+						object do_ = FHIRHelpers_4_3_000.ToValue(dn_);
 
 						return ((do_ as CqlInterval<CqlDateTime>) as object);
 					}
 					else if (db_())
 					{
-						var dp_ = QOLAssessment?.Effective;
-						var dq_ = FHIRHelpers_4_3_000.ToValue(dp_);
+						DataType dp_ = QOLAssessment?.Effective;
+						object dq_ = FHIRHelpers_4_3_000.ToValue(dp_);
 
 						return ((dq_ as CqlDateTime) as object);
 					}
@@ -731,93 +776,93 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 						return null;
 					}
 				};
-				var bn_ = QICoreCommon_2_0_000.earliest(bm_());
-				var bo_ = context.Operators.SameAs(bl_, bn_, "day");
-				var bp_ = QOLAssessment?.Category;
+				CqlDateTime bn_ = QICoreCommon_2_0_000.earliest(bm_());
+				bool? bo_ = context.Operators.SameAs(bl_, bn_, "day");
+				List<CodeableConcept> bp_ = QOLAssessment?.Category;
 				CqlConcept bq_(CodeableConcept @this)
 				{
-					var dr_ = FHIRHelpers_4_3_000.ToConcept(@this);
+					CqlConcept dr_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 					return dr_;
 				};
-				var br_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bp_, bq_);
+				IEnumerable<CqlConcept> br_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)bp_, bq_);
 				bool? bs_(CqlConcept QOLAssessmentCategory)
 				{
-					var ds_ = this.survey();
-					var dt_ = context.Operators.ConvertCodeToConcept(ds_);
-					var du_ = context.Operators.Equivalent(QOLAssessmentCategory, dt_);
+					CqlCode ds_ = this.survey();
+					CqlConcept dt_ = context.Operators.ConvertCodeToConcept(ds_);
+					bool? du_ = context.Operators.Equivalent(QOLAssessmentCategory, dt_);
 
 					return du_;
 				};
-				var bt_ = context.Operators.Where<CqlConcept>(br_, bs_);
-				var bu_ = context.Operators.Exists<CqlConcept>(bt_);
-				var bv_ = context.Operators.And(bo_, bu_);
-				var bw_ = QOLAssessment?.StatusElement;
-				var bx_ = bw_?.Value;
-				var by_ = context.Operators.Convert<Code<ObservationStatus>>(bx_);
-				var bz_ = context.Operators.Convert<string>(by_);
-				var ca_ = new string[]
+				IEnumerable<CqlConcept> bt_ = context.Operators.Where<CqlConcept>(br_, bs_);
+				bool? bu_ = context.Operators.Exists<CqlConcept>(bt_);
+				bool? bv_ = context.Operators.And(bo_, bu_);
+				Code<ObservationStatus> bw_ = QOLAssessment?.StatusElement;
+				ObservationStatus? bx_ = bw_?.Value;
+				Code<ObservationStatus> by_ = context.Operators.Convert<Code<ObservationStatus>>(bx_);
+				string bz_ = context.Operators.Convert<string>(by_);
+				string[] ca_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var cb_ = context.Operators.In<string>(bz_, (ca_ as IEnumerable<string>));
-				var cc_ = context.Operators.And(bv_, cb_);
-				var cd_ = QOLAssessment?.Value;
-				var ce_ = FHIRHelpers_4_3_000.ToValue(cd_);
-				var cf_ = context.Operators.Not((bool?)(ce_ is null));
-				var cg_ = context.Operators.And(cc_, cf_);
+				bool? cb_ = context.Operators.In<string>(bz_, (ca_ as IEnumerable<string>));
+				bool? cc_ = context.Operators.And(bv_, cb_);
+				DataType cd_ = QOLAssessment?.Value;
+				object ce_ = FHIRHelpers_4_3_000.ToValue(cd_);
+				bool? cf_ = context.Operators.Not((bool?)(ce_ is null));
+				bool? cg_ = context.Operators.And(cc_, cf_);
 
 				return cg_;
 			};
-			var ak_ = context.Operators.Where<Observation>(ai_, aj_);
+			IEnumerable<Observation> ak_ = context.Operators.Where<Observation>(ai_, aj_);
 			object al_(Observation @this)
 			{
 				object dv_()
 				{
 					bool dx_()
 					{
-						var ea_ = @this?.Effective;
-						var eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
-						var ec_ = eb_ is CqlDateTime;
+						DataType ea_ = @this?.Effective;
+						object eb_ = FHIRHelpers_4_3_000.ToValue(ea_);
+						bool ec_ = eb_ is CqlDateTime;
 
 						return ec_;
 					};
 					bool dy_()
 					{
-						var ed_ = @this?.Effective;
-						var ee_ = FHIRHelpers_4_3_000.ToValue(ed_);
-						var ef_ = ee_ is CqlInterval<CqlDateTime>;
+						DataType ed_ = @this?.Effective;
+						object ee_ = FHIRHelpers_4_3_000.ToValue(ed_);
+						bool ef_ = ee_ is CqlInterval<CqlDateTime>;
 
 						return ef_;
 					};
 					bool dz_()
 					{
-						var eg_ = @this?.Effective;
-						var eh_ = FHIRHelpers_4_3_000.ToValue(eg_);
-						var ei_ = eh_ is CqlDateTime;
+						DataType eg_ = @this?.Effective;
+						object eh_ = FHIRHelpers_4_3_000.ToValue(eg_);
+						bool ei_ = eh_ is CqlDateTime;
 
 						return ei_;
 					};
 					if (dx_())
 					{
-						var ej_ = @this?.Effective;
-						var ek_ = FHIRHelpers_4_3_000.ToValue(ej_);
+						DataType ej_ = @this?.Effective;
+						object ek_ = FHIRHelpers_4_3_000.ToValue(ej_);
 
 						return ((ek_ as CqlDateTime) as object);
 					}
 					else if (dy_())
 					{
-						var el_ = @this?.Effective;
-						var em_ = FHIRHelpers_4_3_000.ToValue(el_);
+						DataType el_ = @this?.Effective;
+						object em_ = FHIRHelpers_4_3_000.ToValue(el_);
 
 						return ((em_ as CqlInterval<CqlDateTime>) as object);
 					}
 					else if (dz_())
 					{
-						var en_ = @this?.Effective;
-						var eo_ = FHIRHelpers_4_3_000.ToValue(en_);
+						DataType en_ = @this?.Effective;
+						object eo_ = FHIRHelpers_4_3_000.ToValue(en_);
 
 						return ((eo_ as CqlDateTime) as object);
 					}
@@ -826,16 +871,16 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 						return null;
 					}
 				};
-				var dw_ = QICoreCommon_2_0_000.earliest(dv_());
+				CqlDateTime dw_ = QICoreCommon_2_0_000.earliest(dv_());
 
 				return dw_;
 			};
-			var am_ = context.Operators.SortBy<Observation>(ak_, al_, System.ComponentModel.ListSortDirection.Ascending);
-			var an_ = context.Operators.Last<Observation>(am_);
-			var ao_ = an_?.Value;
-			var ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
-			var aq_ = context.Operators.Add((int?)af_, (int?)ap_);
-			var ar_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga
+			IEnumerable<Observation> am_ = context.Operators.SortBy<Observation>(ak_, al_, System.ComponentModel.ListSortDirection.Ascending);
+			Observation an_ = context.Operators.Last<Observation>(am_);
+			DataType ao_ = an_?.Value;
+			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
+			int? aq_ = context.Operators.Add((int?)af_, (int?)ap_);
+			Tuple_GNNDVIQPcTANSdLebhBKYIdga ar_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga
 			{
 				effectiveDatetime = ad_,
 				valueInteger = aq_,
@@ -843,411 +888,435 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
 			return ar_;
 		};
-		var g_ = context.Operators.Select<Observation, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(e_, f_);
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> g_ = context.Operators.Select<Observation, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="AUA_Symptom_Index_and_Quality_of_Life_Assessment_Result_Value"/>
     [CqlDeclaration("AUA Symptom Index and Quality of Life Assessment Result")]
 	public IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> AUA_Symptom_Index_and_Quality_of_Life_Assessment_Result() => 
 		__AUA_Symptom_Index_and_Quality_of_Life_Assessment_Result.Value;
 
+    /// <seealso cref="Urinary_Symptom_Score_Assessment"/>
 	private IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> Urinary_Symptom_Score_Assessment_Value()
 	{
-		var a_ = this.Documented_IPSS_Assessment_Result();
-		var b_ = this.AUA_Symptom_Index_and_Quality_of_Life_Assessment_Result();
-		var c_ = context.Operators.Union<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(a_, b_);
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> a_ = this.Documented_IPSS_Assessment_Result();
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> b_ = this.AUA_Symptom_Index_and_Quality_of_Life_Assessment_Result();
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> c_ = context.Operators.Union<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Urinary_Symptom_Score_Assessment_Value"/>
     [CqlDeclaration("Urinary Symptom Score Assessment")]
 	public IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> Urinary_Symptom_Score_Assessment() => 
 		__Urinary_Symptom_Score_Assessment.Value;
 
+    /// <seealso cref="Urinary_Symptom_Score_Within_1_Month_after_Initial_BPH_Diagnosis"/>
 	private Tuple_GNNDVIQPcTANSdLebhBKYIdga Urinary_Symptom_Score_Within_1_Month_after_Initial_BPH_Diagnosis_Value()
 	{
-		var a_ = this.Urinary_Symptom_Score_Assessment();
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> a_ = this.Urinary_Symptom_Score_Assessment();
 		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> b_(Tuple_GNNDVIQPcTANSdLebhBKYIdga USSAssessment)
 		{
-			var g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
-			var h_ = new Condition[]
+			Condition g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
+			Condition[] h_ = new Condition[]
 			{
 				g_,
 			};
 			bool? i_(Condition InitialBPHDiagnosis)
 			{
-				var m_ = USSAssessment?.effectiveDatetime;
-				var n_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
-				var o_ = context.Operators.Start(n_);
-				var q_ = context.Operators.Start(n_);
-				var r_ = context.Operators.Quantity(1m, "month");
-				var s_ = context.Operators.Add(q_, r_);
-				var t_ = context.Operators.Interval(o_, s_, true, true);
-				var u_ = context.Operators.In<CqlDateTime>(m_, t_, "day");
-				var w_ = context.Operators.Start(n_);
-				var x_ = context.Operators.Not((bool?)(w_ is null));
-				var y_ = context.Operators.And(u_, x_);
+				CqlDateTime m_ = USSAssessment?.effectiveDatetime;
+				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
+				CqlDateTime o_ = context.Operators.Start(n_);
+				CqlDateTime q_ = context.Operators.Start(n_);
+				CqlQuantity r_ = context.Operators.Quantity(1m, "month");
+				CqlDateTime s_ = context.Operators.Add(q_, r_);
+				CqlInterval<CqlDateTime> t_ = context.Operators.Interval(o_, s_, true, true);
+				bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, "day");
+				CqlDateTime w_ = context.Operators.Start(n_);
+				bool? x_ = context.Operators.Not((bool?)(w_ is null));
+				bool? y_ = context.Operators.And(u_, x_);
 
 				return y_;
 			};
-			var j_ = context.Operators.Where<Condition>((IEnumerable<Condition>)h_, i_);
+			IEnumerable<Condition> j_ = context.Operators.Where<Condition>((IEnumerable<Condition>)h_, i_);
 			Tuple_GNNDVIQPcTANSdLebhBKYIdga k_(Condition InitialBPHDiagnosis) => 
 				USSAssessment;
-			var l_ = context.Operators.Select<Condition, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(j_, k_);
+			IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> l_ = context.Operators.Select<Condition, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(a_, b_);
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> c_ = context.Operators.SelectMany<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(a_, b_);
 		object d_(Tuple_GNNDVIQPcTANSdLebhBKYIdga @this)
 		{
-			var z_ = @this?.effectiveDatetime;
+			CqlDateTime z_ = @this?.effectiveDatetime;
 
 			return z_;
 		};
-		var e_ = context.Operators.SortBy<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
-		var f_ = context.Operators.First<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(e_);
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> e_ = context.Operators.SortBy<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
+		Tuple_GNNDVIQPcTANSdLebhBKYIdga f_ = context.Operators.First<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Urinary_Symptom_Score_Within_1_Month_after_Initial_BPH_Diagnosis_Value"/>
     [CqlDeclaration("Urinary Symptom Score Within 1 Month after Initial BPH Diagnosis")]
 	public Tuple_GNNDVIQPcTANSdLebhBKYIdga Urinary_Symptom_Score_Within_1_Month_after_Initial_BPH_Diagnosis() => 
 		__Urinary_Symptom_Score_Within_1_Month_after_Initial_BPH_Diagnosis.Value;
 
+    /// <seealso cref="Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis"/>
 	private Tuple_GNNDVIQPcTANSdLebhBKYIdga Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis_Value()
 	{
-		var a_ = this.Urinary_Symptom_Score_Assessment();
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> a_ = this.Urinary_Symptom_Score_Assessment();
 		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> b_(Tuple_GNNDVIQPcTANSdLebhBKYIdga USSAssessment)
 		{
-			var g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
-			var h_ = new Condition[]
+			Condition g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
+			Condition[] h_ = new Condition[]
 			{
 				g_,
 			};
 			bool? i_(Condition InitialBPHDiagnosis)
 			{
-				var m_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
-				var n_ = context.Operators.Start(m_);
-				var o_ = USSAssessment?.effectiveDatetime;
-				var p_ = context.Operators.DurationBetween(n_, o_, "month");
-				var q_ = context.Operators.Interval(6, 12, true, true);
-				var r_ = context.Operators.In<int?>(p_, q_, null);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				CqlDateTime o_ = USSAssessment?.effectiveDatetime;
+				int? p_ = context.Operators.DurationBetween(n_, o_, "month");
+				CqlInterval<int?> q_ = context.Operators.Interval(6, 12, true, true);
+				bool? r_ = context.Operators.In<int?>(p_, q_, null);
 
 				return r_;
 			};
-			var j_ = context.Operators.Where<Condition>((IEnumerable<Condition>)h_, i_);
+			IEnumerable<Condition> j_ = context.Operators.Where<Condition>((IEnumerable<Condition>)h_, i_);
 			Tuple_GNNDVIQPcTANSdLebhBKYIdga k_(Condition InitialBPHDiagnosis) => 
 				USSAssessment;
-			var l_ = context.Operators.Select<Condition, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(j_, k_);
+			IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> l_ = context.Operators.Select<Condition, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(a_, b_);
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> c_ = context.Operators.SelectMany<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga>(a_, b_);
 		object d_(Tuple_GNNDVIQPcTANSdLebhBKYIdga @this)
 		{
-			var s_ = @this?.effectiveDatetime;
+			CqlDateTime s_ = @this?.effectiveDatetime;
 
 			return s_;
 		};
-		var e_ = context.Operators.SortBy<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
-		var f_ = context.Operators.Last<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(e_);
+		IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> e_ = context.Operators.SortBy<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
+		Tuple_GNNDVIQPcTANSdLebhBKYIdga f_ = context.Operators.Last<Tuple_GNNDVIQPcTANSdLebhBKYIdga>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis_Value"/>
     [CqlDeclaration("Urinary Symptom Score 6 to 12 Months After Initial BPH Diagnosis")]
 	public Tuple_GNNDVIQPcTANSdLebhBKYIdga Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis() => 
 		__Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient_is_Male();
-		var b_ = this.Has_Qualifying_Encounter();
-		var c_ = context.Operators.And(a_, b_);
-		var d_ = this.Has_Qualifying_BPH_Diagnosis();
-		var e_ = context.Operators.And(c_, d_);
-		var f_ = this.Urinary_Symptom_Score_Within_1_Month_after_Initial_BPH_Diagnosis();
-		var g_ = context.Operators.Not((bool?)(f_ is null));
-		var h_ = context.Operators.And(e_, g_);
-		var i_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
-		var j_ = context.Operators.Not((bool?)(i_ is null));
-		var k_ = context.Operators.And(h_, j_);
+		bool? a_ = this.Patient_is_Male();
+		bool? b_ = this.Has_Qualifying_Encounter();
+		bool? c_ = context.Operators.And(a_, b_);
+		bool? d_ = this.Has_Qualifying_BPH_Diagnosis();
+		bool? e_ = context.Operators.And(c_, d_);
+		Tuple_GNNDVIQPcTANSdLebhBKYIdga f_ = this.Urinary_Symptom_Score_Within_1_Month_after_Initial_BPH_Diagnosis();
+		bool? g_ = context.Operators.Not((bool?)(f_ is null));
+		bool? h_ = context.Operators.And(e_, g_);
+		Tuple_GNNDVIQPcTANSdLebhBKYIdga i_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
+		bool? j_ = context.Operators.Not((bool?)(i_ is null));
+		bool? k_ = context.Operators.And(h_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Urinary_Retention_Diagnosis_Starts_Within_1_Year_After_Initial_BPH_Diagnosis"/>
 	private IEnumerable<Condition> Urinary_Retention_Diagnosis_Starts_Within_1_Year_After_Initial_BPH_Diagnosis_Value()
 	{
-		var a_ = this.Urinary_retention();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Urinary_retention();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		IEnumerable<Condition> c_(Condition UrinaryRetention)
 		{
-			var g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
-			var h_ = new Condition[]
+			Condition g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
+			Condition[] h_ = new Condition[]
 			{
 				g_,
 			};
 			bool? i_(Condition InitialBPHDiagnosis)
 			{
-				var m_ = QICoreCommon_2_0_000.prevalenceInterval(UrinaryRetention);
-				var n_ = context.Operators.Start(m_);
-				var o_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
-				var p_ = context.Operators.Start(o_);
-				var r_ = context.Operators.Start(o_);
-				var s_ = context.Operators.Quantity(1m, "year");
-				var t_ = context.Operators.Add(r_, s_);
-				var u_ = context.Operators.Interval(p_, t_, true, true);
-				var v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
-				var x_ = context.Operators.Start(o_);
-				var y_ = context.Operators.Not((bool?)(x_ is null));
-				var z_ = context.Operators.And(v_, y_);
+				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(UrinaryRetention);
+				CqlDateTime n_ = context.Operators.Start(m_);
+				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlDateTime r_ = context.Operators.Start(o_);
+				CqlQuantity s_ = context.Operators.Quantity(1m, "year");
+				CqlDateTime t_ = context.Operators.Add(r_, s_);
+				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
+				CqlDateTime x_ = context.Operators.Start(o_);
+				bool? y_ = context.Operators.Not((bool?)(x_ is null));
+				bool? z_ = context.Operators.And(v_, y_);
 
 				return z_;
 			};
-			var j_ = context.Operators.Where<Condition>((IEnumerable<Condition>)h_, i_);
+			IEnumerable<Condition> j_ = context.Operators.Where<Condition>((IEnumerable<Condition>)h_, i_);
 			Condition k_(Condition InitialBPHDiagnosis) => 
 				UrinaryRetention;
-			var l_ = context.Operators.Select<Condition, Condition>(j_, k_);
+			IEnumerable<Condition> l_ = context.Operators.Select<Condition, Condition>(j_, k_);
 
 			return l_;
 		};
-		var d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+		IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
 		bool? e_(Condition UrinaryRetention)
 		{
-			var aa_ = this.isConfirmedActiveDiagnosis(UrinaryRetention);
+			bool? aa_ = this.isConfirmedActiveDiagnosis(UrinaryRetention);
 
 			return aa_;
 		};
-		var f_ = context.Operators.Where<Condition>(d_, e_);
+		IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Urinary_Retention_Diagnosis_Starts_Within_1_Year_After_Initial_BPH_Diagnosis_Value"/>
     [CqlDeclaration("Urinary Retention Diagnosis Starts Within 1 Year After Initial BPH Diagnosis")]
 	public IEnumerable<Condition> Urinary_Retention_Diagnosis_Starts_Within_1_Year_After_Initial_BPH_Diagnosis() => 
 		__Urinary_Retention_Diagnosis_Starts_Within_1_Year_After_Initial_BPH_Diagnosis.Value;
 
+    /// <seealso cref="Initial_BPH_Diagnosis_Starts_During_or_Within_30_Days_After_End_of_Hospitalization"/>
 	private Condition Initial_BPH_Diagnosis_Starts_During_or_Within_30_Days_After_End_of_Hospitalization_Value()
 	{
-		var a_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
-		var b_ = new Condition[]
+		Condition a_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
+		Condition[] b_ = new Condition[]
 		{
 			a_,
 		};
 		IEnumerable<Condition> c_(Condition InitialBPHDiagnosis)
 		{
-			var f_ = this.Hospital_Services_for_urology_care();
-			var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+			CqlValueSet f_ = this.Hospital_Services_for_urology_care();
+			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
 			bool? h_(Encounter InHospitalServices)
 			{
-				var l_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
-				var m_ = context.Operators.Start(l_);
-				var n_ = InHospitalServices?.Period;
-				var o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var p_ = context.Operators.Start(o_);
-				var r_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				var s_ = context.Operators.End(r_);
-				var t_ = context.Operators.Quantity(31m, "days");
-				var u_ = context.Operators.Add(s_, t_);
-				var v_ = context.Operators.Interval(p_, u_, true, true);
-				var w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
-				var x_ = InHospitalServices?.StatusElement;
-				var y_ = x_?.Value;
-				var z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
-				var aa_ = context.Operators.Equal(z_, "finished");
-				var ab_ = context.Operators.And(w_, aa_);
+				CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
+				CqlDateTime m_ = context.Operators.Start(l_);
+				Period n_ = InHospitalServices?.Period;
+				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlDateTime p_ = context.Operators.Start(o_);
+				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(n_);
+				CqlDateTime s_ = context.Operators.End(r_);
+				CqlQuantity t_ = context.Operators.Quantity(31m, "days");
+				CqlDateTime u_ = context.Operators.Add(s_, t_);
+				CqlInterval<CqlDateTime> v_ = context.Operators.Interval(p_, u_, true, true);
+				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
+				Code<Encounter.EncounterStatus> x_ = InHospitalServices?.StatusElement;
+				Encounter.EncounterStatus? y_ = x_?.Value;
+				Code<Encounter.EncounterStatus> z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
+				bool? aa_ = context.Operators.Equal(z_, "finished");
+				bool? ab_ = context.Operators.And(w_, aa_);
 
 				return ab_;
 			};
-			var i_ = context.Operators.Where<Encounter>(g_, h_);
+			IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
 			Condition j_(Encounter InHospitalServices) => 
 				InitialBPHDiagnosis;
-			var k_ = context.Operators.Select<Encounter, Condition>(i_, j_);
+			IEnumerable<Condition> k_ = context.Operators.Select<Encounter, Condition>(i_, j_);
 
 			return k_;
 		};
-		var d_ = context.Operators.SelectMany<Condition, Condition>((IEnumerable<Condition>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<Condition>(d_);
+		IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>((IEnumerable<Condition>)b_, c_);
+		Condition e_ = context.Operators.SingletonFrom<Condition>(d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Initial_BPH_Diagnosis_Starts_During_or_Within_30_Days_After_End_of_Hospitalization_Value"/>
     [CqlDeclaration("Initial BPH Diagnosis Starts During or Within 30 Days After End of Hospitalization")]
 	public Condition Initial_BPH_Diagnosis_Starts_During_or_Within_30_Days_After_End_of_Hospitalization() => 
 		__Initial_BPH_Diagnosis_Starts_During_or_Within_30_Days_After_End_of_Hospitalization.Value;
 
+    /// <seealso cref="Morbid_Obesity_Diagnosis_On_or_Before_Follow_Up_USS_Assessment"/>
 	private IEnumerable<Condition> Morbid_Obesity_Diagnosis_On_or_Before_Follow_Up_USS_Assessment_Value()
 	{
-		var a_ = this.Morbid_Obesity();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		CqlValueSet a_ = this.Morbid_Obesity();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		IEnumerable<Condition> c_(Condition MorbidObesity)
 		{
-			var e_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
-			var f_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga[]
+			Tuple_GNNDVIQPcTANSdLebhBKYIdga e_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
+			Tuple_GNNDVIQPcTANSdLebhBKYIdga[] f_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga[]
 			{
 				e_,
 			};
 			bool? g_(Tuple_GNNDVIQPcTANSdLebhBKYIdga FollowUpUSSAssessment)
 			{
-				var k_ = QICoreCommon_2_0_000.prevalenceInterval(MorbidObesity);
-				var l_ = this.Measurement_Period();
-				var m_ = context.Operators.Overlaps(k_, l_, null);
-				var o_ = context.Operators.Start(k_);
-				var p_ = FollowUpUSSAssessment?.effectiveDatetime;
-				var q_ = context.Operators.SameOrBefore(o_, p_, null);
-				var r_ = context.Operators.And(m_, q_);
-				var s_ = this.isConfirmedActiveDiagnosis(MorbidObesity);
-				var t_ = context.Operators.And(r_, s_);
+				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.prevalenceInterval(MorbidObesity);
+				CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
+				bool? m_ = context.Operators.Overlaps(k_, l_, null);
+				CqlDateTime o_ = context.Operators.Start(k_);
+				CqlDateTime p_ = FollowUpUSSAssessment?.effectiveDatetime;
+				bool? q_ = context.Operators.SameOrBefore(o_, p_, null);
+				bool? r_ = context.Operators.And(m_, q_);
+				bool? s_ = this.isConfirmedActiveDiagnosis(MorbidObesity);
+				bool? t_ = context.Operators.And(r_, s_);
 
 				return t_;
 			};
-			var h_ = context.Operators.Where<Tuple_GNNDVIQPcTANSdLebhBKYIdga>((IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga>)f_, g_);
+			IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> h_ = context.Operators.Where<Tuple_GNNDVIQPcTANSdLebhBKYIdga>((IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga>)f_, g_);
 			Condition i_(Tuple_GNNDVIQPcTANSdLebhBKYIdga FollowUpUSSAssessment) => 
 				MorbidObesity;
-			var j_ = context.Operators.Select<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Condition>(h_, i_);
+			IEnumerable<Condition> j_ = context.Operators.Select<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Condition>(h_, i_);
 
 			return j_;
 		};
-		var d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+		IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Morbid_Obesity_Diagnosis_On_or_Before_Follow_Up_USS_Assessment_Value"/>
     [CqlDeclaration("Morbid Obesity Diagnosis On or Before Follow Up USS Assessment")]
 	public IEnumerable<Condition> Morbid_Obesity_Diagnosis_On_or_Before_Follow_Up_USS_Assessment() => 
 		__Morbid_Obesity_Diagnosis_On_or_Before_Follow_Up_USS_Assessment.Value;
 
+    /// <seealso cref="Has_BMI_Exam_Result_Greater_Than_or_Equal_To_40_During_Measurement_Period_and_On_or_Before_Follow_Up_USS_Assessment"/>
 	private bool? Has_BMI_Exam_Result_Greater_Than_or_Equal_To_40_During_Measurement_Period_and_On_or_Before_Follow_Up_USS_Assessment_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
 		IEnumerable<Observation> b_(Observation BMIExam)
 		{
-			var g_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
-			var h_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga[]
+			Tuple_GNNDVIQPcTANSdLebhBKYIdga g_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
+			Tuple_GNNDVIQPcTANSdLebhBKYIdga[] h_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga[]
 			{
 				g_,
 			};
 			bool? i_(Tuple_GNNDVIQPcTANSdLebhBKYIdga FollowUpUSSAssessment)
 			{
-				var m_ = BMIExam?.Value;
-				var n_ = context.Operators.Convert<Quantity>(m_);
-				var o_ = FHIRHelpers_4_3_000.ToQuantity(n_);
-				var p_ = context.Operators.Quantity(40m, "kg/m2");
-				var q_ = context.Operators.Greater(o_, p_);
-				var r_ = BMIExam?.StatusElement;
-				var s_ = r_?.Value;
-				var t_ = context.Operators.Convert<string>(s_);
-				var u_ = new string[]
+				DataType m_ = BMIExam?.Value;
+				Quantity n_ = context.Operators.Convert<Quantity>(m_);
+				CqlQuantity o_ = FHIRHelpers_4_3_000.ToQuantity(n_);
+				CqlQuantity p_ = context.Operators.Quantity(40m, "kg/m2");
+				bool? q_ = context.Operators.Greater(o_, p_);
+				Code<ObservationStatus> r_ = BMIExam?.StatusElement;
+				ObservationStatus? s_ = r_?.Value;
+				string t_ = context.Operators.Convert<string>(s_);
+				string[] u_ = new string[]
 				{
 					"final",
 					"amended",
 					"corrected",
 				};
-				var v_ = context.Operators.In<string>(t_, (u_ as IEnumerable<string>));
-				var w_ = context.Operators.And(q_, v_);
-				var x_ = BMIExam?.Effective;
-				var y_ = FHIRHelpers_4_3_000.ToValue(x_);
-				var z_ = QICoreCommon_2_0_000.earliest(y_);
-				var aa_ = this.Measurement_Period();
-				var ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
-				var ac_ = context.Operators.And(w_, ab_);
-				var ae_ = FHIRHelpers_4_3_000.ToValue(x_);
-				var af_ = QICoreCommon_2_0_000.earliest(ae_);
-				var ag_ = FollowUpUSSAssessment?.effectiveDatetime;
-				var ah_ = context.Operators.SameOrBefore(af_, ag_, null);
-				var ai_ = context.Operators.And(ac_, ah_);
+				bool? v_ = context.Operators.In<string>(t_, (u_ as IEnumerable<string>));
+				bool? w_ = context.Operators.And(q_, v_);
+				DataType x_ = BMIExam?.Effective;
+				object y_ = FHIRHelpers_4_3_000.ToValue(x_);
+				CqlDateTime z_ = QICoreCommon_2_0_000.earliest(y_);
+				CqlInterval<CqlDateTime> aa_ = this.Measurement_Period();
+				bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
+				bool? ac_ = context.Operators.And(w_, ab_);
+				object ae_ = FHIRHelpers_4_3_000.ToValue(x_);
+				CqlDateTime af_ = QICoreCommon_2_0_000.earliest(ae_);
+				CqlDateTime ag_ = FollowUpUSSAssessment?.effectiveDatetime;
+				bool? ah_ = context.Operators.SameOrBefore(af_, ag_, null);
+				bool? ai_ = context.Operators.And(ac_, ah_);
 
 				return ai_;
 			};
-			var j_ = context.Operators.Where<Tuple_GNNDVIQPcTANSdLebhBKYIdga>((IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga>)h_, i_);
+			IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga> j_ = context.Operators.Where<Tuple_GNNDVIQPcTANSdLebhBKYIdga>((IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga>)h_, i_);
 			Observation k_(Tuple_GNNDVIQPcTANSdLebhBKYIdga FollowUpUSSAssessment) => 
 				BMIExam;
-			var l_ = context.Operators.Select<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Observation>(j_, k_);
+			IEnumerable<Observation> l_ = context.Operators.Select<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Observation>(j_, k_);
 
 			return l_;
 		};
-		var c_ = context.Operators.SelectMany<Observation, Observation>(a_, b_);
+		IEnumerable<Observation> c_ = context.Operators.SelectMany<Observation, Observation>(a_, b_);
 		CqlDateTime d_(Observation BMIExam)
 		{
-			var aj_ = BMIExam?.Effective;
-			var ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
-			var al_ = QICoreCommon_2_0_000.earliest(ak_);
+			DataType aj_ = BMIExam?.Effective;
+			object ak_ = FHIRHelpers_4_3_000.ToValue(aj_);
+			CqlDateTime al_ = QICoreCommon_2_0_000.earliest(ak_);
 
 			return al_;
 		};
-		var e_ = context.Operators.Select<Observation, CqlDateTime>(c_, d_);
-		var f_ = context.Operators.Exists<CqlDateTime>(e_);
+		IEnumerable<CqlDateTime> e_ = context.Operators.Select<Observation, CqlDateTime>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlDateTime>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Has_BMI_Exam_Result_Greater_Than_or_Equal_To_40_During_Measurement_Period_and_On_or_Before_Follow_Up_USS_Assessment_Value"/>
     [CqlDeclaration("Has BMI Exam Result Greater Than or Equal To 40 During Measurement Period and On or Before Follow Up USS Assessment")]
 	public bool? Has_BMI_Exam_Result_Greater_Than_or_Equal_To_40_During_Measurement_Period_and_On_or_Before_Follow_Up_USS_Assessment() => 
 		__Has_BMI_Exam_Result_Greater_Than_or_Equal_To_40_During_Measurement_Period_and_On_or_Before_Follow_Up_USS_Assessment.Value;
 
+    /// <seealso cref="Has_Morbid_Obesity_Diagnosis_or_BMI_Exam_Result__Greater_Than_or_Equal_to_40_Starts_On_or_Before_Follow_Up_USS_Assessment"/>
 	private bool? Has_Morbid_Obesity_Diagnosis_or_BMI_Exam_Result__Greater_Than_or_Equal_to_40_Starts_On_or_Before_Follow_Up_USS_Assessment_Value()
 	{
-		var a_ = this.Morbid_Obesity_Diagnosis_On_or_Before_Follow_Up_USS_Assessment();
-		var b_ = context.Operators.Exists<Condition>(a_);
-		var c_ = this.Has_BMI_Exam_Result_Greater_Than_or_Equal_To_40_During_Measurement_Period_and_On_or_Before_Follow_Up_USS_Assessment();
-		var d_ = context.Operators.Or(b_, c_);
+		IEnumerable<Condition> a_ = this.Morbid_Obesity_Diagnosis_On_or_Before_Follow_Up_USS_Assessment();
+		bool? b_ = context.Operators.Exists<Condition>(a_);
+		bool? c_ = this.Has_BMI_Exam_Result_Greater_Than_or_Equal_To_40_During_Measurement_Period_and_On_or_Before_Follow_Up_USS_Assessment();
+		bool? d_ = context.Operators.Or(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Has_Morbid_Obesity_Diagnosis_or_BMI_Exam_Result__Greater_Than_or_Equal_to_40_Starts_On_or_Before_Follow_Up_USS_Assessment_Value"/>
     [CqlDeclaration("Has Morbid Obesity Diagnosis or BMI Exam Result  Greater Than or Equal to 40 Starts On or Before Follow Up USS Assessment")]
 	public bool? Has_Morbid_Obesity_Diagnosis_or_BMI_Exam_Result__Greater_Than_or_Equal_to_40_Starts_On_or_Before_Follow_Up_USS_Assessment() => 
 		__Has_Morbid_Obesity_Diagnosis_or_BMI_Exam_Result__Greater_Than_or_Equal_to_40_Starts_On_or_Before_Follow_Up_USS_Assessment.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = this.Urinary_Retention_Diagnosis_Starts_Within_1_Year_After_Initial_BPH_Diagnosis();
-		var b_ = context.Operators.Exists<Condition>(a_);
-		var c_ = this.Initial_BPH_Diagnosis_Starts_During_or_Within_30_Days_After_End_of_Hospitalization();
-		var d_ = context.Operators.Not((bool?)(c_ is null));
-		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Has_Morbid_Obesity_Diagnosis_or_BMI_Exam_Result__Greater_Than_or_Equal_to_40_Starts_On_or_Before_Follow_Up_USS_Assessment();
-		var g_ = context.Operators.Or(e_, f_);
+		IEnumerable<Condition> a_ = this.Urinary_Retention_Diagnosis_Starts_Within_1_Year_After_Initial_BPH_Diagnosis();
+		bool? b_ = context.Operators.Exists<Condition>(a_);
+		Condition c_ = this.Initial_BPH_Diagnosis_Starts_During_or_Within_30_Days_After_End_of_Hospitalization();
+		bool? d_ = context.Operators.Not((bool?)(c_ is null));
+		bool? e_ = context.Operators.Or(b_, d_);
+		bool? f_ = this.Has_Morbid_Obesity_Diagnosis_or_BMI_Exam_Result__Greater_Than_or_Equal_to_40_Starts_On_or_Before_Follow_Up_USS_Assessment();
+		bool? g_ = context.Operators.Or(e_, f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="Urinary_Symptom_Score_Change"/>
 	private int? Urinary_Symptom_Score_Change_Value()
 	{
-		var a_ = this.Urinary_Symptom_Score_Within_1_Month_after_Initial_BPH_Diagnosis();
-		var b_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga[]
+		Tuple_GNNDVIQPcTANSdLebhBKYIdga a_ = this.Urinary_Symptom_Score_Within_1_Month_after_Initial_BPH_Diagnosis();
+		Tuple_GNNDVIQPcTANSdLebhBKYIdga[] b_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga[]
 		{
 			a_,
 		};
-		var c_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
-		var d_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga[]
+		Tuple_GNNDVIQPcTANSdLebhBKYIdga c_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
+		Tuple_GNNDVIQPcTANSdLebhBKYIdga[] d_ = new Tuple_GNNDVIQPcTANSdLebhBKYIdga[]
 		{
 			c_,
 		};
-		var e_ = context.Operators.CrossJoin<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga>((IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga>)b_, (IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga>)d_);
+		IEnumerable<ValueTuple<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga>> e_ = context.Operators.CrossJoin<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga>((IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga>)b_, (IEnumerable<Tuple_GNNDVIQPcTANSdLebhBKYIdga>)d_);
 		Tuple_FBHNjYWJgMKheadEZUgcdQGXN f_(ValueTuple<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga> _valueTuple)
 		{
-			var k_ = new Tuple_FBHNjYWJgMKheadEZUgcdQGXN
+			Tuple_FBHNjYWJgMKheadEZUgcdQGXN k_ = new Tuple_FBHNjYWJgMKheadEZUgcdQGXN
 			{
 				FirstUSSAssessment = _valueTuple.Item1,
 				FollowUpUSSAssessment = _valueTuple.Item2,
@@ -1255,100 +1324,113 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
 			return k_;
 		};
-		var g_ = context.Operators.Select<ValueTuple<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga>, Tuple_FBHNjYWJgMKheadEZUgcdQGXN>(e_, f_);
+		IEnumerable<Tuple_FBHNjYWJgMKheadEZUgcdQGXN> g_ = context.Operators.Select<ValueTuple<Tuple_GNNDVIQPcTANSdLebhBKYIdga, Tuple_GNNDVIQPcTANSdLebhBKYIdga>, Tuple_FBHNjYWJgMKheadEZUgcdQGXN>(e_, f_);
 		int? h_(Tuple_FBHNjYWJgMKheadEZUgcdQGXN tuple_fbhnjywjgmkheadezugcdqgxn)
 		{
-			var l_ = tuple_fbhnjywjgmkheadezugcdqgxn.FirstUSSAssessment?.valueInteger;
-			var m_ = tuple_fbhnjywjgmkheadezugcdqgxn.FollowUpUSSAssessment?.valueInteger;
-			var n_ = context.Operators.Subtract(l_, m_);
+			int? l_ = tuple_fbhnjywjgmkheadezugcdqgxn.FirstUSSAssessment?.valueInteger;
+			int? m_ = tuple_fbhnjywjgmkheadezugcdqgxn.FollowUpUSSAssessment?.valueInteger;
+			int? n_ = context.Operators.Subtract(l_, m_);
 
 			return n_;
 		};
-		var i_ = context.Operators.Select<Tuple_FBHNjYWJgMKheadEZUgcdQGXN, int?>(g_, h_);
-		var j_ = context.Operators.SingletonFrom<int?>(i_);
+		IEnumerable<int?> i_ = context.Operators.Select<Tuple_FBHNjYWJgMKheadEZUgcdQGXN, int?>(g_, h_);
+		int? j_ = context.Operators.SingletonFrom<int?>(i_);
 
 		return j_;
 	}
 
+    /// <seealso cref="Urinary_Symptom_Score_Change_Value"/>
     [CqlDeclaration("Urinary Symptom Score Change")]
 	public int? Urinary_Symptom_Score_Change() => 
 		__Urinary_Symptom_Score_Change.Value;
 
+    /// <seealso cref="Has_Urinary_Symptom_Score_Improvement_Greater_Than_or_Equal_To_3"/>
 	private bool? Has_Urinary_Symptom_Score_Improvement_Greater_Than_or_Equal_To_3_Value()
 	{
-		var a_ = this.Urinary_Symptom_Score_Change();
-		var b_ = new int?[]
+		int? a_ = this.Urinary_Symptom_Score_Change();
+		int?[] b_ = new int?[]
 		{
 			a_,
 		};
 		bool? c_(int? USSImprovement)
 		{
-			var g_ = context.Operators.GreaterOrEqual(USSImprovement, 3);
+			bool? g_ = context.Operators.GreaterOrEqual(USSImprovement, 3);
 
 			return g_;
 		};
-		var d_ = context.Operators.Where<int?>((IEnumerable<int?>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<int?>(d_);
-		var f_ = context.Operators.Not((bool?)(e_ is null));
+		IEnumerable<int?> d_ = context.Operators.Where<int?>((IEnumerable<int?>)b_, c_);
+		int? e_ = context.Operators.SingletonFrom<int?>(d_);
+		bool? f_ = context.Operators.Not((bool?)(e_ is null));
 
 		return f_;
 	}
 
+    /// <seealso cref="Has_Urinary_Symptom_Score_Improvement_Greater_Than_or_Equal_To_3_Value"/>
     [CqlDeclaration("Has Urinary Symptom Score Improvement Greater Than or Equal To 3")]
 	public bool? Has_Urinary_Symptom_Score_Improvement_Greater_Than_or_Equal_To_3() => 
 		__Has_Urinary_Symptom_Score_Improvement_Greater_Than_or_Equal_To_3.Value;
 
+    /// <seealso cref="Numerator"/>
 	private bool? Numerator_Value()
 	{
-		var a_ = this.Has_Urinary_Symptom_Score_Improvement_Greater_Than_or_Equal_To_3();
+		bool? a_ = this.Has_Urinary_Symptom_Score_Improvement_Greater_Than_or_Equal_To_3();
 
 		return a_;
 	}
 
+    /// <seealso cref="Numerator_Value"/>
     [CqlDeclaration("Numerator")]
 	public bool? Numerator() => 
 		__Numerator.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
@@ -212,462 +212,581 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 
     #endregion
 
+    /// <seealso cref="Alcohol_Withdrawal"/>
 	private CqlValueSet Alcohol_Withdrawal_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209", null);
 
+    /// <seealso cref="Alcohol_Withdrawal_Value"/>
     [CqlDeclaration("Alcohol Withdrawal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209")]
 	public CqlValueSet Alcohol_Withdrawal() => 
 		__Alcohol_Withdrawal.Value;
 
+    /// <seealso cref="Annual_Wellness_Visit"/>
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
+    /// <seealso cref="Annual_Wellness_Visit_Value"/>
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
 	public CqlValueSet Annual_Wellness_Visit() => 
 		__Annual_Wellness_Visit.Value;
 
+    /// <seealso cref="Anti_Infectives__other"/>
 	private CqlValueSet Anti_Infectives__other_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481", null);
 
+    /// <seealso cref="Anti_Infectives__other_Value"/>
     [CqlDeclaration("Anti Infectives, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481")]
 	public CqlValueSet Anti_Infectives__other() => 
 		__Anti_Infectives__other.Value;
 
+    /// <seealso cref="Anticholinergics__anti_Parkinson_agents"/>
 	private CqlValueSet Anticholinergics__anti_Parkinson_agents_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049", null);
 
+    /// <seealso cref="Anticholinergics__anti_Parkinson_agents_Value"/>
     [CqlDeclaration("Anticholinergics, anti Parkinson agents")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049")]
 	public CqlValueSet Anticholinergics__anti_Parkinson_agents() => 
 		__Anticholinergics__anti_Parkinson_agents.Value;
 
+    /// <seealso cref="Anticholinergics__first_generation_antihistamines"/>
 	private CqlValueSet Anticholinergics__first_generation_antihistamines_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043", null);
 
+    /// <seealso cref="Anticholinergics__first_generation_antihistamines_Value"/>
     [CqlDeclaration("Anticholinergics, first generation antihistamines")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043")]
 	public CqlValueSet Anticholinergics__first_generation_antihistamines() => 
 		__Anticholinergics__first_generation_antihistamines.Value;
 
+    /// <seealso cref="Antipsychotic"/>
 	private CqlValueSet Antipsychotic_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523", null);
 
+    /// <seealso cref="Antipsychotic_Value"/>
     [CqlDeclaration("Antipsychotic")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523")]
 	public CqlValueSet Antipsychotic() => 
 		__Antipsychotic.Value;
 
+    /// <seealso cref="Antispasmodics"/>
 	private CqlValueSet Antispasmodics_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050", null);
 
+    /// <seealso cref="Antispasmodics_Value"/>
     [CqlDeclaration("Antispasmodics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050")]
 	public CqlValueSet Antispasmodics() => 
 		__Antispasmodics.Value;
 
+    /// <seealso cref="Antithrombotic"/>
 	private CqlValueSet Antithrombotic_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051", null);
 
+    /// <seealso cref="Antithrombotic_Value"/>
     [CqlDeclaration("Antithrombotic")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051")]
 	public CqlValueSet Antithrombotic() => 
 		__Antithrombotic.Value;
 
+    /// <seealso cref="Benzodiazepine_Withdrawal"/>
 	private CqlValueSet Benzodiazepine_Withdrawal_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208", null);
 
+    /// <seealso cref="Benzodiazepine_Withdrawal_Value"/>
     [CqlDeclaration("Benzodiazepine Withdrawal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208")]
 	public CqlValueSet Benzodiazepine_Withdrawal() => 
 		__Benzodiazepine_Withdrawal.Value;
 
+    /// <seealso cref="Benzodiazepine"/>
 	private CqlValueSet Benzodiazepine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522", null);
 
+    /// <seealso cref="Benzodiazepine_Value"/>
     [CqlDeclaration("Benzodiazepine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522")]
 	public CqlValueSet Benzodiazepine() => 
 		__Benzodiazepine.Value;
 
+    /// <seealso cref="Bipolar_Disorder"/>
 	private CqlValueSet Bipolar_Disorder_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157", null);
 
+    /// <seealso cref="Bipolar_Disorder_Value"/>
     [CqlDeclaration("Bipolar Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157")]
 	public CqlValueSet Bipolar_Disorder() => 
 		__Bipolar_Disorder.Value;
 
+    /// <seealso cref="Cardiovascular__alpha_agonists__central"/>
 	private CqlValueSet Cardiovascular__alpha_agonists__central_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052", null);
 
+    /// <seealso cref="Cardiovascular__alpha_agonists__central_Value"/>
     [CqlDeclaration("Cardiovascular, alpha agonists, central")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052")]
 	public CqlValueSet Cardiovascular__alpha_agonists__central() => 
 		__Cardiovascular__alpha_agonists__central.Value;
 
+    /// <seealso cref="Cardiovascular__other"/>
 	private CqlValueSet Cardiovascular__other_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053", null);
 
+    /// <seealso cref="Cardiovascular__other_Value"/>
     [CqlDeclaration("Cardiovascular, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053")]
 	public CqlValueSet Cardiovascular__other() => 
 		__Cardiovascular__other.Value;
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility"/>
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
+    /// <seealso cref="Care_Services_in_Long_Term_Residential_Facility_Value"/>
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
 	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
+    /// <seealso cref="Central_nervous_system__antidepressants"/>
 	private CqlValueSet Central_nervous_system__antidepressants_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054", null);
 
+    /// <seealso cref="Central_nervous_system__antidepressants_Value"/>
     [CqlDeclaration("Central nervous system, antidepressants")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054")]
 	public CqlValueSet Central_nervous_system__antidepressants() => 
 		__Central_nervous_system__antidepressants.Value;
 
+    /// <seealso cref="Central_nervous_system__barbiturates"/>
 	private CqlValueSet Central_nervous_system__barbiturates_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055", null);
 
+    /// <seealso cref="Central_nervous_system__barbiturates_Value"/>
     [CqlDeclaration("Central nervous system, barbiturates")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055")]
 	public CqlValueSet Central_nervous_system__barbiturates() => 
 		__Central_nervous_system__barbiturates.Value;
 
+    /// <seealso cref="Central_nervous_system__other"/>
 	private CqlValueSet Central_nervous_system__other_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057", null);
 
+    /// <seealso cref="Central_nervous_system__other_Value"/>
     [CqlDeclaration("Central nervous system, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057")]
 	public CqlValueSet Central_nervous_system__other() => 
 		__Central_nervous_system__other.Value;
 
+    /// <seealso cref="Central_nervous_system__vasodilators"/>
 	private CqlValueSet Central_nervous_system__vasodilators_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056", null);
 
+    /// <seealso cref="Central_nervous_system__vasodilators_Value"/>
     [CqlDeclaration("Central nervous system, vasodilators")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056")]
 	public CqlValueSet Central_nervous_system__vasodilators() => 
 		__Central_nervous_system__vasodilators.Value;
 
+    /// <seealso cref="Digoxin"/>
 	private CqlValueSet Digoxin_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065", null);
 
+    /// <seealso cref="Digoxin_Value"/>
     [CqlDeclaration("Digoxin")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065")]
 	public CqlValueSet Digoxin() => 
 		__Digoxin.Value;
 
+    /// <seealso cref="Discharge_Services_Nursing_Facility"/>
 	private CqlValueSet Discharge_Services_Nursing_Facility_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", null);
 
+    /// <seealso cref="Discharge_Services_Nursing_Facility_Value"/>
     [CqlDeclaration("Discharge Services Nursing Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013")]
 	public CqlValueSet Discharge_Services_Nursing_Facility() => 
 		__Discharge_Services_Nursing_Facility.Value;
 
+    /// <seealso cref="Doxepin"/>
 	private CqlValueSet Doxepin_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067", null);
 
+    /// <seealso cref="Doxepin_Value"/>
     [CqlDeclaration("Doxepin")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067")]
 	public CqlValueSet Doxepin() => 
 		__Doxepin.Value;
 
+    /// <seealso cref="Endocrine_system__estrogens_with_or_without_progestins"/>
 	private CqlValueSet Endocrine_system__estrogens_with_or_without_progestins_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058", null);
 
+    /// <seealso cref="Endocrine_system__estrogens_with_or_without_progestins_Value"/>
     [CqlDeclaration("Endocrine system, estrogens with or without progestins")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058")]
 	public CqlValueSet Endocrine_system__estrogens_with_or_without_progestins() => 
 		__Endocrine_system__estrogens_with_or_without_progestins.Value;
 
+    /// <seealso cref="Endocrine_system__other"/>
 	private CqlValueSet Endocrine_system__other_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060", null);
 
+    /// <seealso cref="Endocrine_system__other_Value"/>
     [CqlDeclaration("Endocrine system, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060")]
 	public CqlValueSet Endocrine_system__other() => 
 		__Endocrine_system__other.Value;
 
+    /// <seealso cref="Endocrine_system__sulfonylureas__long_duration"/>
 	private CqlValueSet Endocrine_system__sulfonylureas__long_duration_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059", null);
 
+    /// <seealso cref="Endocrine_system__sulfonylureas__long_duration_Value"/>
     [CqlDeclaration("Endocrine system, sulfonylureas, long duration")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059")]
 	public CqlValueSet Endocrine_system__sulfonylureas__long_duration() => 
 		__Endocrine_system__sulfonylureas__long_duration.Value;
 
+    /// <seealso cref="Generalized_Anxiety_Disorder"/>
 	private CqlValueSet Generalized_Anxiety_Disorder_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210", null);
 
+    /// <seealso cref="Generalized_Anxiety_Disorder_Value"/>
     [CqlDeclaration("Generalized Anxiety Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210")]
 	public CqlValueSet Generalized_Anxiety_Disorder() => 
 		__Generalized_Anxiety_Disorder.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Nonbenzodiazepine_hypnotics"/>
 	private CqlValueSet Nonbenzodiazepine_hypnotics_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480", null);
 
+    /// <seealso cref="Nonbenzodiazepine_hypnotics_Value"/>
     [CqlDeclaration("Nonbenzodiazepine hypnotics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480")]
 	public CqlValueSet Nonbenzodiazepine_hypnotics() => 
 		__Nonbenzodiazepine_hypnotics.Value;
 
+    /// <seealso cref="Nursing_Facility_Visit"/>
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
+    /// <seealso cref="Nursing_Facility_Visit_Value"/>
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
 	public CqlValueSet Nursing_Facility_Visit() => 
 		__Nursing_Facility_Visit.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Online_Assessments"/>
 	private CqlValueSet Online_Assessments_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
+    /// <seealso cref="Online_Assessments_Value"/>
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
 	public CqlValueSet Online_Assessments() => 
 		__Online_Assessments.Value;
 
+    /// <seealso cref="Ophthalmologic_Services"/>
 	private CqlValueSet Ophthalmologic_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206", null);
 
+    /// <seealso cref="Ophthalmologic_Services_Value"/>
     [CqlDeclaration("Ophthalmologic Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206")]
 	public CqlValueSet Ophthalmologic_Services() => 
 		__Ophthalmologic_Services.Value;
 
+    /// <seealso cref="Pain_medications__other"/>
 	private CqlValueSet Pain_medications__other_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063", null);
 
+    /// <seealso cref="Pain_medications__other_Value"/>
     [CqlDeclaration("Pain medications, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063")]
 	public CqlValueSet Pain_medications__other() => 
 		__Pain_medications__other.Value;
 
+    /// <seealso cref="Pain_medications__skeletal_muscle_relaxants"/>
 	private CqlValueSet Pain_medications__skeletal_muscle_relaxants_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062", null);
 
+    /// <seealso cref="Pain_medications__skeletal_muscle_relaxants_Value"/>
     [CqlDeclaration("Pain medications, skeletal muscle relaxants")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062")]
 	public CqlValueSet Pain_medications__skeletal_muscle_relaxants() => 
 		__Pain_medications__skeletal_muscle_relaxants.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
+    /// <seealso cref="Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
 	public CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up"/>
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
+    /// <seealso cref="Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value"/>
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
 	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
+    /// <seealso cref="REM_Sleep_Behavior_Disorder"/>
 	private CqlValueSet REM_Sleep_Behavior_Disorder_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207", null);
 
+    /// <seealso cref="REM_Sleep_Behavior_Disorder_Value"/>
     [CqlDeclaration("REM Sleep Behavior Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207")]
 	public CqlValueSet REM_Sleep_Behavior_Disorder() => 
 		__REM_Sleep_Behavior_Disorder.Value;
 
+    /// <seealso cref="Reserpine"/>
 	private CqlValueSet Reserpine_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044", null);
 
+    /// <seealso cref="Reserpine_Value"/>
     [CqlDeclaration("Reserpine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044")]
 	public CqlValueSet Reserpine() => 
 		__Reserpine.Value;
 
+    /// <seealso cref="Schizophrenia"/>
 	private CqlValueSet Schizophrenia_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205", null);
 
+    /// <seealso cref="Schizophrenia_Value"/>
     [CqlDeclaration("Schizophrenia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205")]
 	public CqlValueSet Schizophrenia() => 
 		__Schizophrenia.Value;
 
+    /// <seealso cref="Seizure_Disorder"/>
 	private CqlValueSet Seizure_Disorder_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206", null);
 
+    /// <seealso cref="Seizure_Disorder_Value"/>
     [CqlDeclaration("Seizure Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206")]
 	public CqlValueSet Seizure_Disorder() => 
 		__Seizure_Disorder.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="_1_ML_digoxin_0_1_MG_ML_Injection"/>
 	private CqlCode _1_ML_digoxin_0_1_MG_ML_Injection_Value() => 
 		new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="_1_ML_digoxin_0_1_MG_ML_Injection_Value"/>
     [CqlDeclaration("1 ML digoxin 0.1 MG/ML Injection")]
 	public CqlCode _1_ML_digoxin_0_1_MG_ML_Injection() => 
 		___1_ML_digoxin_0_1_MG_ML_Injection.Value;
 
+    /// <seealso cref="_2_ML_digoxin_0_25_MG_ML_Injection"/>
 	private CqlCode _2_ML_digoxin_0_25_MG_ML_Injection_Value() => 
 		new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="_2_ML_digoxin_0_25_MG_ML_Injection_Value"/>
     [CqlDeclaration("2 ML digoxin 0.25 MG/ML Injection")]
 	public CqlCode _2_ML_digoxin_0_25_MG_ML_Injection() => 
 		___2_ML_digoxin_0_25_MG_ML_Injection.Value;
 
+    /// <seealso cref="digoxin_0_05_MG_ML_Oral_Solution"/>
 	private CqlCode digoxin_0_05_MG_ML_Oral_Solution_Value() => 
 		new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="digoxin_0_05_MG_ML_Oral_Solution_Value"/>
     [CqlDeclaration("digoxin 0.05 MG/ML Oral Solution")]
 	public CqlCode digoxin_0_05_MG_ML_Oral_Solution() => 
 		__digoxin_0_05_MG_ML_Oral_Solution.Value;
 
+    /// <seealso cref="digoxin_0_0625_MG_Oral_Tablet"/>
 	private CqlCode digoxin_0_0625_MG_Oral_Tablet_Value() => 
 		new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="digoxin_0_0625_MG_Oral_Tablet_Value"/>
     [CqlDeclaration("digoxin 0.0625 MG Oral Tablet")]
 	public CqlCode digoxin_0_0625_MG_Oral_Tablet() => 
 		__digoxin_0_0625_MG_Oral_Tablet.Value;
 
+    /// <seealso cref="digoxin_0_125_MG_Oral_Tablet"/>
 	private CqlCode digoxin_0_125_MG_Oral_Tablet_Value() => 
 		new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="digoxin_0_125_MG_Oral_Tablet_Value"/>
     [CqlDeclaration("digoxin 0.125 MG Oral Tablet")]
 	public CqlCode digoxin_0_125_MG_Oral_Tablet() => 
 		__digoxin_0_125_MG_Oral_Tablet.Value;
 
+    /// <seealso cref="digoxin_0_1875_MG_Oral_Tablet"/>
 	private CqlCode digoxin_0_1875_MG_Oral_Tablet_Value() => 
 		new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="digoxin_0_1875_MG_Oral_Tablet_Value"/>
     [CqlDeclaration("digoxin 0.1875 MG Oral Tablet")]
 	public CqlCode digoxin_0_1875_MG_Oral_Tablet() => 
 		__digoxin_0_1875_MG_Oral_Tablet.Value;
 
+    /// <seealso cref="digoxin_0_25_MG_Oral_Tablet"/>
 	private CqlCode digoxin_0_25_MG_Oral_Tablet_Value() => 
 		new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="digoxin_0_25_MG_Oral_Tablet_Value"/>
     [CqlDeclaration("digoxin 0.25 MG Oral Tablet")]
 	public CqlCode digoxin_0_25_MG_Oral_Tablet() => 
 		__digoxin_0_25_MG_Oral_Tablet.Value;
 
+    /// <seealso cref="doxepin_3_MG_Oral_Tablet"/>
 	private CqlCode doxepin_3_MG_Oral_Tablet_Value() => 
 		new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="doxepin_3_MG_Oral_Tablet_Value"/>
     [CqlDeclaration("doxepin 3 MG Oral Tablet")]
 	public CqlCode doxepin_3_MG_Oral_Tablet() => 
 		__doxepin_3_MG_Oral_Tablet.Value;
 
+    /// <seealso cref="doxepin_6_MG_Oral_Tablet"/>
 	private CqlCode doxepin_6_MG_Oral_Tablet_Value() => 
 		new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="doxepin_6_MG_Oral_Tablet_Value"/>
     [CqlDeclaration("doxepin 6 MG Oral Tablet")]
 	public CqlCode doxepin_6_MG_Oral_Tablet() => 
 		__doxepin_6_MG_Oral_Tablet.Value;
 
+    /// <seealso cref="doxepin_hydrochloride_10_MG_Oral_Capsule"/>
 	private CqlCode doxepin_hydrochloride_10_MG_Oral_Capsule_Value() => 
 		new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="doxepin_hydrochloride_10_MG_Oral_Capsule_Value"/>
     [CqlDeclaration("doxepin hydrochloride 10 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_10_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_10_MG_Oral_Capsule.Value;
 
+    /// <seealso cref="doxepin_hydrochloride_10_MG_ML_Oral_Solution"/>
 	private CqlCode doxepin_hydrochloride_10_MG_ML_Oral_Solution_Value() => 
 		new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="doxepin_hydrochloride_10_MG_ML_Oral_Solution_Value"/>
     [CqlDeclaration("doxepin hydrochloride 10 MG/ML Oral Solution")]
 	public CqlCode doxepin_hydrochloride_10_MG_ML_Oral_Solution() => 
 		__doxepin_hydrochloride_10_MG_ML_Oral_Solution.Value;
 
+    /// <seealso cref="doxepin_hydrochloride_100_MG_Oral_Capsule"/>
 	private CqlCode doxepin_hydrochloride_100_MG_Oral_Capsule_Value() => 
 		new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="doxepin_hydrochloride_100_MG_Oral_Capsule_Value"/>
     [CqlDeclaration("doxepin hydrochloride 100 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_100_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_100_MG_Oral_Capsule.Value;
 
+    /// <seealso cref="doxepin_hydrochloride_150_MG_Oral_Capsule"/>
 	private CqlCode doxepin_hydrochloride_150_MG_Oral_Capsule_Value() => 
 		new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="doxepin_hydrochloride_150_MG_Oral_Capsule_Value"/>
     [CqlDeclaration("doxepin hydrochloride 150 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_150_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_150_MG_Oral_Capsule.Value;
 
+    /// <seealso cref="doxepin_hydrochloride_25_MG_Oral_Capsule"/>
 	private CqlCode doxepin_hydrochloride_25_MG_Oral_Capsule_Value() => 
 		new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="doxepin_hydrochloride_25_MG_Oral_Capsule_Value"/>
     [CqlDeclaration("doxepin hydrochloride 25 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_25_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_25_MG_Oral_Capsule.Value;
 
+    /// <seealso cref="doxepin_hydrochloride_50_MG_Oral_Capsule"/>
 	private CqlCode doxepin_hydrochloride_50_MG_Oral_Capsule_Value() => 
 		new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="doxepin_hydrochloride_50_MG_Oral_Capsule_Value"/>
     [CqlDeclaration("doxepin hydrochloride 50 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_50_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_50_MG_Oral_Capsule.Value;
 
+    /// <seealso cref="doxepin_hydrochloride_75_MG_Oral_Capsule"/>
 	private CqlCode doxepin_hydrochloride_75_MG_Oral_Capsule_Value() => 
 		new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="doxepin_hydrochloride_75_MG_Oral_Capsule_Value"/>
     [CqlDeclaration("doxepin hydrochloride 75 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_75_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_75_MG_Oral_Capsule.Value;
 
+    /// <seealso cref="Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_"/>
 	private CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal__Value() => 
 		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null);
 
+    /// <seealso cref="Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal__Value"/>
     [CqlDeclaration("Office or other outpatient visit for the evaluation and management of an established patient, that may not require the presence of a physician or other qualified health care professional. Usually, the presenting problem(s) are minimal.")]
 	public CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_() => 
 		__Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_.Value;
 
+    /// <seealso cref="reserpine_0_1_MG_Oral_Tablet"/>
 	private CqlCode reserpine_0_1_MG_Oral_Tablet_Value() => 
 		new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="reserpine_0_1_MG_Oral_Tablet_Value"/>
     [CqlDeclaration("reserpine 0.1 MG Oral Tablet")]
 	public CqlCode reserpine_0_1_MG_Oral_Tablet() => 
 		__reserpine_0_1_MG_Oral_Tablet.Value;
 
+    /// <seealso cref="reserpine_0_25_MG_Oral_Tablet"/>
 	private CqlCode reserpine_0_25_MG_Oral_Tablet_Value() => 
 		new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
 
+    /// <seealso cref="reserpine_0_25_MG_Oral_Tablet_Value"/>
     [CqlDeclaration("reserpine 0.25 MG Oral Tablet")]
 	public CqlCode reserpine_0_25_MG_Oral_Tablet() => 
 		__reserpine_0_25_MG_Oral_Tablet.Value;
 
+    /// <seealso cref="RXNORM"/>
 	private CqlCode[] RXNORM_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
 			new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
@@ -692,13 +811,15 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="RXNORM_Value"/>
     [CqlDeclaration("RXNORM")]
 	public CqlCode[] RXNORM() => 
 		__RXNORM.Value;
 
+    /// <seealso cref="CPT"/>
 	private CqlCode[] CPT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null),
 		};
@@ -706,154 +827,169 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		return a_;
 	}
 
+    /// <seealso cref="CPT_Value"/>
     [CqlDeclaration("CPT")]
 	public CqlCode[] CPT() => 
 		__CPT.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("UseofHighRiskMedicationsintheElderlyFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("UseofHighRiskMedicationsintheElderlyFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Qualifying_Encounters"/>
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Ophthalmologic_Services();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Discharge_Services_Nursing_Facility();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Nursing_Facility_Visit();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Annual_Wellness_Visit();
-		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
-		var v_ = context.Operators.Union<Encounter>(s_, u_);
-		var w_ = context.Operators.Union<Encounter>(q_, v_);
-		var x_ = this.Home_Healthcare_Services();
-		var y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
-		var z_ = this.Telephone_Visits();
-		var aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
-		var ab_ = context.Operators.Union<Encounter>(y_, aa_);
-		var ac_ = context.Operators.Union<Encounter>(w_, ab_);
-		var ad_ = this.Online_Assessments();
-		var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
-		var af_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Ophthalmologic_Services();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Discharge_Services_Nursing_Facility();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Nursing_Facility_Visit();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Care_Services_in_Long_Term_Residential_Facility();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		CqlValueSet t_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
+		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
+		CqlValueSet x_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		CqlValueSet z_ = this.Telephone_Visits();
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
+		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
+		CqlValueSet ad_ = this.Online_Assessments();
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
 		bool? ag_(Encounter E)
 		{
-			var am_ = E?.Type;
+			List<CodeableConcept> am_ = E?.Type;
 			CqlConcept an_(CodeableConcept @this)
 			{
-				var as_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept as_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return as_;
 			};
-			var ao_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)am_, an_);
+			IEnumerable<CqlConcept> ao_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)am_, an_);
 			bool? ap_(CqlConcept T)
 			{
-				var at_ = this.Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_();
-				var au_ = context.Operators.ConvertCodeToConcept(at_);
-				var av_ = context.Operators.Equivalent(T, au_);
+				CqlCode at_ = this.Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_();
+				CqlConcept au_ = context.Operators.ConvertCodeToConcept(at_);
+				bool? av_ = context.Operators.Equivalent(T, au_);
 
 				return av_;
 			};
-			var aq_ = context.Operators.Where<CqlConcept>(ao_, ap_);
-			var ar_ = context.Operators.Exists<CqlConcept>(aq_);
+			IEnumerable<CqlConcept> aq_ = context.Operators.Where<CqlConcept>(ao_, ap_);
+			bool? ar_ = context.Operators.Exists<CqlConcept>(aq_);
 
 			return ar_;
 		};
-		var ah_ = context.Operators.Where<Encounter>(af_, ag_);
-		var ai_ = context.Operators.Union<Encounter>(ae_, ah_);
-		var aj_ = context.Operators.Union<Encounter>(ac_, ai_);
+		IEnumerable<Encounter> ah_ = context.Operators.Where<Encounter>(af_, ag_);
+		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(ae_, ah_);
+		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ac_, ai_);
 		bool? ak_(Encounter ValidEncounters)
 		{
-			var aw_ = this.Measurement_Period();
-			var ax_ = ValidEncounters?.Period;
-			var ay_ = FHIRHelpers_4_3_000.ToInterval(ax_);
-			var az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, null);
+			CqlInterval<CqlDateTime> aw_ = this.Measurement_Period();
+			Period ax_ = ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_3_000.ToInterval(ax_);
+			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, null);
 
 			return az_;
 		};
-		var al_ = context.Operators.Where<Encounter>(aj_, ak_);
+		IEnumerable<Encounter> al_ = context.Operators.Where<Encounter>(aj_, ak_);
 
 		return al_;
 	}
 
+    /// <seealso cref="Qualifying_Encounters_Value"/>
     [CqlDeclaration("Qualifying Encounters")]
 	public IEnumerable<Encounter> Qualifying_Encounters() => 
 		__Qualifying_Encounters.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.GreaterOrEqual(f_, 65);
-		var h_ = this.Qualifying_Encounters();
-		var i_ = context.Operators.Exists<Encounter>(h_);
-		var j_ = context.Operators.And(g_, i_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		bool? i_ = context.Operators.GreaterOrEqual(h_, 65);
+		IEnumerable<Encounter> j_ = this.Qualifying_Encounters();
+		bool? k_ = context.Operators.Exists<Encounter>(j_);
+		bool? l_ = context.Operators.And(i_, k_);
 
-		return j_;
+		return l_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
-		var c_ = context.Operators.Or(a_, b_);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		bool? b_ = PalliativeCare_1_9_000.Has_Palliative_Care_in_the_Measurement_Period();
+		bool? c_ = context.Operators.Or(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
@@ -861,182 +997,184 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
     [CqlDeclaration("More Than One Order")]
 	public IEnumerable<MedicationRequest> More_Than_One_Order(IEnumerable<MedicationRequest> Medication)
 	{
-		var a_ = Status_1_6_000.Active_or_Completed_Medication_Request(Medication);
+		IEnumerable<MedicationRequest> a_ = Status_1_6_000.Active_or_Completed_Medication_Request(Medication);
 		IEnumerable<MedicationRequest> b_(MedicationRequest OrderMedication1)
 		{
-			var f_ = Status_1_6_000.Active_or_Completed_Medication_Request(Medication);
+			IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(Medication);
 			bool? g_(MedicationRequest OrderMedication2)
 			{
-				var k_ = OrderMedication1?.AuthoredOnElement;
-				var l_ = context.Operators.Convert<CqlDateTime>(k_);
-				var m_ = this.Measurement_Period();
-				var n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
-				var o_ = OrderMedication1?.DispenseRequest;
-				var p_ = o_?.NumberOfRepeatsAllowedElement;
-				var q_ = p_?.Value;
-				var r_ = context.Operators.GreaterOrEqual(q_, 1);
-				var s_ = context.Operators.And(n_, r_);
-				var u_ = context.Operators.Convert<CqlDateTime>(k_);
-				var v_ = context.Operators.DateFrom(u_);
-				var w_ = OrderMedication2?.AuthoredOnElement;
-				var x_ = context.Operators.Convert<CqlDateTime>(w_);
-				var y_ = context.Operators.DateFrom(x_);
-				var z_ = context.Operators.Equivalent(v_, y_);
-				var aa_ = context.Operators.Not(z_);
-				var ac_ = context.Operators.Convert<CqlDateTime>(k_);
-				var ae_ = context.Operators.In<CqlDateTime>(ac_, m_, null);
-				var af_ = context.Operators.And(aa_, ae_);
-				var ah_ = context.Operators.Convert<CqlDateTime>(w_);
-				var aj_ = context.Operators.In<CqlDateTime>(ah_, m_, null);
-				var ak_ = context.Operators.And(af_, aj_);
-				var al_ = context.Operators.Or(s_, ak_);
-				var an_ = context.Operators.Convert<CqlDateTime>(k_);
-				var ao_ = context.Operators.DateFrom(an_);
-				var aq_ = context.Operators.Convert<CqlDateTime>(w_);
-				var ar_ = context.Operators.DateFrom(aq_);
-				var as_ = context.Operators.Equivalent(ao_, ar_);
-				var au_ = context.Operators.Convert<CqlDateTime>(k_);
-				var aw_ = context.Operators.In<CqlDateTime>(au_, m_, null);
-				var ax_ = context.Operators.And(as_, aw_);
-				var ay_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OrderMedication1);
-				var az_ = context.Operators.Start(ay_);
-				var ba_ = context.Operators.ConvertDateToDateTime(az_);
-				var bb_ = context.Operators.DateFrom(ba_);
-				var bc_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OrderMedication2);
-				var bd_ = context.Operators.Start(bc_);
-				var be_ = context.Operators.ConvertDateToDateTime(bd_);
-				var bf_ = context.Operators.DateFrom(be_);
-				var bg_ = context.Operators.Equivalent(bb_, bf_);
-				var bh_ = context.Operators.Not(bg_);
-				var bi_ = context.Operators.And(ax_, bh_);
-				var bk_ = context.Operators.Start(ay_);
-				var bl_ = context.Operators.ConvertDateToDateTime(bk_);
-				var bn_ = context.Operators.In<CqlDateTime>(bl_, m_, null);
-				var bo_ = context.Operators.And(bi_, bn_);
-				var bq_ = context.Operators.Start(bc_);
-				var br_ = context.Operators.ConvertDateToDateTime(bq_);
-				var bt_ = context.Operators.In<CqlDateTime>(br_, m_, null);
-				var bu_ = context.Operators.And(bo_, bt_);
-				var bv_ = context.Operators.Or(al_, bu_);
+				FhirDateTime k_ = OrderMedication1?.AuthoredOnElement;
+				CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
+				CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
+				MedicationRequest.DispenseRequestComponent o_ = OrderMedication1?.DispenseRequest;
+				UnsignedInt p_ = o_?.NumberOfRepeatsAllowedElement;
+				int? q_ = p_?.Value;
+				bool? r_ = context.Operators.GreaterOrEqual(q_, 1);
+				bool? s_ = context.Operators.And(n_, r_);
+				CqlDateTime u_ = context.Operators.Convert<CqlDateTime>(k_);
+				CqlDate v_ = context.Operators.DateFrom(u_);
+				FhirDateTime w_ = OrderMedication2?.AuthoredOnElement;
+				CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
+				CqlDate y_ = context.Operators.DateFrom(x_);
+				bool? z_ = context.Operators.Equivalent(v_, y_);
+				bool? aa_ = context.Operators.Not(z_);
+				CqlDateTime ac_ = context.Operators.Convert<CqlDateTime>(k_);
+				bool? ae_ = context.Operators.In<CqlDateTime>(ac_, m_, null);
+				bool? af_ = context.Operators.And(aa_, ae_);
+				CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(w_);
+				bool? aj_ = context.Operators.In<CqlDateTime>(ah_, m_, null);
+				bool? ak_ = context.Operators.And(af_, aj_);
+				bool? al_ = context.Operators.Or(s_, ak_);
+				CqlDateTime an_ = context.Operators.Convert<CqlDateTime>(k_);
+				CqlDate ao_ = context.Operators.DateFrom(an_);
+				CqlDateTime aq_ = context.Operators.Convert<CqlDateTime>(w_);
+				CqlDate ar_ = context.Operators.DateFrom(aq_);
+				bool? as_ = context.Operators.Equivalent(ao_, ar_);
+				CqlDateTime au_ = context.Operators.Convert<CqlDateTime>(k_);
+				bool? aw_ = context.Operators.In<CqlDateTime>(au_, m_, null);
+				bool? ax_ = context.Operators.And(as_, aw_);
+				CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OrderMedication1);
+				CqlDate az_ = context.Operators.Start(ay_);
+				CqlDateTime ba_ = context.Operators.ConvertDateToDateTime(az_);
+				CqlDate bb_ = context.Operators.DateFrom(ba_);
+				CqlInterval<CqlDate> bc_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OrderMedication2);
+				CqlDate bd_ = context.Operators.Start(bc_);
+				CqlDateTime be_ = context.Operators.ConvertDateToDateTime(bd_);
+				CqlDate bf_ = context.Operators.DateFrom(be_);
+				bool? bg_ = context.Operators.Equivalent(bb_, bf_);
+				bool? bh_ = context.Operators.Not(bg_);
+				bool? bi_ = context.Operators.And(ax_, bh_);
+				CqlDate bk_ = context.Operators.Start(ay_);
+				CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
+				bool? bn_ = context.Operators.In<CqlDateTime>(bl_, m_, null);
+				bool? bo_ = context.Operators.And(bi_, bn_);
+				CqlDate bq_ = context.Operators.Start(bc_);
+				CqlDateTime br_ = context.Operators.ConvertDateToDateTime(bq_);
+				bool? bt_ = context.Operators.In<CqlDateTime>(br_, m_, null);
+				bool? bu_ = context.Operators.And(bo_, bt_);
+				bool? bv_ = context.Operators.Or(al_, bu_);
 
 				return bv_;
 			};
-			var h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+			IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 			MedicationRequest i_(MedicationRequest OrderMedication2) => 
 				OrderMedication1;
-			var j_ = context.Operators.Select<MedicationRequest, MedicationRequest>(h_, i_);
+			IEnumerable<MedicationRequest> j_ = context.Operators.Select<MedicationRequest, MedicationRequest>(h_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(a_, b_);
+		IEnumerable<MedicationRequest> c_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(a_, b_);
 		MedicationRequest d_(MedicationRequest OrderMedication1) => 
 			OrderMedication1;
-		var e_ = context.Operators.Select<MedicationRequest, MedicationRequest>(c_, d_);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Select<MedicationRequest, MedicationRequest>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Same_High_Risk_Medications_Ordered_on_Different_Days"/>
 	private IEnumerable<MedicationRequest> Same_High_Risk_Medications_Ordered_on_Different_Days_Value()
 	{
-		var a_ = this.Anticholinergics__first_generation_antihistamines();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = this.More_Than_One_Order(e_);
-		var g_ = this.Anticholinergics__anti_Parkinson_agents();
-		var h_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, null);
-		var j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, null);
-		var k_ = context.Operators.Union<MedicationRequest>(h_, j_);
-		var l_ = this.More_Than_One_Order(k_);
-		var m_ = context.Operators.Union<MedicationRequest>(f_, l_);
-		var n_ = this.Antispasmodics();
-		var o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
-		var q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
-		var r_ = context.Operators.Union<MedicationRequest>(o_, q_);
-		var s_ = this.More_Than_One_Order(r_);
-		var t_ = this.Antithrombotic();
-		var u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
-		var w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
-		var x_ = context.Operators.Union<MedicationRequest>(u_, w_);
-		var y_ = this.More_Than_One_Order(x_);
-		var z_ = context.Operators.Union<MedicationRequest>(s_, y_);
-		var aa_ = context.Operators.Union<MedicationRequest>(m_, z_);
-		var ab_ = this.Cardiovascular__alpha_agonists__central();
-		var ac_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, null);
-		var ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, null);
-		var af_ = context.Operators.Union<MedicationRequest>(ac_, ae_);
-		var ag_ = this.More_Than_One_Order(af_);
-		var ah_ = this.Cardiovascular__other();
-		var ai_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, null);
-		var ak_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, null);
-		var al_ = context.Operators.Union<MedicationRequest>(ai_, ak_);
-		var am_ = this.More_Than_One_Order(al_);
-		var an_ = context.Operators.Union<MedicationRequest>(ag_, am_);
-		var ao_ = context.Operators.Union<MedicationRequest>(aa_, an_);
-		var ap_ = this.Central_nervous_system__antidepressants();
-		var aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
-		var as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
-		var at_ = context.Operators.Union<MedicationRequest>(aq_, as_);
-		var au_ = this.More_Than_One_Order(at_);
-		var av_ = this.Central_nervous_system__barbiturates();
-		var aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
-		var ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
-		var az_ = context.Operators.Union<MedicationRequest>(aw_, ay_);
-		var ba_ = this.More_Than_One_Order(az_);
-		var bb_ = context.Operators.Union<MedicationRequest>(au_, ba_);
-		var bc_ = context.Operators.Union<MedicationRequest>(ao_, bb_);
-		var bd_ = this.Central_nervous_system__vasodilators();
-		var be_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, null);
-		var bg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, null);
-		var bh_ = context.Operators.Union<MedicationRequest>(be_, bg_);
-		var bi_ = this.More_Than_One_Order(bh_);
-		var bj_ = this.Central_nervous_system__other();
-		var bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, null);
-		var bm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, null);
-		var bn_ = context.Operators.Union<MedicationRequest>(bk_, bm_);
-		var bo_ = this.More_Than_One_Order(bn_);
-		var bp_ = context.Operators.Union<MedicationRequest>(bi_, bo_);
-		var bq_ = context.Operators.Union<MedicationRequest>(bc_, bp_);
-		var br_ = this.Endocrine_system__estrogens_with_or_without_progestins();
-		var bs_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, null);
-		var bu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, null);
-		var bv_ = context.Operators.Union<MedicationRequest>(bs_, bu_);
-		var bw_ = this.More_Than_One_Order(bv_);
-		var bx_ = this.Endocrine_system__sulfonylureas__long_duration();
-		var by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, null);
-		var ca_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, null);
-		var cb_ = context.Operators.Union<MedicationRequest>(by_, ca_);
-		var cc_ = this.More_Than_One_Order(cb_);
-		var cd_ = context.Operators.Union<MedicationRequest>(bw_, cc_);
-		var ce_ = context.Operators.Union<MedicationRequest>(bq_, cd_);
-		var cf_ = this.Endocrine_system__other();
-		var cg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, null);
-		var ci_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, null);
-		var cj_ = context.Operators.Union<MedicationRequest>(cg_, ci_);
-		var ck_ = this.More_Than_One_Order(cj_);
-		var cl_ = this.Nonbenzodiazepine_hypnotics();
-		var cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
-		var co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
-		var cp_ = context.Operators.Union<MedicationRequest>(cm_, co_);
-		var cq_ = this.More_Than_One_Order(cp_);
-		var cr_ = context.Operators.Union<MedicationRequest>(ck_, cq_);
-		var cs_ = context.Operators.Union<MedicationRequest>(ce_, cr_);
-		var ct_ = this.Pain_medications__skeletal_muscle_relaxants();
-		var cu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, null);
-		var cw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, null);
-		var cx_ = context.Operators.Union<MedicationRequest>(cu_, cw_);
-		var cy_ = this.More_Than_One_Order(cx_);
-		var cz_ = this.Pain_medications__other();
-		var da_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, null);
-		var dc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, null);
-		var dd_ = context.Operators.Union<MedicationRequest>(da_, dc_);
-		var de_ = this.More_Than_One_Order(dd_);
-		var df_ = context.Operators.Union<MedicationRequest>(cy_, de_);
-		var dg_ = context.Operators.Union<MedicationRequest>(cs_, df_);
+		CqlValueSet a_ = this.Anticholinergics__first_generation_antihistamines();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
+		CqlValueSet g_ = this.Anticholinergics__anti_Parkinson_agents();
+		IEnumerable<MedicationRequest> h_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, null);
+		IEnumerable<MedicationRequest> j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, null);
+		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(h_, j_);
+		IEnumerable<MedicationRequest> l_ = this.More_Than_One_Order(k_);
+		IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(f_, l_);
+		CqlValueSet n_ = this.Antispasmodics();
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		IEnumerable<MedicationRequest> r_ = context.Operators.Union<MedicationRequest>(o_, q_);
+		IEnumerable<MedicationRequest> s_ = this.More_Than_One_Order(r_);
+		CqlValueSet t_ = this.Antithrombotic();
+		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		IEnumerable<MedicationRequest> x_ = context.Operators.Union<MedicationRequest>(u_, w_);
+		IEnumerable<MedicationRequest> y_ = this.More_Than_One_Order(x_);
+		IEnumerable<MedicationRequest> z_ = context.Operators.Union<MedicationRequest>(s_, y_);
+		IEnumerable<MedicationRequest> aa_ = context.Operators.Union<MedicationRequest>(m_, z_);
+		CqlValueSet ab_ = this.Cardiovascular__alpha_agonists__central();
+		IEnumerable<MedicationRequest> ac_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, null);
+		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, null);
+		IEnumerable<MedicationRequest> af_ = context.Operators.Union<MedicationRequest>(ac_, ae_);
+		IEnumerable<MedicationRequest> ag_ = this.More_Than_One_Order(af_);
+		CqlValueSet ah_ = this.Cardiovascular__other();
+		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, null);
+		IEnumerable<MedicationRequest> ak_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, null);
+		IEnumerable<MedicationRequest> al_ = context.Operators.Union<MedicationRequest>(ai_, ak_);
+		IEnumerable<MedicationRequest> am_ = this.More_Than_One_Order(al_);
+		IEnumerable<MedicationRequest> an_ = context.Operators.Union<MedicationRequest>(ag_, am_);
+		IEnumerable<MedicationRequest> ao_ = context.Operators.Union<MedicationRequest>(aa_, an_);
+		CqlValueSet ap_ = this.Central_nervous_system__antidepressants();
+		IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
+		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
+		IEnumerable<MedicationRequest> at_ = context.Operators.Union<MedicationRequest>(aq_, as_);
+		IEnumerable<MedicationRequest> au_ = this.More_Than_One_Order(at_);
+		CqlValueSet av_ = this.Central_nervous_system__barbiturates();
+		IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
+		IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
+		IEnumerable<MedicationRequest> az_ = context.Operators.Union<MedicationRequest>(aw_, ay_);
+		IEnumerable<MedicationRequest> ba_ = this.More_Than_One_Order(az_);
+		IEnumerable<MedicationRequest> bb_ = context.Operators.Union<MedicationRequest>(au_, ba_);
+		IEnumerable<MedicationRequest> bc_ = context.Operators.Union<MedicationRequest>(ao_, bb_);
+		CqlValueSet bd_ = this.Central_nervous_system__vasodilators();
+		IEnumerable<MedicationRequest> be_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, null);
+		IEnumerable<MedicationRequest> bg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, null);
+		IEnumerable<MedicationRequest> bh_ = context.Operators.Union<MedicationRequest>(be_, bg_);
+		IEnumerable<MedicationRequest> bi_ = this.More_Than_One_Order(bh_);
+		CqlValueSet bj_ = this.Central_nervous_system__other();
+		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, null);
+		IEnumerable<MedicationRequest> bm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, null);
+		IEnumerable<MedicationRequest> bn_ = context.Operators.Union<MedicationRequest>(bk_, bm_);
+		IEnumerable<MedicationRequest> bo_ = this.More_Than_One_Order(bn_);
+		IEnumerable<MedicationRequest> bp_ = context.Operators.Union<MedicationRequest>(bi_, bo_);
+		IEnumerable<MedicationRequest> bq_ = context.Operators.Union<MedicationRequest>(bc_, bp_);
+		CqlValueSet br_ = this.Endocrine_system__estrogens_with_or_without_progestins();
+		IEnumerable<MedicationRequest> bs_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, null);
+		IEnumerable<MedicationRequest> bu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, null);
+		IEnumerable<MedicationRequest> bv_ = context.Operators.Union<MedicationRequest>(bs_, bu_);
+		IEnumerable<MedicationRequest> bw_ = this.More_Than_One_Order(bv_);
+		CqlValueSet bx_ = this.Endocrine_system__sulfonylureas__long_duration();
+		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, null);
+		IEnumerable<MedicationRequest> ca_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, null);
+		IEnumerable<MedicationRequest> cb_ = context.Operators.Union<MedicationRequest>(by_, ca_);
+		IEnumerable<MedicationRequest> cc_ = this.More_Than_One_Order(cb_);
+		IEnumerable<MedicationRequest> cd_ = context.Operators.Union<MedicationRequest>(bw_, cc_);
+		IEnumerable<MedicationRequest> ce_ = context.Operators.Union<MedicationRequest>(bq_, cd_);
+		CqlValueSet cf_ = this.Endocrine_system__other();
+		IEnumerable<MedicationRequest> cg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, null);
+		IEnumerable<MedicationRequest> ci_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, null);
+		IEnumerable<MedicationRequest> cj_ = context.Operators.Union<MedicationRequest>(cg_, ci_);
+		IEnumerable<MedicationRequest> ck_ = this.More_Than_One_Order(cj_);
+		CqlValueSet cl_ = this.Nonbenzodiazepine_hypnotics();
+		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		IEnumerable<MedicationRequest> cp_ = context.Operators.Union<MedicationRequest>(cm_, co_);
+		IEnumerable<MedicationRequest> cq_ = this.More_Than_One_Order(cp_);
+		IEnumerable<MedicationRequest> cr_ = context.Operators.Union<MedicationRequest>(ck_, cq_);
+		IEnumerable<MedicationRequest> cs_ = context.Operators.Union<MedicationRequest>(ce_, cr_);
+		CqlValueSet ct_ = this.Pain_medications__skeletal_muscle_relaxants();
+		IEnumerable<MedicationRequest> cu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, null);
+		IEnumerable<MedicationRequest> cw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, null);
+		IEnumerable<MedicationRequest> cx_ = context.Operators.Union<MedicationRequest>(cu_, cw_);
+		IEnumerable<MedicationRequest> cy_ = this.More_Than_One_Order(cx_);
+		CqlValueSet cz_ = this.Pain_medications__other();
+		IEnumerable<MedicationRequest> da_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, null);
+		IEnumerable<MedicationRequest> dc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, null);
+		IEnumerable<MedicationRequest> dd_ = context.Operators.Union<MedicationRequest>(da_, dc_);
+		IEnumerable<MedicationRequest> de_ = this.More_Than_One_Order(dd_);
+		IEnumerable<MedicationRequest> df_ = context.Operators.Union<MedicationRequest>(cy_, de_);
+		IEnumerable<MedicationRequest> dg_ = context.Operators.Union<MedicationRequest>(cs_, df_);
 
 		return dg_;
 	}
 
+    /// <seealso cref="Same_High_Risk_Medications_Ordered_on_Different_Days_Value"/>
     [CqlDeclaration("Same High Risk Medications Ordered on Different Days")]
 	public IEnumerable<MedicationRequest> Same_High_Risk_Medications_Ordered_on_Different_Days() => 
 		__Same_High_Risk_Medications_Ordered_on_Different_Days.Value;
@@ -1044,101 +1182,103 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
     [CqlDeclaration("MedicationRequestPeriodInDays")]
 	public decimal? MedicationRequestPeriodInDays(MedicationRequest Request)
 	{
-		var a_ = new MedicationRequest[]
+		MedicationRequest[] a_ = new MedicationRequest[]
 		{
 			Request,
 		};
 		decimal? b_(MedicationRequest R)
 		{
-			var e_ = R?.DispenseRequest;
-			var f_ = e_?.ExpectedSupplyDuration;
-			var g_ = FHIRHelpers_4_3_000.ToQuantity((Quantity)f_);
-			var h_ = context.Operators.ConvertQuantity(g_, "d");
-			var i_ = h_?.value;
-			var k_ = e_?.Quantity;
-			var l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
-			var m_ = l_?.value;
-			var n_ = R?.DosageInstruction;
-			var o_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
-			var p_ = o_?.DoseAndRate;
-			var q_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)p_);
-			var r_ = q_?.Dose;
-			var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-			var t_ = context.Operators.End((s_ as CqlInterval<CqlQuantity>));
-			var v_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
-			var w_ = v_?.DoseAndRate;
-			var x_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)w_);
-			var y_ = x_?.Dose;
-			var z_ = FHIRHelpers_4_3_000.ToValue(y_);
-			var aa_ = (t_ ?? (z_ as CqlQuantity))?.value;
-			var ac_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
-			var ad_ = ac_?.Timing;
-			var ae_ = ad_?.Repeat;
-			var af_ = ae_?.FrequencyMaxElement;
-			var ag_ = af_?.Value;
-			var ai_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
-			var aj_ = ai_?.Timing;
-			var ak_ = aj_?.Repeat;
-			var al_ = ak_?.FrequencyElement;
-			var am_ = al_?.Value;
-			var ao_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
-			var ap_ = ao_?.Timing;
-			var aq_ = ap_?.Repeat;
-			var ar_ = aq_?.PeriodElement;
-			var as_ = ar_?.Value;
-			var au_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
-			var av_ = au_?.Timing;
-			var aw_ = av_?.Repeat;
-			var ax_ = aw_?.PeriodUnitElement;
-			var ay_ = ax_?.Value;
-			var az_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(ay_);
-			var ba_ = context.Operators.Convert<string>(az_);
-			var bb_ = CumulativeMedicationDuration_4_0_000.Quantity(as_, ba_);
-			var bc_ = CumulativeMedicationDuration_4_0_000.ToDaily((ag_ ?? am_), bb_);
-			var be_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
-			var bf_ = be_?.Timing;
-			var bg_ = bf_?.Repeat;
-			var bh_ = bg_?.TimeOfDayElement;
-			var bi_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(bh_, "value");
-			var bj_ = context.Operators.Count<CqlTime>(bi_);
-			var bk_ = context.Operators.ConvertIntegerToDecimal(bj_);
-			var bl_ = context.Operators.Multiply(aa_, ((bc_ ?? bk_) ?? 1.0m));
-			var bm_ = context.Operators.Divide(m_, bl_);
-			var bo_ = e_?.NumberOfRepeatsAllowedElement;
-			var bp_ = bo_?.Value;
-			var bq_ = context.Operators.Add(1, (bp_ ?? 0));
-			var br_ = context.Operators.ConvertIntegerToDecimal(bq_);
-			var bs_ = context.Operators.Multiply((i_ ?? bm_), br_);
+			MedicationRequest.DispenseRequestComponent e_ = R?.DispenseRequest;
+			Duration f_ = e_?.ExpectedSupplyDuration;
+			CqlQuantity g_ = FHIRHelpers_4_3_000.ToQuantity((Quantity)f_);
+			CqlQuantity h_ = context.Operators.ConvertQuantity(g_, "d");
+			decimal? i_ = h_?.value;
+			Quantity k_ = e_?.Quantity;
+			CqlQuantity l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
+			decimal? m_ = l_?.value;
+			List<Dosage> n_ = R?.DosageInstruction;
+			Dosage o_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
+			List<Dosage.DoseAndRateComponent> p_ = o_?.DoseAndRate;
+			Dosage.DoseAndRateComponent q_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)p_);
+			DataType r_ = q_?.Dose;
+			object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+			CqlQuantity t_ = context.Operators.End((s_ as CqlInterval<CqlQuantity>));
+			Dosage v_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
+			List<Dosage.DoseAndRateComponent> w_ = v_?.DoseAndRate;
+			Dosage.DoseAndRateComponent x_ = context.Operators.SingletonFrom<Dosage.DoseAndRateComponent>((IEnumerable<Dosage.DoseAndRateComponent>)w_);
+			DataType y_ = x_?.Dose;
+			object z_ = FHIRHelpers_4_3_000.ToValue(y_);
+			decimal? aa_ = (t_ ?? (z_ as CqlQuantity))?.value;
+			Dosage ac_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
+			Timing ad_ = ac_?.Timing;
+			Timing.RepeatComponent ae_ = ad_?.Repeat;
+			PositiveInt af_ = ae_?.FrequencyMaxElement;
+			int? ag_ = af_?.Value;
+			Dosage ai_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
+			Timing aj_ = ai_?.Timing;
+			Timing.RepeatComponent ak_ = aj_?.Repeat;
+			PositiveInt al_ = ak_?.FrequencyElement;
+			int? am_ = al_?.Value;
+			Dosage ao_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
+			Timing ap_ = ao_?.Timing;
+			Timing.RepeatComponent aq_ = ap_?.Repeat;
+			FhirDecimal ar_ = aq_?.PeriodElement;
+			decimal? as_ = ar_?.Value;
+			Dosage au_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
+			Timing av_ = au_?.Timing;
+			Timing.RepeatComponent aw_ = av_?.Repeat;
+			Code<Timing.UnitsOfTime> ax_ = aw_?.PeriodUnitElement;
+			Timing.UnitsOfTime? ay_ = ax_?.Value;
+			Code<Timing.UnitsOfTime> az_ = context.Operators.Convert<Code<Timing.UnitsOfTime>>(ay_);
+			string ba_ = context.Operators.Convert<string>(az_);
+			CqlQuantity bb_ = CumulativeMedicationDuration_4_0_000.Quantity(as_, ba_);
+			decimal? bc_ = CumulativeMedicationDuration_4_0_000.ToDaily((ag_ ?? am_), bb_);
+			Dosage be_ = context.Operators.SingletonFrom<Dosage>((IEnumerable<Dosage>)n_);
+			Timing bf_ = be_?.Timing;
+			Timing.RepeatComponent bg_ = bf_?.Repeat;
+			List<Time> bh_ = bg_?.TimeOfDayElement;
+			IEnumerable<CqlTime> bi_ = context.Operators.LateBoundProperty<IEnumerable<CqlTime>>(bh_, "value");
+			int? bj_ = context.Operators.Count<CqlTime>(bi_);
+			decimal? bk_ = context.Operators.ConvertIntegerToDecimal(bj_);
+			decimal? bl_ = context.Operators.Multiply(aa_, ((bc_ ?? bk_) ?? 1.0m));
+			decimal? bm_ = context.Operators.Divide(m_, bl_);
+			UnsignedInt bo_ = e_?.NumberOfRepeatsAllowedElement;
+			int? bp_ = bo_?.Value;
+			int? bq_ = context.Operators.Add(1, (bp_ ?? 0));
+			decimal? br_ = context.Operators.ConvertIntegerToDecimal(bq_);
+			decimal? bs_ = context.Operators.Multiply((i_ ?? bm_), br_);
 
 			return bs_;
 		};
-		var c_ = context.Operators.Select<MedicationRequest, decimal?>((IEnumerable<MedicationRequest>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<decimal?>(c_);
+		IEnumerable<decimal?> c_ = context.Operators.Select<MedicationRequest, decimal?>((IEnumerable<MedicationRequest>)a_, b_);
+		decimal? d_ = context.Operators.SingletonFrom<decimal?>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Two_High_Risk_Medications_with_Prolonged_Duration"/>
 	private bool? Two_High_Risk_Medications_with_Prolonged_Duration_Value()
 	{
-		var a_ = this.Anti_Infectives__other();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = this.More_Than_One_Order(e_);
+		CqlValueSet a_ = this.Anti_Infectives__other();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
 		decimal? g_(MedicationRequest AntiInfectives)
 		{
-			var l_ = this.MedicationRequestPeriodInDays(AntiInfectives);
+			decimal? l_ = this.MedicationRequestPeriodInDays(AntiInfectives);
 
 			return l_;
 		};
-		var h_ = context.Operators.Select<MedicationRequest, decimal?>(f_, g_);
-		var i_ = context.Operators.Sum(h_);
-		var j_ = context.Operators.ConvertIntegerToDecimal(90);
-		var k_ = context.Operators.Greater(i_, j_);
+		IEnumerable<decimal?> h_ = context.Operators.Select<MedicationRequest, decimal?>(f_, g_);
+		decimal? i_ = context.Operators.Sum(h_);
+		decimal? j_ = context.Operators.ConvertIntegerToDecimal(90);
+		bool? k_ = context.Operators.Greater(i_, j_);
 
 		return k_;
 	}
 
+    /// <seealso cref="Two_High_Risk_Medications_with_Prolonged_Duration_Value"/>
     [CqlDeclaration("Two High Risk Medications with Prolonged Duration")]
 	public bool? Two_High_Risk_Medications_with_Prolonged_Duration() => 
 		__Two_High_Risk_Medications_with_Prolonged_Duration.Value;
@@ -1150,253 +1290,253 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		{
 			bool b_()
 			{
-				var t_ = this.reserpine_0_1_MG_Oral_Tablet();
-				var u_ = context.Operators.ConvertCodeToConcept(t_);
-				var v_ = context.Operators.Equivalent(Strength, u_);
+				CqlCode t_ = this.reserpine_0_1_MG_Oral_Tablet();
+				CqlConcept u_ = context.Operators.ConvertCodeToConcept(t_);
+				bool? v_ = context.Operators.Equivalent(Strength, u_);
 
 				return (v_ ?? false);
 			};
 			bool c_()
 			{
-				var w_ = this.reserpine_0_25_MG_Oral_Tablet();
-				var x_ = context.Operators.ConvertCodeToConcept(w_);
-				var y_ = context.Operators.Equivalent(Strength, x_);
+				CqlCode w_ = this.reserpine_0_25_MG_Oral_Tablet();
+				CqlConcept x_ = context.Operators.ConvertCodeToConcept(w_);
+				bool? y_ = context.Operators.Equivalent(Strength, x_);
 
 				return (y_ ?? false);
 			};
 			bool d_()
 			{
-				var z_ = this.digoxin_0_05_MG_ML_Oral_Solution();
-				var aa_ = context.Operators.ConvertCodeToConcept(z_);
-				var ab_ = context.Operators.Equivalent(Strength, aa_);
+				CqlCode z_ = this.digoxin_0_05_MG_ML_Oral_Solution();
+				CqlConcept aa_ = context.Operators.ConvertCodeToConcept(z_);
+				bool? ab_ = context.Operators.Equivalent(Strength, aa_);
 
 				return (ab_ ?? false);
 			};
 			bool e_()
 			{
-				var ac_ = this.digoxin_0_0625_MG_Oral_Tablet();
-				var ad_ = context.Operators.ConvertCodeToConcept(ac_);
-				var ae_ = context.Operators.Equivalent(Strength, ad_);
+				CqlCode ac_ = this.digoxin_0_0625_MG_Oral_Tablet();
+				CqlConcept ad_ = context.Operators.ConvertCodeToConcept(ac_);
+				bool? ae_ = context.Operators.Equivalent(Strength, ad_);
 
 				return (ae_ ?? false);
 			};
 			bool f_()
 			{
-				var af_ = this._1_ML_digoxin_0_1_MG_ML_Injection();
-				var ag_ = context.Operators.ConvertCodeToConcept(af_);
-				var ah_ = context.Operators.Equivalent(Strength, ag_);
+				CqlCode af_ = this._1_ML_digoxin_0_1_MG_ML_Injection();
+				CqlConcept ag_ = context.Operators.ConvertCodeToConcept(af_);
+				bool? ah_ = context.Operators.Equivalent(Strength, ag_);
 
 				return (ah_ ?? false);
 			};
 			bool g_()
 			{
-				var ai_ = this.digoxin_0_125_MG_Oral_Tablet();
-				var aj_ = context.Operators.ConvertCodeToConcept(ai_);
-				var ak_ = context.Operators.Equivalent(Strength, aj_);
+				CqlCode ai_ = this.digoxin_0_125_MG_Oral_Tablet();
+				CqlConcept aj_ = context.Operators.ConvertCodeToConcept(ai_);
+				bool? ak_ = context.Operators.Equivalent(Strength, aj_);
 
 				return (ak_ ?? false);
 			};
 			bool h_()
 			{
-				var al_ = this.digoxin_0_1875_MG_Oral_Tablet();
-				var am_ = context.Operators.ConvertCodeToConcept(al_);
-				var an_ = context.Operators.Equivalent(Strength, am_);
+				CqlCode al_ = this.digoxin_0_1875_MG_Oral_Tablet();
+				CqlConcept am_ = context.Operators.ConvertCodeToConcept(al_);
+				bool? an_ = context.Operators.Equivalent(Strength, am_);
 
 				return (an_ ?? false);
 			};
 			bool i_()
 			{
-				var ao_ = this.digoxin_0_25_MG_Oral_Tablet();
-				var ap_ = context.Operators.ConvertCodeToConcept(ao_);
-				var aq_ = context.Operators.Equivalent(Strength, ap_);
+				CqlCode ao_ = this.digoxin_0_25_MG_Oral_Tablet();
+				CqlConcept ap_ = context.Operators.ConvertCodeToConcept(ao_);
+				bool? aq_ = context.Operators.Equivalent(Strength, ap_);
 
 				return (aq_ ?? false);
 			};
 			bool j_()
 			{
-				var ar_ = this._2_ML_digoxin_0_25_MG_ML_Injection();
-				var as_ = context.Operators.ConvertCodeToConcept(ar_);
-				var at_ = context.Operators.Equivalent(Strength, as_);
+				CqlCode ar_ = this._2_ML_digoxin_0_25_MG_ML_Injection();
+				CqlConcept as_ = context.Operators.ConvertCodeToConcept(ar_);
+				bool? at_ = context.Operators.Equivalent(Strength, as_);
 
 				return (at_ ?? false);
 			};
 			bool k_()
 			{
-				var au_ = this.doxepin_3_MG_Oral_Tablet();
-				var av_ = context.Operators.ConvertCodeToConcept(au_);
-				var aw_ = context.Operators.Equivalent(Strength, av_);
+				CqlCode au_ = this.doxepin_3_MG_Oral_Tablet();
+				CqlConcept av_ = context.Operators.ConvertCodeToConcept(au_);
+				bool? aw_ = context.Operators.Equivalent(Strength, av_);
 
 				return (aw_ ?? false);
 			};
 			bool l_()
 			{
-				var ax_ = this.doxepin_6_MG_Oral_Tablet();
-				var ay_ = context.Operators.ConvertCodeToConcept(ax_);
-				var az_ = context.Operators.Equivalent(Strength, ay_);
+				CqlCode ax_ = this.doxepin_6_MG_Oral_Tablet();
+				CqlConcept ay_ = context.Operators.ConvertCodeToConcept(ax_);
+				bool? az_ = context.Operators.Equivalent(Strength, ay_);
 
 				return (az_ ?? false);
 			};
 			bool m_()
 			{
-				var ba_ = this.doxepin_hydrochloride_10_MG_Oral_Capsule();
-				var bb_ = context.Operators.ConvertCodeToConcept(ba_);
-				var bc_ = context.Operators.Equivalent(Strength, bb_);
+				CqlCode ba_ = this.doxepin_hydrochloride_10_MG_Oral_Capsule();
+				CqlConcept bb_ = context.Operators.ConvertCodeToConcept(ba_);
+				bool? bc_ = context.Operators.Equivalent(Strength, bb_);
 
 				return (bc_ ?? false);
 			};
 			bool n_()
 			{
-				var bd_ = this.doxepin_hydrochloride_10_MG_ML_Oral_Solution();
-				var be_ = context.Operators.ConvertCodeToConcept(bd_);
-				var bf_ = context.Operators.Equivalent(Strength, be_);
+				CqlCode bd_ = this.doxepin_hydrochloride_10_MG_ML_Oral_Solution();
+				CqlConcept be_ = context.Operators.ConvertCodeToConcept(bd_);
+				bool? bf_ = context.Operators.Equivalent(Strength, be_);
 
 				return (bf_ ?? false);
 			};
 			bool o_()
 			{
-				var bg_ = this.doxepin_hydrochloride_25_MG_Oral_Capsule();
-				var bh_ = context.Operators.ConvertCodeToConcept(bg_);
-				var bi_ = context.Operators.Equivalent(Strength, bh_);
+				CqlCode bg_ = this.doxepin_hydrochloride_25_MG_Oral_Capsule();
+				CqlConcept bh_ = context.Operators.ConvertCodeToConcept(bg_);
+				bool? bi_ = context.Operators.Equivalent(Strength, bh_);
 
 				return (bi_ ?? false);
 			};
 			bool p_()
 			{
-				var bj_ = this.doxepin_hydrochloride_50_MG_Oral_Capsule();
-				var bk_ = context.Operators.ConvertCodeToConcept(bj_);
-				var bl_ = context.Operators.Equivalent(Strength, bk_);
+				CqlCode bj_ = this.doxepin_hydrochloride_50_MG_Oral_Capsule();
+				CqlConcept bk_ = context.Operators.ConvertCodeToConcept(bj_);
+				bool? bl_ = context.Operators.Equivalent(Strength, bk_);
 
 				return (bl_ ?? false);
 			};
 			bool q_()
 			{
-				var bm_ = this.doxepin_hydrochloride_75_MG_Oral_Capsule();
-				var bn_ = context.Operators.ConvertCodeToConcept(bm_);
-				var bo_ = context.Operators.Equivalent(Strength, bn_);
+				CqlCode bm_ = this.doxepin_hydrochloride_75_MG_Oral_Capsule();
+				CqlConcept bn_ = context.Operators.ConvertCodeToConcept(bm_);
+				bool? bo_ = context.Operators.Equivalent(Strength, bn_);
 
 				return (bo_ ?? false);
 			};
 			bool r_()
 			{
-				var bp_ = this.doxepin_hydrochloride_100_MG_Oral_Capsule();
-				var bq_ = context.Operators.ConvertCodeToConcept(bp_);
-				var br_ = context.Operators.Equivalent(Strength, bq_);
+				CqlCode bp_ = this.doxepin_hydrochloride_100_MG_Oral_Capsule();
+				CqlConcept bq_ = context.Operators.ConvertCodeToConcept(bp_);
+				bool? br_ = context.Operators.Equivalent(Strength, bq_);
 
 				return (br_ ?? false);
 			};
 			bool s_()
 			{
-				var bs_ = this.doxepin_hydrochloride_150_MG_Oral_Capsule();
-				var bt_ = context.Operators.ConvertCodeToConcept(bs_);
-				var bu_ = context.Operators.Equivalent(Strength, bt_);
+				CqlCode bs_ = this.doxepin_hydrochloride_150_MG_Oral_Capsule();
+				CqlConcept bt_ = context.Operators.ConvertCodeToConcept(bs_);
+				bool? bu_ = context.Operators.Equivalent(Strength, bt_);
 
 				return (bu_ ?? false);
 			};
 			if (b_())
 			{
-				var bv_ = context.Operators.Quantity(0.1m, "mg");
+				CqlQuantity bv_ = context.Operators.Quantity(0.1m, "mg");
 
 				return bv_;
 			}
 			else if (c_())
 			{
-				var bw_ = context.Operators.Quantity(0.25m, "mg");
+				CqlQuantity bw_ = context.Operators.Quantity(0.25m, "mg");
 
 				return bw_;
 			}
 			else if (d_())
 			{
-				var bx_ = context.Operators.Quantity(0.05m, "mg/mL");
+				CqlQuantity bx_ = context.Operators.Quantity(0.05m, "mg/mL");
 
 				return bx_;
 			}
 			else if (e_())
 			{
-				var by_ = context.Operators.Quantity(0.0625m, "mg");
+				CqlQuantity by_ = context.Operators.Quantity(0.0625m, "mg");
 
 				return by_;
 			}
 			else if (f_())
 			{
-				var bz_ = context.Operators.Quantity(0.1m, "mg/mL");
+				CqlQuantity bz_ = context.Operators.Quantity(0.1m, "mg/mL");
 
 				return bz_;
 			}
 			else if (g_())
 			{
-				var ca_ = context.Operators.Quantity(0.125m, "mg");
+				CqlQuantity ca_ = context.Operators.Quantity(0.125m, "mg");
 
 				return ca_;
 			}
 			else if (h_())
 			{
-				var cb_ = context.Operators.Quantity(0.1875m, "mg");
+				CqlQuantity cb_ = context.Operators.Quantity(0.1875m, "mg");
 
 				return cb_;
 			}
 			else if (i_())
 			{
-				var cc_ = context.Operators.Quantity(0.25m, "mg");
+				CqlQuantity cc_ = context.Operators.Quantity(0.25m, "mg");
 
 				return cc_;
 			}
 			else if (j_())
 			{
-				var cd_ = context.Operators.Quantity(0.25m, "mg/mL");
+				CqlQuantity cd_ = context.Operators.Quantity(0.25m, "mg/mL");
 
 				return cd_;
 			}
 			else if (k_())
 			{
-				var ce_ = context.Operators.Quantity(3m, "mg");
+				CqlQuantity ce_ = context.Operators.Quantity(3m, "mg");
 
 				return ce_;
 			}
 			else if (l_())
 			{
-				var cf_ = context.Operators.Quantity(6m, "mg");
+				CqlQuantity cf_ = context.Operators.Quantity(6m, "mg");
 
 				return cf_;
 			}
 			else if (m_())
 			{
-				var cg_ = context.Operators.Quantity(10m, "mg");
+				CqlQuantity cg_ = context.Operators.Quantity(10m, "mg");
 
 				return cg_;
 			}
 			else if (n_())
 			{
-				var ch_ = context.Operators.Quantity(10m, "mg/mL");
+				CqlQuantity ch_ = context.Operators.Quantity(10m, "mg/mL");
 
 				return ch_;
 			}
 			else if (o_())
 			{
-				var ci_ = context.Operators.Quantity(25m, "mg");
+				CqlQuantity ci_ = context.Operators.Quantity(25m, "mg");
 
 				return ci_;
 			}
 			else if (p_())
 			{
-				var cj_ = context.Operators.Quantity(50m, "mg");
+				CqlQuantity cj_ = context.Operators.Quantity(50m, "mg");
 
 				return cj_;
 			}
 			else if (q_())
 			{
-				var ck_ = context.Operators.Quantity(75m, "mg");
+				CqlQuantity ck_ = context.Operators.Quantity(75m, "mg");
 
 				return ck_;
 			}
 			else if (r_())
 			{
-				var cl_ = context.Operators.Quantity(100m, "mg");
+				CqlQuantity cl_ = context.Operators.Quantity(100m, "mg");
 
 				return cl_;
 			}
 			else if (s_())
 			{
-				var cm_ = context.Operators.Quantity(150m, "mg");
+				CqlQuantity cm_ = context.Operators.Quantity(150m, "mg");
 
 				return cm_;
 			}
@@ -1412,7 +1552,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
     [CqlDeclaration("Average Daily Dose")]
 	public CqlQuantity Average_Daily_Dose(MedicationRequest MedicationRequest)
 	{
-		var a_ = new MedicationRequest[]
+		MedicationRequest[] a_ = new MedicationRequest[]
 		{
 			MedicationRequest,
 		};
@@ -1422,36 +1562,36 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			{
 				bool f_()
 				{
-					var g_ = this.MedicationRequestPeriodInDays(Order);
-					var h_ = context.Operators.Not((bool?)(g_ is null));
-					var i_ = CQMCommon_2_0_000.getMedicationCode(Order);
-					var j_ = this.MedicationStrengthPerUnit(i_);
-					var k_ = j_?.unit;
-					var l_ = context.Operators.Equal(k_, "mg");
-					var n_ = this.MedicationStrengthPerUnit(i_);
-					var o_ = n_?.unit;
-					var p_ = context.Operators.Equal(o_, "mg/mL");
-					var q_ = Order?.DispenseRequest;
-					var r_ = q_?.Quantity;
-					var s_ = FHIRHelpers_4_3_000.ToQuantity(r_);
-					var t_ = s_?.unit;
-					var u_ = context.Operators.Equal(t_, "mL");
-					var v_ = context.Operators.And(p_, u_);
-					var w_ = context.Operators.Or(l_, v_);
-					var x_ = context.Operators.And(h_, w_);
+					decimal? g_ = this.MedicationRequestPeriodInDays(Order);
+					bool? h_ = context.Operators.Not((bool?)(g_ is null));
+					CqlConcept i_ = CQMCommon_2_0_000.getMedicationCode(Order);
+					CqlQuantity j_ = this.MedicationStrengthPerUnit(i_);
+					string k_ = j_?.unit;
+					bool? l_ = context.Operators.Equal(k_, "mg");
+					CqlQuantity n_ = this.MedicationStrengthPerUnit(i_);
+					string o_ = n_?.unit;
+					bool? p_ = context.Operators.Equal(o_, "mg/mL");
+					MedicationRequest.DispenseRequestComponent q_ = Order?.DispenseRequest;
+					Quantity r_ = q_?.Quantity;
+					CqlQuantity s_ = FHIRHelpers_4_3_000.ToQuantity(r_);
+					string t_ = s_?.unit;
+					bool? u_ = context.Operators.Equal(t_, "mL");
+					bool? v_ = context.Operators.And(p_, u_);
+					bool? w_ = context.Operators.Or(l_, v_);
+					bool? x_ = context.Operators.And(h_, w_);
 
 					return (x_ ?? false);
 				};
 				if (f_())
 				{
-					var y_ = Order?.DispenseRequest;
-					var z_ = y_?.Quantity;
-					var aa_ = FHIRHelpers_4_3_000.ToQuantity(z_);
-					var ab_ = CQMCommon_2_0_000.getMedicationCode(Order);
-					var ac_ = this.MedicationStrengthPerUnit(ab_);
-					var ad_ = context.Operators.Multiply(aa_, ac_);
-					var ae_ = this.MedicationRequestPeriodInDays(Order);
-					var af_ = context.Operators.Divide(ad_, new CqlQuantity(ae_, "d"));
+					MedicationRequest.DispenseRequestComponent y_ = Order?.DispenseRequest;
+					Quantity z_ = y_?.Quantity;
+					CqlQuantity aa_ = FHIRHelpers_4_3_000.ToQuantity(z_);
+					CqlConcept ab_ = CQMCommon_2_0_000.getMedicationCode(Order);
+					CqlQuantity ac_ = this.MedicationStrengthPerUnit(ab_);
+					CqlQuantity ad_ = context.Operators.Multiply(aa_, ac_);
+					decimal? ae_ = this.MedicationRequestPeriodInDays(Order);
+					CqlQuantity af_ = context.Operators.Divide(ad_, new CqlQuantity(ae_, "d"));
 
 					return af_;
 				}
@@ -1463,308 +1603,332 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 
 			return e_();
 		};
-		var c_ = context.Operators.Select<MedicationRequest, CqlQuantity>((IEnumerable<MedicationRequest>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlQuantity>(c_);
+		IEnumerable<CqlQuantity> c_ = context.Operators.Select<MedicationRequest, CqlQuantity>((IEnumerable<MedicationRequest>)a_, b_);
+		CqlQuantity d_ = context.Operators.SingletonFrom<CqlQuantity>(c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="High_Risk_Medications_with_Average_Daily_Dose_Criteria"/>
 	private bool? High_Risk_Medications_with_Average_Daily_Dose_Criteria_Value()
 	{
-		var a_ = this.Reserpine();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		CqlValueSet a_ = this.Reserpine();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest ReserpineOrdered)
 		{
-			var ad_ = this.Average_Daily_Dose(ReserpineOrdered);
-			var ae_ = context.Operators.Quantity(0.1m, "mg/d");
-			var af_ = context.Operators.Greater(ad_, ae_);
+			CqlQuantity ad_ = this.Average_Daily_Dose(ReserpineOrdered);
+			CqlQuantity ae_ = context.Operators.Quantity(0.1m, "mg/d");
+			bool? af_ = context.Operators.Greater(ad_, ae_);
 
 			return af_;
 		};
-		var g_ = context.Operators.Where<MedicationRequest>(e_, f_);
-		var h_ = this.More_Than_One_Order(g_);
-		var i_ = context.Operators.Exists<MedicationRequest>(h_);
-		var j_ = this.Digoxin();
-		var k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
-		var m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
-		var n_ = context.Operators.Union<MedicationRequest>(k_, m_);
+		IEnumerable<MedicationRequest> g_ = context.Operators.Where<MedicationRequest>(e_, f_);
+		IEnumerable<MedicationRequest> h_ = this.More_Than_One_Order(g_);
+		bool? i_ = context.Operators.Exists<MedicationRequest>(h_);
+		CqlValueSet j_ = this.Digoxin();
+		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
+		IEnumerable<MedicationRequest> n_ = context.Operators.Union<MedicationRequest>(k_, m_);
 		bool? o_(MedicationRequest DigoxinOrdered)
 		{
-			var ag_ = this.Average_Daily_Dose(DigoxinOrdered);
-			var ah_ = context.Operators.Quantity(0.125m, "mg/d");
-			var ai_ = context.Operators.Greater(ag_, ah_);
+			CqlQuantity ag_ = this.Average_Daily_Dose(DigoxinOrdered);
+			CqlQuantity ah_ = context.Operators.Quantity(0.125m, "mg/d");
+			bool? ai_ = context.Operators.Greater(ag_, ah_);
 
 			return ai_;
 		};
-		var p_ = context.Operators.Where<MedicationRequest>(n_, o_);
-		var q_ = this.More_Than_One_Order(p_);
-		var r_ = context.Operators.Exists<MedicationRequest>(q_);
-		var s_ = context.Operators.Or(i_, r_);
-		var t_ = this.Doxepin();
-		var u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
-		var w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
-		var x_ = context.Operators.Union<MedicationRequest>(u_, w_);
+		IEnumerable<MedicationRequest> p_ = context.Operators.Where<MedicationRequest>(n_, o_);
+		IEnumerable<MedicationRequest> q_ = this.More_Than_One_Order(p_);
+		bool? r_ = context.Operators.Exists<MedicationRequest>(q_);
+		bool? s_ = context.Operators.Or(i_, r_);
+		CqlValueSet t_ = this.Doxepin();
+		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		IEnumerable<MedicationRequest> x_ = context.Operators.Union<MedicationRequest>(u_, w_);
 		bool? y_(MedicationRequest DoxepinOrdered)
 		{
-			var aj_ = this.Average_Daily_Dose(DoxepinOrdered);
-			var ak_ = context.Operators.Quantity(6m, "mg/d");
-			var al_ = context.Operators.Greater(aj_, ak_);
+			CqlQuantity aj_ = this.Average_Daily_Dose(DoxepinOrdered);
+			CqlQuantity ak_ = context.Operators.Quantity(6m, "mg/d");
+			bool? al_ = context.Operators.Greater(aj_, ak_);
 
 			return al_;
 		};
-		var z_ = context.Operators.Where<MedicationRequest>(x_, y_);
-		var aa_ = this.More_Than_One_Order(z_);
-		var ab_ = context.Operators.Exists<MedicationRequest>(aa_);
-		var ac_ = context.Operators.Or(s_, ab_);
+		IEnumerable<MedicationRequest> z_ = context.Operators.Where<MedicationRequest>(x_, y_);
+		IEnumerable<MedicationRequest> aa_ = this.More_Than_One_Order(z_);
+		bool? ab_ = context.Operators.Exists<MedicationRequest>(aa_);
+		bool? ac_ = context.Operators.Or(s_, ab_);
 
 		return ac_;
 	}
 
+    /// <seealso cref="High_Risk_Medications_with_Average_Daily_Dose_Criteria_Value"/>
     [CqlDeclaration("High Risk Medications with Average Daily Dose Criteria")]
 	public bool? High_Risk_Medications_with_Average_Daily_Dose_Criteria() => 
 		__High_Risk_Medications_with_Average_Daily_Dose_Criteria.Value;
 
+    /// <seealso cref="Numerator_1"/>
 	private bool? Numerator_1_Value()
 	{
-		var a_ = this.Same_High_Risk_Medications_Ordered_on_Different_Days();
-		var b_ = context.Operators.Exists<MedicationRequest>(a_);
-		var c_ = this.Two_High_Risk_Medications_with_Prolonged_Duration();
-		var d_ = context.Operators.Or(b_, c_);
-		var e_ = this.High_Risk_Medications_with_Average_Daily_Dose_Criteria();
-		var f_ = context.Operators.Or(d_, e_);
+		IEnumerable<MedicationRequest> a_ = this.Same_High_Risk_Medications_Ordered_on_Different_Days();
+		bool? b_ = context.Operators.Exists<MedicationRequest>(a_);
+		bool? c_ = this.Two_High_Risk_Medications_with_Prolonged_Duration();
+		bool? d_ = context.Operators.Or(b_, c_);
+		bool? e_ = this.High_Risk_Medications_with_Average_Daily_Dose_Criteria();
+		bool? f_ = context.Operators.Or(d_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Numerator_1_Value"/>
     [CqlDeclaration("Numerator 1")]
 	public bool? Numerator_1() => 
 		__Numerator_1.Value;
 
+    /// <seealso cref="More_than_One_Antipsychotic_Order"/>
 	private bool? More_than_One_Antipsychotic_Order_Value()
 	{
-		var a_ = this.Antipsychotic();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = this.More_Than_One_Order(e_);
-		var g_ = context.Operators.Exists<MedicationRequest>(f_);
+		CqlValueSet a_ = this.Antipsychotic();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
+		bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="More_than_One_Antipsychotic_Order_Value"/>
     [CqlDeclaration("More than One Antipsychotic Order")]
 	public bool? More_than_One_Antipsychotic_Order() => 
 		__More_than_One_Antipsychotic_Order.Value;
 
+    /// <seealso cref="Antipsychotic_Index_Prescription_Start_Date"/>
 	private CqlDateTime Antipsychotic_Index_Prescription_Start_Date_Value()
 	{
-		var a_ = this.Antipsychotic();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
+		CqlValueSet a_ = this.Antipsychotic();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
 		bool? g_(MedicationRequest AntipsychoticMedication)
 		{
-			var m_ = AntipsychoticMedication?.AuthoredOnElement;
-			var n_ = context.Operators.Convert<CqlDateTime>(m_);
-			var o_ = this.Measurement_Period();
-			var p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
+			FhirDateTime m_ = AntipsychoticMedication?.AuthoredOnElement;
+			CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
 
 			return p_;
 		};
-		var h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+		IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 		CqlDateTime i_(MedicationRequest AntipsychoticMedication)
 		{
-			var q_ = AntipsychoticMedication?.AuthoredOnElement;
-			var r_ = context.Operators.Convert<CqlDateTime>(q_);
+			FhirDateTime q_ = AntipsychoticMedication?.AuthoredOnElement;
+			CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
 
 			return r_;
 		};
-		var j_ = context.Operators.Select<MedicationRequest, CqlDateTime>(h_, i_);
-		var k_ = context.Operators.ListSort<CqlDateTime>(j_, System.ComponentModel.ListSortDirection.Ascending);
-		var l_ = context.Operators.First<CqlDateTime>(k_);
+		IEnumerable<CqlDateTime> j_ = context.Operators.Select<MedicationRequest, CqlDateTime>(h_, i_);
+		IEnumerable<CqlDateTime> k_ = context.Operators.ListSort<CqlDateTime>(j_, System.ComponentModel.ListSortDirection.Ascending);
+		CqlDateTime l_ = context.Operators.First<CqlDateTime>(k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Antipsychotic_Index_Prescription_Start_Date_Value"/>
     [CqlDeclaration("Antipsychotic Index Prescription Start Date")]
 	public CqlDateTime Antipsychotic_Index_Prescription_Start_Date() => 
 		__Antipsychotic_Index_Prescription_Start_Date.Value;
 
+    /// <seealso cref="More_than_One_Benzodiazepine_Order"/>
 	private bool? More_than_One_Benzodiazepine_Order_Value()
 	{
-		var a_ = this.Benzodiazepine();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = this.More_Than_One_Order(e_);
-		var g_ = context.Operators.Exists<MedicationRequest>(f_);
+		CqlValueSet a_ = this.Benzodiazepine();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
+		bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
 
 		return g_;
 	}
 
+    /// <seealso cref="More_than_One_Benzodiazepine_Order_Value"/>
     [CqlDeclaration("More than One Benzodiazepine Order")]
 	public bool? More_than_One_Benzodiazepine_Order() => 
 		__More_than_One_Benzodiazepine_Order.Value;
 
+    /// <seealso cref="Benzodiazepine_Index_Prescription_Start_Date"/>
 	private CqlDateTime Benzodiazepine_Index_Prescription_Start_Date_Value()
 	{
-		var a_ = this.Benzodiazepine();
-		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		var e_ = context.Operators.Union<MedicationRequest>(b_, d_);
-		var f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
+		CqlValueSet a_ = this.Benzodiazepine();
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
+		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
 		bool? g_(MedicationRequest BenzodiazepineMedication)
 		{
-			var m_ = BenzodiazepineMedication?.AuthoredOnElement;
-			var n_ = context.Operators.Convert<CqlDateTime>(m_);
-			var o_ = this.Measurement_Period();
-			var p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
+			FhirDateTime m_ = BenzodiazepineMedication?.AuthoredOnElement;
+			CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
 
 			return p_;
 		};
-		var h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+		IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
 		CqlDateTime i_(MedicationRequest BenzodiazepineMedication)
 		{
-			var q_ = BenzodiazepineMedication?.AuthoredOnElement;
-			var r_ = context.Operators.Convert<CqlDateTime>(q_);
+			FhirDateTime q_ = BenzodiazepineMedication?.AuthoredOnElement;
+			CqlDateTime r_ = context.Operators.Convert<CqlDateTime>(q_);
 
 			return r_;
 		};
-		var j_ = context.Operators.Select<MedicationRequest, CqlDateTime>(h_, i_);
-		var k_ = context.Operators.ListSort<CqlDateTime>(j_, System.ComponentModel.ListSortDirection.Ascending);
-		var l_ = context.Operators.First<CqlDateTime>(k_);
+		IEnumerable<CqlDateTime> j_ = context.Operators.Select<MedicationRequest, CqlDateTime>(h_, i_);
+		IEnumerable<CqlDateTime> k_ = context.Operators.ListSort<CqlDateTime>(j_, System.ComponentModel.ListSortDirection.Ascending);
+		CqlDateTime l_ = context.Operators.First<CqlDateTime>(k_);
 
 		return l_;
 	}
 
+    /// <seealso cref="Benzodiazepine_Index_Prescription_Start_Date_Value"/>
     [CqlDeclaration("Benzodiazepine Index Prescription Start Date")]
 	public CqlDateTime Benzodiazepine_Index_Prescription_Start_Date() => 
 		__Benzodiazepine_Index_Prescription_Start_Date.Value;
 
+    /// <seealso cref="Numerator_2"/>
 	private bool? Numerator_2_Value()
 	{
-		var a_ = this.More_than_One_Antipsychotic_Order();
-		var b_ = this.Schizophrenia();
-		var c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
-		var d_ = this.Bipolar_Disorder();
-		var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
-		var f_ = context.Operators.Union<Condition>(c_, e_);
+		bool? a_ = this.More_than_One_Antipsychotic_Order();
+		CqlValueSet b_ = this.Schizophrenia();
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		CqlValueSet d_ = this.Bipolar_Disorder();
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(c_, e_);
 		bool? g_(Condition AntipsychoticTreatedDiagnoses)
 		{
-			var ag_ = QICoreCommon_2_0_000.ToPrevalenceInterval(AntipsychoticTreatedDiagnoses);
-			var ah_ = this.Measurement_Period();
-			var ai_ = context.Operators.Start(ah_);
-			var aj_ = context.Operators.Quantity(1m, "year");
-			var ak_ = context.Operators.Subtract(ai_, aj_);
-			var al_ = this.Antipsychotic_Index_Prescription_Start_Date();
-			var am_ = context.Operators.Interval(ak_, al_, true, true);
-			var an_ = context.Operators.Overlaps(ag_, am_, null);
+			CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.ToPrevalenceInterval(AntipsychoticTreatedDiagnoses);
+			CqlInterval<CqlDateTime> ah_ = this.Measurement_Period();
+			CqlDateTime ai_ = context.Operators.Start(ah_);
+			CqlQuantity aj_ = context.Operators.Quantity(1m, "year");
+			CqlDateTime ak_ = context.Operators.Subtract(ai_, aj_);
+			CqlDateTime al_ = this.Antipsychotic_Index_Prescription_Start_Date();
+			CqlInterval<CqlDateTime> am_ = context.Operators.Interval(ak_, al_, true, true);
+			bool? an_ = context.Operators.Overlaps(ag_, am_, null);
 
 			return an_;
 		};
-		var h_ = context.Operators.Where<Condition>(f_, g_);
-		var i_ = context.Operators.Exists<Condition>(h_);
-		var j_ = context.Operators.Not(i_);
-		var k_ = context.Operators.And(a_, j_);
-		var l_ = this.More_than_One_Benzodiazepine_Order();
-		var m_ = this.Seizure_Disorder();
-		var n_ = context.Operators.RetrieveByValueSet<Condition>(m_, null);
-		var o_ = this.REM_Sleep_Behavior_Disorder();
-		var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
-		var q_ = context.Operators.Union<Condition>(n_, p_);
-		var r_ = this.Benzodiazepine_Withdrawal();
-		var s_ = context.Operators.RetrieveByValueSet<Condition>(r_, null);
-		var t_ = this.Alcohol_Withdrawal();
-		var u_ = context.Operators.RetrieveByValueSet<Condition>(t_, null);
-		var v_ = context.Operators.Union<Condition>(s_, u_);
-		var w_ = context.Operators.Union<Condition>(q_, v_);
-		var x_ = this.Generalized_Anxiety_Disorder();
-		var y_ = context.Operators.RetrieveByValueSet<Condition>(x_, null);
-		var z_ = context.Operators.Union<Condition>(w_, y_);
+		IEnumerable<Condition> h_ = context.Operators.Where<Condition>(f_, g_);
+		bool? i_ = context.Operators.Exists<Condition>(h_);
+		bool? j_ = context.Operators.Not(i_);
+		bool? k_ = context.Operators.And(a_, j_);
+		bool? l_ = this.More_than_One_Benzodiazepine_Order();
+		CqlValueSet m_ = this.Seizure_Disorder();
+		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, null);
+		CqlValueSet o_ = this.REM_Sleep_Behavior_Disorder();
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		IEnumerable<Condition> q_ = context.Operators.Union<Condition>(n_, p_);
+		CqlValueSet r_ = this.Benzodiazepine_Withdrawal();
+		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, null);
+		CqlValueSet t_ = this.Alcohol_Withdrawal();
+		IEnumerable<Condition> u_ = context.Operators.RetrieveByValueSet<Condition>(t_, null);
+		IEnumerable<Condition> v_ = context.Operators.Union<Condition>(s_, u_);
+		IEnumerable<Condition> w_ = context.Operators.Union<Condition>(q_, v_);
+		CqlValueSet x_ = this.Generalized_Anxiety_Disorder();
+		IEnumerable<Condition> y_ = context.Operators.RetrieveByValueSet<Condition>(x_, null);
+		IEnumerable<Condition> z_ = context.Operators.Union<Condition>(w_, y_);
 		bool? aa_(Condition BenzodiazepineTreatedDiagnoses)
 		{
-			var ao_ = QICoreCommon_2_0_000.ToPrevalenceInterval(BenzodiazepineTreatedDiagnoses);
-			var ap_ = this.Measurement_Period();
-			var aq_ = context.Operators.Start(ap_);
-			var ar_ = context.Operators.Quantity(1m, "year");
-			var as_ = context.Operators.Subtract(aq_, ar_);
-			var at_ = this.Benzodiazepine_Index_Prescription_Start_Date();
-			var au_ = context.Operators.Interval(as_, at_, true, true);
-			var av_ = context.Operators.Overlaps(ao_, au_, null);
+			CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_0_000.ToPrevalenceInterval(BenzodiazepineTreatedDiagnoses);
+			CqlInterval<CqlDateTime> ap_ = this.Measurement_Period();
+			CqlDateTime aq_ = context.Operators.Start(ap_);
+			CqlQuantity ar_ = context.Operators.Quantity(1m, "year");
+			CqlDateTime as_ = context.Operators.Subtract(aq_, ar_);
+			CqlDateTime at_ = this.Benzodiazepine_Index_Prescription_Start_Date();
+			CqlInterval<CqlDateTime> au_ = context.Operators.Interval(as_, at_, true, true);
+			bool? av_ = context.Operators.Overlaps(ao_, au_, null);
 
 			return av_;
 		};
-		var ab_ = context.Operators.Where<Condition>(z_, aa_);
-		var ac_ = context.Operators.Exists<Condition>(ab_);
-		var ad_ = context.Operators.Not(ac_);
-		var ae_ = context.Operators.And(l_, ad_);
-		var af_ = context.Operators.Or(k_, ae_);
+		IEnumerable<Condition> ab_ = context.Operators.Where<Condition>(z_, aa_);
+		bool? ac_ = context.Operators.Exists<Condition>(ab_);
+		bool? ad_ = context.Operators.Not(ac_);
+		bool? ae_ = context.Operators.And(l_, ad_);
+		bool? af_ = context.Operators.Or(k_, ae_);
 
 		return af_;
 	}
 
+    /// <seealso cref="Numerator_2_Value"/>
     [CqlDeclaration("Numerator 2")]
 	public bool? Numerator_2() => 
 		__Numerator_2.Value;
 
+    /// <seealso cref="Numerator_3"/>
 	private bool? Numerator_3_Value()
 	{
-		var a_ = this.Numerator_2();
-		var b_ = this.Numerator_1();
-		var d_ = context.Operators.Not(a_);
-		var e_ = context.Operators.And(b_, d_);
-		var f_ = context.Operators.Or(a_, e_);
+		bool? a_ = this.Numerator_2();
+		bool? b_ = this.Numerator_1();
+		bool? d_ = context.Operators.Not(a_);
+		bool? e_ = context.Operators.And(b_, d_);
+		bool? f_ = context.Operators.Or(a_, e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Numerator_3_Value"/>
     [CqlDeclaration("Numerator 3")]
 	public bool? Numerator_3() => 
 		__Numerator_3.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;

--- a/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
@@ -54,127 +54,143 @@ public class VTE_8_6_000
 
     #endregion
 
+    /// <seealso cref="Obstetrical_or_Pregnancy_Related_Conditions"/>
 	private CqlValueSet Obstetrical_or_Pregnancy_Related_Conditions_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263", null);
 
+    /// <seealso cref="Obstetrical_or_Pregnancy_Related_Conditions_Value"/>
     [CqlDeclaration("Obstetrical or Pregnancy Related Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263")]
 	public CqlValueSet Obstetrical_or_Pregnancy_Related_Conditions() => 
 		__Obstetrical_or_Pregnancy_Related_Conditions.Value;
 
+    /// <seealso cref="Obstetrics_VTE"/>
 	private CqlValueSet Obstetrics_VTE_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264", null);
 
+    /// <seealso cref="Obstetrics_VTE_Value"/>
     [CqlDeclaration("Obstetrics VTE")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264")]
 	public CqlValueSet Obstetrics_VTE() => 
 		__Obstetrics_VTE.Value;
 
+    /// <seealso cref="Venous_Thromboembolism"/>
 	private CqlValueSet Venous_Thromboembolism_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279", null);
 
+    /// <seealso cref="Venous_Thromboembolism_Value"/>
     [CqlDeclaration("Venous Thromboembolism")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279")]
 	public CqlValueSet Venous_Thromboembolism() => 
 		__Venous_Thromboembolism.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.ResolveParameter("VTE-8.6.000", "Measurement Period", null);
+		object a_ = context.ResolveParameter("VTE-8.6.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="Admission_without_VTE_or_Obstetrical_Conditions"/>
 	private IEnumerable<Encounter> Admission_without_VTE_or_Obstetrical_Conditions_Value()
 	{
-		var a_ = CQMCommon_2_0_000.Inpatient_Encounter();
+		IEnumerable<Encounter> a_ = CQMCommon_2_0_000.Inpatient_Encounter();
 		bool? b_(Encounter InpatientEncounter)
 		{
-			var d_ = CQMCommon_2_0_000.encounterDiagnosis(InpatientEncounter);
+			IEnumerable<Condition> d_ = CQMCommon_2_0_000.encounterDiagnosis(InpatientEncounter);
 			bool? e_(Condition EncDx)
 			{
-				var i_ = EncDx?.Code;
-				var j_ = FHIRHelpers_4_3_000.ToConcept(i_);
-				var k_ = this.Obstetrical_or_Pregnancy_Related_Conditions();
-				var l_ = context.Operators.ConceptInValueSet(j_, k_);
-				var n_ = FHIRHelpers_4_3_000.ToConcept(i_);
-				var o_ = this.Venous_Thromboembolism();
-				var p_ = context.Operators.ConceptInValueSet(n_, o_);
-				var q_ = context.Operators.Or(l_, p_);
-				var s_ = FHIRHelpers_4_3_000.ToConcept(i_);
-				var t_ = this.Obstetrics_VTE();
-				var u_ = context.Operators.ConceptInValueSet(s_, t_);
-				var v_ = context.Operators.Or(q_, u_);
+				CodeableConcept i_ = EncDx?.Code;
+				CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
+				CqlValueSet k_ = this.Obstetrical_or_Pregnancy_Related_Conditions();
+				bool? l_ = context.Operators.ConceptInValueSet(j_, k_);
+				CqlConcept n_ = FHIRHelpers_4_3_000.ToConcept(i_);
+				CqlValueSet o_ = this.Venous_Thromboembolism();
+				bool? p_ = context.Operators.ConceptInValueSet(n_, o_);
+				bool? q_ = context.Operators.Or(l_, p_);
+				CqlConcept s_ = FHIRHelpers_4_3_000.ToConcept(i_);
+				CqlValueSet t_ = this.Obstetrics_VTE();
+				bool? u_ = context.Operators.ConceptInValueSet(s_, t_);
+				bool? v_ = context.Operators.Or(q_, u_);
 
 				return v_;
 			};
-			var f_ = context.Operators.Where<Condition>(d_, e_);
-			var g_ = context.Operators.Exists<Condition>(f_);
-			var h_ = context.Operators.Not(g_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+			bool? g_ = context.Operators.Exists<Condition>(f_);
+			bool? h_ = context.Operators.Not(g_);
 
 			return h_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
 
 		return c_;
 	}
 
+    /// <seealso cref="Admission_without_VTE_or_Obstetrical_Conditions_Value"/>
     [CqlDeclaration("Admission without VTE or Obstetrical Conditions")]
 	public IEnumerable<Encounter> Admission_without_VTE_or_Obstetrical_Conditions() => 
 		__Admission_without_VTE_or_Obstetrical_Conditions.Value;
 
+    /// <seealso cref="Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions"/>
 	private IEnumerable<Encounter> Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions_Value()
 	{
-		var a_ = CQMCommon_2_0_000.Inpatient_Encounter();
+		IEnumerable<Encounter> a_ = CQMCommon_2_0_000.Inpatient_Encounter();
 		bool? b_(Encounter InpatientEncounter)
 		{
-			var f_ = this.Patient();
-			var g_ = f_?.BirthDateElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<CqlDate>(h_);
-			var j_ = InpatientEncounter?.Period;
-			var k_ = FHIRHelpers_4_3_000.ToInterval(j_);
-			var l_ = context.Operators.Start(k_);
-			var m_ = context.Operators.DateFrom(l_);
-			var n_ = context.Operators.CalculateAgeAt(i_, m_, "year");
-			var o_ = context.Operators.GreaterOrEqual(n_, 18);
+			Patient f_ = this.Patient();
+			Date g_ = f_?.BirthDateElement;
+			string h_ = g_?.Value;
+			CqlDate i_ = context.Operators.Convert<CqlDate>(h_);
+			Period j_ = InpatientEncounter?.Period;
+			CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_3_000.ToInterval(j_);
+			CqlDateTime l_ = context.Operators.Start(k_);
+			CqlDate m_ = context.Operators.DateFrom(l_);
+			int? n_ = context.Operators.CalculateAgeAt(i_, m_, "year");
+			bool? o_ = context.Operators.GreaterOrEqual(n_, 18);
 
 			return o_;
 		};
-		var c_ = context.Operators.Where<Encounter>(a_, b_);
-		var d_ = this.Admission_without_VTE_or_Obstetrical_Conditions();
-		var e_ = context.Operators.Intersect<Encounter>(c_, d_);
+		IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+		IEnumerable<Encounter> d_ = this.Admission_without_VTE_or_Obstetrical_Conditions();
+		IEnumerable<Encounter> e_ = context.Operators.Intersect<Encounter>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions_Value"/>
     [CqlDeclaration("Encounter with Age Range and without VTE Diagnosis or Obstetrical Conditions")]
 	public IEnumerable<Encounter> Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions() => 
 		__Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private IEnumerable<Encounter> Initial_Population_Value()
 	{
-		var a_ = this.Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions();
+		IEnumerable<Encounter> a_ = this.Encounter_with_Age_Range_and_without_VTE_Diagnosis_or_Obstetrical_Conditions();
 
 		return a_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public IEnumerable<Encounter> Initial_Population() => 
 		__Initial_Population.Value;
@@ -182,40 +198,42 @@ public class VTE_8_6_000
     [CqlDeclaration("FromDayOfStartOfHospitalizationToDayAfterAdmission")]
 	public CqlInterval<CqlDate> FromDayOfStartOfHospitalizationToDayAfterAdmission(Encounter Encounter)
 	{
-		var a_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateFrom(b_);
-		var d_ = FHIRHelpers_4_3_000.ToInterval(Encounter?.Period);
-		var e_ = context.Operators.Start(d_);
-		var f_ = context.Operators.DateFrom(e_);
-		var g_ = context.Operators.Quantity(1m, "days");
-		var h_ = context.Operators.Add(f_, g_);
-		var i_ = context.Operators.Interval(c_, h_, true, true);
+		CqlInterval<CqlDateTime> a_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
+		CqlDateTime b_ = context.Operators.Start(a_);
+		CqlDate c_ = context.Operators.DateFrom(b_);
+		Period d_ = Encounter?.Period;
+		CqlInterval<CqlDateTime> e_ = FHIRHelpers_4_3_000.ToInterval(d_);
+		CqlDateTime f_ = context.Operators.Start(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		CqlQuantity h_ = context.Operators.Quantity(1m, "days");
+		CqlDate i_ = context.Operators.Add(g_, h_);
+		CqlInterval<CqlDate> j_ = context.Operators.Interval(c_, i_, true, true);
 
-		return i_;
+		return j_;
 	}
 
     [CqlDeclaration("StartOfFirstICU")]
 	public CqlDateTime StartOfFirstICU(Encounter Encounter)
 	{
-		var a_ = CQMCommon_2_0_000.firstInpatientIntensiveCareUnit(Encounter);
-		var b_ = FHIRHelpers_4_3_000.ToInterval(a_?.Period);
-		var c_ = context.Operators.Start(b_);
+		Encounter.LocationComponent a_ = CQMCommon_2_0_000.firstInpatientIntensiveCareUnit(Encounter);
+		Period b_ = a_?.Period;
+		CqlInterval<CqlDateTime> c_ = FHIRHelpers_4_3_000.ToInterval(b_);
+		CqlDateTime d_ = context.Operators.Start(c_);
 
-		return c_;
+		return d_;
 	}
 
     [CqlDeclaration("FromDayOfStartOfHospitalizationToDayAfterFirstICU")]
 	public CqlInterval<CqlDate> FromDayOfStartOfHospitalizationToDayAfterFirstICU(Encounter Encounter)
 	{
-		var a_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
-		var b_ = context.Operators.Start(a_);
-		var c_ = context.Operators.DateFrom(b_);
-		var d_ = this.StartOfFirstICU(Encounter);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.Quantity(1m, "day");
-		var g_ = context.Operators.Add(e_, f_);
-		var h_ = context.Operators.Interval(c_, g_, true, true);
+		CqlInterval<CqlDateTime> a_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
+		CqlDateTime b_ = context.Operators.Start(a_);
+		CqlDate c_ = context.Operators.DateFrom(b_);
+		CqlDateTime d_ = this.StartOfFirstICU(Encounter);
+		CqlDate e_ = context.Operators.DateFrom(d_);
+		CqlQuantity f_ = context.Operators.Quantity(1m, "day");
+		CqlDate g_ = context.Operators.Add(e_, f_);
+		CqlInterval<CqlDate> h_ = context.Operators.Interval(c_, g_, true, true);
 
 		return h_;
 	}

--- a/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
@@ -144,222 +144,279 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
     #endregion
 
+    /// <seealso cref="BMI_percentile"/>
 	private CqlValueSet BMI_percentile_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012", null);
 
+    /// <seealso cref="BMI_percentile_Value"/>
     [CqlDeclaration("BMI percentile")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012")]
 	public CqlValueSet BMI_percentile() => 
 		__BMI_percentile.Value;
 
+    /// <seealso cref="Counseling_for_Nutrition"/>
 	private CqlValueSet Counseling_for_Nutrition_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003", null);
 
+    /// <seealso cref="Counseling_for_Nutrition_Value"/>
     [CqlDeclaration("Counseling for Nutrition")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003")]
 	public CqlValueSet Counseling_for_Nutrition() => 
 		__Counseling_for_Nutrition.Value;
 
+    /// <seealso cref="Counseling_for_Physical_Activity"/>
 	private CqlValueSet Counseling_for_Physical_Activity_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035", null);
 
+    /// <seealso cref="Counseling_for_Physical_Activity_Value"/>
     [CqlDeclaration("Counseling for Physical Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035")]
 	public CqlValueSet Counseling_for_Physical_Activity() => 
 		__Counseling_for_Physical_Activity.Value;
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
+    /// <seealso cref="Discharged_to_Health_Care_Facility_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
 	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care"/>
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
+    /// <seealso cref="Discharged_to_Home_for_Hospice_Care_Value"/>
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
 	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
+    /// <seealso cref="Encounter_Inpatient"/>
 	private CqlValueSet Encounter_Inpatient_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
+    /// <seealso cref="Encounter_Inpatient_Value"/>
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
 	public CqlValueSet Encounter_Inpatient() => 
 		__Encounter_Inpatient.Value;
 
+    /// <seealso cref="Height"/>
 	private CqlValueSet Height_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014", null);
 
+    /// <seealso cref="Height_Value"/>
     [CqlDeclaration("Height")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014")]
 	public CqlValueSet Height() => 
 		__Height.Value;
 
+    /// <seealso cref="Home_Healthcare_Services"/>
 	private CqlValueSet Home_Healthcare_Services_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
+    /// <seealso cref="Home_Healthcare_Services_Value"/>
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
 	public CqlValueSet Home_Healthcare_Services() => 
 		__Home_Healthcare_Services.Value;
 
+    /// <seealso cref="Hospice_care_ambulatory"/>
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
 
+    /// <seealso cref="Hospice_care_ambulatory_Value"/>
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
 	public CqlValueSet Hospice_care_ambulatory() => 
 		__Hospice_care_ambulatory.Value;
 
+    /// <seealso cref="Office_Visit"/>
 	private CqlValueSet Office_Visit_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
+    /// <seealso cref="Office_Visit_Value"/>
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
 	public CqlValueSet Office_Visit() => 
 		__Office_Visit.Value;
 
+    /// <seealso cref="Pregnancy"/>
 	private CqlValueSet Pregnancy_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378", null);
 
+    /// <seealso cref="Pregnancy_Value"/>
     [CqlDeclaration("Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378")]
 	public CqlValueSet Pregnancy() => 
 		__Pregnancy.Value;
 
+    /// <seealso cref="Preventive_Care_Services___Group_Counseling"/>
 	private CqlValueSet Preventive_Care_Services___Group_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
 
+    /// <seealso cref="Preventive_Care_Services___Group_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services - Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
 	public CqlValueSet Preventive_Care_Services___Group_Counseling() => 
 		__Preventive_Care_Services___Group_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
+    /// <seealso cref="Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
 	public CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17() => 
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling"/>
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
 
+    /// <seealso cref="Preventive_Care_Services_Individual_Counseling_Value"/>
     [CqlDeclaration("Preventive Care Services-Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
 	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17"/>
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
+    /// <seealso cref="Preventive_Care__Established_Office_Visit__0_to_17_Value"/>
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
 	public CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17() => 
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
+    /// <seealso cref="Telephone_Visits"/>
 	private CqlValueSet Telephone_Visits_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
+    /// <seealso cref="Telephone_Visits_Value"/>
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
 	public CqlValueSet Telephone_Visits() => 
 		__Telephone_Visits.Value;
 
+    /// <seealso cref="Weight"/>
 	private CqlValueSet Weight_Value() => 
 		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015", null);
 
+    /// <seealso cref="Weight_Value"/>
     [CqlDeclaration("Weight")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015")]
 	public CqlValueSet Weight() => 
 		__Weight.Value;
 
+    /// <seealso cref="_in_i_"/>
 	private CqlCode _in_i__Value() => 
 		new CqlCode("[in_i]", "http://unitsofmeasure.org", null, null);
 
+    /// <seealso cref="_in_i__Value"/>
     [CqlDeclaration("[in_i]")]
 	public CqlCode _in_i_() => 
 		___in_i_.Value;
 
+    /// <seealso cref="_lb_av_"/>
 	private CqlCode _lb_av__Value() => 
 		new CqlCode("[lb_av]", "http://unitsofmeasure.org", null, null);
 
+    /// <seealso cref="_lb_av__Value"/>
     [CqlDeclaration("[lb_av]")]
 	public CqlCode _lb_av_() => 
 		___lb_av_.Value;
 
+    /// <seealso cref="Birth_date"/>
 	private CqlCode Birth_date_Value() => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
+    /// <seealso cref="Birth_date_Value"/>
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
+    /// <seealso cref="Body_height"/>
 	private CqlCode Body_height_Value() => 
 		new CqlCode("8302-2", "http://loinc.org", null, null);
 
+    /// <seealso cref="Body_height_Value"/>
     [CqlDeclaration("Body height")]
 	public CqlCode Body_height() => 
 		__Body_height.Value;
 
+    /// <seealso cref="Body_mass_index__BMI___Ratio_"/>
 	private CqlCode Body_mass_index__BMI___Ratio__Value() => 
 		new CqlCode("39156-5", "http://loinc.org", null, null);
 
+    /// <seealso cref="Body_mass_index__BMI___Ratio__Value"/>
     [CqlDeclaration("Body mass index (BMI) [Ratio]")]
 	public CqlCode Body_mass_index__BMI___Ratio_() => 
 		__Body_mass_index__BMI___Ratio_.Value;
 
+    /// <seealso cref="Body_weight"/>
 	private CqlCode Body_weight_Value() => 
 		new CqlCode("29463-7", "http://loinc.org", null, null);
 
+    /// <seealso cref="Body_weight_Value"/>
     [CqlDeclaration("Body weight")]
 	public CqlCode Body_weight() => 
 		__Body_weight.Value;
 
+    /// <seealso cref="cm"/>
 	private CqlCode cm_Value() => 
 		new CqlCode("cm", "http://unitsofmeasure.org", null, null);
 
+    /// <seealso cref="cm_Value"/>
     [CqlDeclaration("cm")]
 	public CqlCode cm() => 
 		__cm.Value;
 
+    /// <seealso cref="exam"/>
 	private CqlCode exam_Value() => 
 		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="exam_Value"/>
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
+    /// <seealso cref="g"/>
 	private CqlCode g_Value() => 
 		new CqlCode("g", "http://unitsofmeasure.org", null, null);
 
+    /// <seealso cref="g_Value"/>
     [CqlDeclaration("g")]
 	public CqlCode g() => 
 		__g.Value;
 
+    /// <seealso cref="kg"/>
 	private CqlCode kg_Value() => 
 		new CqlCode("kg", "http://unitsofmeasure.org", null, null);
 
+    /// <seealso cref="kg_Value"/>
     [CqlDeclaration("kg")]
 	public CqlCode kg() => 
 		__kg.Value;
 
+    /// <seealso cref="vital_signs"/>
 	private CqlCode vital_signs_Value() => 
 		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
+    /// <seealso cref="vital_signs_Value"/>
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
+    /// <seealso cref="UCUM"/>
 	private CqlCode[] UCUM_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("[in_i]", "http://unitsofmeasure.org", null, null),
 			new CqlCode("[lb_av]", "http://unitsofmeasure.org", null, null),
@@ -371,13 +428,15 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		return a_;
 	}
 
+    /// <seealso cref="UCUM_Value"/>
     [CqlDeclaration("UCUM")]
 	public CqlCode[] UCUM() => 
 		__UCUM.Value;
 
+    /// <seealso cref="LOINC"/>
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("21112-8", "http://loinc.org", null, null),
 			new CqlCode("8302-2", "http://loinc.org", null, null),
@@ -388,13 +447,15 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		return a_;
 	}
 
+    /// <seealso cref="LOINC_Value"/>
     [CqlDeclaration("LOINC")]
 	public CqlCode[] LOINC() => 
 		__LOINC.Value;
 
+    /// <seealso cref="ObservationCategoryCodes"/>
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
 			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
@@ -403,374 +464,419 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		return a_;
 	}
 
+    /// <seealso cref="ObservationCategoryCodes_Value"/>
     [CqlDeclaration("ObservationCategoryCodes")]
 	public CqlCode[] ObservationCategoryCodes() => 
 		__ObservationCategoryCodes.Value;
 
+    /// <seealso cref="Measurement_Period"/>
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
 
+    /// <seealso cref="Measurement_Period_Value"/>
     [CqlDeclaration("Measurement Period")]
 	public CqlInterval<CqlDateTime> Measurement_Period() => 
 		__Measurement_Period.Value;
 
+    /// <seealso cref="Patient"/>
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
 
+    /// <seealso cref="Patient_Value"/>
     [CqlDeclaration("Patient")]
 	public Patient Patient() => 
 		__Patient.Value;
 
+    /// <seealso cref="SDE_Ethnicity"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Ethnicity_Value"/>
     [CqlDeclaration("SDE Ethnicity")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Ethnicity() => 
 		__SDE_Ethnicity.Value;
 
+    /// <seealso cref="SDE_Payer"/>
 	private IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Payer();
+		IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> a_ = SupplementalDataElements_3_4_000.SDE_Payer();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Payer_Value"/>
     [CqlDeclaration("SDE Payer")]
 	public IEnumerable<Tuple_GPRWMPNAYaJRiGDFSTLJOPeIJ> SDE_Payer() => 
 		__SDE_Payer.Value;
 
+    /// <seealso cref="SDE_Race"/>
 	private Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Race();
+		Tuple_HPcCiDPXQfZTXIORThMLfTQDR a_ = SupplementalDataElements_3_4_000.SDE_Race();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Race_Value"/>
     [CqlDeclaration("SDE Race")]
 	public Tuple_HPcCiDPXQfZTXIORThMLfTQDR SDE_Race() => 
 		__SDE_Race.Value;
 
+    /// <seealso cref="SDE_Sex"/>
 	private CqlCode SDE_Sex_Value()
 	{
-		var a_ = SupplementalDataElements_3_4_000.SDE_Sex();
+		CqlCode a_ = SupplementalDataElements_3_4_000.SDE_Sex();
 
 		return a_;
 	}
 
+    /// <seealso cref="SDE_Sex_Value"/>
     [CqlDeclaration("SDE Sex")]
 	public CqlCode SDE_Sex() => 
 		__SDE_Sex.Value;
 
+    /// <seealso cref="Qualifying_Encounter"/>
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Preventive_Care_Services_Individual_Counseling();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Preventive_Care_Services___Group_Counseling();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Home_Healthcare_Services();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Telephone_Visits();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = context.Operators.Union<Encounter>(q_, s_);
-		var u_ = Status_1_6_000.Finished_Encounter(t_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Preventive_Care_Services_Individual_Counseling();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Preventive_Care_Services___Group_Counseling();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Telephone_Visits();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
+		IEnumerable<Encounter> u_ = Status_1_6_000.Finished_Encounter(t_);
 		bool? v_(Encounter ValidEncounters)
 		{
-			var x_ = this.Measurement_Period();
-			var y_ = ValidEncounters?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = QICoreCommon_2_0_000.ToInterval((z_ as object));
-			var ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, null);
+			CqlInterval<CqlDateTime> x_ = this.Measurement_Period();
+			Period y_ = ValidEncounters?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlInterval<CqlDateTime> aa_ = QICoreCommon_2_0_000.ToInterval((z_ as object));
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, null);
 
 			return ab_;
 		};
-		var w_ = context.Operators.Where<Encounter>(u_, v_);
+		IEnumerable<Encounter> w_ = context.Operators.Where<Encounter>(u_, v_);
 
 		return w_;
 	}
 
+    /// <seealso cref="Qualifying_Encounter_Value"/>
     [CqlDeclaration("Qualifying Encounter")]
 	public IEnumerable<Encounter> Qualifying_Encounter() => 
 		__Qualifying_Encounter.Value;
 
+    /// <seealso cref="Initial_Population"/>
 	private bool? Initial_Population_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(3, 17, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
-		var i_ = this.Qualifying_Encounter();
-		var j_ = context.Operators.Exists<Encounter>(i_);
-		var k_ = context.Operators.And(h_, j_);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(3, 17, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		IEnumerable<Encounter> k_ = this.Qualifying_Encounter();
+		bool? l_ = context.Operators.Exists<Encounter>(k_);
+		bool? m_ = context.Operators.And(j_, l_);
 
-		return k_;
+		return m_;
 	}
 
+    /// <seealso cref="Initial_Population_Value"/>
     [CqlDeclaration("Initial Population")]
 	public bool? Initial_Population() => 
 		__Initial_Population.Value;
 
+    /// <seealso cref="Denominator"/>
 	private bool? Denominator_Value()
 	{
-		var a_ = this.Initial_Population();
+		bool? a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    /// <seealso cref="Denominator_Value"/>
     [CqlDeclaration("Denominator")]
 	public bool? Denominator() => 
 		__Denominator.Value;
 
+    /// <seealso cref="Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period"/>
 	private IEnumerable<Condition> Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period_Value()
 	{
-		var a_ = this.Pregnancy();
-		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = Status_1_6_000.Active_Condition(b_);
+		CqlValueSet a_ = this.Pregnancy();
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition Pregnancy)
 		{
-			var f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Pregnancy);
-			var g_ = this.Measurement_Period();
-			var h_ = context.Operators.Overlaps(f_, g_, null);
+			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Pregnancy);
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			bool? h_ = context.Operators.Overlaps(f_, g_, null);
 
 			return h_;
 		};
-		var e_ = context.Operators.Where<Condition>(c_, d_);
+		IEnumerable<Condition> e_ = context.Operators.Where<Condition>(c_, d_);
 
 		return e_;
 	}
 
+    /// <seealso cref="Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period_Value"/>
     [CqlDeclaration("Pregnancy Diagnosis Which Overlaps Measurement Period")]
 	public IEnumerable<Condition> Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period() => 
 		__Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period.Value;
 
+    /// <seealso cref="Denominator_Exclusions"/>
 	private bool? Denominator_Exclusions_Value()
 	{
-		var a_ = Hospice_6_9_000.Has_Hospice_Services();
-		var b_ = this.Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period();
-		var c_ = context.Operators.Exists<Condition>(b_);
-		var d_ = context.Operators.Or(a_, c_);
+		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
+		IEnumerable<Condition> b_ = this.Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period();
+		bool? c_ = context.Operators.Exists<Condition>(b_);
+		bool? d_ = context.Operators.Or(a_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Denominator_Exclusions_Value"/>
     [CqlDeclaration("Denominator Exclusions")]
 	public bool? Denominator_Exclusions() => 
 		__Denominator_Exclusions.Value;
 
+    /// <seealso cref="BMI_Percentile_in_Measurement_Period"/>
 	private IEnumerable<Observation> BMI_Percentile_in_Measurement_Period_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
-		var b_ = Status_1_6_000.BMI(a_);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> b_ = Status_1_6_000.BMI(a_);
 		bool? c_(Observation BMIPercentile)
 		{
-			var e_ = this.Measurement_Period();
-			var f_ = BMIPercentile?.Effective;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-			var j_ = BMIPercentile?.Value;
-			var k_ = context.Operators.Convert<Quantity>(j_);
-			var l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
-			var m_ = context.Operators.Not((bool?)(l_ is null));
-			var n_ = context.Operators.And(i_, m_);
+			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+			DataType f_ = BMIPercentile?.Effective;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
+			DataType j_ = BMIPercentile?.Value;
+			Quantity k_ = context.Operators.Convert<Quantity>(j_);
+			CqlQuantity l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
+			bool? m_ = context.Operators.Not((bool?)(l_ is null));
+			bool? n_ = context.Operators.And(i_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="BMI_Percentile_in_Measurement_Period_Value"/>
     [CqlDeclaration("BMI Percentile in Measurement Period")]
 	public IEnumerable<Observation> BMI_Percentile_in_Measurement_Period() => 
 		__BMI_Percentile_in_Measurement_Period.Value;
 
+    /// <seealso cref="Height_in_Measurement_Period"/>
 	private IEnumerable<Observation> Height_in_Measurement_Period_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
-		var b_ = Status_1_6_000.BodyHeight(a_);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> b_ = Status_1_6_000.BodyHeight(a_);
 		bool? c_(Observation Height)
 		{
-			var e_ = this.Measurement_Period();
-			var f_ = Height?.Effective;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-			var j_ = Height?.Value;
-			var k_ = context.Operators.Convert<Quantity>(j_);
-			var l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
-			var m_ = context.Operators.Not((bool?)(l_ is null));
-			var n_ = context.Operators.And(i_, m_);
+			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+			DataType f_ = Height?.Effective;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
+			DataType j_ = Height?.Value;
+			Quantity k_ = context.Operators.Convert<Quantity>(j_);
+			CqlQuantity l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
+			bool? m_ = context.Operators.Not((bool?)(l_ is null));
+			bool? n_ = context.Operators.And(i_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Height_in_Measurement_Period_Value"/>
     [CqlDeclaration("Height in Measurement Period")]
 	public IEnumerable<Observation> Height_in_Measurement_Period() => 
 		__Height_in_Measurement_Period.Value;
 
+    /// <seealso cref="Weight_in_Measurement_Period"/>
 	private IEnumerable<Observation> Weight_in_Measurement_Period_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
-		var b_ = Status_1_6_000.BodyWeight(a_);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> b_ = Status_1_6_000.BodyWeight(a_);
 		bool? c_(Observation Weight)
 		{
-			var e_ = this.Measurement_Period();
-			var f_ = Weight?.Effective;
-			var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-			var h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
-			var j_ = Weight?.Value;
-			var k_ = context.Operators.Convert<Quantity>(j_);
-			var l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
-			var m_ = context.Operators.Not((bool?)(l_ is null));
-			var n_ = context.Operators.And(i_, m_);
+			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+			DataType f_ = Weight?.Effective;
+			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
+			DataType j_ = Weight?.Value;
+			Quantity k_ = context.Operators.Convert<Quantity>(j_);
+			CqlQuantity l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
+			bool? m_ = context.Operators.Not((bool?)(l_ is null));
+			bool? n_ = context.Operators.And(i_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Observation>(b_, c_);
+		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 
 		return d_;
 	}
 
+    /// <seealso cref="Weight_in_Measurement_Period_Value"/>
     [CqlDeclaration("Weight in Measurement Period")]
 	public IEnumerable<Observation> Weight_in_Measurement_Period() => 
 		__Weight_in_Measurement_Period.Value;
 
+    /// <seealso cref="Numerator_1"/>
 	private bool? Numerator_1_Value()
 	{
-		var a_ = this.BMI_Percentile_in_Measurement_Period();
-		var b_ = context.Operators.Exists<Observation>(a_);
-		var c_ = this.Height_in_Measurement_Period();
-		var d_ = context.Operators.Exists<Observation>(c_);
-		var e_ = context.Operators.And(b_, d_);
-		var f_ = this.Weight_in_Measurement_Period();
-		var g_ = context.Operators.Exists<Observation>(f_);
-		var h_ = context.Operators.And(e_, g_);
+		IEnumerable<Observation> a_ = this.BMI_Percentile_in_Measurement_Period();
+		bool? b_ = context.Operators.Exists<Observation>(a_);
+		IEnumerable<Observation> c_ = this.Height_in_Measurement_Period();
+		bool? d_ = context.Operators.Exists<Observation>(c_);
+		bool? e_ = context.Operators.And(b_, d_);
+		IEnumerable<Observation> f_ = this.Weight_in_Measurement_Period();
+		bool? g_ = context.Operators.Exists<Observation>(f_);
+		bool? h_ = context.Operators.And(e_, g_);
 
 		return h_;
 	}
 
+    /// <seealso cref="Numerator_1_Value"/>
     [CqlDeclaration("Numerator 1")]
 	public bool? Numerator_1() => 
 		__Numerator_1.Value;
 
+    /// <seealso cref="Numerator_2"/>
 	private bool? Numerator_2_Value()
 	{
-		var a_ = this.Counseling_for_Nutrition();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		CqlValueSet a_ = this.Counseling_for_Nutrition();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure NutritionCounseling)
 		{
-			var g_ = this.Measurement_Period();
-			var h_ = NutritionCounseling?.Performed;
-			var i_ = FHIRHelpers_4_3_000.ToValue(h_);
-			var j_ = QICoreCommon_2_0_000.ToInterval(i_);
-			var k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			DataType h_ = NutritionCounseling?.Performed;
+			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
+			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval(i_);
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
 
 			return k_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
-		var f_ = context.Operators.Exists<Procedure>(e_);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
+		bool? f_ = context.Operators.Exists<Procedure>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Numerator_2_Value"/>
     [CqlDeclaration("Numerator 2")]
 	public bool? Numerator_2() => 
 		__Numerator_2.Value;
 
+    /// <seealso cref="Numerator_3"/>
 	private bool? Numerator_3_Value()
 	{
-		var a_ = this.Counseling_for_Physical_Activity();
-		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = Status_1_6_000.Completed_Procedure(b_);
+		CqlValueSet a_ = this.Counseling_for_Physical_Activity();
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure ActivityCounseling)
 		{
-			var g_ = this.Measurement_Period();
-			var h_ = ActivityCounseling?.Performed;
-			var i_ = FHIRHelpers_4_3_000.ToValue(h_);
-			var j_ = QICoreCommon_2_0_000.ToInterval(i_);
-			var k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
+			DataType h_ = ActivityCounseling?.Performed;
+			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
+			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval(i_);
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
 
 			return k_;
 		};
-		var e_ = context.Operators.Where<Procedure>(c_, d_);
-		var f_ = context.Operators.Exists<Procedure>(e_);
+		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
+		bool? f_ = context.Operators.Exists<Procedure>(e_);
 
 		return f_;
 	}
 
+    /// <seealso cref="Numerator_3_Value"/>
     [CqlDeclaration("Numerator 3")]
 	public bool? Numerator_3() => 
 		__Numerator_3.Value;
 
+    /// <seealso cref="Stratifaction_1"/>
 	private bool? Stratifaction_1_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(3, 11, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(3, 11, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Stratifaction_1_Value"/>
     [CqlDeclaration("Stratifaction 1")]
 	public bool? Stratifaction_1() => 
 		__Stratifaction_1.Value;
 
+    /// <seealso cref="Stratifaction_2"/>
 	private bool? Stratifaction_2_Value()
 	{
-		var a_ = this.Patient();
-		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period();
-		var d_ = context.Operators.End(c_);
-		var e_ = context.Operators.DateFrom(d_);
-		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
-		var g_ = context.Operators.Interval(12, 17, true, true);
-		var h_ = context.Operators.In<int?>(f_, g_, null);
+		Patient a_ = this.Patient();
+		Date b_ = a_?.BirthDateElement;
+		string c_ = b_?.Value;
+		CqlDate d_ = context.Operators.Convert<CqlDate>(c_);
+		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
+		CqlDateTime f_ = context.Operators.End(e_);
+		CqlDate g_ = context.Operators.DateFrom(f_);
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		CqlInterval<int?> i_ = context.Operators.Interval(12, 17, true, true);
+		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
-		return h_;
+		return j_;
 	}
 
+    /// <seealso cref="Stratifaction_2_Value"/>
     [CqlDeclaration("Stratifaction 2")]
 	public bool? Stratifaction_2() => 
 		__Stratifaction_2.Value;


### PR DESCRIPTION
ℹ️Fix for #347 

## Fix
* Added tests: `CqlContextOperatorTests`
  * Test equality between Code<T> and string and vice versa
  * Test conversion  between Code<T> and string and vice versa
* Added a decorator base type for `ICqlComparer`
* Updated `CqlComparers` to prioritize different types such that a type from the System namespace (such as `string`) is always on the right. This will allow us to get to the comparer on `Code<T>` first
* `CqlComparerExtensions.AddFhirComparers` will register a decorator type `CodeStringComparer` to handle `Code<T>` It will check if the right type is a `string` and handle it itself, otherwise it falls back to the `CodeComparer<>` type

## Other
* Remove following PackagerCLI args: `-d` and `-f`, since they were not implemented in 2.0
* Added the following argument `--log-debug` to force debug level logging
* Close/Flush the log after application exit
* Update `Cql.Targets.xml` to build up the PackagerCLIArgs property from other supplied properties.