### PR TITLE
432 maxdepth exceeded when parsing json elm for cms measures

### DIFF
--- a/Cql/Elm/Library-serialization.cs
+++ b/Cql/Elm/Library-serialization.cs
@@ -70,7 +70,7 @@ public partial class Library
     /// </summary>
     public static Library LoadFromJson(Stream stream, bool validate = true, string? originalFilePath = null)
     {
-        var node = JsonNode.Parse(stream) ??
+        var node = JsonNode.Parse(stream, documentOptions: JsonDocumentOptions) ??
                    throw new InvalidOperationException("JsonNode.Parse unexpectedly returned null.");
 
         originalFilePath ??= stream switch
@@ -179,16 +179,26 @@ public partial class Library
     }
 
 
-        private static JsonSerializerOptions JsonSerializerOptions =
-        BuildSerializerOptions(allowOldStyleTypeDiscriminators: false);
-    private static JsonSerializerOptions JsonDeserializerOptions =
-        BuildSerializerOptions(allowOldStyleTypeDiscriminators: true);
+    private const int MaxDepth = 4096; // int.MaxValue is not a good idea
+    private static JsonSerializerOptions JsonSerializerOptions = BuildSerializerOptions(allowOldStyleTypeDiscriminators: false);
+    private static JsonSerializerOptions JsonDeserializerOptions = BuildSerializerOptions(allowOldStyleTypeDiscriminators: true);
+    private static JsonDocumentOptions JsonDocumentOptions = BuildJsonDocumentOptions();
+
+    private static JsonDocumentOptions BuildJsonDocumentOptions()
+    {
+        var options = new JsonDocumentOptions()
+        {
+            MaxDepth = MaxDepth,
+        };
+
+        return options;
+    }
 
     internal static JsonSerializerOptions BuildSerializerOptions(bool allowOldStyleTypeDiscriminators = false)
     {
         var options = new JsonSerializerOptions
         {
-            MaxDepth = int.MaxValue,
+            MaxDepth = MaxDepth,
             UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
         };
 

--- a/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
@@ -190,7 +190,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 			CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
 			Period j_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_3_000.ToInterval(j_);
-			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, k_, "day");
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, k_, null);
 			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;

--- a/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
@@ -149,7 +149,7 @@ public class ParametersExample_0_0_1
 		Date a_ = this.Patient_Birthdate();
 		CqlDate b_ = FHIRHelpers_4_3_000.ToDate(a_);
 		CqlDate c_ = this.CurrentDate();
-		int? d_ = context.Operators.DurationBetween(b_, c_, "year");
+		int? d_ = context.Operators.DurationBetween(b_, c_, null);
 
 		return d_;
 	}

--- a/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
@@ -2432,7 +2432,7 @@ public class QICoreCommon_2_0_000
 	{
 		CqlDateTime a_ = context.Operators.Start(Period);
 		CqlDateTime b_ = context.Operators.End(Period);
-		int? c_ = context.Operators.DurationBetween(a_, b_, "day");
+		int? c_ = context.Operators.DurationBetween(a_, b_, null);
 		CqlInterval<int?> d_ = context.Operators.Interval(1, c_, true, true);
 		CqlInterval<int?>[] e_ = new CqlInterval<int?>[]
 		{
@@ -2456,7 +2456,7 @@ public class QICoreCommon_2_0_000
 	{
 		CqlDateTime a_ = context.Operators.Start(Period);
 		CqlDateTime b_ = context.Operators.End(Period);
-		int? c_ = context.Operators.DurationBetween(a_, b_, "day");
+		int? c_ = context.Operators.DurationBetween(a_, b_, null);
 		CqlInterval<int?> d_ = context.Operators.Interval(1, c_, true, true);
 		CqlInterval<int?>[] e_ = new CqlInterval<int?>[]
 		{
@@ -2499,7 +2499,7 @@ public class QICoreCommon_2_0_000
 					CqlQuantity r_ = context.Operators.Multiply(o_, q_);
 					CqlDateTime s_ = context.Operators.Add(n_, r_);
 					CqlDateTime t_ = context.Operators.End(Period);
-					int? u_ = context.Operators.DurationBetween(s_, t_, "hour");
+					int? u_ = context.Operators.DurationBetween(s_, t_, null);
 					bool? v_ = context.Operators.Less(u_, 24);
 
 					return (v_ ?? false);
@@ -2564,7 +2564,7 @@ public class QICoreCommon_2_0_000
 					CqlQuantity r_ = context.Operators.Multiply(o_, q_);
 					CqlDateTime s_ = context.Operators.Add(n_, r_);
 					CqlDateTime t_ = context.Operators.End(Period);
-					int? u_ = context.Operators.DurationBetween(s_, t_, "hour");
+					int? u_ = context.Operators.DurationBetween(s_, t_, null);
 					bool? v_ = context.Operators.Less(u_, 24);
 
 					return (v_ ?? false);

--- a/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
@@ -659,7 +659,7 @@ public class AHAOverall_2_6_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
 		IEnumerable<Encounter> j_ = this.Qualifying_Outpatient_Encounter_During_Measurement_Period();
 		IEnumerable<Encounter> k_(Encounter Encounter1)
@@ -754,7 +754,7 @@ public class AHAOverall_2_6_000
 			CqlDateTime f_ = context.Operators.Convert<CqlDateTime>(e_);
 			Period g_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			bool? i_ = context.Operators.In<CqlDateTime>(f_, h_, "day");
+			bool? i_ = context.Operators.In<CqlDateTime>(f_, h_, null);
 			Code<MedicationRequest.MedicationrequestStatus> j_ = Order?.StatusElement;
 			MedicationRequest.MedicationrequestStatus? k_ = j_?.Value;
 			string l_ = context.Operators.Convert<string>(k_);
@@ -801,7 +801,7 @@ public class AHAOverall_2_6_000
 			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.prevalenceInterval(Diagnosis);
 			Period f_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 			CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_3_000.ToInterval(f_);
-			bool? h_ = context.Operators.Overlaps(e_, g_, "day");
+			bool? h_ = context.Operators.Overlaps(e_, g_, null);
 			bool? i_ = this.isConfirmedActiveDiagnosis(Diagnosis);
 			bool? j_ = context.Operators.And(h_, i_);
 
@@ -826,7 +826,7 @@ public class AHAOverall_2_6_000
 					CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval((Event as Condition));
 					Period g_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 					CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-					bool? i_ = context.Operators.OverlapsAfter(f_, h_, "day");
+					bool? i_ = context.Operators.OverlapsAfter(f_, h_, null);
 					bool? j_ = this.isConfirmedActiveDiagnosis((Event as Condition));
 					bool? k_ = context.Operators.And(i_, j_);
 
@@ -839,7 +839,7 @@ public class AHAOverall_2_6_000
 					CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
 					Period o_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 					CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-					bool? q_ = context.Operators.OverlapsAfter(n_, p_, "day");
+					bool? q_ = context.Operators.OverlapsAfter(n_, p_, null);
 					Code<EventStatus> r_ = (Event as Procedure)?.StatusElement;
 					EventStatus? s_ = r_?.Value;
 					string t_ = context.Operators.Convert<string>(s_);
@@ -859,7 +859,7 @@ public class AHAOverall_2_6_000
 					CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(z_, ab_, true, true);
 					Period ad_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 					CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_3_000.ToInterval(ad_);
-					bool? af_ = context.Operators.OverlapsAfter(ac_, ae_, "day");
+					bool? af_ = context.Operators.OverlapsAfter(ac_, ae_, null);
 					CodeableConcept ag_ = (Event as AllergyIntolerance)?.ClinicalStatus;
 					CqlConcept ah_ = FHIRHelpers_4_3_000.ToConcept(ag_);
 					CqlCode ai_ = QICoreCommon_2_0_000.allergy_active();
@@ -973,7 +973,7 @@ public class AHAOverall_2_6_000
 					CqlInterval<CqlDateTime> ce_ = context.Operators.First<CqlInterval<CqlDateTime>>(cd_);
 					Period cf_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 					CqlInterval<CqlDateTime> cg_ = FHIRHelpers_4_3_000.ToInterval(cf_);
-					bool? ch_ = context.Operators.OverlapsAfter(ce_, cg_, "day");
+					bool? ch_ = context.Operators.OverlapsAfter(ce_, cg_, null);
 					Code<MedicationRequest.MedicationrequestStatus> ci_ = (Event as MedicationRequest)?.StatusElement;
 					MedicationRequest.MedicationrequestStatus? cj_ = ci_?.Value;
 					string ck_ = context.Operators.Convert<string>(cj_);
@@ -1012,7 +1012,7 @@ public class AHAOverall_2_6_000
 					CqlInterval<CqlDateTime> do_ = QICoreCommon_2_0_000.toInterval(dn_);
 					Period dp_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 					CqlInterval<CqlDateTime> dq_ = FHIRHelpers_4_3_000.ToInterval(dp_);
-					bool? dr_ = context.Operators.OverlapsAfter(do_, dq_, "day");
+					bool? dr_ = context.Operators.OverlapsAfter(do_, dq_, null);
 					Code<ObservationStatus> ds_ = (Event as Observation)?.StatusElement;
 					ObservationStatus? dt_ = ds_?.Value;
 					string du_ = context.Operators.Convert<string>(dt_);

--- a/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
@@ -163,7 +163,7 @@ public class ALARACTOQRFHIR_0_1_001
 			CqlDate n_ = context.Operators.ConvertStringToDate(m_);
 			CqlDateTime p_ = context.Operators.Start(f_);
 			CqlDate q_ = context.Operators.DateFrom(p_);
-			int? r_ = context.Operators.CalculateAgeAt(n_, q_, "year");
+			int? r_ = context.Operators.CalculateAgeAt(n_, q_, null);
 			bool? s_ = context.Operators.GreaterOrEqual(r_, 18);
 			bool? t_ = context.Operators.And(j_, s_);
 

--- a/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
@@ -118,7 +118,7 @@ public class AdultOutpatientEncounters_4_8_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.ResolveParameter("AdultOutpatientEncounters-4.8.000", "Measurement Period", null);
+		object a_ = context.ResolveParameter("AdultOutpatientEncounters-4.8.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
@@ -129,8 +129,8 @@ public class AdultOutpatientEncounters_4_8_000
 
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
@@ -141,38 +141,38 @@ public class AdultOutpatientEncounters_4_8_000
 
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
-		var a_ = this.Office_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Annual_Wellness_Visit();
-		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
-		var e_ = context.Operators.Union<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
-		var j_ = context.Operators.Union<Encounter>(g_, i_);
-		var k_ = context.Operators.Union<Encounter>(e_, j_);
-		var l_ = this.Home_Healthcare_Services();
-		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Online_Assessments();
-		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
-		var p_ = context.Operators.Union<Encounter>(m_, o_);
-		var q_ = context.Operators.Union<Encounter>(k_, p_);
-		var r_ = this.Telephone_Visits();
-		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = context.Operators.Union<Encounter>(q_, s_);
-		var u_ = Status_1_6_000.isEncounterPerformed(t_);
+		CqlValueSet a_ = this.Office_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet c_ = this.Annual_Wellness_Visit();
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+		CqlValueSet l_ = this.Home_Healthcare_Services();
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		CqlValueSet n_ = this.Online_Assessments();
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+		CqlValueSet r_ = this.Telephone_Visits();
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
+		IEnumerable<Encounter> u_ = Status_1_6_000.isEncounterPerformed(t_);
 		bool? v_(Encounter ValidEncounter)
 		{
-			var x_ = this.Measurement_Period();
-			var y_ = ValidEncounter?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = QICoreCommon_2_0_000.toInterval((z_ as object));
-			var ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, "day");
+			CqlInterval<CqlDateTime> x_ = this.Measurement_Period();
+			Period y_ = ValidEncounter?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlInterval<CqlDateTime> aa_ = QICoreCommon_2_0_000.toInterval((z_ as object));
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, null);
 
 			return ab_;
 		};
-		var w_ = context.Operators.Where<Encounter>(u_, v_);
+		IEnumerable<Encounter> w_ = context.Operators.Where<Encounter>(u_, v_);
 
 		return w_;
 	}

--- a/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
@@ -273,7 +273,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 			FhirDateTime ap_ = FrailtyDeviceOrder?.AuthoredOnElement;
 			CqlDateTime aq_ = context.Operators.Convert<CqlDateTime>(ap_);
 			CqlInterval<CqlDateTime> ar_ = QICoreCommon_2_0_000.toInterval((aq_ as object));
-			bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, ar_, "day");
+			bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, ar_, null);
 			bool? at_ = context.Operators.And(an_, as_);
 
 			return at_;
@@ -295,7 +295,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 			CqlInterval<CqlDateTime> ba_ = QICoreCommon_2_0_000.toInterval(az_);
 			CqlDateTime bb_ = context.Operators.End(ba_);
 			CqlInterval<CqlDateTime> bc_ = this.Measurement_Period();
-			bool? bd_ = context.Operators.In<CqlDateTime>(bb_, bc_, "day");
+			bool? bd_ = context.Operators.In<CqlDateTime>(bb_, bc_, null);
 			bool? be_ = context.Operators.And(ax_, bd_);
 
 			return be_;
@@ -309,7 +309,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		{
 			CqlInterval<CqlDateTime> bf_ = QICoreCommon_2_0_000.prevalenceInterval(FrailtyDiagnosis);
 			CqlInterval<CqlDateTime> bg_ = this.Measurement_Period();
-			bool? bh_ = context.Operators.Overlaps(bf_, bg_, "day");
+			bool? bh_ = context.Operators.Overlaps(bf_, bg_, null);
 
 			return bh_;
 		};
@@ -325,7 +325,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 			CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
 			CqlInterval<CqlDateTime> bk_ = QICoreCommon_2_0_000.toInterval((bj_ as object));
 			CqlInterval<CqlDateTime> bl_ = this.Measurement_Period();
-			bool? bm_ = context.Operators.Overlaps(bk_, bl_, "day");
+			bool? bm_ = context.Operators.Overlaps(bk_, bl_, null);
 
 			return bm_;
 		};
@@ -341,7 +341,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 			object bo_ = FHIRHelpers_4_3_000.ToValue(bn_);
 			CqlInterval<CqlDateTime> bp_ = QICoreCommon_2_0_000.toInterval(bo_);
 			CqlInterval<CqlDateTime> bq_ = this.Measurement_Period();
-			bool? br_ = context.Operators.Overlaps(bp_, bq_, "day");
+			bool? br_ = context.Operators.Overlaps(bp_, bq_, null);
 
 			return br_;
 		};
@@ -394,7 +394,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 			CqlDateTime z_ = context.Operators.Subtract(x_, y_);
 			CqlDateTime ab_ = context.Operators.End(w_);
 			CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(z_, ab_, true, true);
-			bool? ad_ = context.Operators.In<CqlDateTime>(v_, ac_, "day");
+			bool? ad_ = context.Operators.In<CqlDateTime>(v_, ac_, null);
 			bool? ae_ = context.Operators.And(r_, ad_);
 
 			return ae_;
@@ -433,7 +433,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 			CqlDateTime q_ = context.Operators.End(p_);
 			CqlQuantity r_ = context.Operators.Quantity(1m, "day");
 			CqlDateTime s_ = context.Operators.Add(q_, r_);
-			bool? t_ = context.Operators.SameOrAfter(n_, s_, "day");
+			bool? t_ = context.Operators.SameOrAfter(n_, s_, null);
 
 			return t_;
 		};
@@ -479,7 +479,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 			CqlDateTime r_ = context.Operators.Subtract(p_, q_);
 			CqlDateTime t_ = context.Operators.End(o_);
 			CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
-			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
+			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
 			bool? w_ = context.Operators.And(j_, v_);
 
 			return w_;
@@ -521,7 +521,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
 			CqlDateTime ad_ = context.Operators.End(y_);
 			CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ab_, ad_, true, true);
-			bool? af_ = context.Operators.Overlaps(x_, ae_, "day");
+			bool? af_ = context.Operators.Overlaps(x_, ae_, null);
 			bool? ag_ = context.Operators.And(m_, af_);
 
 			return ag_;
@@ -545,7 +545,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 66);
 		bool? j_ = this.Has_Criteria_Indicating_Frailty();
 		bool? k_ = context.Operators.And(i_, j_);
@@ -572,7 +572,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		bool? k_ = this.Has_Criteria_Indicating_Frailty();
@@ -588,7 +588,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		CqlDate v_ = context.Operators.ConvertStringToDate(u_);
 		CqlDateTime x_ = context.Operators.End(e_);
 		CqlDate y_ = context.Operators.DateFrom(x_);
-		int? z_ = context.Operators.CalculateAgeAt(v_, y_, "year");
+		int? z_ = context.Operators.CalculateAgeAt(v_, y_, null);
 		bool? aa_ = context.Operators.GreaterOrEqual(z_, 81);
 		bool? ac_ = context.Operators.And(aa_, k_);
 		bool? ad_ = context.Operators.Or(r_, ac_);
@@ -609,7 +609,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 66);
 		CqlCode j_ = this.Housing_status();
 		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
@@ -623,7 +623,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 			CqlDateTime ab_ = context.Operators.End(aa_);
 			CqlInterval<CqlDateTime> ac_ = this.Measurement_Period();
 			CqlDateTime ad_ = context.Operators.End(ac_);
-			bool? ae_ = context.Operators.SameOrBefore(ab_, ad_, "day");
+			bool? ae_ = context.Operators.SameOrBefore(ab_, ad_, null);
 
 			return ae_;
 		};

--- a/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
@@ -208,7 +208,7 @@ public class AlaraCTFHIR_0_1_001
 			string m_ = l_?.Value;
 			CqlDateTime n_ = context.Operators.ConvertStringToDateTime(m_);
 			CqlDateTime p_ = context.Operators.Start(f_);
-			int? q_ = context.Operators.CalculateAgeAt(n_, p_, "year");
+			int? q_ = context.Operators.CalculateAgeAt(n_, p_, null);
 			bool? r_ = context.Operators.GreaterOrEqual(q_, 18);
 			bool? s_ = context.Operators.And(j_, r_);
 

--- a/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
@@ -161,7 +161,7 @@ public class AlaraCTIQRFHIR_0_1_000
 			CqlDate l_ = context.Operators.ConvertStringToDate(k_);
 			CqlDateTime n_ = context.Operators.Start(g_);
 			CqlDate o_ = context.Operators.DateFrom(n_);
-			int? p_ = context.Operators.CalculateAgeAt(l_, o_, "year");
+			int? p_ = context.Operators.CalculateAgeAt(l_, o_, null);
 			bool? q_ = context.Operators.GreaterOrEqual(p_, 18);
 			bool? r_ = context.Operators.And(h_, q_);
 

--- a/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
@@ -123,7 +123,7 @@ public class Antibiotic_1_5_000
 				CqlQuantity q_ = context.Operators.Quantity(3m, "days");
 				CqlDateTime r_ = context.Operators.Add(p_, q_);
 				CqlInterval<CqlDateTime> s_ = context.Operators.Interval(m_, r_, true, true);
-				bool? t_ = context.Operators.In<CqlDateTime>(j_, s_, "day");
+				bool? t_ = context.Operators.In<CqlDateTime>(j_, s_, null);
 				CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(k_);
 				CqlDateTime w_ = context.Operators.Start(v_);
 				bool? x_ = context.Operators.Not((bool?)(w_ is null));
@@ -229,7 +229,7 @@ public class Antibiotic_1_5_000
 					CqlInterval<CqlDate> ch_ = context.Operators.Interval(bz_, cg_, true, true);
 					bool? ci_ = ch_?.highClosed;
 					CqlInterval<CqlDateTime> cj_ = context.Operators.Interval(al_, bc_, bs_, ci_);
-					bool? ck_ = context.Operators.Overlaps(u_, cj_, "day");
+					bool? ck_ = context.Operators.Overlaps(u_, cj_, null);
 
 					return ck_;
 				};

--- a/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
@@ -240,7 +240,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		decimal? d_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime e_ = context.Operators.DateTime(c_, 4, 30, 23, 59, 59, 0, d_);
 
@@ -255,7 +255,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		int? d_ = context.Operators.Subtract(c_, 1);
 		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime f_ = context.Operators.DateTime(d_, 5, 1, 0, 0, 0, 0, e_);
@@ -293,7 +293,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 			CqlDate p_ = context.Operators.Start(o_);
 			CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
 			CqlInterval<CqlDateTime> r_ = this.Intake_Period();
-			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
 
 			return s_;
 		};
@@ -427,7 +427,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		CqlDate d_ = context.Operators.ConvertStringToDate(c_);
 		CqlDateTime e_ = this.April_30_of_the_Measurement_Period();
 		CqlDate f_ = context.Operators.DateFrom(e_);
-		int? g_ = context.Operators.CalculateAgeAt(d_, f_, "year");
+		int? g_ = context.Operators.CalculateAgeAt(d_, f_, null);
 		bool? h_ = context.Operators.GreaterOrEqual(g_, 18);
 		bool? i_ = this.Has_Initial_Major_Depression_Diagnosis();
 		bool? j_ = context.Operators.And(h_, i_);

--- a/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
@@ -807,7 +807,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			Period ai_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
-			bool? al_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ah_, ak_, "day");
+			bool? al_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ah_, ak_, null);
 
 			return al_;
 		};
@@ -829,7 +829,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(50, 63, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
@@ -1230,7 +1230,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime d_ = context.Operators.Start(c_);
 			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 			CqlDateTime f_ = context.Operators.End(e_);
-			bool? g_ = context.Operators.SameOrBefore(d_, f_, "day");
+			bool? g_ = context.Operators.SameOrBefore(d_, f_, null);
 
 			return g_;
 		};
@@ -1251,7 +1251,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime g_ = context.Operators.End(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.SameOrBefore(g_, i_, "day");
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, null);
 
 			return j_;
 		};

--- a/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
@@ -642,7 +642,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, null);
 			bool? n_ = context.Operators.GreaterOrEqual(m_, 3);
 
 			return n_;
@@ -767,7 +767,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			CqlDateTime v_ = context.Operators.End(u_);
 			CqlDateTime x_ = context.Operators.Add(v_, r_);
 			CqlInterval<CqlDateTime> y_ = context.Operators.Interval(s_, x_, true, true);
-			bool? z_ = context.Operators.In<CqlDateTime>(n_, y_, "day");
+			bool? z_ = context.Operators.In<CqlDateTime>(n_, y_, null);
 
 			return z_;
 		};
@@ -795,7 +795,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, null);
 			CqlInterval<int?> n_ = context.Operators.Interval(3, 17, true, true);
 			bool? o_ = context.Operators.In<int?>(m_, n_, null);
 
@@ -825,7 +825,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, null);
 			CqlInterval<int?> n_ = context.Operators.Interval(18, 64, true, true);
 			bool? o_ = context.Operators.In<int?>(m_, n_, null);
 
@@ -855,7 +855,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, null);
 			bool? n_ = context.Operators.GreaterOrEqual(m_, 65);
 
 			return n_;

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
@@ -589,7 +589,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				bool? ae_ = context.Operators.And(y_, ad_);
 				CqlInterval<CqlDateTime> af_ = this.Measurement_Period();
 				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				bool? ai_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ah_, "day");
+				bool? ai_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(af_, ah_, null);
 				bool? aj_ = context.Operators.And(ae_, ai_);
 
 				return aj_;
@@ -636,7 +636,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
 			CqlDateTime j_ = context.Operators.Start(i_);
 			CqlDate k_ = context.Operators.DateFrom(j_);
-			int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
+			int? l_ = context.Operators.CalculateAgeAt(g_, k_, null);
 			bool? m_ = context.Operators.GreaterOrEqual(l_, 18);
 
 			return m_;

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
@@ -450,7 +450,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			CqlQuantity br_ = context.Operators.Quantity(3m, "days");
 			CqlDateTime bs_ = context.Operators.Subtract(bq_, br_);
 			CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(bo_, bs_, true, true);
-			bool? bu_ = context.Operators.In<CqlDateTime>(bm_, bt_, "day");
+			bool? bu_ = context.Operators.In<CqlDateTime>(bm_, bt_, null);
 
 			return bu_;
 		};
@@ -487,7 +487,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			Period n_ = tuple_figmirinmncaavfkbmahdktce.QualifyingEncounters?.Period;
 			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
 			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.ToInterval((o_ as object));
-			bool? q_ = context.Operators.In<CqlDateTime>(m_, p_, "day");
+			bool? q_ = context.Operators.In<CqlDateTime>(m_, p_, null);
 			CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
 			bool? v_ = context.Operators.OverlapsBefore(l_, u_, null);
@@ -519,7 +519,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "month");
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, null);
 			bool? n_ = context.Operators.GreaterOrEqual(m_, 3);
 
 			return n_;
@@ -655,14 +655,14 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "month");
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, null);
 			bool? n_ = context.Operators.GreaterOrEqual(m_, 3);
 			Date p_ = f_?.BirthDateElement;
 			string q_ = p_?.Value;
 			CqlDate r_ = context.Operators.ConvertStringToDate(q_);
 			CqlDateTime t_ = context.Operators.Start(j_);
 			CqlDate u_ = context.Operators.DateFrom(t_);
-			int? v_ = context.Operators.CalculateAgeAt(r_, u_, "year");
+			int? v_ = context.Operators.CalculateAgeAt(r_, u_, null);
 			bool? w_ = context.Operators.LessOrEqual(v_, 17);
 			bool? x_ = context.Operators.And(n_, w_);
 
@@ -692,7 +692,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, null);
 			CqlInterval<int?> n_ = context.Operators.Interval(18, 64, true, true);
 			bool? o_ = context.Operators.In<int?>(m_, n_, null);
 
@@ -722,7 +722,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, null);
 			bool? n_ = context.Operators.GreaterOrEqual(m_, 65);
 
 			return n_;

--- a/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
@@ -106,10 +106,10 @@ public class CQMCommon_2_0_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		var a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		var b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
-		var c_ = context.Operators.Interval(a_, b_, true, false);
-		var d_ = context.ResolveParameter("CQMCommon-2.0.000", "Measurement Period", c_);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+		object d_ = context.ResolveParameter("CQMCommon-2.0.000", "Measurement Period", c_);
 
 		return (CqlInterval<CqlDateTime>)d_;
 	}
@@ -120,8 +120,8 @@ public class CQMCommon_2_0_000
 
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
@@ -132,24 +132,24 @@ public class CQMCommon_2_0_000
 
 	private IEnumerable<Encounter> Inpatient_Encounter_Value()
 	{
-		var a_ = this.Encounter_Inpatient();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Encounter_Inpatient();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EncounterInpatient)
 		{
-			var e_ = EncounterInpatient?.StatusElement;
-			var f_ = e_?.Value;
-			var g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
-			var h_ = context.Operators.Equal(g_, "finished");
-			var i_ = EncounterInpatient?.Period;
-			var j_ = FHIRHelpers_4_3_000.ToInterval(i_);
-			var k_ = context.Operators.End(j_);
-			var l_ = this.Measurement_Period();
-			var m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
-			var n_ = context.Operators.And(h_, m_);
+			Code<Encounter.EncounterStatus> e_ = EncounterInpatient?.StatusElement;
+			Encounter.EncounterStatus? f_ = e_?.Value;
+			Code<Encounter.EncounterStatus> g_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(f_);
+			bool? h_ = context.Operators.Equal(g_, "finished");
+			Period i_ = EncounterInpatient?.Period;
+			CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
+			CqlDateTime k_ = context.Operators.End(j_);
+			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
+			bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, null);
+			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 
 		return d_;
 	}
@@ -163,11 +163,11 @@ public class CQMCommon_2_0_000
     [CqlTag("comment", "This function returns an interval constructed using the `date from` extractor on the start and end values of the input date-time interval. Note that using a precision specifier such as `day of` as part of a timing phrase is preferred to communicate intent to perform day-level comparison, as well as for general readability.")]
 	public CqlInterval<CqlDate> ToDateInterval(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.Start(period);
-		var b_ = context.Operators.DateFrom(a_);
-		var c_ = context.Operators.End(period);
-		var d_ = context.Operators.DateFrom(c_);
-		var e_ = context.Operators.Interval(b_, d_, true, true);
+		CqlDateTime a_ = context.Operators.Start(period);
+		CqlDate b_ = context.Operators.DateFrom(a_);
+		CqlDateTime c_ = context.Operators.End(period);
+		CqlDate d_ = context.Operators.DateFrom(c_);
+		CqlInterval<CqlDate> e_ = context.Operators.Interval(b_, d_, true, true);
 
 		return e_;
 	}
@@ -177,9 +177,9 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function in deprecated. Use the fluent function `lengthInDays()` instead.")]
 	public int? LengthInDays(CqlInterval<CqlDateTime> Value)
 	{
-		var a_ = context.Operators.Start(Value);
-		var b_ = context.Operators.End(Value);
-		var c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		CqlDateTime a_ = context.Operators.Start(Value);
+		CqlDateTime b_ = context.Operators.End(Value);
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, null);
 
 		return c_;
 	}
@@ -188,9 +188,9 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Calculates the difference in calendar days between the start and end of the given interval.")]
 	public int? lengthInDays(CqlInterval<CqlDateTime> Value)
 	{
-		var a_ = context.Operators.Start(Value);
-		var b_ = context.Operators.End(Value);
-		var c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		CqlDateTime a_ = context.Operators.Start(Value);
+		CqlDateTime b_ = context.Operators.End(Value);
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, null);
 
 		return c_;
 	}
@@ -200,45 +200,45 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `edVisit()` instead.")]
 	public Encounter ED_Visit(Encounter TheEncounter)
 	{
-		var a_ = this.Emergency_Department_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Emergency_Department_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EDVisit)
 		{
-			var h_ = EDVisit?.StatusElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
-			var k_ = context.Operators.Equal(j_, "finished");
-			var l_ = EDVisit?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.End(m_);
-			var o_ = TheEncounter?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.Start(p_);
-			var r_ = context.Operators.Quantity(1m, "hour");
-			var s_ = context.Operators.Subtract(q_, r_);
-			var u_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var v_ = context.Operators.Start(u_);
-			var w_ = context.Operators.Interval(s_, v_, true, true);
-			var x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
-			var z_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var aa_ = context.Operators.Start(z_);
-			var ab_ = context.Operators.Not((bool?)(aa_ is null));
-			var ac_ = context.Operators.And(x_, ab_);
-			var ad_ = context.Operators.And(k_, ac_);
+			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
+			Encounter.EncounterStatus? i_ = h_?.Value;
+			Code<Encounter.EncounterStatus> j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
+			bool? k_ = context.Operators.Equal(j_, "finished");
+			Period l_ = EDVisit?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.End(m_);
+			Period o_ = TheEncounter?.Period;
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime q_ = context.Operators.Start(p_);
+			CqlQuantity r_ = context.Operators.Quantity(1m, "hour");
+			CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime v_ = context.Operators.Start(u_);
+			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
+			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime aa_ = context.Operators.Start(z_);
+			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+			bool? ac_ = context.Operators.And(x_, ab_);
+			bool? ad_ = context.Operators.And(k_, ac_);
 
 			return ad_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 		object e_(Encounter @this)
 		{
-			var ae_ = @this?.Period;
-			var af_ = FHIRHelpers_4_3_000.ToInterval(ae_);
-			var ag_ = context.Operators.End(af_);
+			Period ae_ = @this?.Period;
+			CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_3_000.ToInterval(ae_);
+			CqlDateTime ag_ = context.Operators.End(af_);
 
 			return ag_;
 		};
-		var f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-		var g_ = context.Operators.Last<Encounter>(f_);
+		IEnumerable<Encounter> f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter g_ = context.Operators.Last<Encounter>(f_);
 
 		return g_;
 	}
@@ -247,45 +247,45 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the most recent emergency department visit, if any, that occurs 1 hour or less prior to the given encounter.")]
 	public Encounter edVisit(Encounter TheEncounter)
 	{
-		var a_ = this.Emergency_Department_Visit();
-		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		CqlValueSet a_ = this.Emergency_Department_Visit();
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EDVisit)
 		{
-			var h_ = EDVisit?.StatusElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
-			var k_ = context.Operators.Equal(j_, "finished");
-			var l_ = EDVisit?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.End(m_);
-			var o_ = TheEncounter?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.Start(p_);
-			var r_ = context.Operators.Quantity(1m, "hour");
-			var s_ = context.Operators.Subtract(q_, r_);
-			var u_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var v_ = context.Operators.Start(u_);
-			var w_ = context.Operators.Interval(s_, v_, true, true);
-			var x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
-			var z_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var aa_ = context.Operators.Start(z_);
-			var ab_ = context.Operators.Not((bool?)(aa_ is null));
-			var ac_ = context.Operators.And(x_, ab_);
-			var ad_ = context.Operators.And(k_, ac_);
+			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
+			Encounter.EncounterStatus? i_ = h_?.Value;
+			Code<Encounter.EncounterStatus> j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
+			bool? k_ = context.Operators.Equal(j_, "finished");
+			Period l_ = EDVisit?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.End(m_);
+			Period o_ = TheEncounter?.Period;
+			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime q_ = context.Operators.Start(p_);
+			CqlQuantity r_ = context.Operators.Quantity(1m, "hour");
+			CqlDateTime s_ = context.Operators.Subtract(q_, r_);
+			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime v_ = context.Operators.Start(u_);
+			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
+			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(o_);
+			CqlDateTime aa_ = context.Operators.Start(z_);
+			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
+			bool? ac_ = context.Operators.And(x_, ab_);
+			bool? ad_ = context.Operators.And(k_, ac_);
 
 			return ad_;
 		};
-		var d_ = context.Operators.Where<Encounter>(b_, c_);
+		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 		object e_(Encounter @this)
 		{
-			var ae_ = @this?.Period;
-			var af_ = FHIRHelpers_4_3_000.ToInterval(ae_);
-			var ag_ = context.Operators.End(af_);
+			Period ae_ = @this?.Period;
+			CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_3_000.ToInterval(ae_);
+			CqlDateTime ag_ = context.Operators.End(af_);
 
 			return ag_;
 		};
-		var f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
-		var g_ = context.Operators.Last<Encounter>(f_);
+		IEnumerable<Encounter> f_ = context.Operators.SortBy<Encounter>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter g_ = context.Operators.Last<Encounter>(f_);
 
 		return g_;
 	}
@@ -295,8 +295,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalization()` instead.")]
 	public CqlInterval<CqlDateTime> Hospitalization(Encounter TheEncounter)
 	{
-		var a_ = this.ED_Visit(TheEncounter);
-		var b_ = new Encounter[]
+		Encounter a_ = this.ED_Visit(TheEncounter);
+		Encounter[] b_ = new Encounter[]
 		{
 			a_,
 		};
@@ -306,20 +306,20 @@ public class CQMCommon_2_0_000
 			{
 				if ((X is null))
 				{
-					var g_ = TheEncounter?.Period;
-					var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+					Period g_ = TheEncounter?.Period;
+					CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
 
 					return h_;
 				}
 				else
 				{
-					var i_ = X?.Period;
-					var j_ = FHIRHelpers_4_3_000.ToInterval(i_);
-					var k_ = context.Operators.Start(j_);
-					var l_ = TheEncounter?.Period;
-					var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-					var n_ = context.Operators.End(m_);
-					var o_ = context.Operators.Interval(k_, n_, true, false);
+					Period i_ = X?.Period;
+					CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
+					CqlDateTime k_ = context.Operators.Start(j_);
+					Period l_ = TheEncounter?.Period;
+					CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+					CqlDateTime n_ = context.Operators.End(m_);
+					CqlInterval<CqlDateTime> o_ = context.Operators.Interval(k_, n_, true, false);
 
 					return o_;
 				}
@@ -327,8 +327,8 @@ public class CQMCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(d_);
+		IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)b_, c_);
+		CqlInterval<CqlDateTime> e_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(d_);
 
 		return e_;
 	}
@@ -337,8 +337,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Hospitalization returns the total interval for admission to discharge for the given encounter, or for the admission of any immediately prior emergency department visit to the discharge of the given encounter.")]
 	public CqlInterval<CqlDateTime> hospitalization(Encounter TheEncounter)
 	{
-		var a_ = this.edVisit(TheEncounter);
-		var b_ = new Encounter[]
+		Encounter a_ = this.edVisit(TheEncounter);
+		Encounter[] b_ = new Encounter[]
 		{
 			a_,
 		};
@@ -348,20 +348,20 @@ public class CQMCommon_2_0_000
 			{
 				if ((X is null))
 				{
-					var g_ = TheEncounter?.Period;
-					var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
+					Period g_ = TheEncounter?.Period;
+					CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
 
 					return h_;
 				}
 				else
 				{
-					var i_ = X?.Period;
-					var j_ = FHIRHelpers_4_3_000.ToInterval(i_);
-					var k_ = context.Operators.Start(j_);
-					var l_ = TheEncounter?.Period;
-					var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-					var n_ = context.Operators.End(m_);
-					var o_ = context.Operators.Interval(k_, n_, true, true);
+					Period i_ = X?.Period;
+					CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
+					CqlDateTime k_ = context.Operators.Start(j_);
+					Period l_ = TheEncounter?.Period;
+					CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+					CqlDateTime n_ = context.Operators.End(m_);
+					CqlInterval<CqlDateTime> o_ = context.Operators.Interval(k_, n_, true, true);
 
 					return o_;
 				}
@@ -369,8 +369,8 @@ public class CQMCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(d_);
+		IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)b_, c_);
+		CqlInterval<CqlDateTime> e_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(d_);
 
 		return e_;
 	}
@@ -380,8 +380,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationLocations()` instead.")]
 	public IEnumerable<Encounter.LocationComponent> Hospitalization_Locations(Encounter TheEncounter)
 	{
-		var a_ = this.ED_Visit(TheEncounter);
-		var b_ = new Encounter[]
+		Encounter a_ = this.ED_Visit(TheEncounter);
+		Encounter[] b_ = new Encounter[]
 		{
 			a_,
 		};
@@ -391,20 +391,20 @@ public class CQMCommon_2_0_000
 			{
 				if ((EDEncounter is null))
 				{
-					var g_ = TheEncounter?.Location;
+					List<Encounter.LocationComponent> g_ = TheEncounter?.Location;
 
 					return (IEnumerable<Encounter.LocationComponent>)g_;
 				}
 				else
 				{
-					var h_ = EDEncounter?.Location;
-					var i_ = TheEncounter?.Location;
-					var j_ = new IEnumerable<Encounter.LocationComponent>[]
+					List<Encounter.LocationComponent> h_ = EDEncounter?.Location;
+					List<Encounter.LocationComponent> i_ = TheEncounter?.Location;
+					IEnumerable<Encounter.LocationComponent>[] j_ = new IEnumerable<Encounter.LocationComponent>[]
 					{
 						(IEnumerable<Encounter.LocationComponent>)h_,
 						(IEnumerable<Encounter.LocationComponent>)i_,
 					};
-					var k_ = context.Operators.Flatten<Encounter.LocationComponent>((j_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>));
+					IEnumerable<Encounter.LocationComponent> k_ = context.Operators.Flatten<Encounter.LocationComponent>((j_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>));
 
 					return k_;
 				}
@@ -412,8 +412,8 @@ public class CQMCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<Encounter, IEnumerable<Encounter.LocationComponent>>((IEnumerable<Encounter>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<IEnumerable<Encounter.LocationComponent>>(d_);
+		IEnumerable<IEnumerable<Encounter.LocationComponent>> d_ = context.Operators.Select<Encounter, IEnumerable<Encounter.LocationComponent>>((IEnumerable<Encounter>)b_, c_);
+		IEnumerable<Encounter.LocationComponent> e_ = context.Operators.SingletonFrom<IEnumerable<Encounter.LocationComponent>>(d_);
 
 		return e_;
 	}
@@ -422,8 +422,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns list of all locations within an encounter, including locations for immediately prior ED visit.")]
 	public IEnumerable<Encounter.LocationComponent> hospitalizationLocations(Encounter TheEncounter)
 	{
-		var a_ = this.edVisit(TheEncounter);
-		var b_ = new Encounter[]
+		Encounter a_ = this.edVisit(TheEncounter);
+		Encounter[] b_ = new Encounter[]
 		{
 			a_,
 		};
@@ -433,20 +433,20 @@ public class CQMCommon_2_0_000
 			{
 				if ((EDEncounter is null))
 				{
-					var g_ = TheEncounter?.Location;
+					List<Encounter.LocationComponent> g_ = TheEncounter?.Location;
 
 					return (IEnumerable<Encounter.LocationComponent>)g_;
 				}
 				else
 				{
-					var h_ = EDEncounter?.Location;
-					var i_ = TheEncounter?.Location;
-					var j_ = new IEnumerable<Encounter.LocationComponent>[]
+					List<Encounter.LocationComponent> h_ = EDEncounter?.Location;
+					List<Encounter.LocationComponent> i_ = TheEncounter?.Location;
+					IEnumerable<Encounter.LocationComponent>[] j_ = new IEnumerable<Encounter.LocationComponent>[]
 					{
 						(IEnumerable<Encounter.LocationComponent>)h_,
 						(IEnumerable<Encounter.LocationComponent>)i_,
 					};
-					var k_ = context.Operators.Flatten<Encounter.LocationComponent>((j_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>));
+					IEnumerable<Encounter.LocationComponent> k_ = context.Operators.Flatten<Encounter.LocationComponent>((j_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>));
 
 					return k_;
 				}
@@ -454,8 +454,8 @@ public class CQMCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<Encounter, IEnumerable<Encounter.LocationComponent>>((IEnumerable<Encounter>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<IEnumerable<Encounter.LocationComponent>>(d_);
+		IEnumerable<IEnumerable<Encounter.LocationComponent>> d_ = context.Operators.Select<Encounter, IEnumerable<Encounter.LocationComponent>>((IEnumerable<Encounter>)b_, c_);
+		IEnumerable<Encounter.LocationComponent> e_ = context.Operators.SingletonFrom<IEnumerable<Encounter.LocationComponent>>(d_);
 
 		return e_;
 	}
@@ -465,8 +465,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationLengthOfStay()` instead.")]
 	public int? Hospitalization_Length_of_Stay(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization(TheEncounter);
-		var b_ = this.LengthInDays(a_);
+		CqlInterval<CqlDateTime> a_ = this.Hospitalization(TheEncounter);
+		int? b_ = this.LengthInDays(a_);
 
 		return b_;
 	}
@@ -475,8 +475,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the length of stay in days (i.e. the number of days between admission and discharge) for the given encounter, or from the admission of any immediately prior emergency department visit to the discharge of the encounter")]
 	public int? hospitalizationLengthOfStay(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalization(TheEncounter);
-		var b_ = this.lengthInDays(a_);
+		CqlInterval<CqlDateTime> a_ = this.hospitalization(TheEncounter);
+		int? b_ = this.lengthInDays(a_);
 
 		return b_;
 	}
@@ -486,8 +486,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalAdmissionTime()` instead.")]
 	public CqlDateTime Hospital_Admission_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization(TheEncounter);
-		var b_ = context.Operators.Start(a_);
+		CqlInterval<CqlDateTime> a_ = this.Hospitalization(TheEncounter);
+		CqlDateTime b_ = context.Operators.Start(a_);
 
 		return b_;
 	}
@@ -496,8 +496,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns admission time for an encounter or for immediately prior emergency department visit.")]
 	public CqlDateTime hospitalAdmissionTime(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalization(TheEncounter);
-		var b_ = context.Operators.Start(a_);
+		CqlInterval<CqlDateTime> a_ = this.hospitalization(TheEncounter);
+		CqlDateTime b_ = context.Operators.Start(a_);
 
 		return b_;
 	}
@@ -507,20 +507,22 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalDischargeTime()` instead.")]
 	public CqlDateTime Hospital_Discharge_Time(Encounter TheEncounter)
 	{
-		var a_ = FHIRHelpers_4_3_000.ToInterval(TheEncounter?.Period);
-		var b_ = context.Operators.End(a_);
+		Period a_ = TheEncounter?.Period;
+		CqlInterval<CqlDateTime> b_ = FHIRHelpers_4_3_000.ToInterval(a_);
+		CqlDateTime c_ = context.Operators.End(b_);
 
-		return b_;
+		return c_;
 	}
 
     [CqlDeclaration("hospitalDischargeTime")]
     [CqlTag("description", "Hospital Discharge Time returns the discharge time for an encounter")]
 	public CqlDateTime hospitalDischargeTime(Encounter TheEncounter)
 	{
-		var a_ = FHIRHelpers_4_3_000.ToInterval(TheEncounter?.Period);
-		var b_ = context.Operators.End(a_);
+		Period a_ = TheEncounter?.Period;
+		CqlInterval<CqlDateTime> b_ = FHIRHelpers_4_3_000.ToInterval(a_);
+		CqlDateTime c_ = context.Operators.End(b_);
 
-		return b_;
+		return c_;
 	}
 
     [CqlDeclaration("Hospital Arrival Time")]
@@ -528,42 +530,44 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalArrivalTime()` instead.")]
 	public CqlDateTime Hospital_Arrival_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization_Locations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.Hospitalization_Locations(TheEncounter);
 		object b_(Encounter.LocationComponent @this)
 		{
-			var g_ = @this?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.Start(h_);
+			Period h_ = @this?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
 
-			return i_;
+			return j_;
 		};
-		var c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
-		var d_ = context.Operators.First<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.Start(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent d_ = context.Operators.First<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.Start(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("hospitalArrivalTime")]
     [CqlTag("description", "Returns earliest arrival time for an encounter including any prior ED visit.")]
 	public CqlDateTime hospitalArrivalTime(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalizationLocations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.hospitalizationLocations(TheEncounter);
 		object b_(Encounter.LocationComponent @this)
 		{
-			var g_ = @this?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.Start(h_);
+			Period h_ = @this?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
 
-			return i_;
+			return j_;
 		};
-		var c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
-		var d_ = context.Operators.First<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.Start(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent d_ = context.Operators.First<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.Start(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("Hospital Departure Time")]
@@ -571,42 +575,44 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalDepartureTime()` instead.")]
 	public CqlDateTime Hospital_Departure_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization_Locations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.Hospitalization_Locations(TheEncounter);
 		object b_(Encounter.LocationComponent @this)
 		{
-			var g_ = @this?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.Start(h_);
+			Period h_ = @this?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
 
-			return i_;
+			return j_;
 		};
-		var c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
-		var d_ = context.Operators.Last<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.End(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent d_ = context.Operators.Last<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.End(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("hospitalDepartureTime")]
     [CqlTag("description", "Returns the latest departure time for encounter including any prior ED visit.")]
 	public CqlDateTime hospitalDepartureTime(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalizationLocations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.hospitalizationLocations(TheEncounter);
 		object b_(Encounter.LocationComponent @this)
 		{
-			var g_ = @this?.Period;
-			var h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			var i_ = context.Operators.Start(h_);
+			Period h_ = @this?.Period;
+			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
+			CqlDateTime j_ = context.Operators.Start(i_);
 
-			return i_;
+			return j_;
 		};
-		var c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
-		var d_ = context.Operators.Last<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.End(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.SortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent d_ = context.Operators.Last<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.End(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("GetLocation")]
@@ -614,20 +620,20 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getLocation()` instead.")]
 	public Location GetLocation(ResourceReference reference)
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
 		bool? b_(Location L)
 		{
-			var e_ = L?.IdElement;
-			var f_ = e_?.Value;
-			var g_ = reference?.ReferenceElement;
-			var h_ = g_?.Value;
-			var i_ = QICoreCommon_2_0_000.getId(h_);
-			var j_ = context.Operators.Equal(f_, i_);
+			Id e_ = L?.IdElement;
+			string f_ = e_?.Value;
+			FhirString g_ = reference?.ReferenceElement;
+			string h_ = g_?.Value;
+			string i_ = QICoreCommon_2_0_000.getId(h_);
+			bool? j_ = context.Operators.Equal(f_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Location>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Location>(c_);
+		IEnumerable<Location> c_ = context.Operators.Where<Location>(a_, b_);
+		Location d_ = context.Operators.SingletonFrom<Location>(c_);
 
 		return d_;
 	}
@@ -636,60 +642,62 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the emergency department arrival time for the encounter.")]
 	public CqlDateTime Emergency_Department_Arrival_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization_Locations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.Hospitalization_Locations(TheEncounter);
 		bool? b_(Encounter.LocationComponent HospitalLocation)
 		{
-			var g_ = HospitalLocation?.Location;
-			var h_ = this.GetLocation(g_);
-			var i_ = h_?.Type;
-			CqlConcept j_(CodeableConcept @this)
+			ResourceReference h_ = HospitalLocation?.Location;
+			Location i_ = this.GetLocation(h_);
+			List<CodeableConcept> j_ = i_?.Type;
+			CqlConcept k_(CodeableConcept @this)
 			{
-				var n_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-				return n_;
+				return o_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
-			var l_ = this.Emergency_Department_Visit();
-			var m_ = context.Operators.ConceptsInValueSet(k_, l_);
+			IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
+			CqlValueSet m_ = this.Emergency_Department_Visit();
+			bool? n_ = context.Operators.ConceptsInValueSet(l_, m_);
 
-			return m_;
+			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter.LocationComponent>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.Start(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>(a_, b_);
+		Encounter.LocationComponent d_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.Start(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("emergencyDepartmentArrivalTime")]
     [CqlTag("description", "Returns the emergency department arrival time for the encounter.")]
 	public CqlDateTime emergencyDepartmentArrivalTime(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalizationLocations(TheEncounter);
+		IEnumerable<Encounter.LocationComponent> a_ = this.hospitalizationLocations(TheEncounter);
 		bool? b_(Encounter.LocationComponent HospitalLocation)
 		{
-			var g_ = HospitalLocation?.Location;
-			var h_ = this.GetLocation(g_);
-			var i_ = h_?.Type;
-			CqlConcept j_(CodeableConcept @this)
+			ResourceReference h_ = HospitalLocation?.Location;
+			Location i_ = this.GetLocation(h_);
+			List<CodeableConcept> j_ = i_?.Type;
+			CqlConcept k_(CodeableConcept @this)
 			{
-				var n_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-				return n_;
+				return o_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
-			var l_ = this.Emergency_Department_Visit();
-			var m_ = context.Operators.ConceptsInValueSet(k_, l_);
+			IEnumerable<CqlConcept> l_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)j_, k_);
+			CqlValueSet m_ = this.Emergency_Department_Visit();
+			bool? n_ = context.Operators.ConceptsInValueSet(l_, m_);
 
-			return m_;
+			return n_;
 		};
-		var c_ = context.Operators.Where<Encounter.LocationComponent>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_3_000.ToInterval(d_?.Period);
-		var f_ = context.Operators.Start(e_);
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>(a_, b_);
+		Encounter.LocationComponent d_ = context.Operators.SingletonFrom<Encounter.LocationComponent>(c_);
+		Period e_ = d_?.Period;
+		CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
+		CqlDateTime g_ = context.Operators.Start(f_);
 
-		return f_;
+		return g_;
 	}
 
     [CqlDeclaration("HospitalizationWithObservationAndOutpatientSurgeryService")]
@@ -697,888 +705,888 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationWithObservationAndOutpatientSurgeryService()` instead.")]
 	public CqlInterval<CqlDateTime> HospitalizationWithObservationAndOutpatientSurgeryService(Encounter TheEncounter)
 	{
-		var a_ = new Encounter[]
+		Encounter[] a_ = new Encounter[]
 		{
 			TheEncounter,
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Outpatient_Surgery_Service();
-			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			CqlValueSet e_ = this.Outpatient_Surgery_Service();
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastSurgeryOP)
 			{
-				var ap_ = LastSurgeryOP?.Period;
-				var aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				var ar_ = context.Operators.End(aq_);
-				var as_ = this.Emergency_Department_Visit();
-				var at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				Period ap_ = LastSurgeryOP?.Period;
+				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
+				CqlDateTime ar_ = context.Operators.End(aq_);
+				CqlValueSet as_ = this.Emergency_Department_Visit();
+				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? au_(Encounter LastED)
 				{
-					var dp_ = LastED?.StatusElement;
-					var dq_ = dp_?.Value;
-					var dr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dq_);
-					var ds_ = context.Operators.Equal(dr_, "finished");
-					var dt_ = LastED?.Period;
-					var du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
-					var dv_ = context.Operators.End(du_);
-					var dw_ = this.Observation_Services();
-					var dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					Code<Encounter.EncounterStatus> dp_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? dq_ = dp_?.Value;
+					Code<Encounter.EncounterStatus> dr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dq_);
+					bool? ds_ = context.Operators.Equal(dr_, "finished");
+					Period dt_ = LastED?.Period;
+					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
+					CqlDateTime dv_ = context.Operators.End(du_);
+					CqlValueSet dw_ = this.Observation_Services();
+					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? dy_(Encounter LastObs)
 					{
-						var fq_ = LastObs?.StatusElement;
-						var fr_ = fq_?.Value;
-						var fs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fr_);
-						var ft_ = context.Operators.Equal(fs_, "finished");
-						var fu_ = LastObs?.Period;
-						var fv_ = FHIRHelpers_4_3_000.ToInterval(fu_);
-						var fw_ = context.Operators.End(fv_);
-						var fx_ = Visit?.Period;
-						var fy_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var fz_ = context.Operators.Start(fy_);
-						var ga_ = context.Operators.Quantity(1m, "hour");
-						var gb_ = context.Operators.Subtract(fz_, ga_);
-						var gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var ge_ = context.Operators.Start(gd_);
-						var gf_ = context.Operators.Interval(gb_, ge_, true, true);
-						var gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
-						var gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var gj_ = context.Operators.Start(gi_);
-						var gk_ = context.Operators.Not((bool?)(gj_ is null));
-						var gl_ = context.Operators.And(gg_, gk_);
-						var gm_ = context.Operators.And(ft_, gl_);
+						Code<Encounter.EncounterStatus> fq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? fr_ = fq_?.Value;
+						Code<Encounter.EncounterStatus> fs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fr_);
+						bool? ft_ = context.Operators.Equal(fs_, "finished");
+						Period fu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> fv_ = FHIRHelpers_4_3_000.ToInterval(fu_);
+						CqlDateTime fw_ = context.Operators.End(fv_);
+						Period fx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> fy_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime fz_ = context.Operators.Start(fy_);
+						CqlQuantity ga_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime gb_ = context.Operators.Subtract(fz_, ga_);
+						CqlInterval<CqlDateTime> gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime ge_ = context.Operators.Start(gd_);
+						CqlInterval<CqlDateTime> gf_ = context.Operators.Interval(gb_, ge_, true, true);
+						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
+						CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime gj_ = context.Operators.Start(gi_);
+						bool? gk_ = context.Operators.Not((bool?)(gj_ is null));
+						bool? gl_ = context.Operators.And(gg_, gk_);
+						bool? gm_ = context.Operators.And(ft_, gl_);
 
 						return gm_;
 					};
-					var dz_ = context.Operators.Where<Encounter>(dx_, dy_);
+					IEnumerable<Encounter> dz_ = context.Operators.Where<Encounter>(dx_, dy_);
 					object ea_(Encounter @this)
 					{
-						var gn_ = @this?.Period;
-						var go_ = FHIRHelpers_4_3_000.ToInterval(gn_);
-						var gp_ = context.Operators.End(go_);
+						Period gn_ = @this?.Period;
+						CqlInterval<CqlDateTime> go_ = FHIRHelpers_4_3_000.ToInterval(gn_);
+						CqlDateTime gp_ = context.Operators.End(go_);
 
 						return gp_;
 					};
-					var eb_ = context.Operators.SortBy<Encounter>(dz_, ea_, System.ComponentModel.ListSortDirection.Ascending);
-					var ec_ = context.Operators.Last<Encounter>(eb_);
-					var ed_ = ec_?.Period;
-					var ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
-					var ef_ = context.Operators.Start(ee_);
-					var eg_ = Visit?.Period;
-					var eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var ei_ = context.Operators.Start(eh_);
-					var ej_ = context.Operators.Quantity(1m, "hour");
-					var ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
-					var em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> eb_ = context.Operators.SortBy<Encounter>(dz_, ea_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter ec_ = context.Operators.Last<Encounter>(eb_);
+					Period ed_ = ec_?.Period;
+					CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
+					CqlDateTime ef_ = context.Operators.Start(ee_);
+					Period eg_ = Visit?.Period;
+					CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime ei_ = context.Operators.Start(eh_);
+					CqlQuantity ej_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
+					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? en_(Encounter LastObs)
 					{
-						var gq_ = LastObs?.StatusElement;
-						var gr_ = gq_?.Value;
-						var gs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gr_);
-						var gt_ = context.Operators.Equal(gs_, "finished");
-						var gu_ = LastObs?.Period;
-						var gv_ = FHIRHelpers_4_3_000.ToInterval(gu_);
-						var gw_ = context.Operators.End(gv_);
-						var gx_ = Visit?.Period;
-						var gy_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var gz_ = context.Operators.Start(gy_);
-						var ha_ = context.Operators.Quantity(1m, "hour");
-						var hb_ = context.Operators.Subtract(gz_, ha_);
-						var hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var he_ = context.Operators.Start(hd_);
-						var hf_ = context.Operators.Interval(hb_, he_, true, true);
-						var hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
-						var hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var hj_ = context.Operators.Start(hi_);
-						var hk_ = context.Operators.Not((bool?)(hj_ is null));
-						var hl_ = context.Operators.And(hg_, hk_);
-						var hm_ = context.Operators.And(gt_, hl_);
+						Code<Encounter.EncounterStatus> gq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? gr_ = gq_?.Value;
+						Code<Encounter.EncounterStatus> gs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gr_);
+						bool? gt_ = context.Operators.Equal(gs_, "finished");
+						Period gu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> gv_ = FHIRHelpers_4_3_000.ToInterval(gu_);
+						CqlDateTime gw_ = context.Operators.End(gv_);
+						Period gx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> gy_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime gz_ = context.Operators.Start(gy_);
+						CqlQuantity ha_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime hb_ = context.Operators.Subtract(gz_, ha_);
+						CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime he_ = context.Operators.Start(hd_);
+						CqlInterval<CqlDateTime> hf_ = context.Operators.Interval(hb_, he_, true, true);
+						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
+						CqlInterval<CqlDateTime> hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime hj_ = context.Operators.Start(hi_);
+						bool? hk_ = context.Operators.Not((bool?)(hj_ is null));
+						bool? hl_ = context.Operators.And(hg_, hk_);
+						bool? hm_ = context.Operators.And(gt_, hl_);
 
 						return hm_;
 					};
-					var eo_ = context.Operators.Where<Encounter>(em_, en_);
+					IEnumerable<Encounter> eo_ = context.Operators.Where<Encounter>(em_, en_);
 					object ep_(Encounter @this)
 					{
-						var hn_ = @this?.Period;
-						var ho_ = FHIRHelpers_4_3_000.ToInterval(hn_);
-						var hp_ = context.Operators.End(ho_);
+						Period hn_ = @this?.Period;
+						CqlInterval<CqlDateTime> ho_ = FHIRHelpers_4_3_000.ToInterval(hn_);
+						CqlDateTime hp_ = context.Operators.End(ho_);
 
 						return hp_;
 					};
-					var eq_ = context.Operators.SortBy<Encounter>(eo_, ep_, System.ComponentModel.ListSortDirection.Ascending);
-					var er_ = context.Operators.Last<Encounter>(eq_);
-					var es_ = er_?.Period;
-					var et_ = FHIRHelpers_4_3_000.ToInterval(es_);
-					var eu_ = context.Operators.Start(et_);
-					var ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var ex_ = context.Operators.Start(ew_);
-					var ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
-					var ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
-					var fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> eq_ = context.Operators.SortBy<Encounter>(eo_, ep_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter er_ = context.Operators.Last<Encounter>(eq_);
+					Period es_ = er_?.Period;
+					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(es_);
+					CqlDateTime eu_ = context.Operators.Start(et_);
+					CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime ex_ = context.Operators.Start(ew_);
+					CqlInterval<CqlDateTime> ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
+					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
+					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? fc_(Encounter LastObs)
 					{
-						var hq_ = LastObs?.StatusElement;
-						var hr_ = hq_?.Value;
-						var hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
-						var ht_ = context.Operators.Equal(hs_, "finished");
-						var hu_ = LastObs?.Period;
-						var hv_ = FHIRHelpers_4_3_000.ToInterval(hu_);
-						var hw_ = context.Operators.End(hv_);
-						var hx_ = Visit?.Period;
-						var hy_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var hz_ = context.Operators.Start(hy_);
-						var ia_ = context.Operators.Quantity(1m, "hour");
-						var ib_ = context.Operators.Subtract(hz_, ia_);
-						var id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var ie_ = context.Operators.Start(id_);
-						var if_ = context.Operators.Interval(ib_, ie_, true, true);
-						var ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
-						var ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var ij_ = context.Operators.Start(ii_);
-						var ik_ = context.Operators.Not((bool?)(ij_ is null));
-						var il_ = context.Operators.And(ig_, ik_);
-						var im_ = context.Operators.And(ht_, il_);
+						Code<Encounter.EncounterStatus> hq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? hr_ = hq_?.Value;
+						Code<Encounter.EncounterStatus> hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
+						bool? ht_ = context.Operators.Equal(hs_, "finished");
+						Period hu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> hv_ = FHIRHelpers_4_3_000.ToInterval(hu_);
+						CqlDateTime hw_ = context.Operators.End(hv_);
+						Period hx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> hy_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime hz_ = context.Operators.Start(hy_);
+						CqlQuantity ia_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime ib_ = context.Operators.Subtract(hz_, ia_);
+						CqlInterval<CqlDateTime> id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime ie_ = context.Operators.Start(id_);
+						CqlInterval<CqlDateTime> if_ = context.Operators.Interval(ib_, ie_, true, true);
+						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
+						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime ij_ = context.Operators.Start(ii_);
+						bool? ik_ = context.Operators.Not((bool?)(ij_ is null));
+						bool? il_ = context.Operators.And(ig_, ik_);
+						bool? im_ = context.Operators.And(ht_, il_);
 
 						return im_;
 					};
-					var fd_ = context.Operators.Where<Encounter>(fb_, fc_);
+					IEnumerable<Encounter> fd_ = context.Operators.Where<Encounter>(fb_, fc_);
 					object fe_(Encounter @this)
 					{
-						var in_ = @this?.Period;
-						var io_ = FHIRHelpers_4_3_000.ToInterval(in_);
-						var ip_ = context.Operators.End(io_);
+						Period in_ = @this?.Period;
+						CqlInterval<CqlDateTime> io_ = FHIRHelpers_4_3_000.ToInterval(in_);
+						CqlDateTime ip_ = context.Operators.End(io_);
 
 						return ip_;
 					};
-					var ff_ = context.Operators.SortBy<Encounter>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
-					var fg_ = context.Operators.Last<Encounter>(ff_);
-					var fh_ = fg_?.Period;
-					var fi_ = FHIRHelpers_4_3_000.ToInterval(fh_);
-					var fj_ = context.Operators.Start(fi_);
-					var fl_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var fm_ = context.Operators.Start(fl_);
-					var fn_ = context.Operators.Not((bool?)((fj_ ?? fm_) is null));
-					var fo_ = context.Operators.And(ez_, fn_);
-					var fp_ = context.Operators.And(ds_, fo_);
+					IEnumerable<Encounter> ff_ = context.Operators.SortBy<Encounter>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter fg_ = context.Operators.Last<Encounter>(ff_);
+					Period fh_ = fg_?.Period;
+					CqlInterval<CqlDateTime> fi_ = FHIRHelpers_4_3_000.ToInterval(fh_);
+					CqlDateTime fj_ = context.Operators.Start(fi_);
+					CqlInterval<CqlDateTime> fl_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime fm_ = context.Operators.Start(fl_);
+					bool? fn_ = context.Operators.Not((bool?)((fj_ ?? fm_) is null));
+					bool? fo_ = context.Operators.And(ez_, fn_);
+					bool? fp_ = context.Operators.And(ds_, fo_);
 
 					return fp_;
 				};
-				var av_ = context.Operators.Where<Encounter>(at_, au_);
+				IEnumerable<Encounter> av_ = context.Operators.Where<Encounter>(at_, au_);
 				object aw_(Encounter @this)
 				{
-					var iq_ = @this?.Period;
-					var ir_ = FHIRHelpers_4_3_000.ToInterval(iq_);
-					var is_ = context.Operators.End(ir_);
+					Period iq_ = @this?.Period;
+					CqlInterval<CqlDateTime> ir_ = FHIRHelpers_4_3_000.ToInterval(iq_);
+					CqlDateTime is_ = context.Operators.End(ir_);
 
 					return is_;
 				};
-				var ax_ = context.Operators.SortBy<Encounter>(av_, aw_, System.ComponentModel.ListSortDirection.Ascending);
-				var ay_ = context.Operators.Last<Encounter>(ax_);
-				var az_ = ay_?.Period;
-				var ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
-				var bb_ = context.Operators.Start(ba_);
-				var bc_ = this.Observation_Services();
-				var bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> ax_ = context.Operators.SortBy<Encounter>(av_, aw_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter ay_ = context.Operators.Last<Encounter>(ax_);
+				Period az_ = ay_?.Period;
+				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
+				CqlDateTime bb_ = context.Operators.Start(ba_);
+				CqlValueSet bc_ = this.Observation_Services();
+				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? be_(Encounter LastObs)
 				{
-					var it_ = LastObs?.StatusElement;
-					var iu_ = it_?.Value;
-					var iv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iu_);
-					var iw_ = context.Operators.Equal(iv_, "finished");
-					var ix_ = LastObs?.Period;
-					var iy_ = FHIRHelpers_4_3_000.ToInterval(ix_);
-					var iz_ = context.Operators.End(iy_);
-					var ja_ = Visit?.Period;
-					var jb_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jc_ = context.Operators.Start(jb_);
-					var jd_ = context.Operators.Quantity(1m, "hour");
-					var je_ = context.Operators.Subtract(jc_, jd_);
-					var jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jh_ = context.Operators.Start(jg_);
-					var ji_ = context.Operators.Interval(je_, jh_, true, true);
-					var jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
-					var jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jm_ = context.Operators.Start(jl_);
-					var jn_ = context.Operators.Not((bool?)(jm_ is null));
-					var jo_ = context.Operators.And(jj_, jn_);
-					var jp_ = context.Operators.And(iw_, jo_);
+					Code<Encounter.EncounterStatus> it_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? iu_ = it_?.Value;
+					Code<Encounter.EncounterStatus> iv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iu_);
+					bool? iw_ = context.Operators.Equal(iv_, "finished");
+					Period ix_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> iy_ = FHIRHelpers_4_3_000.ToInterval(ix_);
+					CqlDateTime iz_ = context.Operators.End(iy_);
+					Period ja_ = Visit?.Period;
+					CqlInterval<CqlDateTime> jb_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jc_ = context.Operators.Start(jb_);
+					CqlQuantity jd_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime je_ = context.Operators.Subtract(jc_, jd_);
+					CqlInterval<CqlDateTime> jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jh_ = context.Operators.Start(jg_);
+					CqlInterval<CqlDateTime> ji_ = context.Operators.Interval(je_, jh_, true, true);
+					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
+					CqlInterval<CqlDateTime> jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jm_ = context.Operators.Start(jl_);
+					bool? jn_ = context.Operators.Not((bool?)(jm_ is null));
+					bool? jo_ = context.Operators.And(jj_, jn_);
+					bool? jp_ = context.Operators.And(iw_, jo_);
 
 					return jp_;
 				};
-				var bf_ = context.Operators.Where<Encounter>(bd_, be_);
+				IEnumerable<Encounter> bf_ = context.Operators.Where<Encounter>(bd_, be_);
 				object bg_(Encounter @this)
 				{
-					var jq_ = @this?.Period;
-					var jr_ = FHIRHelpers_4_3_000.ToInterval(jq_);
-					var js_ = context.Operators.End(jr_);
+					Period jq_ = @this?.Period;
+					CqlInterval<CqlDateTime> jr_ = FHIRHelpers_4_3_000.ToInterval(jq_);
+					CqlDateTime js_ = context.Operators.End(jr_);
 
 					return js_;
 				};
-				var bh_ = context.Operators.SortBy<Encounter>(bf_, bg_, System.ComponentModel.ListSortDirection.Ascending);
-				var bi_ = context.Operators.Last<Encounter>(bh_);
-				var bj_ = bi_?.Period;
-				var bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
-				var bl_ = context.Operators.Start(bk_);
-				var bm_ = Visit?.Period;
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var bo_ = context.Operators.Start(bn_);
-				var bp_ = context.Operators.Quantity(1m, "hour");
-				var bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
-				var bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> bh_ = context.Operators.SortBy<Encounter>(bf_, bg_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bi_ = context.Operators.Last<Encounter>(bh_);
+				Period bj_ = bi_?.Period;
+				CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
+				CqlDateTime bl_ = context.Operators.Start(bk_);
+				Period bm_ = Visit?.Period;
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlQuantity bp_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
+				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? bt_(Encounter LastED)
 				{
-					var jt_ = LastED?.StatusElement;
-					var ju_ = jt_?.Value;
-					var jv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ju_);
-					var jw_ = context.Operators.Equal(jv_, "finished");
-					var jx_ = LastED?.Period;
-					var jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
-					var jz_ = context.Operators.End(jy_);
-					var ka_ = this.Observation_Services();
-					var kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					Code<Encounter.EncounterStatus> jt_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? ju_ = jt_?.Value;
+					Code<Encounter.EncounterStatus> jv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ju_);
+					bool? jw_ = context.Operators.Equal(jv_, "finished");
+					Period jx_ = LastED?.Period;
+					CqlInterval<CqlDateTime> jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
+					CqlDateTime jz_ = context.Operators.End(jy_);
+					CqlValueSet ka_ = this.Observation_Services();
+					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? kc_(Encounter LastObs)
 					{
-						var lu_ = LastObs?.StatusElement;
-						var lv_ = lu_?.Value;
-						var lw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lv_);
-						var lx_ = context.Operators.Equal(lw_, "finished");
-						var ly_ = LastObs?.Period;
-						var lz_ = FHIRHelpers_4_3_000.ToInterval(ly_);
-						var ma_ = context.Operators.End(lz_);
-						var mb_ = Visit?.Period;
-						var mc_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var md_ = context.Operators.Start(mc_);
-						var me_ = context.Operators.Quantity(1m, "hour");
-						var mf_ = context.Operators.Subtract(md_, me_);
-						var mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var mi_ = context.Operators.Start(mh_);
-						var mj_ = context.Operators.Interval(mf_, mi_, true, true);
-						var mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
-						var mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var mn_ = context.Operators.Start(mm_);
-						var mo_ = context.Operators.Not((bool?)(mn_ is null));
-						var mp_ = context.Operators.And(mk_, mo_);
-						var mq_ = context.Operators.And(lx_, mp_);
+						Code<Encounter.EncounterStatus> lu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? lv_ = lu_?.Value;
+						Code<Encounter.EncounterStatus> lw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lv_);
+						bool? lx_ = context.Operators.Equal(lw_, "finished");
+						Period ly_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> lz_ = FHIRHelpers_4_3_000.ToInterval(ly_);
+						CqlDateTime ma_ = context.Operators.End(lz_);
+						Period mb_ = Visit?.Period;
+						CqlInterval<CqlDateTime> mc_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime md_ = context.Operators.Start(mc_);
+						CqlQuantity me_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime mf_ = context.Operators.Subtract(md_, me_);
+						CqlInterval<CqlDateTime> mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime mi_ = context.Operators.Start(mh_);
+						CqlInterval<CqlDateTime> mj_ = context.Operators.Interval(mf_, mi_, true, true);
+						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
+						CqlInterval<CqlDateTime> mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime mn_ = context.Operators.Start(mm_);
+						bool? mo_ = context.Operators.Not((bool?)(mn_ is null));
+						bool? mp_ = context.Operators.And(mk_, mo_);
+						bool? mq_ = context.Operators.And(lx_, mp_);
 
 						return mq_;
 					};
-					var kd_ = context.Operators.Where<Encounter>(kb_, kc_);
+					IEnumerable<Encounter> kd_ = context.Operators.Where<Encounter>(kb_, kc_);
 					object ke_(Encounter @this)
 					{
-						var mr_ = @this?.Period;
-						var ms_ = FHIRHelpers_4_3_000.ToInterval(mr_);
-						var mt_ = context.Operators.End(ms_);
+						Period mr_ = @this?.Period;
+						CqlInterval<CqlDateTime> ms_ = FHIRHelpers_4_3_000.ToInterval(mr_);
+						CqlDateTime mt_ = context.Operators.End(ms_);
 
 						return mt_;
 					};
-					var kf_ = context.Operators.SortBy<Encounter>(kd_, ke_, System.ComponentModel.ListSortDirection.Ascending);
-					var kg_ = context.Operators.Last<Encounter>(kf_);
-					var kh_ = kg_?.Period;
-					var ki_ = FHIRHelpers_4_3_000.ToInterval(kh_);
-					var kj_ = context.Operators.Start(ki_);
-					var kk_ = Visit?.Period;
-					var kl_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var km_ = context.Operators.Start(kl_);
-					var kn_ = context.Operators.Quantity(1m, "hour");
-					var ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
-					var kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> kf_ = context.Operators.SortBy<Encounter>(kd_, ke_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter kg_ = context.Operators.Last<Encounter>(kf_);
+					Period kh_ = kg_?.Period;
+					CqlInterval<CqlDateTime> ki_ = FHIRHelpers_4_3_000.ToInterval(kh_);
+					CqlDateTime kj_ = context.Operators.Start(ki_);
+					Period kk_ = Visit?.Period;
+					CqlInterval<CqlDateTime> kl_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime km_ = context.Operators.Start(kl_);
+					CqlQuantity kn_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
+					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? kr_(Encounter LastObs)
 					{
-						var mu_ = LastObs?.StatusElement;
-						var mv_ = mu_?.Value;
-						var mw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mv_);
-						var mx_ = context.Operators.Equal(mw_, "finished");
-						var my_ = LastObs?.Period;
-						var mz_ = FHIRHelpers_4_3_000.ToInterval(my_);
-						var na_ = context.Operators.End(mz_);
-						var nb_ = Visit?.Period;
-						var nc_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var nd_ = context.Operators.Start(nc_);
-						var ne_ = context.Operators.Quantity(1m, "hour");
-						var nf_ = context.Operators.Subtract(nd_, ne_);
-						var nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var ni_ = context.Operators.Start(nh_);
-						var nj_ = context.Operators.Interval(nf_, ni_, true, true);
-						var nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
-						var nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var nn_ = context.Operators.Start(nm_);
-						var no_ = context.Operators.Not((bool?)(nn_ is null));
-						var np_ = context.Operators.And(nk_, no_);
-						var nq_ = context.Operators.And(mx_, np_);
+						Code<Encounter.EncounterStatus> mu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? mv_ = mu_?.Value;
+						Code<Encounter.EncounterStatus> mw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mv_);
+						bool? mx_ = context.Operators.Equal(mw_, "finished");
+						Period my_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> mz_ = FHIRHelpers_4_3_000.ToInterval(my_);
+						CqlDateTime na_ = context.Operators.End(mz_);
+						Period nb_ = Visit?.Period;
+						CqlInterval<CqlDateTime> nc_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime nd_ = context.Operators.Start(nc_);
+						CqlQuantity ne_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime nf_ = context.Operators.Subtract(nd_, ne_);
+						CqlInterval<CqlDateTime> nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime ni_ = context.Operators.Start(nh_);
+						CqlInterval<CqlDateTime> nj_ = context.Operators.Interval(nf_, ni_, true, true);
+						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
+						CqlInterval<CqlDateTime> nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime nn_ = context.Operators.Start(nm_);
+						bool? no_ = context.Operators.Not((bool?)(nn_ is null));
+						bool? np_ = context.Operators.And(nk_, no_);
+						bool? nq_ = context.Operators.And(mx_, np_);
 
 						return nq_;
 					};
-					var ks_ = context.Operators.Where<Encounter>(kq_, kr_);
+					IEnumerable<Encounter> ks_ = context.Operators.Where<Encounter>(kq_, kr_);
 					object kt_(Encounter @this)
 					{
-						var nr_ = @this?.Period;
-						var ns_ = FHIRHelpers_4_3_000.ToInterval(nr_);
-						var nt_ = context.Operators.End(ns_);
+						Period nr_ = @this?.Period;
+						CqlInterval<CqlDateTime> ns_ = FHIRHelpers_4_3_000.ToInterval(nr_);
+						CqlDateTime nt_ = context.Operators.End(ns_);
 
 						return nt_;
 					};
-					var ku_ = context.Operators.SortBy<Encounter>(ks_, kt_, System.ComponentModel.ListSortDirection.Ascending);
-					var kv_ = context.Operators.Last<Encounter>(ku_);
-					var kw_ = kv_?.Period;
-					var kx_ = FHIRHelpers_4_3_000.ToInterval(kw_);
-					var ky_ = context.Operators.Start(kx_);
-					var la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var lb_ = context.Operators.Start(la_);
-					var lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
-					var ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
-					var lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> ku_ = context.Operators.SortBy<Encounter>(ks_, kt_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter kv_ = context.Operators.Last<Encounter>(ku_);
+					Period kw_ = kv_?.Period;
+					CqlInterval<CqlDateTime> kx_ = FHIRHelpers_4_3_000.ToInterval(kw_);
+					CqlDateTime ky_ = context.Operators.Start(kx_);
+					CqlInterval<CqlDateTime> la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime lb_ = context.Operators.Start(la_);
+					CqlInterval<CqlDateTime> lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
+					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
+					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? lg_(Encounter LastObs)
 					{
-						var nu_ = LastObs?.StatusElement;
-						var nv_ = nu_?.Value;
-						var nw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nv_);
-						var nx_ = context.Operators.Equal(nw_, "finished");
-						var ny_ = LastObs?.Period;
-						var nz_ = FHIRHelpers_4_3_000.ToInterval(ny_);
-						var oa_ = context.Operators.End(nz_);
-						var ob_ = Visit?.Period;
-						var oc_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var od_ = context.Operators.Start(oc_);
-						var oe_ = context.Operators.Quantity(1m, "hour");
-						var of_ = context.Operators.Subtract(od_, oe_);
-						var oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var oi_ = context.Operators.Start(oh_);
-						var oj_ = context.Operators.Interval(of_, oi_, true, true);
-						var ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
-						var om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var on_ = context.Operators.Start(om_);
-						var oo_ = context.Operators.Not((bool?)(on_ is null));
-						var op_ = context.Operators.And(ok_, oo_);
-						var oq_ = context.Operators.And(nx_, op_);
+						Code<Encounter.EncounterStatus> nu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? nv_ = nu_?.Value;
+						Code<Encounter.EncounterStatus> nw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nv_);
+						bool? nx_ = context.Operators.Equal(nw_, "finished");
+						Period ny_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> nz_ = FHIRHelpers_4_3_000.ToInterval(ny_);
+						CqlDateTime oa_ = context.Operators.End(nz_);
+						Period ob_ = Visit?.Period;
+						CqlInterval<CqlDateTime> oc_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime od_ = context.Operators.Start(oc_);
+						CqlQuantity oe_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime of_ = context.Operators.Subtract(od_, oe_);
+						CqlInterval<CqlDateTime> oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime oi_ = context.Operators.Start(oh_);
+						CqlInterval<CqlDateTime> oj_ = context.Operators.Interval(of_, oi_, true, true);
+						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
+						CqlInterval<CqlDateTime> om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime on_ = context.Operators.Start(om_);
+						bool? oo_ = context.Operators.Not((bool?)(on_ is null));
+						bool? op_ = context.Operators.And(ok_, oo_);
+						bool? oq_ = context.Operators.And(nx_, op_);
 
 						return oq_;
 					};
-					var lh_ = context.Operators.Where<Encounter>(lf_, lg_);
+					IEnumerable<Encounter> lh_ = context.Operators.Where<Encounter>(lf_, lg_);
 					object li_(Encounter @this)
 					{
-						var or_ = @this?.Period;
-						var os_ = FHIRHelpers_4_3_000.ToInterval(or_);
-						var ot_ = context.Operators.End(os_);
+						Period or_ = @this?.Period;
+						CqlInterval<CqlDateTime> os_ = FHIRHelpers_4_3_000.ToInterval(or_);
+						CqlDateTime ot_ = context.Operators.End(os_);
 
 						return ot_;
 					};
-					var lj_ = context.Operators.SortBy<Encounter>(lh_, li_, System.ComponentModel.ListSortDirection.Ascending);
-					var lk_ = context.Operators.Last<Encounter>(lj_);
-					var ll_ = lk_?.Period;
-					var lm_ = FHIRHelpers_4_3_000.ToInterval(ll_);
-					var ln_ = context.Operators.Start(lm_);
-					var lp_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var lq_ = context.Operators.Start(lp_);
-					var lr_ = context.Operators.Not((bool?)((ln_ ?? lq_) is null));
-					var ls_ = context.Operators.And(ld_, lr_);
-					var lt_ = context.Operators.And(jw_, ls_);
+					IEnumerable<Encounter> lj_ = context.Operators.SortBy<Encounter>(lh_, li_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter lk_ = context.Operators.Last<Encounter>(lj_);
+					Period ll_ = lk_?.Period;
+					CqlInterval<CqlDateTime> lm_ = FHIRHelpers_4_3_000.ToInterval(ll_);
+					CqlDateTime ln_ = context.Operators.Start(lm_);
+					CqlInterval<CqlDateTime> lp_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime lq_ = context.Operators.Start(lp_);
+					bool? lr_ = context.Operators.Not((bool?)((ln_ ?? lq_) is null));
+					bool? ls_ = context.Operators.And(ld_, lr_);
+					bool? lt_ = context.Operators.And(jw_, ls_);
 
 					return lt_;
 				};
-				var bu_ = context.Operators.Where<Encounter>(bs_, bt_);
+				IEnumerable<Encounter> bu_ = context.Operators.Where<Encounter>(bs_, bt_);
 				object bv_(Encounter @this)
 				{
-					var ou_ = @this?.Period;
-					var ov_ = FHIRHelpers_4_3_000.ToInterval(ou_);
-					var ow_ = context.Operators.End(ov_);
+					Period ou_ = @this?.Period;
+					CqlInterval<CqlDateTime> ov_ = FHIRHelpers_4_3_000.ToInterval(ou_);
+					CqlDateTime ow_ = context.Operators.End(ov_);
 
 					return ow_;
 				};
-				var bw_ = context.Operators.SortBy<Encounter>(bu_, bv_, System.ComponentModel.ListSortDirection.Ascending);
-				var bx_ = context.Operators.Last<Encounter>(bw_);
-				var by_ = bx_?.Period;
-				var bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
-				var ca_ = context.Operators.Start(bz_);
-				var cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> bw_ = context.Operators.SortBy<Encounter>(bu_, bv_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bx_ = context.Operators.Last<Encounter>(bw_);
+				Period by_ = bx_?.Period;
+				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
+				CqlDateTime ca_ = context.Operators.Start(bz_);
+				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? cd_(Encounter LastObs)
 				{
-					var ox_ = LastObs?.StatusElement;
-					var oy_ = ox_?.Value;
-					var oz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oy_);
-					var pa_ = context.Operators.Equal(oz_, "finished");
-					var pb_ = LastObs?.Period;
-					var pc_ = FHIRHelpers_4_3_000.ToInterval(pb_);
-					var pd_ = context.Operators.End(pc_);
-					var pe_ = Visit?.Period;
-					var pf_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pg_ = context.Operators.Start(pf_);
-					var ph_ = context.Operators.Quantity(1m, "hour");
-					var pi_ = context.Operators.Subtract(pg_, ph_);
-					var pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pl_ = context.Operators.Start(pk_);
-					var pm_ = context.Operators.Interval(pi_, pl_, true, true);
-					var pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
-					var pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pq_ = context.Operators.Start(pp_);
-					var pr_ = context.Operators.Not((bool?)(pq_ is null));
-					var ps_ = context.Operators.And(pn_, pr_);
-					var pt_ = context.Operators.And(pa_, ps_);
+					Code<Encounter.EncounterStatus> ox_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? oy_ = ox_?.Value;
+					Code<Encounter.EncounterStatus> oz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oy_);
+					bool? pa_ = context.Operators.Equal(oz_, "finished");
+					Period pb_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> pc_ = FHIRHelpers_4_3_000.ToInterval(pb_);
+					CqlDateTime pd_ = context.Operators.End(pc_);
+					Period pe_ = Visit?.Period;
+					CqlInterval<CqlDateTime> pf_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pg_ = context.Operators.Start(pf_);
+					CqlQuantity ph_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime pi_ = context.Operators.Subtract(pg_, ph_);
+					CqlInterval<CqlDateTime> pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pl_ = context.Operators.Start(pk_);
+					CqlInterval<CqlDateTime> pm_ = context.Operators.Interval(pi_, pl_, true, true);
+					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
+					CqlInterval<CqlDateTime> pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pq_ = context.Operators.Start(pp_);
+					bool? pr_ = context.Operators.Not((bool?)(pq_ is null));
+					bool? ps_ = context.Operators.And(pn_, pr_);
+					bool? pt_ = context.Operators.And(pa_, ps_);
 
 					return pt_;
 				};
-				var ce_ = context.Operators.Where<Encounter>(cc_, cd_);
+				IEnumerable<Encounter> ce_ = context.Operators.Where<Encounter>(cc_, cd_);
 				object cf_(Encounter @this)
 				{
-					var pu_ = @this?.Period;
-					var pv_ = FHIRHelpers_4_3_000.ToInterval(pu_);
-					var pw_ = context.Operators.End(pv_);
+					Period pu_ = @this?.Period;
+					CqlInterval<CqlDateTime> pv_ = FHIRHelpers_4_3_000.ToInterval(pu_);
+					CqlDateTime pw_ = context.Operators.End(pv_);
 
 					return pw_;
 				};
-				var cg_ = context.Operators.SortBy<Encounter>(ce_, cf_, System.ComponentModel.ListSortDirection.Ascending);
-				var ch_ = context.Operators.Last<Encounter>(cg_);
-				var ci_ = ch_?.Period;
-				var cj_ = FHIRHelpers_4_3_000.ToInterval(ci_);
-				var ck_ = context.Operators.Start(cj_);
-				var cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var cn_ = context.Operators.Start(cm_);
-				var co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
-				var cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
-				var cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> cg_ = context.Operators.SortBy<Encounter>(ce_, cf_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter ch_ = context.Operators.Last<Encounter>(cg_);
+				Period ci_ = ch_?.Period;
+				CqlInterval<CqlDateTime> cj_ = FHIRHelpers_4_3_000.ToInterval(ci_);
+				CqlDateTime ck_ = context.Operators.Start(cj_);
+				CqlInterval<CqlDateTime> cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime cn_ = context.Operators.Start(cm_);
+				CqlInterval<CqlDateTime> co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
+				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
+				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? cs_(Encounter LastED)
 				{
-					var px_ = LastED?.StatusElement;
-					var py_ = px_?.Value;
-					var pz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(py_);
-					var qa_ = context.Operators.Equal(pz_, "finished");
-					var qb_ = LastED?.Period;
-					var qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
-					var qd_ = context.Operators.End(qc_);
-					var qe_ = this.Observation_Services();
-					var qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					Code<Encounter.EncounterStatus> px_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? py_ = px_?.Value;
+					Code<Encounter.EncounterStatus> pz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(py_);
+					bool? qa_ = context.Operators.Equal(pz_, "finished");
+					Period qb_ = LastED?.Period;
+					CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
+					CqlDateTime qd_ = context.Operators.End(qc_);
+					CqlValueSet qe_ = this.Observation_Services();
+					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? qg_(Encounter LastObs)
 					{
-						var ry_ = LastObs?.StatusElement;
-						var rz_ = ry_?.Value;
-						var sa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rz_);
-						var sb_ = context.Operators.Equal(sa_, "finished");
-						var sc_ = LastObs?.Period;
-						var sd_ = FHIRHelpers_4_3_000.ToInterval(sc_);
-						var se_ = context.Operators.End(sd_);
-						var sf_ = Visit?.Period;
-						var sg_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sh_ = context.Operators.Start(sg_);
-						var si_ = context.Operators.Quantity(1m, "hour");
-						var sj_ = context.Operators.Subtract(sh_, si_);
-						var sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sm_ = context.Operators.Start(sl_);
-						var sn_ = context.Operators.Interval(sj_, sm_, true, true);
-						var so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
-						var sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sr_ = context.Operators.Start(sq_);
-						var ss_ = context.Operators.Not((bool?)(sr_ is null));
-						var st_ = context.Operators.And(so_, ss_);
-						var su_ = context.Operators.And(sb_, st_);
+						Code<Encounter.EncounterStatus> ry_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? rz_ = ry_?.Value;
+						Code<Encounter.EncounterStatus> sa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rz_);
+						bool? sb_ = context.Operators.Equal(sa_, "finished");
+						Period sc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> sd_ = FHIRHelpers_4_3_000.ToInterval(sc_);
+						CqlDateTime se_ = context.Operators.End(sd_);
+						Period sf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> sg_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sh_ = context.Operators.Start(sg_);
+						CqlQuantity si_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime sj_ = context.Operators.Subtract(sh_, si_);
+						CqlInterval<CqlDateTime> sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sm_ = context.Operators.Start(sl_);
+						CqlInterval<CqlDateTime> sn_ = context.Operators.Interval(sj_, sm_, true, true);
+						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
+						CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sr_ = context.Operators.Start(sq_);
+						bool? ss_ = context.Operators.Not((bool?)(sr_ is null));
+						bool? st_ = context.Operators.And(so_, ss_);
+						bool? su_ = context.Operators.And(sb_, st_);
 
 						return su_;
 					};
-					var qh_ = context.Operators.Where<Encounter>(qf_, qg_);
+					IEnumerable<Encounter> qh_ = context.Operators.Where<Encounter>(qf_, qg_);
 					object qi_(Encounter @this)
 					{
-						var sv_ = @this?.Period;
-						var sw_ = FHIRHelpers_4_3_000.ToInterval(sv_);
-						var sx_ = context.Operators.End(sw_);
+						Period sv_ = @this?.Period;
+						CqlInterval<CqlDateTime> sw_ = FHIRHelpers_4_3_000.ToInterval(sv_);
+						CqlDateTime sx_ = context.Operators.End(sw_);
 
 						return sx_;
 					};
-					var qj_ = context.Operators.SortBy<Encounter>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
-					var qk_ = context.Operators.Last<Encounter>(qj_);
-					var ql_ = qk_?.Period;
-					var qm_ = FHIRHelpers_4_3_000.ToInterval(ql_);
-					var qn_ = context.Operators.Start(qm_);
-					var qo_ = Visit?.Period;
-					var qp_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var qq_ = context.Operators.Start(qp_);
-					var qr_ = context.Operators.Quantity(1m, "hour");
-					var qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
-					var qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qj_ = context.Operators.SortBy<Encounter>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter qk_ = context.Operators.Last<Encounter>(qj_);
+					Period ql_ = qk_?.Period;
+					CqlInterval<CqlDateTime> qm_ = FHIRHelpers_4_3_000.ToInterval(ql_);
+					CqlDateTime qn_ = context.Operators.Start(qm_);
+					Period qo_ = Visit?.Period;
+					CqlInterval<CqlDateTime> qp_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime qq_ = context.Operators.Start(qp_);
+					CqlQuantity qr_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
+					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? qv_(Encounter LastObs)
 					{
-						var sy_ = LastObs?.StatusElement;
-						var sz_ = sy_?.Value;
-						var ta_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sz_);
-						var tb_ = context.Operators.Equal(ta_, "finished");
-						var tc_ = LastObs?.Period;
-						var td_ = FHIRHelpers_4_3_000.ToInterval(tc_);
-						var te_ = context.Operators.End(td_);
-						var tf_ = Visit?.Period;
-						var tg_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var th_ = context.Operators.Start(tg_);
-						var ti_ = context.Operators.Quantity(1m, "hour");
-						var tj_ = context.Operators.Subtract(th_, ti_);
-						var tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var tm_ = context.Operators.Start(tl_);
-						var tn_ = context.Operators.Interval(tj_, tm_, true, true);
-						var to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
-						var tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var tr_ = context.Operators.Start(tq_);
-						var ts_ = context.Operators.Not((bool?)(tr_ is null));
-						var tt_ = context.Operators.And(to_, ts_);
-						var tu_ = context.Operators.And(tb_, tt_);
+						Code<Encounter.EncounterStatus> sy_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? sz_ = sy_?.Value;
+						Code<Encounter.EncounterStatus> ta_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sz_);
+						bool? tb_ = context.Operators.Equal(ta_, "finished");
+						Period tc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> td_ = FHIRHelpers_4_3_000.ToInterval(tc_);
+						CqlDateTime te_ = context.Operators.End(td_);
+						Period tf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> tg_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime th_ = context.Operators.Start(tg_);
+						CqlQuantity ti_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime tj_ = context.Operators.Subtract(th_, ti_);
+						CqlInterval<CqlDateTime> tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime tm_ = context.Operators.Start(tl_);
+						CqlInterval<CqlDateTime> tn_ = context.Operators.Interval(tj_, tm_, true, true);
+						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
+						CqlInterval<CqlDateTime> tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime tr_ = context.Operators.Start(tq_);
+						bool? ts_ = context.Operators.Not((bool?)(tr_ is null));
+						bool? tt_ = context.Operators.And(to_, ts_);
+						bool? tu_ = context.Operators.And(tb_, tt_);
 
 						return tu_;
 					};
-					var qw_ = context.Operators.Where<Encounter>(qu_, qv_);
+					IEnumerable<Encounter> qw_ = context.Operators.Where<Encounter>(qu_, qv_);
 					object qx_(Encounter @this)
 					{
-						var tv_ = @this?.Period;
-						var tw_ = FHIRHelpers_4_3_000.ToInterval(tv_);
-						var tx_ = context.Operators.End(tw_);
+						Period tv_ = @this?.Period;
+						CqlInterval<CqlDateTime> tw_ = FHIRHelpers_4_3_000.ToInterval(tv_);
+						CqlDateTime tx_ = context.Operators.End(tw_);
 
 						return tx_;
 					};
-					var qy_ = context.Operators.SortBy<Encounter>(qw_, qx_, System.ComponentModel.ListSortDirection.Ascending);
-					var qz_ = context.Operators.Last<Encounter>(qy_);
-					var ra_ = qz_?.Period;
-					var rb_ = FHIRHelpers_4_3_000.ToInterval(ra_);
-					var rc_ = context.Operators.Start(rb_);
-					var re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var rf_ = context.Operators.Start(re_);
-					var rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
-					var rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
-					var rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qy_ = context.Operators.SortBy<Encounter>(qw_, qx_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter qz_ = context.Operators.Last<Encounter>(qy_);
+					Period ra_ = qz_?.Period;
+					CqlInterval<CqlDateTime> rb_ = FHIRHelpers_4_3_000.ToInterval(ra_);
+					CqlDateTime rc_ = context.Operators.Start(rb_);
+					CqlInterval<CqlDateTime> re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime rf_ = context.Operators.Start(re_);
+					CqlInterval<CqlDateTime> rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
+					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
+					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? rk_(Encounter LastObs)
 					{
-						var ty_ = LastObs?.StatusElement;
-						var tz_ = ty_?.Value;
-						var ua_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tz_);
-						var ub_ = context.Operators.Equal(ua_, "finished");
-						var uc_ = LastObs?.Period;
-						var ud_ = FHIRHelpers_4_3_000.ToInterval(uc_);
-						var ue_ = context.Operators.End(ud_);
-						var uf_ = Visit?.Period;
-						var ug_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var uh_ = context.Operators.Start(ug_);
-						var ui_ = context.Operators.Quantity(1m, "hour");
-						var uj_ = context.Operators.Subtract(uh_, ui_);
-						var ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var um_ = context.Operators.Start(ul_);
-						var un_ = context.Operators.Interval(uj_, um_, true, true);
-						var uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
-						var uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var ur_ = context.Operators.Start(uq_);
-						var us_ = context.Operators.Not((bool?)(ur_ is null));
-						var ut_ = context.Operators.And(uo_, us_);
-						var uu_ = context.Operators.And(ub_, ut_);
+						Code<Encounter.EncounterStatus> ty_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? tz_ = ty_?.Value;
+						Code<Encounter.EncounterStatus> ua_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tz_);
+						bool? ub_ = context.Operators.Equal(ua_, "finished");
+						Period uc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> ud_ = FHIRHelpers_4_3_000.ToInterval(uc_);
+						CqlDateTime ue_ = context.Operators.End(ud_);
+						Period uf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> ug_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime uh_ = context.Operators.Start(ug_);
+						CqlQuantity ui_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime uj_ = context.Operators.Subtract(uh_, ui_);
+						CqlInterval<CqlDateTime> ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime um_ = context.Operators.Start(ul_);
+						CqlInterval<CqlDateTime> un_ = context.Operators.Interval(uj_, um_, true, true);
+						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
+						CqlInterval<CqlDateTime> uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime ur_ = context.Operators.Start(uq_);
+						bool? us_ = context.Operators.Not((bool?)(ur_ is null));
+						bool? ut_ = context.Operators.And(uo_, us_);
+						bool? uu_ = context.Operators.And(ub_, ut_);
 
 						return uu_;
 					};
-					var rl_ = context.Operators.Where<Encounter>(rj_, rk_);
+					IEnumerable<Encounter> rl_ = context.Operators.Where<Encounter>(rj_, rk_);
 					object rm_(Encounter @this)
 					{
-						var uv_ = @this?.Period;
-						var uw_ = FHIRHelpers_4_3_000.ToInterval(uv_);
-						var ux_ = context.Operators.End(uw_);
+						Period uv_ = @this?.Period;
+						CqlInterval<CqlDateTime> uw_ = FHIRHelpers_4_3_000.ToInterval(uv_);
+						CqlDateTime ux_ = context.Operators.End(uw_);
 
 						return ux_;
 					};
-					var rn_ = context.Operators.SortBy<Encounter>(rl_, rm_, System.ComponentModel.ListSortDirection.Ascending);
-					var ro_ = context.Operators.Last<Encounter>(rn_);
-					var rp_ = ro_?.Period;
-					var rq_ = FHIRHelpers_4_3_000.ToInterval(rp_);
-					var rr_ = context.Operators.Start(rq_);
-					var rt_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var ru_ = context.Operators.Start(rt_);
-					var rv_ = context.Operators.Not((bool?)((rr_ ?? ru_) is null));
-					var rw_ = context.Operators.And(rh_, rv_);
-					var rx_ = context.Operators.And(qa_, rw_);
+					IEnumerable<Encounter> rn_ = context.Operators.SortBy<Encounter>(rl_, rm_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter ro_ = context.Operators.Last<Encounter>(rn_);
+					Period rp_ = ro_?.Period;
+					CqlInterval<CqlDateTime> rq_ = FHIRHelpers_4_3_000.ToInterval(rp_);
+					CqlDateTime rr_ = context.Operators.Start(rq_);
+					CqlInterval<CqlDateTime> rt_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime ru_ = context.Operators.Start(rt_);
+					bool? rv_ = context.Operators.Not((bool?)((rr_ ?? ru_) is null));
+					bool? rw_ = context.Operators.And(rh_, rv_);
+					bool? rx_ = context.Operators.And(qa_, rw_);
 
 					return rx_;
 				};
-				var ct_ = context.Operators.Where<Encounter>(cr_, cs_);
+				IEnumerable<Encounter> ct_ = context.Operators.Where<Encounter>(cr_, cs_);
 				object cu_(Encounter @this)
 				{
-					var uy_ = @this?.Period;
-					var uz_ = FHIRHelpers_4_3_000.ToInterval(uy_);
-					var va_ = context.Operators.End(uz_);
+					Period uy_ = @this?.Period;
+					CqlInterval<CqlDateTime> uz_ = FHIRHelpers_4_3_000.ToInterval(uy_);
+					CqlDateTime va_ = context.Operators.End(uz_);
 
 					return va_;
 				};
-				var cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
-				var cw_ = context.Operators.Last<Encounter>(cv_);
-				var cx_ = cw_?.Period;
-				var cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
-				var cz_ = context.Operators.Start(cy_);
-				var db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter cw_ = context.Operators.Last<Encounter>(cv_);
+				Period cx_ = cw_?.Period;
+				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
+				CqlDateTime cz_ = context.Operators.Start(cy_);
+				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? dc_(Encounter LastObs)
 				{
-					var vb_ = LastObs?.StatusElement;
-					var vc_ = vb_?.Value;
-					var vd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vc_);
-					var ve_ = context.Operators.Equal(vd_, "finished");
-					var vf_ = LastObs?.Period;
-					var vg_ = FHIRHelpers_4_3_000.ToInterval(vf_);
-					var vh_ = context.Operators.End(vg_);
-					var vi_ = Visit?.Period;
-					var vj_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vk_ = context.Operators.Start(vj_);
-					var vl_ = context.Operators.Quantity(1m, "hour");
-					var vm_ = context.Operators.Subtract(vk_, vl_);
-					var vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vp_ = context.Operators.Start(vo_);
-					var vq_ = context.Operators.Interval(vm_, vp_, true, true);
-					var vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
-					var vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vu_ = context.Operators.Start(vt_);
-					var vv_ = context.Operators.Not((bool?)(vu_ is null));
-					var vw_ = context.Operators.And(vr_, vv_);
-					var vx_ = context.Operators.And(ve_, vw_);
+					Code<Encounter.EncounterStatus> vb_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? vc_ = vb_?.Value;
+					Code<Encounter.EncounterStatus> vd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vc_);
+					bool? ve_ = context.Operators.Equal(vd_, "finished");
+					Period vf_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> vg_ = FHIRHelpers_4_3_000.ToInterval(vf_);
+					CqlDateTime vh_ = context.Operators.End(vg_);
+					Period vi_ = Visit?.Period;
+					CqlInterval<CqlDateTime> vj_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vk_ = context.Operators.Start(vj_);
+					CqlQuantity vl_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime vm_ = context.Operators.Subtract(vk_, vl_);
+					CqlInterval<CqlDateTime> vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vp_ = context.Operators.Start(vo_);
+					CqlInterval<CqlDateTime> vq_ = context.Operators.Interval(vm_, vp_, true, true);
+					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
+					CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vu_ = context.Operators.Start(vt_);
+					bool? vv_ = context.Operators.Not((bool?)(vu_ is null));
+					bool? vw_ = context.Operators.And(vr_, vv_);
+					bool? vx_ = context.Operators.And(ve_, vw_);
 
 					return vx_;
 				};
-				var dd_ = context.Operators.Where<Encounter>(db_, dc_);
+				IEnumerable<Encounter> dd_ = context.Operators.Where<Encounter>(db_, dc_);
 				object de_(Encounter @this)
 				{
-					var vy_ = @this?.Period;
-					var vz_ = FHIRHelpers_4_3_000.ToInterval(vy_);
-					var wa_ = context.Operators.End(vz_);
+					Period vy_ = @this?.Period;
+					CqlInterval<CqlDateTime> vz_ = FHIRHelpers_4_3_000.ToInterval(vy_);
+					CqlDateTime wa_ = context.Operators.End(vz_);
 
 					return wa_;
 				};
-				var df_ = context.Operators.SortBy<Encounter>(dd_, de_, System.ComponentModel.ListSortDirection.Ascending);
-				var dg_ = context.Operators.Last<Encounter>(df_);
-				var dh_ = dg_?.Period;
-				var di_ = FHIRHelpers_4_3_000.ToInterval(dh_);
-				var dj_ = context.Operators.Start(di_);
-				var dl_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var dm_ = context.Operators.Start(dl_);
-				var dn_ = context.Operators.Not((bool?)((cz_ ?? (dj_ ?? dm_)) is null));
-				var do_ = context.Operators.And(cp_, dn_);
+				IEnumerable<Encounter> df_ = context.Operators.SortBy<Encounter>(dd_, de_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter dg_ = context.Operators.Last<Encounter>(df_);
+				Period dh_ = dg_?.Period;
+				CqlInterval<CqlDateTime> di_ = FHIRHelpers_4_3_000.ToInterval(dh_);
+				CqlDateTime dj_ = context.Operators.Start(di_);
+				CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime dm_ = context.Operators.Start(dl_);
+				bool? dn_ = context.Operators.Not((bool?)((cz_ ?? (dj_ ?? dm_)) is null));
+				bool? do_ = context.Operators.And(cp_, dn_);
 
 				return do_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var wb_ = @this?.Period;
-				var wc_ = FHIRHelpers_4_3_000.ToInterval(wb_);
-				var wd_ = context.Operators.End(wc_);
+				Period wb_ = @this?.Period;
+				CqlInterval<CqlDateTime> wc_ = FHIRHelpers_4_3_000.ToInterval(wb_);
+				CqlDateTime wd_ = context.Operators.End(wc_);
 
 				return wd_;
 			};
-			var j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Encounter>(j_);
-			var l_ = k_?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Emergency_Department_Visit();
-			var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter k_ = context.Operators.Last<Encounter>(j_);
+			Period l_ = k_?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlValueSet o_ = this.Emergency_Department_Visit();
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
 			bool? q_(Encounter LastED)
 			{
-				var we_ = LastED?.StatusElement;
-				var wf_ = we_?.Value;
-				var wg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wf_);
-				var wh_ = context.Operators.Equal(wg_, "finished");
-				var wi_ = LastED?.Period;
-				var wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
-				var wk_ = context.Operators.End(wj_);
-				var wl_ = this.Observation_Services();
-				var wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				Code<Encounter.EncounterStatus> we_ = LastED?.StatusElement;
+				Encounter.EncounterStatus? wf_ = we_?.Value;
+				Code<Encounter.EncounterStatus> wg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wf_);
+				bool? wh_ = context.Operators.Equal(wg_, "finished");
+				Period wi_ = LastED?.Period;
+				CqlInterval<CqlDateTime> wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
+				CqlDateTime wk_ = context.Operators.End(wj_);
+				CqlValueSet wl_ = this.Observation_Services();
+				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? wn_(Encounter LastObs)
 				{
-					var yf_ = LastObs?.StatusElement;
-					var yg_ = yf_?.Value;
-					var yh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(yg_);
-					var yi_ = context.Operators.Equal(yh_, "finished");
-					var yj_ = LastObs?.Period;
-					var yk_ = FHIRHelpers_4_3_000.ToInterval(yj_);
-					var yl_ = context.Operators.End(yk_);
-					var ym_ = Visit?.Period;
-					var yn_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yo_ = context.Operators.Start(yn_);
-					var yp_ = context.Operators.Quantity(1m, "hour");
-					var yq_ = context.Operators.Subtract(yo_, yp_);
-					var ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yt_ = context.Operators.Start(ys_);
-					var yu_ = context.Operators.Interval(yq_, yt_, true, true);
-					var yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
-					var yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yy_ = context.Operators.Start(yx_);
-					var yz_ = context.Operators.Not((bool?)(yy_ is null));
-					var za_ = context.Operators.And(yv_, yz_);
-					var zb_ = context.Operators.And(yi_, za_);
+					Code<Encounter.EncounterStatus> yf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? yg_ = yf_?.Value;
+					Code<Encounter.EncounterStatus> yh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(yg_);
+					bool? yi_ = context.Operators.Equal(yh_, "finished");
+					Period yj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> yk_ = FHIRHelpers_4_3_000.ToInterval(yj_);
+					CqlDateTime yl_ = context.Operators.End(yk_);
+					Period ym_ = Visit?.Period;
+					CqlInterval<CqlDateTime> yn_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yo_ = context.Operators.Start(yn_);
+					CqlQuantity yp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime yq_ = context.Operators.Subtract(yo_, yp_);
+					CqlInterval<CqlDateTime> ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yt_ = context.Operators.Start(ys_);
+					CqlInterval<CqlDateTime> yu_ = context.Operators.Interval(yq_, yt_, true, true);
+					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
+					CqlInterval<CqlDateTime> yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yy_ = context.Operators.Start(yx_);
+					bool? yz_ = context.Operators.Not((bool?)(yy_ is null));
+					bool? za_ = context.Operators.And(yv_, yz_);
+					bool? zb_ = context.Operators.And(yi_, za_);
 
 					return zb_;
 				};
-				var wo_ = context.Operators.Where<Encounter>(wm_, wn_);
+				IEnumerable<Encounter> wo_ = context.Operators.Where<Encounter>(wm_, wn_);
 				object wp_(Encounter @this)
 				{
-					var zc_ = @this?.Period;
-					var zd_ = FHIRHelpers_4_3_000.ToInterval(zc_);
-					var ze_ = context.Operators.End(zd_);
+					Period zc_ = @this?.Period;
+					CqlInterval<CqlDateTime> zd_ = FHIRHelpers_4_3_000.ToInterval(zc_);
+					CqlDateTime ze_ = context.Operators.End(zd_);
 
 					return ze_;
 				};
-				var wq_ = context.Operators.SortBy<Encounter>(wo_, wp_, System.ComponentModel.ListSortDirection.Ascending);
-				var wr_ = context.Operators.Last<Encounter>(wq_);
-				var ws_ = wr_?.Period;
-				var wt_ = FHIRHelpers_4_3_000.ToInterval(ws_);
-				var wu_ = context.Operators.Start(wt_);
-				var wv_ = Visit?.Period;
-				var ww_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var wx_ = context.Operators.Start(ww_);
-				var wy_ = context.Operators.Quantity(1m, "hour");
-				var wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
-				var xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> wq_ = context.Operators.SortBy<Encounter>(wo_, wp_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter wr_ = context.Operators.Last<Encounter>(wq_);
+				Period ws_ = wr_?.Period;
+				CqlInterval<CqlDateTime> wt_ = FHIRHelpers_4_3_000.ToInterval(ws_);
+				CqlDateTime wu_ = context.Operators.Start(wt_);
+				Period wv_ = Visit?.Period;
+				CqlInterval<CqlDateTime> ww_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime wx_ = context.Operators.Start(ww_);
+				CqlQuantity wy_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
+				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? xc_(Encounter LastObs)
 				{
-					var zf_ = LastObs?.StatusElement;
-					var zg_ = zf_?.Value;
-					var zh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(zg_);
-					var zi_ = context.Operators.Equal(zh_, "finished");
-					var zj_ = LastObs?.Period;
-					var zk_ = FHIRHelpers_4_3_000.ToInterval(zj_);
-					var zl_ = context.Operators.End(zk_);
-					var zm_ = Visit?.Period;
-					var zn_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zo_ = context.Operators.Start(zn_);
-					var zp_ = context.Operators.Quantity(1m, "hour");
-					var zq_ = context.Operators.Subtract(zo_, zp_);
-					var zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zt_ = context.Operators.Start(zs_);
-					var zu_ = context.Operators.Interval(zq_, zt_, true, true);
-					var zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
-					var zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zy_ = context.Operators.Start(zx_);
-					var zz_ = context.Operators.Not((bool?)(zy_ is null));
-					var aza_ = context.Operators.And(zv_, zz_);
-					var azb_ = context.Operators.And(zi_, aza_);
+					Code<Encounter.EncounterStatus> zf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? zg_ = zf_?.Value;
+					Code<Encounter.EncounterStatus> zh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(zg_);
+					bool? zi_ = context.Operators.Equal(zh_, "finished");
+					Period zj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> zk_ = FHIRHelpers_4_3_000.ToInterval(zj_);
+					CqlDateTime zl_ = context.Operators.End(zk_);
+					Period zm_ = Visit?.Period;
+					CqlInterval<CqlDateTime> zn_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zo_ = context.Operators.Start(zn_);
+					CqlQuantity zp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime zq_ = context.Operators.Subtract(zo_, zp_);
+					CqlInterval<CqlDateTime> zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zt_ = context.Operators.Start(zs_);
+					CqlInterval<CqlDateTime> zu_ = context.Operators.Interval(zq_, zt_, true, true);
+					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
+					CqlInterval<CqlDateTime> zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zy_ = context.Operators.Start(zx_);
+					bool? zz_ = context.Operators.Not((bool?)(zy_ is null));
+					bool? aza_ = context.Operators.And(zv_, zz_);
+					bool? azb_ = context.Operators.And(zi_, aza_);
 
 					return azb_;
 				};
-				var xd_ = context.Operators.Where<Encounter>(xb_, xc_);
+				IEnumerable<Encounter> xd_ = context.Operators.Where<Encounter>(xb_, xc_);
 				object xe_(Encounter @this)
 				{
-					var azc_ = @this?.Period;
-					var azd_ = FHIRHelpers_4_3_000.ToInterval(azc_);
-					var aze_ = context.Operators.End(azd_);
+					Period azc_ = @this?.Period;
+					CqlInterval<CqlDateTime> azd_ = FHIRHelpers_4_3_000.ToInterval(azc_);
+					CqlDateTime aze_ = context.Operators.End(azd_);
 
 					return aze_;
 				};
-				var xf_ = context.Operators.SortBy<Encounter>(xd_, xe_, System.ComponentModel.ListSortDirection.Ascending);
-				var xg_ = context.Operators.Last<Encounter>(xf_);
-				var xh_ = xg_?.Period;
-				var xi_ = FHIRHelpers_4_3_000.ToInterval(xh_);
-				var xj_ = context.Operators.Start(xi_);
-				var xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var xm_ = context.Operators.Start(xl_);
-				var xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
-				var xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
-				var xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> xf_ = context.Operators.SortBy<Encounter>(xd_, xe_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter xg_ = context.Operators.Last<Encounter>(xf_);
+				Period xh_ = xg_?.Period;
+				CqlInterval<CqlDateTime> xi_ = FHIRHelpers_4_3_000.ToInterval(xh_);
+				CqlDateTime xj_ = context.Operators.Start(xi_);
+				CqlInterval<CqlDateTime> xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime xm_ = context.Operators.Start(xl_);
+				CqlInterval<CqlDateTime> xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
+				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
+				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? xr_(Encounter LastObs)
 				{
-					var azf_ = LastObs?.StatusElement;
-					var azg_ = azf_?.Value;
-					var azh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(azg_);
-					var azi_ = context.Operators.Equal(azh_, "finished");
-					var azj_ = LastObs?.Period;
-					var azk_ = FHIRHelpers_4_3_000.ToInterval(azj_);
-					var azl_ = context.Operators.End(azk_);
-					var azm_ = Visit?.Period;
-					var azn_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azo_ = context.Operators.Start(azn_);
-					var azp_ = context.Operators.Quantity(1m, "hour");
-					var azq_ = context.Operators.Subtract(azo_, azp_);
-					var azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azt_ = context.Operators.Start(azs_);
-					var azu_ = context.Operators.Interval(azq_, azt_, true, true);
-					var azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
-					var azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azy_ = context.Operators.Start(azx_);
-					var azz_ = context.Operators.Not((bool?)(azy_ is null));
-					var bza_ = context.Operators.And(azv_, azz_);
-					var bzb_ = context.Operators.And(azi_, bza_);
+					Code<Encounter.EncounterStatus> azf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? azg_ = azf_?.Value;
+					Code<Encounter.EncounterStatus> azh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(azg_);
+					bool? azi_ = context.Operators.Equal(azh_, "finished");
+					Period azj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> azk_ = FHIRHelpers_4_3_000.ToInterval(azj_);
+					CqlDateTime azl_ = context.Operators.End(azk_);
+					Period azm_ = Visit?.Period;
+					CqlInterval<CqlDateTime> azn_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azo_ = context.Operators.Start(azn_);
+					CqlQuantity azp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime azq_ = context.Operators.Subtract(azo_, azp_);
+					CqlInterval<CqlDateTime> azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azt_ = context.Operators.Start(azs_);
+					CqlInterval<CqlDateTime> azu_ = context.Operators.Interval(azq_, azt_, true, true);
+					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
+					CqlInterval<CqlDateTime> azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azy_ = context.Operators.Start(azx_);
+					bool? azz_ = context.Operators.Not((bool?)(azy_ is null));
+					bool? bza_ = context.Operators.And(azv_, azz_);
+					bool? bzb_ = context.Operators.And(azi_, bza_);
 
 					return bzb_;
 				};
-				var xs_ = context.Operators.Where<Encounter>(xq_, xr_);
+				IEnumerable<Encounter> xs_ = context.Operators.Where<Encounter>(xq_, xr_);
 				object xt_(Encounter @this)
 				{
-					var bzc_ = @this?.Period;
-					var bzd_ = FHIRHelpers_4_3_000.ToInterval(bzc_);
-					var bze_ = context.Operators.End(bzd_);
+					Period bzc_ = @this?.Period;
+					CqlInterval<CqlDateTime> bzd_ = FHIRHelpers_4_3_000.ToInterval(bzc_);
+					CqlDateTime bze_ = context.Operators.End(bzd_);
 
 					return bze_;
 				};
-				var xu_ = context.Operators.SortBy<Encounter>(xs_, xt_, System.ComponentModel.ListSortDirection.Ascending);
-				var xv_ = context.Operators.Last<Encounter>(xu_);
-				var xw_ = xv_?.Period;
-				var xx_ = FHIRHelpers_4_3_000.ToInterval(xw_);
-				var xy_ = context.Operators.Start(xx_);
-				var ya_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var yb_ = context.Operators.Start(ya_);
-				var yc_ = context.Operators.Not((bool?)((xy_ ?? yb_) is null));
-				var yd_ = context.Operators.And(xo_, yc_);
-				var ye_ = context.Operators.And(wh_, yd_);
+				IEnumerable<Encounter> xu_ = context.Operators.SortBy<Encounter>(xs_, xt_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter xv_ = context.Operators.Last<Encounter>(xu_);
+				Period xw_ = xv_?.Period;
+				CqlInterval<CqlDateTime> xx_ = FHIRHelpers_4_3_000.ToInterval(xw_);
+				CqlDateTime xy_ = context.Operators.Start(xx_);
+				CqlInterval<CqlDateTime> ya_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime yb_ = context.Operators.Start(ya_);
+				bool? yc_ = context.Operators.Not((bool?)((xy_ ?? yb_) is null));
+				bool? yd_ = context.Operators.And(xo_, yc_);
+				bool? ye_ = context.Operators.And(wh_, yd_);
 
 				return ye_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 			object s_(Encounter @this)
 			{
-				var bzf_ = @this?.Period;
-				var bzg_ = FHIRHelpers_4_3_000.ToInterval(bzf_);
-				var bzh_ = context.Operators.End(bzg_);
+				Period bzf_ = @this?.Period;
+				CqlInterval<CqlDateTime> bzg_ = FHIRHelpers_4_3_000.ToInterval(bzf_);
+				CqlDateTime bzh_ = context.Operators.End(bzg_);
 
 				return bzh_;
 			};
-			var t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.Last<Encounter>(t_);
-			var v_ = u_?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
-			var y_ = this.Observation_Services();
-			var z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
+			IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter u_ = context.Operators.Last<Encounter>(t_);
+			Period v_ = u_?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			CqlValueSet y_ = this.Observation_Services();
+			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
 			bool? aa_(Encounter LastObs)
 			{
-				var bzi_ = LastObs?.StatusElement;
-				var bzj_ = bzi_?.Value;
-				var bzk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bzj_);
-				var bzl_ = context.Operators.Equal(bzk_, "finished");
-				var bzm_ = LastObs?.Period;
-				var bzn_ = FHIRHelpers_4_3_000.ToInterval(bzm_);
-				var bzo_ = context.Operators.End(bzn_);
-				var bzp_ = Visit?.Period;
-				var bzq_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var bzr_ = context.Operators.Start(bzq_);
-				var bzs_ = context.Operators.Quantity(1m, "hour");
-				var bzt_ = context.Operators.Subtract(bzr_, bzs_);
-				var bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var bzw_ = context.Operators.Start(bzv_);
-				var bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
-				var bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
-				var cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var czb_ = context.Operators.Start(cza_);
-				var czc_ = context.Operators.Not((bool?)(czb_ is null));
-				var czd_ = context.Operators.And(bzy_, czc_);
-				var cze_ = context.Operators.And(bzl_, czd_);
+				Code<Encounter.EncounterStatus> bzi_ = LastObs?.StatusElement;
+				Encounter.EncounterStatus? bzj_ = bzi_?.Value;
+				Code<Encounter.EncounterStatus> bzk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bzj_);
+				bool? bzl_ = context.Operators.Equal(bzk_, "finished");
+				Period bzm_ = LastObs?.Period;
+				CqlInterval<CqlDateTime> bzn_ = FHIRHelpers_4_3_000.ToInterval(bzm_);
+				CqlDateTime bzo_ = context.Operators.End(bzn_);
+				Period bzp_ = Visit?.Period;
+				CqlInterval<CqlDateTime> bzq_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime bzr_ = context.Operators.Start(bzq_);
+				CqlQuantity bzs_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime bzt_ = context.Operators.Subtract(bzr_, bzs_);
+				CqlInterval<CqlDateTime> bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime bzw_ = context.Operators.Start(bzv_);
+				CqlInterval<CqlDateTime> bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
+				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
+				CqlInterval<CqlDateTime> cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime czb_ = context.Operators.Start(cza_);
+				bool? czc_ = context.Operators.Not((bool?)(czb_ is null));
+				bool? czd_ = context.Operators.And(bzy_, czc_);
+				bool? cze_ = context.Operators.And(bzl_, czd_);
 
 				return cze_;
 			};
-			var ab_ = context.Operators.Where<Encounter>(z_, aa_);
+			IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
 			object ac_(Encounter @this)
 			{
-				var czf_ = @this?.Period;
-				var czg_ = FHIRHelpers_4_3_000.ToInterval(czf_);
-				var czh_ = context.Operators.End(czg_);
+				Period czf_ = @this?.Period;
+				CqlInterval<CqlDateTime> czg_ = FHIRHelpers_4_3_000.ToInterval(czf_);
+				CqlDateTime czh_ = context.Operators.End(czg_);
 
 				return czh_;
 			};
-			var ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
-			var ae_ = context.Operators.Last<Encounter>(ad_);
-			var af_ = ae_?.Period;
-			var ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-			var ah_ = context.Operators.Start(ag_);
-			var ai_ = Visit?.Period;
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-			var ak_ = context.Operators.Start(aj_);
-			var am_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-			var an_ = context.Operators.End(am_);
-			var ao_ = context.Operators.Interval((n_ ?? (x_ ?? (ah_ ?? ak_))), an_, true, true);
+			IEnumerable<Encounter> ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter ae_ = context.Operators.Last<Encounter>(ad_);
+			Period af_ = ae_?.Period;
+			CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
+			CqlDateTime ah_ = context.Operators.Start(ag_);
+			Period ai_ = Visit?.Period;
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+			CqlDateTime an_ = context.Operators.End(am_);
+			CqlInterval<CqlDateTime> ao_ = context.Operators.Interval((n_ ?? (x_ ?? (ah_ ?? ak_))), an_, true, true);
 
 			return ao_;
 		};
-		var c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
+		CqlInterval<CqlDateTime> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
 
 		return d_;
 	}
@@ -1587,888 +1595,888 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Hospitalization with Observation and Outpatient Surgery Service returns the total interval from the start of any immediately prior emergency department visit, outpatient surgery visit or observation visit to the discharge of the given encounter.")]
 	public CqlInterval<CqlDateTime> hospitalizationWithObservationAndOutpatientSurgeryService(Encounter TheEncounter)
 	{
-		var a_ = new Encounter[]
+		Encounter[] a_ = new Encounter[]
 		{
 			TheEncounter,
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Outpatient_Surgery_Service();
-			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			CqlValueSet e_ = this.Outpatient_Surgery_Service();
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastSurgeryOP)
 			{
-				var ap_ = LastSurgeryOP?.Period;
-				var aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				var ar_ = context.Operators.End(aq_);
-				var as_ = this.Emergency_Department_Visit();
-				var at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				Period ap_ = LastSurgeryOP?.Period;
+				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
+				CqlDateTime ar_ = context.Operators.End(aq_);
+				CqlValueSet as_ = this.Emergency_Department_Visit();
+				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? au_(Encounter LastED)
 				{
-					var dp_ = LastED?.StatusElement;
-					var dq_ = dp_?.Value;
-					var dr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dq_);
-					var ds_ = context.Operators.Equal(dr_, "finished");
-					var dt_ = LastED?.Period;
-					var du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
-					var dv_ = context.Operators.End(du_);
-					var dw_ = this.Observation_Services();
-					var dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					Code<Encounter.EncounterStatus> dp_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? dq_ = dp_?.Value;
+					Code<Encounter.EncounterStatus> dr_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dq_);
+					bool? ds_ = context.Operators.Equal(dr_, "finished");
+					Period dt_ = LastED?.Period;
+					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
+					CqlDateTime dv_ = context.Operators.End(du_);
+					CqlValueSet dw_ = this.Observation_Services();
+					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? dy_(Encounter LastObs)
 					{
-						var fq_ = LastObs?.StatusElement;
-						var fr_ = fq_?.Value;
-						var fs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fr_);
-						var ft_ = context.Operators.Equal(fs_, "finished");
-						var fu_ = LastObs?.Period;
-						var fv_ = FHIRHelpers_4_3_000.ToInterval(fu_);
-						var fw_ = context.Operators.End(fv_);
-						var fx_ = Visit?.Period;
-						var fy_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var fz_ = context.Operators.Start(fy_);
-						var ga_ = context.Operators.Quantity(1m, "hour");
-						var gb_ = context.Operators.Subtract(fz_, ga_);
-						var gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var ge_ = context.Operators.Start(gd_);
-						var gf_ = context.Operators.Interval(gb_, ge_, true, true);
-						var gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
-						var gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
-						var gj_ = context.Operators.Start(gi_);
-						var gk_ = context.Operators.Not((bool?)(gj_ is null));
-						var gl_ = context.Operators.And(gg_, gk_);
-						var gm_ = context.Operators.And(ft_, gl_);
+						Code<Encounter.EncounterStatus> fq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? fr_ = fq_?.Value;
+						Code<Encounter.EncounterStatus> fs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fr_);
+						bool? ft_ = context.Operators.Equal(fs_, "finished");
+						Period fu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> fv_ = FHIRHelpers_4_3_000.ToInterval(fu_);
+						CqlDateTime fw_ = context.Operators.End(fv_);
+						Period fx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> fy_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime fz_ = context.Operators.Start(fy_);
+						CqlQuantity ga_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime gb_ = context.Operators.Subtract(fz_, ga_);
+						CqlInterval<CqlDateTime> gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime ge_ = context.Operators.Start(gd_);
+						CqlInterval<CqlDateTime> gf_ = context.Operators.Interval(gb_, ge_, true, true);
+						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
+						CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
+						CqlDateTime gj_ = context.Operators.Start(gi_);
+						bool? gk_ = context.Operators.Not((bool?)(gj_ is null));
+						bool? gl_ = context.Operators.And(gg_, gk_);
+						bool? gm_ = context.Operators.And(ft_, gl_);
 
 						return gm_;
 					};
-					var dz_ = context.Operators.Where<Encounter>(dx_, dy_);
+					IEnumerable<Encounter> dz_ = context.Operators.Where<Encounter>(dx_, dy_);
 					object ea_(Encounter @this)
 					{
-						var gn_ = @this?.Period;
-						var go_ = FHIRHelpers_4_3_000.ToInterval(gn_);
-						var gp_ = context.Operators.End(go_);
+						Period gn_ = @this?.Period;
+						CqlInterval<CqlDateTime> go_ = FHIRHelpers_4_3_000.ToInterval(gn_);
+						CqlDateTime gp_ = context.Operators.End(go_);
 
 						return gp_;
 					};
-					var eb_ = context.Operators.SortBy<Encounter>(dz_, ea_, System.ComponentModel.ListSortDirection.Ascending);
-					var ec_ = context.Operators.Last<Encounter>(eb_);
-					var ed_ = ec_?.Period;
-					var ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
-					var ef_ = context.Operators.Start(ee_);
-					var eg_ = Visit?.Period;
-					var eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var ei_ = context.Operators.Start(eh_);
-					var ej_ = context.Operators.Quantity(1m, "hour");
-					var ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
-					var em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> eb_ = context.Operators.SortBy<Encounter>(dz_, ea_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter ec_ = context.Operators.Last<Encounter>(eb_);
+					Period ed_ = ec_?.Period;
+					CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
+					CqlDateTime ef_ = context.Operators.Start(ee_);
+					Period eg_ = Visit?.Period;
+					CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime ei_ = context.Operators.Start(eh_);
+					CqlQuantity ej_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
+					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? en_(Encounter LastObs)
 					{
-						var gq_ = LastObs?.StatusElement;
-						var gr_ = gq_?.Value;
-						var gs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gr_);
-						var gt_ = context.Operators.Equal(gs_, "finished");
-						var gu_ = LastObs?.Period;
-						var gv_ = FHIRHelpers_4_3_000.ToInterval(gu_);
-						var gw_ = context.Operators.End(gv_);
-						var gx_ = Visit?.Period;
-						var gy_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var gz_ = context.Operators.Start(gy_);
-						var ha_ = context.Operators.Quantity(1m, "hour");
-						var hb_ = context.Operators.Subtract(gz_, ha_);
-						var hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var he_ = context.Operators.Start(hd_);
-						var hf_ = context.Operators.Interval(hb_, he_, true, true);
-						var hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
-						var hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
-						var hj_ = context.Operators.Start(hi_);
-						var hk_ = context.Operators.Not((bool?)(hj_ is null));
-						var hl_ = context.Operators.And(hg_, hk_);
-						var hm_ = context.Operators.And(gt_, hl_);
+						Code<Encounter.EncounterStatus> gq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? gr_ = gq_?.Value;
+						Code<Encounter.EncounterStatus> gs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(gr_);
+						bool? gt_ = context.Operators.Equal(gs_, "finished");
+						Period gu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> gv_ = FHIRHelpers_4_3_000.ToInterval(gu_);
+						CqlDateTime gw_ = context.Operators.End(gv_);
+						Period gx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> gy_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime gz_ = context.Operators.Start(gy_);
+						CqlQuantity ha_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime hb_ = context.Operators.Subtract(gz_, ha_);
+						CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime he_ = context.Operators.Start(hd_);
+						CqlInterval<CqlDateTime> hf_ = context.Operators.Interval(hb_, he_, true, true);
+						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
+						CqlInterval<CqlDateTime> hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
+						CqlDateTime hj_ = context.Operators.Start(hi_);
+						bool? hk_ = context.Operators.Not((bool?)(hj_ is null));
+						bool? hl_ = context.Operators.And(hg_, hk_);
+						bool? hm_ = context.Operators.And(gt_, hl_);
 
 						return hm_;
 					};
-					var eo_ = context.Operators.Where<Encounter>(em_, en_);
+					IEnumerable<Encounter> eo_ = context.Operators.Where<Encounter>(em_, en_);
 					object ep_(Encounter @this)
 					{
-						var hn_ = @this?.Period;
-						var ho_ = FHIRHelpers_4_3_000.ToInterval(hn_);
-						var hp_ = context.Operators.End(ho_);
+						Period hn_ = @this?.Period;
+						CqlInterval<CqlDateTime> ho_ = FHIRHelpers_4_3_000.ToInterval(hn_);
+						CqlDateTime hp_ = context.Operators.End(ho_);
 
 						return hp_;
 					};
-					var eq_ = context.Operators.SortBy<Encounter>(eo_, ep_, System.ComponentModel.ListSortDirection.Ascending);
-					var er_ = context.Operators.Last<Encounter>(eq_);
-					var es_ = er_?.Period;
-					var et_ = FHIRHelpers_4_3_000.ToInterval(es_);
-					var eu_ = context.Operators.Start(et_);
-					var ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var ex_ = context.Operators.Start(ew_);
-					var ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
-					var ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
-					var fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> eq_ = context.Operators.SortBy<Encounter>(eo_, ep_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter er_ = context.Operators.Last<Encounter>(eq_);
+					Period es_ = er_?.Period;
+					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(es_);
+					CqlDateTime eu_ = context.Operators.Start(et_);
+					CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime ex_ = context.Operators.Start(ew_);
+					CqlInterval<CqlDateTime> ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
+					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
+					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
 					bool? fc_(Encounter LastObs)
 					{
-						var hq_ = LastObs?.StatusElement;
-						var hr_ = hq_?.Value;
-						var hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
-						var ht_ = context.Operators.Equal(hs_, "finished");
-						var hu_ = LastObs?.Period;
-						var hv_ = FHIRHelpers_4_3_000.ToInterval(hu_);
-						var hw_ = context.Operators.End(hv_);
-						var hx_ = Visit?.Period;
-						var hy_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var hz_ = context.Operators.Start(hy_);
-						var ia_ = context.Operators.Quantity(1m, "hour");
-						var ib_ = context.Operators.Subtract(hz_, ia_);
-						var id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var ie_ = context.Operators.Start(id_);
-						var if_ = context.Operators.Interval(ib_, ie_, true, true);
-						var ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
-						var ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
-						var ij_ = context.Operators.Start(ii_);
-						var ik_ = context.Operators.Not((bool?)(ij_ is null));
-						var il_ = context.Operators.And(ig_, ik_);
-						var im_ = context.Operators.And(ht_, il_);
+						Code<Encounter.EncounterStatus> hq_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? hr_ = hq_?.Value;
+						Code<Encounter.EncounterStatus> hs_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(hr_);
+						bool? ht_ = context.Operators.Equal(hs_, "finished");
+						Period hu_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> hv_ = FHIRHelpers_4_3_000.ToInterval(hu_);
+						CqlDateTime hw_ = context.Operators.End(hv_);
+						Period hx_ = Visit?.Period;
+						CqlInterval<CqlDateTime> hy_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime hz_ = context.Operators.Start(hy_);
+						CqlQuantity ia_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime ib_ = context.Operators.Subtract(hz_, ia_);
+						CqlInterval<CqlDateTime> id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime ie_ = context.Operators.Start(id_);
+						CqlInterval<CqlDateTime> if_ = context.Operators.Interval(ib_, ie_, true, true);
+						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
+						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
+						CqlDateTime ij_ = context.Operators.Start(ii_);
+						bool? ik_ = context.Operators.Not((bool?)(ij_ is null));
+						bool? il_ = context.Operators.And(ig_, ik_);
+						bool? im_ = context.Operators.And(ht_, il_);
 
 						return im_;
 					};
-					var fd_ = context.Operators.Where<Encounter>(fb_, fc_);
+					IEnumerable<Encounter> fd_ = context.Operators.Where<Encounter>(fb_, fc_);
 					object fe_(Encounter @this)
 					{
-						var in_ = @this?.Period;
-						var io_ = FHIRHelpers_4_3_000.ToInterval(in_);
-						var ip_ = context.Operators.End(io_);
+						Period in_ = @this?.Period;
+						CqlInterval<CqlDateTime> io_ = FHIRHelpers_4_3_000.ToInterval(in_);
+						CqlDateTime ip_ = context.Operators.End(io_);
 
 						return ip_;
 					};
-					var ff_ = context.Operators.SortBy<Encounter>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
-					var fg_ = context.Operators.Last<Encounter>(ff_);
-					var fh_ = fg_?.Period;
-					var fi_ = FHIRHelpers_4_3_000.ToInterval(fh_);
-					var fj_ = context.Operators.Start(fi_);
-					var fl_ = FHIRHelpers_4_3_000.ToInterval(eg_);
-					var fm_ = context.Operators.Start(fl_);
-					var fn_ = context.Operators.Not((bool?)((fj_ ?? fm_) is null));
-					var fo_ = context.Operators.And(ez_, fn_);
-					var fp_ = context.Operators.And(ds_, fo_);
+					IEnumerable<Encounter> ff_ = context.Operators.SortBy<Encounter>(fd_, fe_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter fg_ = context.Operators.Last<Encounter>(ff_);
+					Period fh_ = fg_?.Period;
+					CqlInterval<CqlDateTime> fi_ = FHIRHelpers_4_3_000.ToInterval(fh_);
+					CqlDateTime fj_ = context.Operators.Start(fi_);
+					CqlInterval<CqlDateTime> fl_ = FHIRHelpers_4_3_000.ToInterval(eg_);
+					CqlDateTime fm_ = context.Operators.Start(fl_);
+					bool? fn_ = context.Operators.Not((bool?)((fj_ ?? fm_) is null));
+					bool? fo_ = context.Operators.And(ez_, fn_);
+					bool? fp_ = context.Operators.And(ds_, fo_);
 
 					return fp_;
 				};
-				var av_ = context.Operators.Where<Encounter>(at_, au_);
+				IEnumerable<Encounter> av_ = context.Operators.Where<Encounter>(at_, au_);
 				object aw_(Encounter @this)
 				{
-					var iq_ = @this?.Period;
-					var ir_ = FHIRHelpers_4_3_000.ToInterval(iq_);
-					var is_ = context.Operators.End(ir_);
+					Period iq_ = @this?.Period;
+					CqlInterval<CqlDateTime> ir_ = FHIRHelpers_4_3_000.ToInterval(iq_);
+					CqlDateTime is_ = context.Operators.End(ir_);
 
 					return is_;
 				};
-				var ax_ = context.Operators.SortBy<Encounter>(av_, aw_, System.ComponentModel.ListSortDirection.Ascending);
-				var ay_ = context.Operators.Last<Encounter>(ax_);
-				var az_ = ay_?.Period;
-				var ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
-				var bb_ = context.Operators.Start(ba_);
-				var bc_ = this.Observation_Services();
-				var bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> ax_ = context.Operators.SortBy<Encounter>(av_, aw_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter ay_ = context.Operators.Last<Encounter>(ax_);
+				Period az_ = ay_?.Period;
+				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
+				CqlDateTime bb_ = context.Operators.Start(ba_);
+				CqlValueSet bc_ = this.Observation_Services();
+				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? be_(Encounter LastObs)
 				{
-					var it_ = LastObs?.StatusElement;
-					var iu_ = it_?.Value;
-					var iv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iu_);
-					var iw_ = context.Operators.Equal(iv_, "finished");
-					var ix_ = LastObs?.Period;
-					var iy_ = FHIRHelpers_4_3_000.ToInterval(ix_);
-					var iz_ = context.Operators.End(iy_);
-					var ja_ = Visit?.Period;
-					var jb_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jc_ = context.Operators.Start(jb_);
-					var jd_ = context.Operators.Quantity(1m, "hour");
-					var je_ = context.Operators.Subtract(jc_, jd_);
-					var jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jh_ = context.Operators.Start(jg_);
-					var ji_ = context.Operators.Interval(je_, jh_, true, true);
-					var jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
-					var jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
-					var jm_ = context.Operators.Start(jl_);
-					var jn_ = context.Operators.Not((bool?)(jm_ is null));
-					var jo_ = context.Operators.And(jj_, jn_);
-					var jp_ = context.Operators.And(iw_, jo_);
+					Code<Encounter.EncounterStatus> it_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? iu_ = it_?.Value;
+					Code<Encounter.EncounterStatus> iv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(iu_);
+					bool? iw_ = context.Operators.Equal(iv_, "finished");
+					Period ix_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> iy_ = FHIRHelpers_4_3_000.ToInterval(ix_);
+					CqlDateTime iz_ = context.Operators.End(iy_);
+					Period ja_ = Visit?.Period;
+					CqlInterval<CqlDateTime> jb_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jc_ = context.Operators.Start(jb_);
+					CqlQuantity jd_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime je_ = context.Operators.Subtract(jc_, jd_);
+					CqlInterval<CqlDateTime> jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jh_ = context.Operators.Start(jg_);
+					CqlInterval<CqlDateTime> ji_ = context.Operators.Interval(je_, jh_, true, true);
+					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
+					CqlInterval<CqlDateTime> jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
+					CqlDateTime jm_ = context.Operators.Start(jl_);
+					bool? jn_ = context.Operators.Not((bool?)(jm_ is null));
+					bool? jo_ = context.Operators.And(jj_, jn_);
+					bool? jp_ = context.Operators.And(iw_, jo_);
 
 					return jp_;
 				};
-				var bf_ = context.Operators.Where<Encounter>(bd_, be_);
+				IEnumerable<Encounter> bf_ = context.Operators.Where<Encounter>(bd_, be_);
 				object bg_(Encounter @this)
 				{
-					var jq_ = @this?.Period;
-					var jr_ = FHIRHelpers_4_3_000.ToInterval(jq_);
-					var js_ = context.Operators.End(jr_);
+					Period jq_ = @this?.Period;
+					CqlInterval<CqlDateTime> jr_ = FHIRHelpers_4_3_000.ToInterval(jq_);
+					CqlDateTime js_ = context.Operators.End(jr_);
 
 					return js_;
 				};
-				var bh_ = context.Operators.SortBy<Encounter>(bf_, bg_, System.ComponentModel.ListSortDirection.Ascending);
-				var bi_ = context.Operators.Last<Encounter>(bh_);
-				var bj_ = bi_?.Period;
-				var bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
-				var bl_ = context.Operators.Start(bk_);
-				var bm_ = Visit?.Period;
-				var bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var bo_ = context.Operators.Start(bn_);
-				var bp_ = context.Operators.Quantity(1m, "hour");
-				var bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
-				var bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> bh_ = context.Operators.SortBy<Encounter>(bf_, bg_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bi_ = context.Operators.Last<Encounter>(bh_);
+				Period bj_ = bi_?.Period;
+				CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
+				CqlDateTime bl_ = context.Operators.Start(bk_);
+				Period bm_ = Visit?.Period;
+				CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime bo_ = context.Operators.Start(bn_);
+				CqlQuantity bp_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
+				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? bt_(Encounter LastED)
 				{
-					var jt_ = LastED?.StatusElement;
-					var ju_ = jt_?.Value;
-					var jv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ju_);
-					var jw_ = context.Operators.Equal(jv_, "finished");
-					var jx_ = LastED?.Period;
-					var jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
-					var jz_ = context.Operators.End(jy_);
-					var ka_ = this.Observation_Services();
-					var kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					Code<Encounter.EncounterStatus> jt_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? ju_ = jt_?.Value;
+					Code<Encounter.EncounterStatus> jv_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ju_);
+					bool? jw_ = context.Operators.Equal(jv_, "finished");
+					Period jx_ = LastED?.Period;
+					CqlInterval<CqlDateTime> jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
+					CqlDateTime jz_ = context.Operators.End(jy_);
+					CqlValueSet ka_ = this.Observation_Services();
+					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? kc_(Encounter LastObs)
 					{
-						var lu_ = LastObs?.StatusElement;
-						var lv_ = lu_?.Value;
-						var lw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lv_);
-						var lx_ = context.Operators.Equal(lw_, "finished");
-						var ly_ = LastObs?.Period;
-						var lz_ = FHIRHelpers_4_3_000.ToInterval(ly_);
-						var ma_ = context.Operators.End(lz_);
-						var mb_ = Visit?.Period;
-						var mc_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var md_ = context.Operators.Start(mc_);
-						var me_ = context.Operators.Quantity(1m, "hour");
-						var mf_ = context.Operators.Subtract(md_, me_);
-						var mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var mi_ = context.Operators.Start(mh_);
-						var mj_ = context.Operators.Interval(mf_, mi_, true, true);
-						var mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
-						var mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
-						var mn_ = context.Operators.Start(mm_);
-						var mo_ = context.Operators.Not((bool?)(mn_ is null));
-						var mp_ = context.Operators.And(mk_, mo_);
-						var mq_ = context.Operators.And(lx_, mp_);
+						Code<Encounter.EncounterStatus> lu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? lv_ = lu_?.Value;
+						Code<Encounter.EncounterStatus> lw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(lv_);
+						bool? lx_ = context.Operators.Equal(lw_, "finished");
+						Period ly_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> lz_ = FHIRHelpers_4_3_000.ToInterval(ly_);
+						CqlDateTime ma_ = context.Operators.End(lz_);
+						Period mb_ = Visit?.Period;
+						CqlInterval<CqlDateTime> mc_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime md_ = context.Operators.Start(mc_);
+						CqlQuantity me_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime mf_ = context.Operators.Subtract(md_, me_);
+						CqlInterval<CqlDateTime> mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime mi_ = context.Operators.Start(mh_);
+						CqlInterval<CqlDateTime> mj_ = context.Operators.Interval(mf_, mi_, true, true);
+						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
+						CqlInterval<CqlDateTime> mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
+						CqlDateTime mn_ = context.Operators.Start(mm_);
+						bool? mo_ = context.Operators.Not((bool?)(mn_ is null));
+						bool? mp_ = context.Operators.And(mk_, mo_);
+						bool? mq_ = context.Operators.And(lx_, mp_);
 
 						return mq_;
 					};
-					var kd_ = context.Operators.Where<Encounter>(kb_, kc_);
+					IEnumerable<Encounter> kd_ = context.Operators.Where<Encounter>(kb_, kc_);
 					object ke_(Encounter @this)
 					{
-						var mr_ = @this?.Period;
-						var ms_ = FHIRHelpers_4_3_000.ToInterval(mr_);
-						var mt_ = context.Operators.End(ms_);
+						Period mr_ = @this?.Period;
+						CqlInterval<CqlDateTime> ms_ = FHIRHelpers_4_3_000.ToInterval(mr_);
+						CqlDateTime mt_ = context.Operators.End(ms_);
 
 						return mt_;
 					};
-					var kf_ = context.Operators.SortBy<Encounter>(kd_, ke_, System.ComponentModel.ListSortDirection.Ascending);
-					var kg_ = context.Operators.Last<Encounter>(kf_);
-					var kh_ = kg_?.Period;
-					var ki_ = FHIRHelpers_4_3_000.ToInterval(kh_);
-					var kj_ = context.Operators.Start(ki_);
-					var kk_ = Visit?.Period;
-					var kl_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var km_ = context.Operators.Start(kl_);
-					var kn_ = context.Operators.Quantity(1m, "hour");
-					var ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
-					var kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> kf_ = context.Operators.SortBy<Encounter>(kd_, ke_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter kg_ = context.Operators.Last<Encounter>(kf_);
+					Period kh_ = kg_?.Period;
+					CqlInterval<CqlDateTime> ki_ = FHIRHelpers_4_3_000.ToInterval(kh_);
+					CqlDateTime kj_ = context.Operators.Start(ki_);
+					Period kk_ = Visit?.Period;
+					CqlInterval<CqlDateTime> kl_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime km_ = context.Operators.Start(kl_);
+					CqlQuantity kn_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
+					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? kr_(Encounter LastObs)
 					{
-						var mu_ = LastObs?.StatusElement;
-						var mv_ = mu_?.Value;
-						var mw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mv_);
-						var mx_ = context.Operators.Equal(mw_, "finished");
-						var my_ = LastObs?.Period;
-						var mz_ = FHIRHelpers_4_3_000.ToInterval(my_);
-						var na_ = context.Operators.End(mz_);
-						var nb_ = Visit?.Period;
-						var nc_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var nd_ = context.Operators.Start(nc_);
-						var ne_ = context.Operators.Quantity(1m, "hour");
-						var nf_ = context.Operators.Subtract(nd_, ne_);
-						var nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var ni_ = context.Operators.Start(nh_);
-						var nj_ = context.Operators.Interval(nf_, ni_, true, true);
-						var nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
-						var nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
-						var nn_ = context.Operators.Start(nm_);
-						var no_ = context.Operators.Not((bool?)(nn_ is null));
-						var np_ = context.Operators.And(nk_, no_);
-						var nq_ = context.Operators.And(mx_, np_);
+						Code<Encounter.EncounterStatus> mu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? mv_ = mu_?.Value;
+						Code<Encounter.EncounterStatus> mw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(mv_);
+						bool? mx_ = context.Operators.Equal(mw_, "finished");
+						Period my_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> mz_ = FHIRHelpers_4_3_000.ToInterval(my_);
+						CqlDateTime na_ = context.Operators.End(mz_);
+						Period nb_ = Visit?.Period;
+						CqlInterval<CqlDateTime> nc_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime nd_ = context.Operators.Start(nc_);
+						CqlQuantity ne_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime nf_ = context.Operators.Subtract(nd_, ne_);
+						CqlInterval<CqlDateTime> nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime ni_ = context.Operators.Start(nh_);
+						CqlInterval<CqlDateTime> nj_ = context.Operators.Interval(nf_, ni_, true, true);
+						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
+						CqlInterval<CqlDateTime> nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
+						CqlDateTime nn_ = context.Operators.Start(nm_);
+						bool? no_ = context.Operators.Not((bool?)(nn_ is null));
+						bool? np_ = context.Operators.And(nk_, no_);
+						bool? nq_ = context.Operators.And(mx_, np_);
 
 						return nq_;
 					};
-					var ks_ = context.Operators.Where<Encounter>(kq_, kr_);
+					IEnumerable<Encounter> ks_ = context.Operators.Where<Encounter>(kq_, kr_);
 					object kt_(Encounter @this)
 					{
-						var nr_ = @this?.Period;
-						var ns_ = FHIRHelpers_4_3_000.ToInterval(nr_);
-						var nt_ = context.Operators.End(ns_);
+						Period nr_ = @this?.Period;
+						CqlInterval<CqlDateTime> ns_ = FHIRHelpers_4_3_000.ToInterval(nr_);
+						CqlDateTime nt_ = context.Operators.End(ns_);
 
 						return nt_;
 					};
-					var ku_ = context.Operators.SortBy<Encounter>(ks_, kt_, System.ComponentModel.ListSortDirection.Ascending);
-					var kv_ = context.Operators.Last<Encounter>(ku_);
-					var kw_ = kv_?.Period;
-					var kx_ = FHIRHelpers_4_3_000.ToInterval(kw_);
-					var ky_ = context.Operators.Start(kx_);
-					var la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var lb_ = context.Operators.Start(la_);
-					var lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
-					var ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
-					var lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> ku_ = context.Operators.SortBy<Encounter>(ks_, kt_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter kv_ = context.Operators.Last<Encounter>(ku_);
+					Period kw_ = kv_?.Period;
+					CqlInterval<CqlDateTime> kx_ = FHIRHelpers_4_3_000.ToInterval(kw_);
+					CqlDateTime ky_ = context.Operators.Start(kx_);
+					CqlInterval<CqlDateTime> la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime lb_ = context.Operators.Start(la_);
+					CqlInterval<CqlDateTime> lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
+					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
+					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
 					bool? lg_(Encounter LastObs)
 					{
-						var nu_ = LastObs?.StatusElement;
-						var nv_ = nu_?.Value;
-						var nw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nv_);
-						var nx_ = context.Operators.Equal(nw_, "finished");
-						var ny_ = LastObs?.Period;
-						var nz_ = FHIRHelpers_4_3_000.ToInterval(ny_);
-						var oa_ = context.Operators.End(nz_);
-						var ob_ = Visit?.Period;
-						var oc_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var od_ = context.Operators.Start(oc_);
-						var oe_ = context.Operators.Quantity(1m, "hour");
-						var of_ = context.Operators.Subtract(od_, oe_);
-						var oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var oi_ = context.Operators.Start(oh_);
-						var oj_ = context.Operators.Interval(of_, oi_, true, true);
-						var ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
-						var om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
-						var on_ = context.Operators.Start(om_);
-						var oo_ = context.Operators.Not((bool?)(on_ is null));
-						var op_ = context.Operators.And(ok_, oo_);
-						var oq_ = context.Operators.And(nx_, op_);
+						Code<Encounter.EncounterStatus> nu_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? nv_ = nu_?.Value;
+						Code<Encounter.EncounterStatus> nw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(nv_);
+						bool? nx_ = context.Operators.Equal(nw_, "finished");
+						Period ny_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> nz_ = FHIRHelpers_4_3_000.ToInterval(ny_);
+						CqlDateTime oa_ = context.Operators.End(nz_);
+						Period ob_ = Visit?.Period;
+						CqlInterval<CqlDateTime> oc_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime od_ = context.Operators.Start(oc_);
+						CqlQuantity oe_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime of_ = context.Operators.Subtract(od_, oe_);
+						CqlInterval<CqlDateTime> oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime oi_ = context.Operators.Start(oh_);
+						CqlInterval<CqlDateTime> oj_ = context.Operators.Interval(of_, oi_, true, true);
+						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
+						CqlInterval<CqlDateTime> om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
+						CqlDateTime on_ = context.Operators.Start(om_);
+						bool? oo_ = context.Operators.Not((bool?)(on_ is null));
+						bool? op_ = context.Operators.And(ok_, oo_);
+						bool? oq_ = context.Operators.And(nx_, op_);
 
 						return oq_;
 					};
-					var lh_ = context.Operators.Where<Encounter>(lf_, lg_);
+					IEnumerable<Encounter> lh_ = context.Operators.Where<Encounter>(lf_, lg_);
 					object li_(Encounter @this)
 					{
-						var or_ = @this?.Period;
-						var os_ = FHIRHelpers_4_3_000.ToInterval(or_);
-						var ot_ = context.Operators.End(os_);
+						Period or_ = @this?.Period;
+						CqlInterval<CqlDateTime> os_ = FHIRHelpers_4_3_000.ToInterval(or_);
+						CqlDateTime ot_ = context.Operators.End(os_);
 
 						return ot_;
 					};
-					var lj_ = context.Operators.SortBy<Encounter>(lh_, li_, System.ComponentModel.ListSortDirection.Ascending);
-					var lk_ = context.Operators.Last<Encounter>(lj_);
-					var ll_ = lk_?.Period;
-					var lm_ = FHIRHelpers_4_3_000.ToInterval(ll_);
-					var ln_ = context.Operators.Start(lm_);
-					var lp_ = FHIRHelpers_4_3_000.ToInterval(kk_);
-					var lq_ = context.Operators.Start(lp_);
-					var lr_ = context.Operators.Not((bool?)((ln_ ?? lq_) is null));
-					var ls_ = context.Operators.And(ld_, lr_);
-					var lt_ = context.Operators.And(jw_, ls_);
+					IEnumerable<Encounter> lj_ = context.Operators.SortBy<Encounter>(lh_, li_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter lk_ = context.Operators.Last<Encounter>(lj_);
+					Period ll_ = lk_?.Period;
+					CqlInterval<CqlDateTime> lm_ = FHIRHelpers_4_3_000.ToInterval(ll_);
+					CqlDateTime ln_ = context.Operators.Start(lm_);
+					CqlInterval<CqlDateTime> lp_ = FHIRHelpers_4_3_000.ToInterval(kk_);
+					CqlDateTime lq_ = context.Operators.Start(lp_);
+					bool? lr_ = context.Operators.Not((bool?)((ln_ ?? lq_) is null));
+					bool? ls_ = context.Operators.And(ld_, lr_);
+					bool? lt_ = context.Operators.And(jw_, ls_);
 
 					return lt_;
 				};
-				var bu_ = context.Operators.Where<Encounter>(bs_, bt_);
+				IEnumerable<Encounter> bu_ = context.Operators.Where<Encounter>(bs_, bt_);
 				object bv_(Encounter @this)
 				{
-					var ou_ = @this?.Period;
-					var ov_ = FHIRHelpers_4_3_000.ToInterval(ou_);
-					var ow_ = context.Operators.End(ov_);
+					Period ou_ = @this?.Period;
+					CqlInterval<CqlDateTime> ov_ = FHIRHelpers_4_3_000.ToInterval(ou_);
+					CqlDateTime ow_ = context.Operators.End(ov_);
 
 					return ow_;
 				};
-				var bw_ = context.Operators.SortBy<Encounter>(bu_, bv_, System.ComponentModel.ListSortDirection.Ascending);
-				var bx_ = context.Operators.Last<Encounter>(bw_);
-				var by_ = bx_?.Period;
-				var bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
-				var ca_ = context.Operators.Start(bz_);
-				var cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> bw_ = context.Operators.SortBy<Encounter>(bu_, bv_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bx_ = context.Operators.Last<Encounter>(bw_);
+				Period by_ = bx_?.Period;
+				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
+				CqlDateTime ca_ = context.Operators.Start(bz_);
+				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? cd_(Encounter LastObs)
 				{
-					var ox_ = LastObs?.StatusElement;
-					var oy_ = ox_?.Value;
-					var oz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oy_);
-					var pa_ = context.Operators.Equal(oz_, "finished");
-					var pb_ = LastObs?.Period;
-					var pc_ = FHIRHelpers_4_3_000.ToInterval(pb_);
-					var pd_ = context.Operators.End(pc_);
-					var pe_ = Visit?.Period;
-					var pf_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pg_ = context.Operators.Start(pf_);
-					var ph_ = context.Operators.Quantity(1m, "hour");
-					var pi_ = context.Operators.Subtract(pg_, ph_);
-					var pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pl_ = context.Operators.Start(pk_);
-					var pm_ = context.Operators.Interval(pi_, pl_, true, true);
-					var pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
-					var pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
-					var pq_ = context.Operators.Start(pp_);
-					var pr_ = context.Operators.Not((bool?)(pq_ is null));
-					var ps_ = context.Operators.And(pn_, pr_);
-					var pt_ = context.Operators.And(pa_, ps_);
+					Code<Encounter.EncounterStatus> ox_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? oy_ = ox_?.Value;
+					Code<Encounter.EncounterStatus> oz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(oy_);
+					bool? pa_ = context.Operators.Equal(oz_, "finished");
+					Period pb_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> pc_ = FHIRHelpers_4_3_000.ToInterval(pb_);
+					CqlDateTime pd_ = context.Operators.End(pc_);
+					Period pe_ = Visit?.Period;
+					CqlInterval<CqlDateTime> pf_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pg_ = context.Operators.Start(pf_);
+					CqlQuantity ph_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime pi_ = context.Operators.Subtract(pg_, ph_);
+					CqlInterval<CqlDateTime> pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pl_ = context.Operators.Start(pk_);
+					CqlInterval<CqlDateTime> pm_ = context.Operators.Interval(pi_, pl_, true, true);
+					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
+					CqlInterval<CqlDateTime> pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
+					CqlDateTime pq_ = context.Operators.Start(pp_);
+					bool? pr_ = context.Operators.Not((bool?)(pq_ is null));
+					bool? ps_ = context.Operators.And(pn_, pr_);
+					bool? pt_ = context.Operators.And(pa_, ps_);
 
 					return pt_;
 				};
-				var ce_ = context.Operators.Where<Encounter>(cc_, cd_);
+				IEnumerable<Encounter> ce_ = context.Operators.Where<Encounter>(cc_, cd_);
 				object cf_(Encounter @this)
 				{
-					var pu_ = @this?.Period;
-					var pv_ = FHIRHelpers_4_3_000.ToInterval(pu_);
-					var pw_ = context.Operators.End(pv_);
+					Period pu_ = @this?.Period;
+					CqlInterval<CqlDateTime> pv_ = FHIRHelpers_4_3_000.ToInterval(pu_);
+					CqlDateTime pw_ = context.Operators.End(pv_);
 
 					return pw_;
 				};
-				var cg_ = context.Operators.SortBy<Encounter>(ce_, cf_, System.ComponentModel.ListSortDirection.Ascending);
-				var ch_ = context.Operators.Last<Encounter>(cg_);
-				var ci_ = ch_?.Period;
-				var cj_ = FHIRHelpers_4_3_000.ToInterval(ci_);
-				var ck_ = context.Operators.Start(cj_);
-				var cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var cn_ = context.Operators.Start(cm_);
-				var co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
-				var cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
-				var cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> cg_ = context.Operators.SortBy<Encounter>(ce_, cf_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter ch_ = context.Operators.Last<Encounter>(cg_);
+				Period ci_ = ch_?.Period;
+				CqlInterval<CqlDateTime> cj_ = FHIRHelpers_4_3_000.ToInterval(ci_);
+				CqlDateTime ck_ = context.Operators.Start(cj_);
+				CqlInterval<CqlDateTime> cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime cn_ = context.Operators.Start(cm_);
+				CqlInterval<CqlDateTime> co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
+				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
+				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
 				bool? cs_(Encounter LastED)
 				{
-					var px_ = LastED?.StatusElement;
-					var py_ = px_?.Value;
-					var pz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(py_);
-					var qa_ = context.Operators.Equal(pz_, "finished");
-					var qb_ = LastED?.Period;
-					var qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
-					var qd_ = context.Operators.End(qc_);
-					var qe_ = this.Observation_Services();
-					var qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					Code<Encounter.EncounterStatus> px_ = LastED?.StatusElement;
+					Encounter.EncounterStatus? py_ = px_?.Value;
+					Code<Encounter.EncounterStatus> pz_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(py_);
+					bool? qa_ = context.Operators.Equal(pz_, "finished");
+					Period qb_ = LastED?.Period;
+					CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
+					CqlDateTime qd_ = context.Operators.End(qc_);
+					CqlValueSet qe_ = this.Observation_Services();
+					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? qg_(Encounter LastObs)
 					{
-						var ry_ = LastObs?.StatusElement;
-						var rz_ = ry_?.Value;
-						var sa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rz_);
-						var sb_ = context.Operators.Equal(sa_, "finished");
-						var sc_ = LastObs?.Period;
-						var sd_ = FHIRHelpers_4_3_000.ToInterval(sc_);
-						var se_ = context.Operators.End(sd_);
-						var sf_ = Visit?.Period;
-						var sg_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sh_ = context.Operators.Start(sg_);
-						var si_ = context.Operators.Quantity(1m, "hour");
-						var sj_ = context.Operators.Subtract(sh_, si_);
-						var sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sm_ = context.Operators.Start(sl_);
-						var sn_ = context.Operators.Interval(sj_, sm_, true, true);
-						var so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
-						var sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
-						var sr_ = context.Operators.Start(sq_);
-						var ss_ = context.Operators.Not((bool?)(sr_ is null));
-						var st_ = context.Operators.And(so_, ss_);
-						var su_ = context.Operators.And(sb_, st_);
+						Code<Encounter.EncounterStatus> ry_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? rz_ = ry_?.Value;
+						Code<Encounter.EncounterStatus> sa_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(rz_);
+						bool? sb_ = context.Operators.Equal(sa_, "finished");
+						Period sc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> sd_ = FHIRHelpers_4_3_000.ToInterval(sc_);
+						CqlDateTime se_ = context.Operators.End(sd_);
+						Period sf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> sg_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sh_ = context.Operators.Start(sg_);
+						CqlQuantity si_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime sj_ = context.Operators.Subtract(sh_, si_);
+						CqlInterval<CqlDateTime> sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sm_ = context.Operators.Start(sl_);
+						CqlInterval<CqlDateTime> sn_ = context.Operators.Interval(sj_, sm_, true, true);
+						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
+						CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
+						CqlDateTime sr_ = context.Operators.Start(sq_);
+						bool? ss_ = context.Operators.Not((bool?)(sr_ is null));
+						bool? st_ = context.Operators.And(so_, ss_);
+						bool? su_ = context.Operators.And(sb_, st_);
 
 						return su_;
 					};
-					var qh_ = context.Operators.Where<Encounter>(qf_, qg_);
+					IEnumerable<Encounter> qh_ = context.Operators.Where<Encounter>(qf_, qg_);
 					object qi_(Encounter @this)
 					{
-						var sv_ = @this?.Period;
-						var sw_ = FHIRHelpers_4_3_000.ToInterval(sv_);
-						var sx_ = context.Operators.End(sw_);
+						Period sv_ = @this?.Period;
+						CqlInterval<CqlDateTime> sw_ = FHIRHelpers_4_3_000.ToInterval(sv_);
+						CqlDateTime sx_ = context.Operators.End(sw_);
 
 						return sx_;
 					};
-					var qj_ = context.Operators.SortBy<Encounter>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
-					var qk_ = context.Operators.Last<Encounter>(qj_);
-					var ql_ = qk_?.Period;
-					var qm_ = FHIRHelpers_4_3_000.ToInterval(ql_);
-					var qn_ = context.Operators.Start(qm_);
-					var qo_ = Visit?.Period;
-					var qp_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var qq_ = context.Operators.Start(qp_);
-					var qr_ = context.Operators.Quantity(1m, "hour");
-					var qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
-					var qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qj_ = context.Operators.SortBy<Encounter>(qh_, qi_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter qk_ = context.Operators.Last<Encounter>(qj_);
+					Period ql_ = qk_?.Period;
+					CqlInterval<CqlDateTime> qm_ = FHIRHelpers_4_3_000.ToInterval(ql_);
+					CqlDateTime qn_ = context.Operators.Start(qm_);
+					Period qo_ = Visit?.Period;
+					CqlInterval<CqlDateTime> qp_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime qq_ = context.Operators.Start(qp_);
+					CqlQuantity qr_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
+					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? qv_(Encounter LastObs)
 					{
-						var sy_ = LastObs?.StatusElement;
-						var sz_ = sy_?.Value;
-						var ta_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sz_);
-						var tb_ = context.Operators.Equal(ta_, "finished");
-						var tc_ = LastObs?.Period;
-						var td_ = FHIRHelpers_4_3_000.ToInterval(tc_);
-						var te_ = context.Operators.End(td_);
-						var tf_ = Visit?.Period;
-						var tg_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var th_ = context.Operators.Start(tg_);
-						var ti_ = context.Operators.Quantity(1m, "hour");
-						var tj_ = context.Operators.Subtract(th_, ti_);
-						var tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var tm_ = context.Operators.Start(tl_);
-						var tn_ = context.Operators.Interval(tj_, tm_, true, true);
-						var to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
-						var tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
-						var tr_ = context.Operators.Start(tq_);
-						var ts_ = context.Operators.Not((bool?)(tr_ is null));
-						var tt_ = context.Operators.And(to_, ts_);
-						var tu_ = context.Operators.And(tb_, tt_);
+						Code<Encounter.EncounterStatus> sy_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? sz_ = sy_?.Value;
+						Code<Encounter.EncounterStatus> ta_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(sz_);
+						bool? tb_ = context.Operators.Equal(ta_, "finished");
+						Period tc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> td_ = FHIRHelpers_4_3_000.ToInterval(tc_);
+						CqlDateTime te_ = context.Operators.End(td_);
+						Period tf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> tg_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime th_ = context.Operators.Start(tg_);
+						CqlQuantity ti_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime tj_ = context.Operators.Subtract(th_, ti_);
+						CqlInterval<CqlDateTime> tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime tm_ = context.Operators.Start(tl_);
+						CqlInterval<CqlDateTime> tn_ = context.Operators.Interval(tj_, tm_, true, true);
+						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
+						CqlInterval<CqlDateTime> tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
+						CqlDateTime tr_ = context.Operators.Start(tq_);
+						bool? ts_ = context.Operators.Not((bool?)(tr_ is null));
+						bool? tt_ = context.Operators.And(to_, ts_);
+						bool? tu_ = context.Operators.And(tb_, tt_);
 
 						return tu_;
 					};
-					var qw_ = context.Operators.Where<Encounter>(qu_, qv_);
+					IEnumerable<Encounter> qw_ = context.Operators.Where<Encounter>(qu_, qv_);
 					object qx_(Encounter @this)
 					{
-						var tv_ = @this?.Period;
-						var tw_ = FHIRHelpers_4_3_000.ToInterval(tv_);
-						var tx_ = context.Operators.End(tw_);
+						Period tv_ = @this?.Period;
+						CqlInterval<CqlDateTime> tw_ = FHIRHelpers_4_3_000.ToInterval(tv_);
+						CqlDateTime tx_ = context.Operators.End(tw_);
 
 						return tx_;
 					};
-					var qy_ = context.Operators.SortBy<Encounter>(qw_, qx_, System.ComponentModel.ListSortDirection.Ascending);
-					var qz_ = context.Operators.Last<Encounter>(qy_);
-					var ra_ = qz_?.Period;
-					var rb_ = FHIRHelpers_4_3_000.ToInterval(ra_);
-					var rc_ = context.Operators.Start(rb_);
-					var re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var rf_ = context.Operators.Start(re_);
-					var rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
-					var rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
-					var rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qy_ = context.Operators.SortBy<Encounter>(qw_, qx_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter qz_ = context.Operators.Last<Encounter>(qy_);
+					Period ra_ = qz_?.Period;
+					CqlInterval<CqlDateTime> rb_ = FHIRHelpers_4_3_000.ToInterval(ra_);
+					CqlDateTime rc_ = context.Operators.Start(rb_);
+					CqlInterval<CqlDateTime> re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime rf_ = context.Operators.Start(re_);
+					CqlInterval<CqlDateTime> rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
+					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
+					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
 					bool? rk_(Encounter LastObs)
 					{
-						var ty_ = LastObs?.StatusElement;
-						var tz_ = ty_?.Value;
-						var ua_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tz_);
-						var ub_ = context.Operators.Equal(ua_, "finished");
-						var uc_ = LastObs?.Period;
-						var ud_ = FHIRHelpers_4_3_000.ToInterval(uc_);
-						var ue_ = context.Operators.End(ud_);
-						var uf_ = Visit?.Period;
-						var ug_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var uh_ = context.Operators.Start(ug_);
-						var ui_ = context.Operators.Quantity(1m, "hour");
-						var uj_ = context.Operators.Subtract(uh_, ui_);
-						var ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var um_ = context.Operators.Start(ul_);
-						var un_ = context.Operators.Interval(uj_, um_, true, true);
-						var uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
-						var uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
-						var ur_ = context.Operators.Start(uq_);
-						var us_ = context.Operators.Not((bool?)(ur_ is null));
-						var ut_ = context.Operators.And(uo_, us_);
-						var uu_ = context.Operators.And(ub_, ut_);
+						Code<Encounter.EncounterStatus> ty_ = LastObs?.StatusElement;
+						Encounter.EncounterStatus? tz_ = ty_?.Value;
+						Code<Encounter.EncounterStatus> ua_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(tz_);
+						bool? ub_ = context.Operators.Equal(ua_, "finished");
+						Period uc_ = LastObs?.Period;
+						CqlInterval<CqlDateTime> ud_ = FHIRHelpers_4_3_000.ToInterval(uc_);
+						CqlDateTime ue_ = context.Operators.End(ud_);
+						Period uf_ = Visit?.Period;
+						CqlInterval<CqlDateTime> ug_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime uh_ = context.Operators.Start(ug_);
+						CqlQuantity ui_ = context.Operators.Quantity(1m, "hour");
+						CqlDateTime uj_ = context.Operators.Subtract(uh_, ui_);
+						CqlInterval<CqlDateTime> ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime um_ = context.Operators.Start(ul_);
+						CqlInterval<CqlDateTime> un_ = context.Operators.Interval(uj_, um_, true, true);
+						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
+						CqlInterval<CqlDateTime> uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
+						CqlDateTime ur_ = context.Operators.Start(uq_);
+						bool? us_ = context.Operators.Not((bool?)(ur_ is null));
+						bool? ut_ = context.Operators.And(uo_, us_);
+						bool? uu_ = context.Operators.And(ub_, ut_);
 
 						return uu_;
 					};
-					var rl_ = context.Operators.Where<Encounter>(rj_, rk_);
+					IEnumerable<Encounter> rl_ = context.Operators.Where<Encounter>(rj_, rk_);
 					object rm_(Encounter @this)
 					{
-						var uv_ = @this?.Period;
-						var uw_ = FHIRHelpers_4_3_000.ToInterval(uv_);
-						var ux_ = context.Operators.End(uw_);
+						Period uv_ = @this?.Period;
+						CqlInterval<CqlDateTime> uw_ = FHIRHelpers_4_3_000.ToInterval(uv_);
+						CqlDateTime ux_ = context.Operators.End(uw_);
 
 						return ux_;
 					};
-					var rn_ = context.Operators.SortBy<Encounter>(rl_, rm_, System.ComponentModel.ListSortDirection.Ascending);
-					var ro_ = context.Operators.Last<Encounter>(rn_);
-					var rp_ = ro_?.Period;
-					var rq_ = FHIRHelpers_4_3_000.ToInterval(rp_);
-					var rr_ = context.Operators.Start(rq_);
-					var rt_ = FHIRHelpers_4_3_000.ToInterval(qo_);
-					var ru_ = context.Operators.Start(rt_);
-					var rv_ = context.Operators.Not((bool?)((rr_ ?? ru_) is null));
-					var rw_ = context.Operators.And(rh_, rv_);
-					var rx_ = context.Operators.And(qa_, rw_);
+					IEnumerable<Encounter> rn_ = context.Operators.SortBy<Encounter>(rl_, rm_, System.ComponentModel.ListSortDirection.Ascending);
+					Encounter ro_ = context.Operators.Last<Encounter>(rn_);
+					Period rp_ = ro_?.Period;
+					CqlInterval<CqlDateTime> rq_ = FHIRHelpers_4_3_000.ToInterval(rp_);
+					CqlDateTime rr_ = context.Operators.Start(rq_);
+					CqlInterval<CqlDateTime> rt_ = FHIRHelpers_4_3_000.ToInterval(qo_);
+					CqlDateTime ru_ = context.Operators.Start(rt_);
+					bool? rv_ = context.Operators.Not((bool?)((rr_ ?? ru_) is null));
+					bool? rw_ = context.Operators.And(rh_, rv_);
+					bool? rx_ = context.Operators.And(qa_, rw_);
 
 					return rx_;
 				};
-				var ct_ = context.Operators.Where<Encounter>(cr_, cs_);
+				IEnumerable<Encounter> ct_ = context.Operators.Where<Encounter>(cr_, cs_);
 				object cu_(Encounter @this)
 				{
-					var uy_ = @this?.Period;
-					var uz_ = FHIRHelpers_4_3_000.ToInterval(uy_);
-					var va_ = context.Operators.End(uz_);
+					Period uy_ = @this?.Period;
+					CqlInterval<CqlDateTime> uz_ = FHIRHelpers_4_3_000.ToInterval(uy_);
+					CqlDateTime va_ = context.Operators.End(uz_);
 
 					return va_;
 				};
-				var cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
-				var cw_ = context.Operators.Last<Encounter>(cv_);
-				var cx_ = cw_?.Period;
-				var cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
-				var cz_ = context.Operators.Start(cy_);
-				var db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> cv_ = context.Operators.SortBy<Encounter>(ct_, cu_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter cw_ = context.Operators.Last<Encounter>(cv_);
+				Period cx_ = cw_?.Period;
+				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
+				CqlDateTime cz_ = context.Operators.Start(cy_);
+				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
 				bool? dc_(Encounter LastObs)
 				{
-					var vb_ = LastObs?.StatusElement;
-					var vc_ = vb_?.Value;
-					var vd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vc_);
-					var ve_ = context.Operators.Equal(vd_, "finished");
-					var vf_ = LastObs?.Period;
-					var vg_ = FHIRHelpers_4_3_000.ToInterval(vf_);
-					var vh_ = context.Operators.End(vg_);
-					var vi_ = Visit?.Period;
-					var vj_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vk_ = context.Operators.Start(vj_);
-					var vl_ = context.Operators.Quantity(1m, "hour");
-					var vm_ = context.Operators.Subtract(vk_, vl_);
-					var vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vp_ = context.Operators.Start(vo_);
-					var vq_ = context.Operators.Interval(vm_, vp_, true, true);
-					var vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
-					var vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
-					var vu_ = context.Operators.Start(vt_);
-					var vv_ = context.Operators.Not((bool?)(vu_ is null));
-					var vw_ = context.Operators.And(vr_, vv_);
-					var vx_ = context.Operators.And(ve_, vw_);
+					Code<Encounter.EncounterStatus> vb_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? vc_ = vb_?.Value;
+					Code<Encounter.EncounterStatus> vd_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(vc_);
+					bool? ve_ = context.Operators.Equal(vd_, "finished");
+					Period vf_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> vg_ = FHIRHelpers_4_3_000.ToInterval(vf_);
+					CqlDateTime vh_ = context.Operators.End(vg_);
+					Period vi_ = Visit?.Period;
+					CqlInterval<CqlDateTime> vj_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vk_ = context.Operators.Start(vj_);
+					CqlQuantity vl_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime vm_ = context.Operators.Subtract(vk_, vl_);
+					CqlInterval<CqlDateTime> vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vp_ = context.Operators.Start(vo_);
+					CqlInterval<CqlDateTime> vq_ = context.Operators.Interval(vm_, vp_, true, true);
+					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
+					CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
+					CqlDateTime vu_ = context.Operators.Start(vt_);
+					bool? vv_ = context.Operators.Not((bool?)(vu_ is null));
+					bool? vw_ = context.Operators.And(vr_, vv_);
+					bool? vx_ = context.Operators.And(ve_, vw_);
 
 					return vx_;
 				};
-				var dd_ = context.Operators.Where<Encounter>(db_, dc_);
+				IEnumerable<Encounter> dd_ = context.Operators.Where<Encounter>(db_, dc_);
 				object de_(Encounter @this)
 				{
-					var vy_ = @this?.Period;
-					var vz_ = FHIRHelpers_4_3_000.ToInterval(vy_);
-					var wa_ = context.Operators.End(vz_);
+					Period vy_ = @this?.Period;
+					CqlInterval<CqlDateTime> vz_ = FHIRHelpers_4_3_000.ToInterval(vy_);
+					CqlDateTime wa_ = context.Operators.End(vz_);
 
 					return wa_;
 				};
-				var df_ = context.Operators.SortBy<Encounter>(dd_, de_, System.ComponentModel.ListSortDirection.Ascending);
-				var dg_ = context.Operators.Last<Encounter>(df_);
-				var dh_ = dg_?.Period;
-				var di_ = FHIRHelpers_4_3_000.ToInterval(dh_);
-				var dj_ = context.Operators.Start(di_);
-				var dl_ = FHIRHelpers_4_3_000.ToInterval(bm_);
-				var dm_ = context.Operators.Start(dl_);
-				var dn_ = context.Operators.Not((bool?)((cz_ ?? (dj_ ?? dm_)) is null));
-				var do_ = context.Operators.And(cp_, dn_);
+				IEnumerable<Encounter> df_ = context.Operators.SortBy<Encounter>(dd_, de_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter dg_ = context.Operators.Last<Encounter>(df_);
+				Period dh_ = dg_?.Period;
+				CqlInterval<CqlDateTime> di_ = FHIRHelpers_4_3_000.ToInterval(dh_);
+				CqlDateTime dj_ = context.Operators.Start(di_);
+				CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_3_000.ToInterval(bm_);
+				CqlDateTime dm_ = context.Operators.Start(dl_);
+				bool? dn_ = context.Operators.Not((bool?)((cz_ ?? (dj_ ?? dm_)) is null));
+				bool? do_ = context.Operators.And(cp_, dn_);
 
 				return do_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var wb_ = @this?.Period;
-				var wc_ = FHIRHelpers_4_3_000.ToInterval(wb_);
-				var wd_ = context.Operators.End(wc_);
+				Period wb_ = @this?.Period;
+				CqlInterval<CqlDateTime> wc_ = FHIRHelpers_4_3_000.ToInterval(wb_);
+				CqlDateTime wd_ = context.Operators.End(wc_);
 
 				return wd_;
 			};
-			var j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Encounter>(j_);
-			var l_ = k_?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Emergency_Department_Visit();
-			var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter k_ = context.Operators.Last<Encounter>(j_);
+			Period l_ = k_?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlValueSet o_ = this.Emergency_Department_Visit();
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
 			bool? q_(Encounter LastED)
 			{
-				var we_ = LastED?.StatusElement;
-				var wf_ = we_?.Value;
-				var wg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wf_);
-				var wh_ = context.Operators.Equal(wg_, "finished");
-				var wi_ = LastED?.Period;
-				var wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
-				var wk_ = context.Operators.End(wj_);
-				var wl_ = this.Observation_Services();
-				var wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				Code<Encounter.EncounterStatus> we_ = LastED?.StatusElement;
+				Encounter.EncounterStatus? wf_ = we_?.Value;
+				Code<Encounter.EncounterStatus> wg_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(wf_);
+				bool? wh_ = context.Operators.Equal(wg_, "finished");
+				Period wi_ = LastED?.Period;
+				CqlInterval<CqlDateTime> wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
+				CqlDateTime wk_ = context.Operators.End(wj_);
+				CqlValueSet wl_ = this.Observation_Services();
+				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? wn_(Encounter LastObs)
 				{
-					var yf_ = LastObs?.StatusElement;
-					var yg_ = yf_?.Value;
-					var yh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(yg_);
-					var yi_ = context.Operators.Equal(yh_, "finished");
-					var yj_ = LastObs?.Period;
-					var yk_ = FHIRHelpers_4_3_000.ToInterval(yj_);
-					var yl_ = context.Operators.End(yk_);
-					var ym_ = Visit?.Period;
-					var yn_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yo_ = context.Operators.Start(yn_);
-					var yp_ = context.Operators.Quantity(1m, "hour");
-					var yq_ = context.Operators.Subtract(yo_, yp_);
-					var ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yt_ = context.Operators.Start(ys_);
-					var yu_ = context.Operators.Interval(yq_, yt_, true, true);
-					var yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
-					var yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
-					var yy_ = context.Operators.Start(yx_);
-					var yz_ = context.Operators.Not((bool?)(yy_ is null));
-					var za_ = context.Operators.And(yv_, yz_);
-					var zb_ = context.Operators.And(yi_, za_);
+					Code<Encounter.EncounterStatus> yf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? yg_ = yf_?.Value;
+					Code<Encounter.EncounterStatus> yh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(yg_);
+					bool? yi_ = context.Operators.Equal(yh_, "finished");
+					Period yj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> yk_ = FHIRHelpers_4_3_000.ToInterval(yj_);
+					CqlDateTime yl_ = context.Operators.End(yk_);
+					Period ym_ = Visit?.Period;
+					CqlInterval<CqlDateTime> yn_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yo_ = context.Operators.Start(yn_);
+					CqlQuantity yp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime yq_ = context.Operators.Subtract(yo_, yp_);
+					CqlInterval<CqlDateTime> ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yt_ = context.Operators.Start(ys_);
+					CqlInterval<CqlDateTime> yu_ = context.Operators.Interval(yq_, yt_, true, true);
+					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
+					CqlInterval<CqlDateTime> yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
+					CqlDateTime yy_ = context.Operators.Start(yx_);
+					bool? yz_ = context.Operators.Not((bool?)(yy_ is null));
+					bool? za_ = context.Operators.And(yv_, yz_);
+					bool? zb_ = context.Operators.And(yi_, za_);
 
 					return zb_;
 				};
-				var wo_ = context.Operators.Where<Encounter>(wm_, wn_);
+				IEnumerable<Encounter> wo_ = context.Operators.Where<Encounter>(wm_, wn_);
 				object wp_(Encounter @this)
 				{
-					var zc_ = @this?.Period;
-					var zd_ = FHIRHelpers_4_3_000.ToInterval(zc_);
-					var ze_ = context.Operators.End(zd_);
+					Period zc_ = @this?.Period;
+					CqlInterval<CqlDateTime> zd_ = FHIRHelpers_4_3_000.ToInterval(zc_);
+					CqlDateTime ze_ = context.Operators.End(zd_);
 
 					return ze_;
 				};
-				var wq_ = context.Operators.SortBy<Encounter>(wo_, wp_, System.ComponentModel.ListSortDirection.Ascending);
-				var wr_ = context.Operators.Last<Encounter>(wq_);
-				var ws_ = wr_?.Period;
-				var wt_ = FHIRHelpers_4_3_000.ToInterval(ws_);
-				var wu_ = context.Operators.Start(wt_);
-				var wv_ = Visit?.Period;
-				var ww_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var wx_ = context.Operators.Start(ww_);
-				var wy_ = context.Operators.Quantity(1m, "hour");
-				var wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
-				var xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> wq_ = context.Operators.SortBy<Encounter>(wo_, wp_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter wr_ = context.Operators.Last<Encounter>(wq_);
+				Period ws_ = wr_?.Period;
+				CqlInterval<CqlDateTime> wt_ = FHIRHelpers_4_3_000.ToInterval(ws_);
+				CqlDateTime wu_ = context.Operators.Start(wt_);
+				Period wv_ = Visit?.Period;
+				CqlInterval<CqlDateTime> ww_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime wx_ = context.Operators.Start(ww_);
+				CqlQuantity wy_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
+				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? xc_(Encounter LastObs)
 				{
-					var zf_ = LastObs?.StatusElement;
-					var zg_ = zf_?.Value;
-					var zh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(zg_);
-					var zi_ = context.Operators.Equal(zh_, "finished");
-					var zj_ = LastObs?.Period;
-					var zk_ = FHIRHelpers_4_3_000.ToInterval(zj_);
-					var zl_ = context.Operators.End(zk_);
-					var zm_ = Visit?.Period;
-					var zn_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zo_ = context.Operators.Start(zn_);
-					var zp_ = context.Operators.Quantity(1m, "hour");
-					var zq_ = context.Operators.Subtract(zo_, zp_);
-					var zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zt_ = context.Operators.Start(zs_);
-					var zu_ = context.Operators.Interval(zq_, zt_, true, true);
-					var zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
-					var zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
-					var zy_ = context.Operators.Start(zx_);
-					var zz_ = context.Operators.Not((bool?)(zy_ is null));
-					var aza_ = context.Operators.And(zv_, zz_);
-					var azb_ = context.Operators.And(zi_, aza_);
+					Code<Encounter.EncounterStatus> zf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? zg_ = zf_?.Value;
+					Code<Encounter.EncounterStatus> zh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(zg_);
+					bool? zi_ = context.Operators.Equal(zh_, "finished");
+					Period zj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> zk_ = FHIRHelpers_4_3_000.ToInterval(zj_);
+					CqlDateTime zl_ = context.Operators.End(zk_);
+					Period zm_ = Visit?.Period;
+					CqlInterval<CqlDateTime> zn_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zo_ = context.Operators.Start(zn_);
+					CqlQuantity zp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime zq_ = context.Operators.Subtract(zo_, zp_);
+					CqlInterval<CqlDateTime> zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zt_ = context.Operators.Start(zs_);
+					CqlInterval<CqlDateTime> zu_ = context.Operators.Interval(zq_, zt_, true, true);
+					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
+					CqlInterval<CqlDateTime> zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
+					CqlDateTime zy_ = context.Operators.Start(zx_);
+					bool? zz_ = context.Operators.Not((bool?)(zy_ is null));
+					bool? aza_ = context.Operators.And(zv_, zz_);
+					bool? azb_ = context.Operators.And(zi_, aza_);
 
 					return azb_;
 				};
-				var xd_ = context.Operators.Where<Encounter>(xb_, xc_);
+				IEnumerable<Encounter> xd_ = context.Operators.Where<Encounter>(xb_, xc_);
 				object xe_(Encounter @this)
 				{
-					var azc_ = @this?.Period;
-					var azd_ = FHIRHelpers_4_3_000.ToInterval(azc_);
-					var aze_ = context.Operators.End(azd_);
+					Period azc_ = @this?.Period;
+					CqlInterval<CqlDateTime> azd_ = FHIRHelpers_4_3_000.ToInterval(azc_);
+					CqlDateTime aze_ = context.Operators.End(azd_);
 
 					return aze_;
 				};
-				var xf_ = context.Operators.SortBy<Encounter>(xd_, xe_, System.ComponentModel.ListSortDirection.Ascending);
-				var xg_ = context.Operators.Last<Encounter>(xf_);
-				var xh_ = xg_?.Period;
-				var xi_ = FHIRHelpers_4_3_000.ToInterval(xh_);
-				var xj_ = context.Operators.Start(xi_);
-				var xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var xm_ = context.Operators.Start(xl_);
-				var xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
-				var xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
-				var xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> xf_ = context.Operators.SortBy<Encounter>(xd_, xe_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter xg_ = context.Operators.Last<Encounter>(xf_);
+				Period xh_ = xg_?.Period;
+				CqlInterval<CqlDateTime> xi_ = FHIRHelpers_4_3_000.ToInterval(xh_);
+				CqlDateTime xj_ = context.Operators.Start(xi_);
+				CqlInterval<CqlDateTime> xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime xm_ = context.Operators.Start(xl_);
+				CqlInterval<CqlDateTime> xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
+				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
+				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
 				bool? xr_(Encounter LastObs)
 				{
-					var azf_ = LastObs?.StatusElement;
-					var azg_ = azf_?.Value;
-					var azh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(azg_);
-					var azi_ = context.Operators.Equal(azh_, "finished");
-					var azj_ = LastObs?.Period;
-					var azk_ = FHIRHelpers_4_3_000.ToInterval(azj_);
-					var azl_ = context.Operators.End(azk_);
-					var azm_ = Visit?.Period;
-					var azn_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azo_ = context.Operators.Start(azn_);
-					var azp_ = context.Operators.Quantity(1m, "hour");
-					var azq_ = context.Operators.Subtract(azo_, azp_);
-					var azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azt_ = context.Operators.Start(azs_);
-					var azu_ = context.Operators.Interval(azq_, azt_, true, true);
-					var azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
-					var azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
-					var azy_ = context.Operators.Start(azx_);
-					var azz_ = context.Operators.Not((bool?)(azy_ is null));
-					var bza_ = context.Operators.And(azv_, azz_);
-					var bzb_ = context.Operators.And(azi_, bza_);
+					Code<Encounter.EncounterStatus> azf_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? azg_ = azf_?.Value;
+					Code<Encounter.EncounterStatus> azh_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(azg_);
+					bool? azi_ = context.Operators.Equal(azh_, "finished");
+					Period azj_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> azk_ = FHIRHelpers_4_3_000.ToInterval(azj_);
+					CqlDateTime azl_ = context.Operators.End(azk_);
+					Period azm_ = Visit?.Period;
+					CqlInterval<CqlDateTime> azn_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azo_ = context.Operators.Start(azn_);
+					CqlQuantity azp_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime azq_ = context.Operators.Subtract(azo_, azp_);
+					CqlInterval<CqlDateTime> azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azt_ = context.Operators.Start(azs_);
+					CqlInterval<CqlDateTime> azu_ = context.Operators.Interval(azq_, azt_, true, true);
+					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
+					CqlInterval<CqlDateTime> azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
+					CqlDateTime azy_ = context.Operators.Start(azx_);
+					bool? azz_ = context.Operators.Not((bool?)(azy_ is null));
+					bool? bza_ = context.Operators.And(azv_, azz_);
+					bool? bzb_ = context.Operators.And(azi_, bza_);
 
 					return bzb_;
 				};
-				var xs_ = context.Operators.Where<Encounter>(xq_, xr_);
+				IEnumerable<Encounter> xs_ = context.Operators.Where<Encounter>(xq_, xr_);
 				object xt_(Encounter @this)
 				{
-					var bzc_ = @this?.Period;
-					var bzd_ = FHIRHelpers_4_3_000.ToInterval(bzc_);
-					var bze_ = context.Operators.End(bzd_);
+					Period bzc_ = @this?.Period;
+					CqlInterval<CqlDateTime> bzd_ = FHIRHelpers_4_3_000.ToInterval(bzc_);
+					CqlDateTime bze_ = context.Operators.End(bzd_);
 
 					return bze_;
 				};
-				var xu_ = context.Operators.SortBy<Encounter>(xs_, xt_, System.ComponentModel.ListSortDirection.Ascending);
-				var xv_ = context.Operators.Last<Encounter>(xu_);
-				var xw_ = xv_?.Period;
-				var xx_ = FHIRHelpers_4_3_000.ToInterval(xw_);
-				var xy_ = context.Operators.Start(xx_);
-				var ya_ = FHIRHelpers_4_3_000.ToInterval(wv_);
-				var yb_ = context.Operators.Start(ya_);
-				var yc_ = context.Operators.Not((bool?)((xy_ ?? yb_) is null));
-				var yd_ = context.Operators.And(xo_, yc_);
-				var ye_ = context.Operators.And(wh_, yd_);
+				IEnumerable<Encounter> xu_ = context.Operators.SortBy<Encounter>(xs_, xt_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter xv_ = context.Operators.Last<Encounter>(xu_);
+				Period xw_ = xv_?.Period;
+				CqlInterval<CqlDateTime> xx_ = FHIRHelpers_4_3_000.ToInterval(xw_);
+				CqlDateTime xy_ = context.Operators.Start(xx_);
+				CqlInterval<CqlDateTime> ya_ = FHIRHelpers_4_3_000.ToInterval(wv_);
+				CqlDateTime yb_ = context.Operators.Start(ya_);
+				bool? yc_ = context.Operators.Not((bool?)((xy_ ?? yb_) is null));
+				bool? yd_ = context.Operators.And(xo_, yc_);
+				bool? ye_ = context.Operators.And(wh_, yd_);
 
 				return ye_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 			object s_(Encounter @this)
 			{
-				var bzf_ = @this?.Period;
-				var bzg_ = FHIRHelpers_4_3_000.ToInterval(bzf_);
-				var bzh_ = context.Operators.End(bzg_);
+				Period bzf_ = @this?.Period;
+				CqlInterval<CqlDateTime> bzg_ = FHIRHelpers_4_3_000.ToInterval(bzf_);
+				CqlDateTime bzh_ = context.Operators.End(bzg_);
 
 				return bzh_;
 			};
-			var t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.Last<Encounter>(t_);
-			var v_ = u_?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
-			var y_ = this.Observation_Services();
-			var z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
+			IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter u_ = context.Operators.Last<Encounter>(t_);
+			Period v_ = u_?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			CqlValueSet y_ = this.Observation_Services();
+			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
 			bool? aa_(Encounter LastObs)
 			{
-				var bzi_ = LastObs?.StatusElement;
-				var bzj_ = bzi_?.Value;
-				var bzk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bzj_);
-				var bzl_ = context.Operators.Equal(bzk_, "finished");
-				var bzm_ = LastObs?.Period;
-				var bzn_ = FHIRHelpers_4_3_000.ToInterval(bzm_);
-				var bzo_ = context.Operators.End(bzn_);
-				var bzp_ = Visit?.Period;
-				var bzq_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var bzr_ = context.Operators.Start(bzq_);
-				var bzs_ = context.Operators.Quantity(1m, "hour");
-				var bzt_ = context.Operators.Subtract(bzr_, bzs_);
-				var bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var bzw_ = context.Operators.Start(bzv_);
-				var bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
-				var bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
-				var cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
-				var czb_ = context.Operators.Start(cza_);
-				var czc_ = context.Operators.Not((bool?)(czb_ is null));
-				var czd_ = context.Operators.And(bzy_, czc_);
-				var cze_ = context.Operators.And(bzl_, czd_);
+				Code<Encounter.EncounterStatus> bzi_ = LastObs?.StatusElement;
+				Encounter.EncounterStatus? bzj_ = bzi_?.Value;
+				Code<Encounter.EncounterStatus> bzk_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bzj_);
+				bool? bzl_ = context.Operators.Equal(bzk_, "finished");
+				Period bzm_ = LastObs?.Period;
+				CqlInterval<CqlDateTime> bzn_ = FHIRHelpers_4_3_000.ToInterval(bzm_);
+				CqlDateTime bzo_ = context.Operators.End(bzn_);
+				Period bzp_ = Visit?.Period;
+				CqlInterval<CqlDateTime> bzq_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime bzr_ = context.Operators.Start(bzq_);
+				CqlQuantity bzs_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime bzt_ = context.Operators.Subtract(bzr_, bzs_);
+				CqlInterval<CqlDateTime> bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime bzw_ = context.Operators.Start(bzv_);
+				CqlInterval<CqlDateTime> bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
+				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
+				CqlInterval<CqlDateTime> cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
+				CqlDateTime czb_ = context.Operators.Start(cza_);
+				bool? czc_ = context.Operators.Not((bool?)(czb_ is null));
+				bool? czd_ = context.Operators.And(bzy_, czc_);
+				bool? cze_ = context.Operators.And(bzl_, czd_);
 
 				return cze_;
 			};
-			var ab_ = context.Operators.Where<Encounter>(z_, aa_);
+			IEnumerable<Encounter> ab_ = context.Operators.Where<Encounter>(z_, aa_);
 			object ac_(Encounter @this)
 			{
-				var czf_ = @this?.Period;
-				var czg_ = FHIRHelpers_4_3_000.ToInterval(czf_);
-				var czh_ = context.Operators.End(czg_);
+				Period czf_ = @this?.Period;
+				CqlInterval<CqlDateTime> czg_ = FHIRHelpers_4_3_000.ToInterval(czf_);
+				CqlDateTime czh_ = context.Operators.End(czg_);
 
 				return czh_;
 			};
-			var ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
-			var ae_ = context.Operators.Last<Encounter>(ad_);
-			var af_ = ae_?.Period;
-			var ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-			var ah_ = context.Operators.Start(ag_);
-			var ai_ = Visit?.Period;
-			var aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-			var ak_ = context.Operators.Start(aj_);
-			var am_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-			var an_ = context.Operators.End(am_);
-			var ao_ = context.Operators.Interval((n_ ?? (x_ ?? (ah_ ?? ak_))), an_, true, true);
+			IEnumerable<Encounter> ad_ = context.Operators.SortBy<Encounter>(ab_, ac_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter ae_ = context.Operators.Last<Encounter>(ad_);
+			Period af_ = ae_?.Period;
+			CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
+			CqlDateTime ah_ = context.Operators.Start(ag_);
+			Period ai_ = Visit?.Period;
+			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+			CqlDateTime ak_ = context.Operators.Start(aj_);
+			CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_3_000.ToInterval(ai_);
+			CqlDateTime an_ = context.Operators.End(am_);
+			CqlInterval<CqlDateTime> ao_ = context.Operators.Interval((n_ ?? (x_ ?? (ah_ ?? ak_))), an_, true, true);
 
 			return ao_;
 		};
-		var c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
+		CqlInterval<CqlDateTime> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
 
 		return d_;
 	}
@@ -2478,231 +2486,231 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationWithObservation()` instead.")]
 	public CqlInterval<CqlDateTime> HospitalizationWithObservation(Encounter TheEncounter)
 	{
-		var a_ = new Encounter[]
+		Encounter[] a_ = new Encounter[]
 		{
 			TheEncounter,
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Emergency_Department_Visit();
-			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			CqlValueSet e_ = this.Emergency_Department_Visit();
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastED)
 			{
-				var af_ = LastED?.StatusElement;
-				var ag_ = af_?.Value;
-				var ah_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ag_);
-				var ai_ = context.Operators.Equal(ah_, "finished");
-				var aj_ = LastED?.Period;
-				var ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
-				var al_ = context.Operators.End(ak_);
-				var am_ = this.Observation_Services();
-				var an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				Code<Encounter.EncounterStatus> af_ = LastED?.StatusElement;
+				Encounter.EncounterStatus? ag_ = af_?.Value;
+				Code<Encounter.EncounterStatus> ah_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ag_);
+				bool? ai_ = context.Operators.Equal(ah_, "finished");
+				Period aj_ = LastED?.Period;
+				CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
+				CqlDateTime al_ = context.Operators.End(ak_);
+				CqlValueSet am_ = this.Observation_Services();
+				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? ao_(Encounter LastObs)
 				{
-					var cg_ = LastObs?.StatusElement;
-					var ch_ = cg_?.Value;
-					var ci_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ch_);
-					var cj_ = context.Operators.Equal(ci_, "finished");
-					var ck_ = LastObs?.Period;
-					var cl_ = FHIRHelpers_4_3_000.ToInterval(ck_);
-					var cm_ = context.Operators.End(cl_);
-					var cn_ = Visit?.Period;
-					var co_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cp_ = context.Operators.Start(co_);
-					var cq_ = context.Operators.Quantity(1m, "hour");
-					var cr_ = context.Operators.Subtract(cp_, cq_);
-					var ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cu_ = context.Operators.Start(ct_);
-					var cv_ = context.Operators.Interval(cr_, cu_, true, true);
-					var cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
-					var cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cz_ = context.Operators.Start(cy_);
-					var da_ = context.Operators.Not((bool?)(cz_ is null));
-					var db_ = context.Operators.And(cw_, da_);
-					var dc_ = context.Operators.And(cj_, db_);
+					Code<Encounter.EncounterStatus> cg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? ch_ = cg_?.Value;
+					Code<Encounter.EncounterStatus> ci_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ch_);
+					bool? cj_ = context.Operators.Equal(ci_, "finished");
+					Period ck_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> cl_ = FHIRHelpers_4_3_000.ToInterval(ck_);
+					CqlDateTime cm_ = context.Operators.End(cl_);
+					Period cn_ = Visit?.Period;
+					CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cp_ = context.Operators.Start(co_);
+					CqlQuantity cq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime cr_ = context.Operators.Subtract(cp_, cq_);
+					CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cu_ = context.Operators.Start(ct_);
+					CqlInterval<CqlDateTime> cv_ = context.Operators.Interval(cr_, cu_, true, true);
+					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
+					CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cz_ = context.Operators.Start(cy_);
+					bool? da_ = context.Operators.Not((bool?)(cz_ is null));
+					bool? db_ = context.Operators.And(cw_, da_);
+					bool? dc_ = context.Operators.And(cj_, db_);
 
 					return dc_;
 				};
-				var ap_ = context.Operators.Where<Encounter>(an_, ao_);
+				IEnumerable<Encounter> ap_ = context.Operators.Where<Encounter>(an_, ao_);
 				object aq_(Encounter @this)
 				{
-					var dd_ = @this?.Period;
-					var de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
-					var df_ = context.Operators.End(de_);
+					Period dd_ = @this?.Period;
+					CqlInterval<CqlDateTime> de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
+					CqlDateTime df_ = context.Operators.End(de_);
 
 					return df_;
 				};
-				var ar_ = context.Operators.SortBy<Encounter>(ap_, aq_, System.ComponentModel.ListSortDirection.Ascending);
-				var as_ = context.Operators.Last<Encounter>(ar_);
-				var at_ = as_?.Period;
-				var au_ = FHIRHelpers_4_3_000.ToInterval(at_);
-				var av_ = context.Operators.Start(au_);
-				var aw_ = Visit?.Period;
-				var ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var ay_ = context.Operators.Start(ax_);
-				var az_ = context.Operators.Quantity(1m, "hour");
-				var ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
-				var bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> ar_ = context.Operators.SortBy<Encounter>(ap_, aq_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter as_ = context.Operators.Last<Encounter>(ar_);
+				Period at_ = as_?.Period;
+				CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_3_000.ToInterval(at_);
+				CqlDateTime av_ = context.Operators.Start(au_);
+				Period aw_ = Visit?.Period;
+				CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime ay_ = context.Operators.Start(ax_);
+				CqlQuantity az_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
+				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? bd_(Encounter LastObs)
 				{
-					var dg_ = LastObs?.StatusElement;
-					var dh_ = dg_?.Value;
-					var di_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dh_);
-					var dj_ = context.Operators.Equal(di_, "finished");
-					var dk_ = LastObs?.Period;
-					var dl_ = FHIRHelpers_4_3_000.ToInterval(dk_);
-					var dm_ = context.Operators.End(dl_);
-					var dn_ = Visit?.Period;
-					var do_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var dp_ = context.Operators.Start(do_);
-					var dq_ = context.Operators.Quantity(1m, "hour");
-					var dr_ = context.Operators.Subtract(dp_, dq_);
-					var dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var du_ = context.Operators.Start(dt_);
-					var dv_ = context.Operators.Interval(dr_, du_, true, true);
-					var dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
-					var dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var dz_ = context.Operators.Start(dy_);
-					var ea_ = context.Operators.Not((bool?)(dz_ is null));
-					var eb_ = context.Operators.And(dw_, ea_);
-					var ec_ = context.Operators.And(dj_, eb_);
+					Code<Encounter.EncounterStatus> dg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? dh_ = dg_?.Value;
+					Code<Encounter.EncounterStatus> di_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dh_);
+					bool? dj_ = context.Operators.Equal(di_, "finished");
+					Period dk_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_3_000.ToInterval(dk_);
+					CqlDateTime dm_ = context.Operators.End(dl_);
+					Period dn_ = Visit?.Period;
+					CqlInterval<CqlDateTime> do_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime dp_ = context.Operators.Start(do_);
+					CqlQuantity dq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime dr_ = context.Operators.Subtract(dp_, dq_);
+					CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime du_ = context.Operators.Start(dt_);
+					CqlInterval<CqlDateTime> dv_ = context.Operators.Interval(dr_, du_, true, true);
+					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
+					CqlInterval<CqlDateTime> dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime dz_ = context.Operators.Start(dy_);
+					bool? ea_ = context.Operators.Not((bool?)(dz_ is null));
+					bool? eb_ = context.Operators.And(dw_, ea_);
+					bool? ec_ = context.Operators.And(dj_, eb_);
 
 					return ec_;
 				};
-				var be_ = context.Operators.Where<Encounter>(bc_, bd_);
+				IEnumerable<Encounter> be_ = context.Operators.Where<Encounter>(bc_, bd_);
 				object bf_(Encounter @this)
 				{
-					var ed_ = @this?.Period;
-					var ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
-					var ef_ = context.Operators.End(ee_);
+					Period ed_ = @this?.Period;
+					CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
+					CqlDateTime ef_ = context.Operators.End(ee_);
 
 					return ef_;
 				};
-				var bg_ = context.Operators.SortBy<Encounter>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
-				var bh_ = context.Operators.Last<Encounter>(bg_);
-				var bi_ = bh_?.Period;
-				var bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
-				var bk_ = context.Operators.Start(bj_);
-				var bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var bn_ = context.Operators.Start(bm_);
-				var bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
-				var bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
-				var br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> bg_ = context.Operators.SortBy<Encounter>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bh_ = context.Operators.Last<Encounter>(bg_);
+				Period bi_ = bh_?.Period;
+				CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
+				CqlDateTime bk_ = context.Operators.Start(bj_);
+				CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime bn_ = context.Operators.Start(bm_);
+				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
+				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
+				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? bs_(Encounter LastObs)
 				{
-					var eg_ = LastObs?.StatusElement;
-					var eh_ = eg_?.Value;
-					var ei_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eh_);
-					var ej_ = context.Operators.Equal(ei_, "finished");
-					var ek_ = LastObs?.Period;
-					var el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
-					var em_ = context.Operators.End(el_);
-					var en_ = Visit?.Period;
-					var eo_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var ep_ = context.Operators.Start(eo_);
-					var eq_ = context.Operators.Quantity(1m, "hour");
-					var er_ = context.Operators.Subtract(ep_, eq_);
-					var et_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var eu_ = context.Operators.Start(et_);
-					var ev_ = context.Operators.Interval(er_, eu_, true, true);
-					var ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
-					var ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var ez_ = context.Operators.Start(ey_);
-					var fa_ = context.Operators.Not((bool?)(ez_ is null));
-					var fb_ = context.Operators.And(ew_, fa_);
-					var fc_ = context.Operators.And(ej_, fb_);
+					Code<Encounter.EncounterStatus> eg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? eh_ = eg_?.Value;
+					Code<Encounter.EncounterStatus> ei_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eh_);
+					bool? ej_ = context.Operators.Equal(ei_, "finished");
+					Period ek_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
+					CqlDateTime em_ = context.Operators.End(el_);
+					Period en_ = Visit?.Period;
+					CqlInterval<CqlDateTime> eo_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime ep_ = context.Operators.Start(eo_);
+					CqlQuantity eq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime er_ = context.Operators.Subtract(ep_, eq_);
+					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime eu_ = context.Operators.Start(et_);
+					CqlInterval<CqlDateTime> ev_ = context.Operators.Interval(er_, eu_, true, true);
+					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
+					CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime ez_ = context.Operators.Start(ey_);
+					bool? fa_ = context.Operators.Not((bool?)(ez_ is null));
+					bool? fb_ = context.Operators.And(ew_, fa_);
+					bool? fc_ = context.Operators.And(ej_, fb_);
 
 					return fc_;
 				};
-				var bt_ = context.Operators.Where<Encounter>(br_, bs_);
+				IEnumerable<Encounter> bt_ = context.Operators.Where<Encounter>(br_, bs_);
 				object bu_(Encounter @this)
 				{
-					var fd_ = @this?.Period;
-					var fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
-					var ff_ = context.Operators.End(fe_);
+					Period fd_ = @this?.Period;
+					CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
+					CqlDateTime ff_ = context.Operators.End(fe_);
 
 					return ff_;
 				};
-				var bv_ = context.Operators.SortBy<Encounter>(bt_, bu_, System.ComponentModel.ListSortDirection.Ascending);
-				var bw_ = context.Operators.Last<Encounter>(bv_);
-				var bx_ = bw_?.Period;
-				var by_ = FHIRHelpers_4_3_000.ToInterval(bx_);
-				var bz_ = context.Operators.Start(by_);
-				var cb_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var cc_ = context.Operators.Start(cb_);
-				var cd_ = context.Operators.Not((bool?)((bz_ ?? cc_) is null));
-				var ce_ = context.Operators.And(bp_, cd_);
-				var cf_ = context.Operators.And(ai_, ce_);
+				IEnumerable<Encounter> bv_ = context.Operators.SortBy<Encounter>(bt_, bu_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bw_ = context.Operators.Last<Encounter>(bv_);
+				Period bx_ = bw_?.Period;
+				CqlInterval<CqlDateTime> by_ = FHIRHelpers_4_3_000.ToInterval(bx_);
+				CqlDateTime bz_ = context.Operators.Start(by_);
+				CqlInterval<CqlDateTime> cb_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime cc_ = context.Operators.Start(cb_);
+				bool? cd_ = context.Operators.Not((bool?)((bz_ ?? cc_) is null));
+				bool? ce_ = context.Operators.And(bp_, cd_);
+				bool? cf_ = context.Operators.And(ai_, ce_);
 
 				return cf_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var fg_ = @this?.Period;
-				var fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
-				var fi_ = context.Operators.End(fh_);
+				Period fg_ = @this?.Period;
+				CqlInterval<CqlDateTime> fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
+				CqlDateTime fi_ = context.Operators.End(fh_);
 
 				return fi_;
 			};
-			var j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Encounter>(j_);
-			var l_ = k_?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Observation_Services();
-			var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter k_ = context.Operators.Last<Encounter>(j_);
+			Period l_ = k_?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlValueSet o_ = this.Observation_Services();
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
 			bool? q_(Encounter LastObs)
 			{
-				var fj_ = LastObs?.StatusElement;
-				var fk_ = fj_?.Value;
-				var fl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fk_);
-				var fm_ = context.Operators.Equal(fl_, "finished");
-				var fn_ = LastObs?.Period;
-				var fo_ = FHIRHelpers_4_3_000.ToInterval(fn_);
-				var fp_ = context.Operators.End(fo_);
-				var fq_ = Visit?.Period;
-				var fr_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var fs_ = context.Operators.Start(fr_);
-				var ft_ = context.Operators.Quantity(1m, "hour");
-				var fu_ = context.Operators.Subtract(fs_, ft_);
-				var fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var fx_ = context.Operators.Start(fw_);
-				var fy_ = context.Operators.Interval(fu_, fx_, true, true);
-				var fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
-				var gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var gc_ = context.Operators.Start(gb_);
-				var gd_ = context.Operators.Not((bool?)(gc_ is null));
-				var ge_ = context.Operators.And(fz_, gd_);
-				var gf_ = context.Operators.And(fm_, ge_);
+				Code<Encounter.EncounterStatus> fj_ = LastObs?.StatusElement;
+				Encounter.EncounterStatus? fk_ = fj_?.Value;
+				Code<Encounter.EncounterStatus> fl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fk_);
+				bool? fm_ = context.Operators.Equal(fl_, "finished");
+				Period fn_ = LastObs?.Period;
+				CqlInterval<CqlDateTime> fo_ = FHIRHelpers_4_3_000.ToInterval(fn_);
+				CqlDateTime fp_ = context.Operators.End(fo_);
+				Period fq_ = Visit?.Period;
+				CqlInterval<CqlDateTime> fr_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime fs_ = context.Operators.Start(fr_);
+				CqlQuantity ft_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime fu_ = context.Operators.Subtract(fs_, ft_);
+				CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime fx_ = context.Operators.Start(fw_);
+				CqlInterval<CqlDateTime> fy_ = context.Operators.Interval(fu_, fx_, true, true);
+				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
+				CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime gc_ = context.Operators.Start(gb_);
+				bool? gd_ = context.Operators.Not((bool?)(gc_ is null));
+				bool? ge_ = context.Operators.And(fz_, gd_);
+				bool? gf_ = context.Operators.And(fm_, ge_);
 
 				return gf_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 			object s_(Encounter @this)
 			{
-				var gg_ = @this?.Period;
-				var gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
-				var gi_ = context.Operators.End(gh_);
+				Period gg_ = @this?.Period;
+				CqlInterval<CqlDateTime> gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
+				CqlDateTime gi_ = context.Operators.End(gh_);
 
 				return gi_;
 			};
-			var t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.Last<Encounter>(t_);
-			var v_ = u_?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
-			var y_ = Visit?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = context.Operators.Start(z_);
-			var ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var ad_ = context.Operators.End(ac_);
-			var ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
+			IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter u_ = context.Operators.Last<Encounter>(t_);
+			Period v_ = u_?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			Period y_ = Visit?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime aa_ = context.Operators.Start(z_);
+			CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime ad_ = context.Operators.End(ac_);
+			CqlInterval<CqlDateTime> ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
 
 			return ae_;
 		};
-		var c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
+		CqlInterval<CqlDateTime> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
 
 		return d_;
 	}
@@ -2711,231 +2719,231 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Hospitalization with Observation returns the total interval from the start of any immediately prior emergency department visit through the observation visit to the discharge of the given encounter")]
 	public CqlInterval<CqlDateTime> hospitalizationWithObservation(Encounter TheEncounter)
 	{
-		var a_ = new Encounter[]
+		Encounter[] a_ = new Encounter[]
 		{
 			TheEncounter,
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Emergency_Department_Visit();
-			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			CqlValueSet e_ = this.Emergency_Department_Visit();
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastED)
 			{
-				var af_ = LastED?.StatusElement;
-				var ag_ = af_?.Value;
-				var ah_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ag_);
-				var ai_ = context.Operators.Equal(ah_, "finished");
-				var aj_ = LastED?.Period;
-				var ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
-				var al_ = context.Operators.End(ak_);
-				var am_ = this.Observation_Services();
-				var an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				Code<Encounter.EncounterStatus> af_ = LastED?.StatusElement;
+				Encounter.EncounterStatus? ag_ = af_?.Value;
+				Code<Encounter.EncounterStatus> ah_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ag_);
+				bool? ai_ = context.Operators.Equal(ah_, "finished");
+				Period aj_ = LastED?.Period;
+				CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
+				CqlDateTime al_ = context.Operators.End(ak_);
+				CqlValueSet am_ = this.Observation_Services();
+				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? ao_(Encounter LastObs)
 				{
-					var cg_ = LastObs?.StatusElement;
-					var ch_ = cg_?.Value;
-					var ci_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ch_);
-					var cj_ = context.Operators.Equal(ci_, "finished");
-					var ck_ = LastObs?.Period;
-					var cl_ = FHIRHelpers_4_3_000.ToInterval(ck_);
-					var cm_ = context.Operators.End(cl_);
-					var cn_ = Visit?.Period;
-					var co_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cp_ = context.Operators.Start(co_);
-					var cq_ = context.Operators.Quantity(1m, "hour");
-					var cr_ = context.Operators.Subtract(cp_, cq_);
-					var ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cu_ = context.Operators.Start(ct_);
-					var cv_ = context.Operators.Interval(cr_, cu_, true, true);
-					var cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
-					var cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
-					var cz_ = context.Operators.Start(cy_);
-					var da_ = context.Operators.Not((bool?)(cz_ is null));
-					var db_ = context.Operators.And(cw_, da_);
-					var dc_ = context.Operators.And(cj_, db_);
+					Code<Encounter.EncounterStatus> cg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? ch_ = cg_?.Value;
+					Code<Encounter.EncounterStatus> ci_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ch_);
+					bool? cj_ = context.Operators.Equal(ci_, "finished");
+					Period ck_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> cl_ = FHIRHelpers_4_3_000.ToInterval(ck_);
+					CqlDateTime cm_ = context.Operators.End(cl_);
+					Period cn_ = Visit?.Period;
+					CqlInterval<CqlDateTime> co_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cp_ = context.Operators.Start(co_);
+					CqlQuantity cq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime cr_ = context.Operators.Subtract(cp_, cq_);
+					CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cu_ = context.Operators.Start(ct_);
+					CqlInterval<CqlDateTime> cv_ = context.Operators.Interval(cr_, cu_, true, true);
+					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
+					CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
+					CqlDateTime cz_ = context.Operators.Start(cy_);
+					bool? da_ = context.Operators.Not((bool?)(cz_ is null));
+					bool? db_ = context.Operators.And(cw_, da_);
+					bool? dc_ = context.Operators.And(cj_, db_);
 
 					return dc_;
 				};
-				var ap_ = context.Operators.Where<Encounter>(an_, ao_);
+				IEnumerable<Encounter> ap_ = context.Operators.Where<Encounter>(an_, ao_);
 				object aq_(Encounter @this)
 				{
-					var dd_ = @this?.Period;
-					var de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
-					var df_ = context.Operators.End(de_);
+					Period dd_ = @this?.Period;
+					CqlInterval<CqlDateTime> de_ = FHIRHelpers_4_3_000.ToInterval(dd_);
+					CqlDateTime df_ = context.Operators.End(de_);
 
 					return df_;
 				};
-				var ar_ = context.Operators.SortBy<Encounter>(ap_, aq_, System.ComponentModel.ListSortDirection.Ascending);
-				var as_ = context.Operators.Last<Encounter>(ar_);
-				var at_ = as_?.Period;
-				var au_ = FHIRHelpers_4_3_000.ToInterval(at_);
-				var av_ = context.Operators.Start(au_);
-				var aw_ = Visit?.Period;
-				var ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var ay_ = context.Operators.Start(ax_);
-				var az_ = context.Operators.Quantity(1m, "hour");
-				var ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
-				var bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> ar_ = context.Operators.SortBy<Encounter>(ap_, aq_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter as_ = context.Operators.Last<Encounter>(ar_);
+				Period at_ = as_?.Period;
+				CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_3_000.ToInterval(at_);
+				CqlDateTime av_ = context.Operators.Start(au_);
+				Period aw_ = Visit?.Period;
+				CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime ay_ = context.Operators.Start(ax_);
+				CqlQuantity az_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
+				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? bd_(Encounter LastObs)
 				{
-					var dg_ = LastObs?.StatusElement;
-					var dh_ = dg_?.Value;
-					var di_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dh_);
-					var dj_ = context.Operators.Equal(di_, "finished");
-					var dk_ = LastObs?.Period;
-					var dl_ = FHIRHelpers_4_3_000.ToInterval(dk_);
-					var dm_ = context.Operators.End(dl_);
-					var dn_ = Visit?.Period;
-					var do_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var dp_ = context.Operators.Start(do_);
-					var dq_ = context.Operators.Quantity(1m, "hour");
-					var dr_ = context.Operators.Subtract(dp_, dq_);
-					var dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var du_ = context.Operators.Start(dt_);
-					var dv_ = context.Operators.Interval(dr_, du_, true, true);
-					var dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
-					var dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
-					var dz_ = context.Operators.Start(dy_);
-					var ea_ = context.Operators.Not((bool?)(dz_ is null));
-					var eb_ = context.Operators.And(dw_, ea_);
-					var ec_ = context.Operators.And(dj_, eb_);
+					Code<Encounter.EncounterStatus> dg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? dh_ = dg_?.Value;
+					Code<Encounter.EncounterStatus> di_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(dh_);
+					bool? dj_ = context.Operators.Equal(di_, "finished");
+					Period dk_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_3_000.ToInterval(dk_);
+					CqlDateTime dm_ = context.Operators.End(dl_);
+					Period dn_ = Visit?.Period;
+					CqlInterval<CqlDateTime> do_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime dp_ = context.Operators.Start(do_);
+					CqlQuantity dq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime dr_ = context.Operators.Subtract(dp_, dq_);
+					CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime du_ = context.Operators.Start(dt_);
+					CqlInterval<CqlDateTime> dv_ = context.Operators.Interval(dr_, du_, true, true);
+					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
+					CqlInterval<CqlDateTime> dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
+					CqlDateTime dz_ = context.Operators.Start(dy_);
+					bool? ea_ = context.Operators.Not((bool?)(dz_ is null));
+					bool? eb_ = context.Operators.And(dw_, ea_);
+					bool? ec_ = context.Operators.And(dj_, eb_);
 
 					return ec_;
 				};
-				var be_ = context.Operators.Where<Encounter>(bc_, bd_);
+				IEnumerable<Encounter> be_ = context.Operators.Where<Encounter>(bc_, bd_);
 				object bf_(Encounter @this)
 				{
-					var ed_ = @this?.Period;
-					var ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
-					var ef_ = context.Operators.End(ee_);
+					Period ed_ = @this?.Period;
+					CqlInterval<CqlDateTime> ee_ = FHIRHelpers_4_3_000.ToInterval(ed_);
+					CqlDateTime ef_ = context.Operators.End(ee_);
 
 					return ef_;
 				};
-				var bg_ = context.Operators.SortBy<Encounter>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
-				var bh_ = context.Operators.Last<Encounter>(bg_);
-				var bi_ = bh_?.Period;
-				var bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
-				var bk_ = context.Operators.Start(bj_);
-				var bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var bn_ = context.Operators.Start(bm_);
-				var bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
-				var bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
-				var br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> bg_ = context.Operators.SortBy<Encounter>(be_, bf_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bh_ = context.Operators.Last<Encounter>(bg_);
+				Period bi_ = bh_?.Period;
+				CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_3_000.ToInterval(bi_);
+				CqlDateTime bk_ = context.Operators.Start(bj_);
+				CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime bn_ = context.Operators.Start(bm_);
+				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
+				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
+				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
 				bool? bs_(Encounter LastObs)
 				{
-					var eg_ = LastObs?.StatusElement;
-					var eh_ = eg_?.Value;
-					var ei_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eh_);
-					var ej_ = context.Operators.Equal(ei_, "finished");
-					var ek_ = LastObs?.Period;
-					var el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
-					var em_ = context.Operators.End(el_);
-					var en_ = Visit?.Period;
-					var eo_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var ep_ = context.Operators.Start(eo_);
-					var eq_ = context.Operators.Quantity(1m, "hour");
-					var er_ = context.Operators.Subtract(ep_, eq_);
-					var et_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var eu_ = context.Operators.Start(et_);
-					var ev_ = context.Operators.Interval(er_, eu_, true, true);
-					var ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
-					var ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
-					var ez_ = context.Operators.Start(ey_);
-					var fa_ = context.Operators.Not((bool?)(ez_ is null));
-					var fb_ = context.Operators.And(ew_, fa_);
-					var fc_ = context.Operators.And(ej_, fb_);
+					Code<Encounter.EncounterStatus> eg_ = LastObs?.StatusElement;
+					Encounter.EncounterStatus? eh_ = eg_?.Value;
+					Code<Encounter.EncounterStatus> ei_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(eh_);
+					bool? ej_ = context.Operators.Equal(ei_, "finished");
+					Period ek_ = LastObs?.Period;
+					CqlInterval<CqlDateTime> el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
+					CqlDateTime em_ = context.Operators.End(el_);
+					Period en_ = Visit?.Period;
+					CqlInterval<CqlDateTime> eo_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime ep_ = context.Operators.Start(eo_);
+					CqlQuantity eq_ = context.Operators.Quantity(1m, "hour");
+					CqlDateTime er_ = context.Operators.Subtract(ep_, eq_);
+					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime eu_ = context.Operators.Start(et_);
+					CqlInterval<CqlDateTime> ev_ = context.Operators.Interval(er_, eu_, true, true);
+					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
+					CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
+					CqlDateTime ez_ = context.Operators.Start(ey_);
+					bool? fa_ = context.Operators.Not((bool?)(ez_ is null));
+					bool? fb_ = context.Operators.And(ew_, fa_);
+					bool? fc_ = context.Operators.And(ej_, fb_);
 
 					return fc_;
 				};
-				var bt_ = context.Operators.Where<Encounter>(br_, bs_);
+				IEnumerable<Encounter> bt_ = context.Operators.Where<Encounter>(br_, bs_);
 				object bu_(Encounter @this)
 				{
-					var fd_ = @this?.Period;
-					var fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
-					var ff_ = context.Operators.End(fe_);
+					Period fd_ = @this?.Period;
+					CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
+					CqlDateTime ff_ = context.Operators.End(fe_);
 
 					return ff_;
 				};
-				var bv_ = context.Operators.SortBy<Encounter>(bt_, bu_, System.ComponentModel.ListSortDirection.Ascending);
-				var bw_ = context.Operators.Last<Encounter>(bv_);
-				var bx_ = bw_?.Period;
-				var by_ = FHIRHelpers_4_3_000.ToInterval(bx_);
-				var bz_ = context.Operators.Start(by_);
-				var cb_ = FHIRHelpers_4_3_000.ToInterval(aw_);
-				var cc_ = context.Operators.Start(cb_);
-				var cd_ = context.Operators.Not((bool?)((bz_ ?? cc_) is null));
-				var ce_ = context.Operators.And(bp_, cd_);
-				var cf_ = context.Operators.And(ai_, ce_);
+				IEnumerable<Encounter> bv_ = context.Operators.SortBy<Encounter>(bt_, bu_, System.ComponentModel.ListSortDirection.Ascending);
+				Encounter bw_ = context.Operators.Last<Encounter>(bv_);
+				Period bx_ = bw_?.Period;
+				CqlInterval<CqlDateTime> by_ = FHIRHelpers_4_3_000.ToInterval(bx_);
+				CqlDateTime bz_ = context.Operators.Start(by_);
+				CqlInterval<CqlDateTime> cb_ = FHIRHelpers_4_3_000.ToInterval(aw_);
+				CqlDateTime cc_ = context.Operators.Start(cb_);
+				bool? cd_ = context.Operators.Not((bool?)((bz_ ?? cc_) is null));
+				bool? ce_ = context.Operators.And(bp_, cd_);
+				bool? cf_ = context.Operators.And(ai_, ce_);
 
 				return cf_;
 			};
-			var h_ = context.Operators.Where<Encounter>(f_, g_);
+			IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var fg_ = @this?.Period;
-				var fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
-				var fi_ = context.Operators.End(fh_);
+				Period fg_ = @this?.Period;
+				CqlInterval<CqlDateTime> fh_ = FHIRHelpers_4_3_000.ToInterval(fg_);
+				CqlDateTime fi_ = context.Operators.End(fh_);
 
 				return fi_;
 			};
-			var j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
-			var k_ = context.Operators.Last<Encounter>(j_);
-			var l_ = k_?.Period;
-			var m_ = FHIRHelpers_4_3_000.ToInterval(l_);
-			var n_ = context.Operators.Start(m_);
-			var o_ = this.Observation_Services();
-			var p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> j_ = context.Operators.SortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter k_ = context.Operators.Last<Encounter>(j_);
+			Period l_ = k_?.Period;
+			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
+			CqlDateTime n_ = context.Operators.Start(m_);
+			CqlValueSet o_ = this.Observation_Services();
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
 			bool? q_(Encounter LastObs)
 			{
-				var fj_ = LastObs?.StatusElement;
-				var fk_ = fj_?.Value;
-				var fl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fk_);
-				var fm_ = context.Operators.Equal(fl_, "finished");
-				var fn_ = LastObs?.Period;
-				var fo_ = FHIRHelpers_4_3_000.ToInterval(fn_);
-				var fp_ = context.Operators.End(fo_);
-				var fq_ = Visit?.Period;
-				var fr_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var fs_ = context.Operators.Start(fr_);
-				var ft_ = context.Operators.Quantity(1m, "hour");
-				var fu_ = context.Operators.Subtract(fs_, ft_);
-				var fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var fx_ = context.Operators.Start(fw_);
-				var fy_ = context.Operators.Interval(fu_, fx_, true, true);
-				var fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
-				var gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
-				var gc_ = context.Operators.Start(gb_);
-				var gd_ = context.Operators.Not((bool?)(gc_ is null));
-				var ge_ = context.Operators.And(fz_, gd_);
-				var gf_ = context.Operators.And(fm_, ge_);
+				Code<Encounter.EncounterStatus> fj_ = LastObs?.StatusElement;
+				Encounter.EncounterStatus? fk_ = fj_?.Value;
+				Code<Encounter.EncounterStatus> fl_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(fk_);
+				bool? fm_ = context.Operators.Equal(fl_, "finished");
+				Period fn_ = LastObs?.Period;
+				CqlInterval<CqlDateTime> fo_ = FHIRHelpers_4_3_000.ToInterval(fn_);
+				CqlDateTime fp_ = context.Operators.End(fo_);
+				Period fq_ = Visit?.Period;
+				CqlInterval<CqlDateTime> fr_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime fs_ = context.Operators.Start(fr_);
+				CqlQuantity ft_ = context.Operators.Quantity(1m, "hour");
+				CqlDateTime fu_ = context.Operators.Subtract(fs_, ft_);
+				CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime fx_ = context.Operators.Start(fw_);
+				CqlInterval<CqlDateTime> fy_ = context.Operators.Interval(fu_, fx_, true, true);
+				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
+				CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
+				CqlDateTime gc_ = context.Operators.Start(gb_);
+				bool? gd_ = context.Operators.Not((bool?)(gc_ is null));
+				bool? ge_ = context.Operators.And(fz_, gd_);
+				bool? gf_ = context.Operators.And(fm_, ge_);
 
 				return gf_;
 			};
-			var r_ = context.Operators.Where<Encounter>(p_, q_);
+			IEnumerable<Encounter> r_ = context.Operators.Where<Encounter>(p_, q_);
 			object s_(Encounter @this)
 			{
-				var gg_ = @this?.Period;
-				var gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
-				var gi_ = context.Operators.End(gh_);
+				Period gg_ = @this?.Period;
+				CqlInterval<CqlDateTime> gh_ = FHIRHelpers_4_3_000.ToInterval(gg_);
+				CqlDateTime gi_ = context.Operators.End(gh_);
 
 				return gi_;
 			};
-			var t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
-			var u_ = context.Operators.Last<Encounter>(t_);
-			var v_ = u_?.Period;
-			var w_ = FHIRHelpers_4_3_000.ToInterval(v_);
-			var x_ = context.Operators.Start(w_);
-			var y_ = Visit?.Period;
-			var z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var aa_ = context.Operators.Start(z_);
-			var ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			var ad_ = context.Operators.End(ac_);
-			var ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
+			IEnumerable<Encounter> t_ = context.Operators.SortBy<Encounter>(r_, s_, System.ComponentModel.ListSortDirection.Ascending);
+			Encounter u_ = context.Operators.Last<Encounter>(t_);
+			Period v_ = u_?.Period;
+			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
+			CqlDateTime x_ = context.Operators.Start(w_);
+			Period y_ = Visit?.Period;
+			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime aa_ = context.Operators.Start(z_);
+			CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(y_);
+			CqlDateTime ad_ = context.Operators.End(ac_);
+			CqlInterval<CqlDateTime> ae_ = context.Operators.Interval((n_ ?? (x_ ?? aa_)), ad_, true, true);
 
 			return ae_;
 		};
-		var c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
-		var d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
+		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Select<Encounter, CqlInterval<CqlDateTime>>((IEnumerable<Encounter>)a_, b_);
+		CqlInterval<CqlDateTime> d_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(c_);
 
 		return d_;
 	}
@@ -2945,8 +2953,8 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hospitalizationWithObservationLengthofStay()` instead.")]
 	public int? HospitalizationWithObservationLengthofStay(Encounter TheEncounter)
 	{
-		var a_ = this.HospitalizationWithObservation(TheEncounter);
-		var b_ = this.LengthInDays(a_);
+		CqlInterval<CqlDateTime> a_ = this.HospitalizationWithObservation(TheEncounter);
+		int? b_ = this.LengthInDays(a_);
 
 		return b_;
 	}
@@ -2955,8 +2963,8 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Hospitalization with Observation Length of Stay returns the length in days from the start of any immediately prior emergency department visit through the observation visit to the discharge of the given encounter")]
 	public int? hospitalizationWithObservationLengthofStay(Encounter TheEncounter)
 	{
-		var a_ = this.hospitalizationWithObservation(TheEncounter);
-		var b_ = this.lengthInDays(a_);
+		CqlInterval<CqlDateTime> a_ = this.hospitalizationWithObservation(TheEncounter);
+		int? b_ = this.lengthInDays(a_);
 
 		return b_;
 	}
@@ -2966,84 +2974,86 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `firstInpatientIntensiveCareUnit()` instead.")]
 	public Encounter.LocationComponent FirstInpatientIntensiveCareUnit(Encounter Encounter)
 	{
-		bool? a_(Encounter.LocationComponent HospitalLocation)
+		List<Encounter.LocationComponent> a_ = Encounter?.Location;
+		bool? b_(Encounter.LocationComponent HospitalLocation)
 		{
-			var f_ = HospitalLocation?.Location;
-			var g_ = this.GetLocation(f_);
-			var h_ = g_?.Type;
-			CqlConcept i_(CodeableConcept @this)
+			ResourceReference g_ = HospitalLocation?.Location;
+			Location h_ = this.GetLocation(g_);
+			List<CodeableConcept> i_ = h_?.Type;
+			CqlConcept j_(CodeableConcept @this)
 			{
-				var s_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept t_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-				return s_;
+				return t_;
 			};
-			var j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
-			var k_ = this.Intensive_Care_Unit();
-			var l_ = context.Operators.ConceptsInValueSet(j_, k_);
-			var m_ = Encounter?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = HospitalLocation?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, p_, null);
-			var r_ = context.Operators.And(l_, q_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			CqlValueSet l_ = this.Intensive_Care_Unit();
+			bool? m_ = context.Operators.ConceptsInValueSet(k_, l_);
+			Period n_ = Encounter?.Period;
+			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+			Period p_ = HospitalLocation?.Period;
+			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, null);
+			bool? s_ = context.Operators.And(m_, r_);
 
-			return r_;
+			return s_;
 		};
-		var b_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)Encounter?.Location, a_);
-		object c_(Encounter.LocationComponent @this)
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
+		object d_(Encounter.LocationComponent @this)
 		{
-			var t_ = @this?.Period;
-			var u_ = FHIRHelpers_4_3_000.ToInterval(t_);
-			var v_ = context.Operators.Start(u_);
+			Period u_ = @this?.Period;
+			CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(u_);
+			CqlDateTime w_ = context.Operators.Start(v_);
 
-			return v_;
+			return w_;
 		};
-		var d_ = context.Operators.SortBy<Encounter.LocationComponent>(b_, c_, System.ComponentModel.ListSortDirection.Ascending);
-		var e_ = context.Operators.First<Encounter.LocationComponent>(d_);
+		IEnumerable<Encounter.LocationComponent> e_ = context.Operators.SortBy<Encounter.LocationComponent>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent f_ = context.Operators.First<Encounter.LocationComponent>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("firstInpatientIntensiveCareUnit")]
     [CqlTag("description", "First Inpatient Intensive Care Unit returns the first intensive care unit for the given encounter, without considering any immediately prior emergency department visit.")]
 	public Encounter.LocationComponent firstInpatientIntensiveCareUnit(Encounter Encounter)
 	{
-		bool? a_(Encounter.LocationComponent HospitalLocation)
+		List<Encounter.LocationComponent> a_ = Encounter?.Location;
+		bool? b_(Encounter.LocationComponent HospitalLocation)
 		{
-			var f_ = HospitalLocation?.Location;
-			var g_ = this.GetLocation(f_);
-			var h_ = g_?.Type;
-			CqlConcept i_(CodeableConcept @this)
+			ResourceReference g_ = HospitalLocation?.Location;
+			Location h_ = this.GetLocation(g_);
+			List<CodeableConcept> i_ = h_?.Type;
+			CqlConcept j_(CodeableConcept @this)
 			{
-				var s_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept t_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-				return s_;
+				return t_;
 			};
-			var j_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)h_, i_);
-			var k_ = this.Intensive_Care_Unit();
-			var l_ = context.Operators.ConceptsInValueSet(j_, k_);
-			var m_ = Encounter?.Period;
-			var n_ = FHIRHelpers_4_3_000.ToInterval(m_);
-			var o_ = HospitalLocation?.Period;
-			var p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-			var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, p_, null);
-			var r_ = context.Operators.And(l_, q_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			CqlValueSet l_ = this.Intensive_Care_Unit();
+			bool? m_ = context.Operators.ConceptsInValueSet(k_, l_);
+			Period n_ = Encounter?.Period;
+			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
+			Period p_ = HospitalLocation?.Period;
+			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, null);
+			bool? s_ = context.Operators.And(m_, r_);
 
-			return r_;
+			return s_;
 		};
-		var b_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)Encounter?.Location, a_);
-		object c_(Encounter.LocationComponent @this)
+		IEnumerable<Encounter.LocationComponent> c_ = context.Operators.Where<Encounter.LocationComponent>((IEnumerable<Encounter.LocationComponent>)a_, b_);
+		object d_(Encounter.LocationComponent @this)
 		{
-			var t_ = @this?.Period;
-			var u_ = FHIRHelpers_4_3_000.ToInterval(t_);
-			var v_ = context.Operators.Start(u_);
+			Period u_ = @this?.Period;
+			CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(u_);
+			CqlDateTime w_ = context.Operators.Start(v_);
 
-			return v_;
+			return w_;
 		};
-		var d_ = context.Operators.SortBy<Encounter.LocationComponent>(b_, c_, System.ComponentModel.ListSortDirection.Ascending);
-		var e_ = context.Operators.First<Encounter.LocationComponent>(d_);
+		IEnumerable<Encounter.LocationComponent> e_ = context.Operators.SortBy<Encounter.LocationComponent>(c_, d_, System.ComponentModel.ListSortDirection.Ascending);
+		Encounter.LocationComponent f_ = context.Operators.First<Encounter.LocationComponent>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("EncounterDiagnosis")]
@@ -3051,58 +3061,60 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `encounterDiagnosis()` instead.")]
 	public IEnumerable<Condition> EncounterDiagnosis(Encounter Encounter)
 	{
-		Condition a_(Encounter.DiagnosisComponent D)
+		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
+		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			var c_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-			bool? d_(Condition C)
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? e_(Condition C)
 			{
-				var g_ = C?.IdElement;
-				var h_ = g_?.Value;
-				var i_ = D?.Condition;
-				var j_ = i_?.ReferenceElement;
-				var k_ = j_?.Value;
-				var l_ = QICoreCommon_2_0_000.getId(k_);
-				var m_ = context.Operators.Equal(h_, l_);
+				Id h_ = C?.IdElement;
+				string i_ = h_?.Value;
+				ResourceReference j_ = D?.Condition;
+				FhirString k_ = j_?.ReferenceElement;
+				string l_ = k_?.Value;
+				string m_ = QICoreCommon_2_0_000.getId(l_);
+				bool? n_ = context.Operators.Equal(i_, m_);
 
-				return m_;
+				return n_;
 			};
-			var e_ = context.Operators.Where<Condition>(c_, d_);
-			var f_ = context.Operators.SingletonFrom<Condition>(e_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+			Condition g_ = context.Operators.SingletonFrom<Condition>(f_);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>((IEnumerable<Encounter.DiagnosisComponent>)Encounter?.Diagnosis, a_);
+		IEnumerable<Condition> c_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 
-		return b_;
+		return c_;
 	}
 
     [CqlDeclaration("encounterDiagnosis")]
     [CqlTag("description", "Returns the Condition resources referenced by the diagnosis element of the Encounter")]
 	public IEnumerable<Condition> encounterDiagnosis(Encounter Encounter)
 	{
-		Condition a_(Encounter.DiagnosisComponent D)
+		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
+		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			var c_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-			bool? d_(Condition C)
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? e_(Condition C)
 			{
-				var g_ = C?.IdElement;
-				var h_ = g_?.Value;
-				var i_ = D?.Condition;
-				var j_ = i_?.ReferenceElement;
-				var k_ = j_?.Value;
-				var l_ = QICoreCommon_2_0_000.getId(k_);
-				var m_ = context.Operators.Equal(h_, l_);
+				Id h_ = C?.IdElement;
+				string i_ = h_?.Value;
+				ResourceReference j_ = D?.Condition;
+				FhirString k_ = j_?.ReferenceElement;
+				string l_ = k_?.Value;
+				string m_ = QICoreCommon_2_0_000.getId(l_);
+				bool? n_ = context.Operators.Equal(i_, m_);
 
-				return m_;
+				return n_;
 			};
-			var e_ = context.Operators.Where<Condition>(c_, d_);
-			var f_ = context.Operators.SingletonFrom<Condition>(e_);
+			IEnumerable<Condition> f_ = context.Operators.Where<Condition>(d_, e_);
+			Condition g_ = context.Operators.SingletonFrom<Condition>(f_);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>((IEnumerable<Encounter.DiagnosisComponent>)Encounter?.Diagnosis, a_);
+		IEnumerable<Condition> c_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 
-		return b_;
+		return c_;
 	}
 
     [CqlDeclaration("GetCondition")]
@@ -3110,20 +3122,20 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getCondition()` instead")]
 	public Condition GetCondition(ResourceReference reference)
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
 		bool? b_(Condition C)
 		{
-			var e_ = C?.IdElement;
-			var f_ = e_?.Value;
-			var g_ = reference?.ReferenceElement;
-			var h_ = g_?.Value;
-			var i_ = QICoreCommon_2_0_000.getId(h_);
-			var j_ = context.Operators.Equal(f_, i_);
+			Id e_ = C?.IdElement;
+			string f_ = e_?.Value;
+			FhirString g_ = reference?.ReferenceElement;
+			string h_ = g_?.Value;
+			string i_ = QICoreCommon_2_0_000.getId(h_);
+			bool? j_ = context.Operators.Equal(f_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Condition>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Condition>(c_);
+		IEnumerable<Condition> c_ = context.Operators.Where<Condition>(a_, b_);
+		Condition d_ = context.Operators.SingletonFrom<Condition>(c_);
 
 		return d_;
 	}
@@ -3132,20 +3144,20 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the Condition resource for the given reference")]
 	public Condition getCondition(ResourceReference reference)
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
 		bool? b_(Condition C)
 		{
-			var e_ = C?.IdElement;
-			var f_ = e_?.Value;
-			var g_ = reference?.ReferenceElement;
-			var h_ = g_?.Value;
-			var i_ = QICoreCommon_2_0_000.getId(h_);
-			var j_ = context.Operators.Equal(f_, i_);
+			Id e_ = C?.IdElement;
+			string f_ = e_?.Value;
+			FhirString g_ = reference?.ReferenceElement;
+			string h_ = g_?.Value;
+			string i_ = QICoreCommon_2_0_000.getId(h_);
+			bool? j_ = context.Operators.Equal(f_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Condition>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Condition>(c_);
+		IEnumerable<Condition> c_ = context.Operators.Where<Condition>(a_, b_);
+		Condition d_ = context.Operators.SingletonFrom<Condition>(c_);
 
 		return d_;
 	}
@@ -3155,98 +3167,100 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `principalDiagnosis()` instead.")]
 	public Condition PrincipalDiagnosis(Encounter Encounter)
 	{
-		bool? a_(Encounter.DiagnosisComponent D)
+		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
+		bool? b_(Encounter.DiagnosisComponent D)
 		{
-			var f_ = D?.RankElement;
-			var g_ = f_?.Value;
-			var h_ = context.Operators.Equal(g_, 1);
+			PositiveInt g_ = D?.RankElement;
+			int? h_ = g_?.Value;
+			bool? i_ = context.Operators.Equal(h_, 1);
 
-			return h_;
+			return i_;
 		};
-		var b_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)Encounter?.Diagnosis, a_);
-		Condition c_(Encounter.DiagnosisComponent PD)
+		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
+		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			var i_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-			bool? j_(Condition C)
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? k_(Condition C)
 			{
-				var m_ = C?.IdElement;
-				var n_ = m_?.Value;
-				var o_ = PD?.Condition;
-				var p_ = o_?.ReferenceElement;
-				var q_ = p_?.Value;
-				var r_ = QICoreCommon_2_0_000.getId(q_);
-				var s_ = context.Operators.Equal(n_, r_);
+				Id n_ = C?.IdElement;
+				string o_ = n_?.Value;
+				ResourceReference p_ = PD?.Condition;
+				FhirString q_ = p_?.ReferenceElement;
+				string r_ = q_?.Value;
+				string s_ = QICoreCommon_2_0_000.getId(r_);
+				bool? t_ = context.Operators.Equal(o_, s_);
 
-				return s_;
+				return t_;
 			};
-			var k_ = context.Operators.Where<Condition>(i_, j_);
-			var l_ = context.Operators.SingletonFrom<Condition>(k_);
+			IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
+			Condition m_ = context.Operators.SingletonFrom<Condition>(l_);
 
-			return l_;
+			return m_;
 		};
-		var d_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<Condition>(d_);
+		IEnumerable<Condition> e_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(c_, d_);
+		Condition f_ = context.Operators.SingletonFrom<Condition>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("principalDiagnosis")]
     [CqlTag("description", "Returns the condition that is specified as the principal diagnosis for the encounter")]
 	public Condition principalDiagnosis(Encounter Encounter)
 	{
-		bool? a_(Encounter.DiagnosisComponent D)
+		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
+		bool? b_(Encounter.DiagnosisComponent D)
 		{
-			var f_ = D?.RankElement;
-			var g_ = f_?.Value;
-			var h_ = context.Operators.Equal(g_, 1);
+			PositiveInt g_ = D?.RankElement;
+			int? h_ = g_?.Value;
+			bool? i_ = context.Operators.Equal(h_, 1);
 
-			return h_;
+			return i_;
 		};
-		var b_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)Encounter?.Diagnosis, a_);
-		Condition c_(Encounter.DiagnosisComponent PD)
+		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
+		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			var i_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-			bool? j_(Condition C)
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			bool? k_(Condition C)
 			{
-				var m_ = C?.IdElement;
-				var n_ = m_?.Value;
-				var o_ = PD?.Condition;
-				var p_ = o_?.ReferenceElement;
-				var q_ = p_?.Value;
-				var r_ = QICoreCommon_2_0_000.getId(q_);
-				var s_ = context.Operators.Equal(n_, r_);
+				Id n_ = C?.IdElement;
+				string o_ = n_?.Value;
+				ResourceReference p_ = PD?.Condition;
+				FhirString q_ = p_?.ReferenceElement;
+				string r_ = q_?.Value;
+				string s_ = QICoreCommon_2_0_000.getId(r_);
+				bool? t_ = context.Operators.Equal(o_, s_);
 
-				return s_;
+				return t_;
 			};
-			var k_ = context.Operators.Where<Condition>(i_, j_);
-			var l_ = context.Operators.SingletonFrom<Condition>(k_);
+			IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
+			Condition m_ = context.Operators.SingletonFrom<Condition>(l_);
 
-			return l_;
+			return m_;
 		};
-		var d_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<Condition>(d_);
+		IEnumerable<Condition> e_ = context.Operators.Select<Encounter.DiagnosisComponent, Condition>(c_, d_);
+		Condition f_ = context.Operators.SingletonFrom<Condition>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("getLocation")]
     [CqlTag("description", "Returns the Location resource specified by the given reference.")]
 	public Location getLocation(ResourceReference reference)
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
 		bool? b_(Location L)
 		{
-			var e_ = L?.IdElement;
-			var f_ = e_?.Value;
-			var g_ = reference?.ReferenceElement;
-			var h_ = g_?.Value;
-			var i_ = QICoreCommon_2_0_000.getId(h_);
-			var j_ = context.Operators.Equal(f_, i_);
+			Id e_ = L?.IdElement;
+			string f_ = e_?.Value;
+			FhirString g_ = reference?.ReferenceElement;
+			string h_ = g_?.Value;
+			string i_ = QICoreCommon_2_0_000.getId(h_);
+			bool? j_ = context.Operators.Equal(f_, i_);
 
 			return j_;
 		};
-		var c_ = context.Operators.Where<Location>(a_, b_);
-		var d_ = context.Operators.SingletonFrom<Location>(c_);
+		IEnumerable<Location> c_ = context.Operators.Where<Location>(a_, b_);
+		Location d_ = context.Operators.SingletonFrom<Location>(c_);
 
 		return d_;
 	}
@@ -3260,40 +3274,41 @@ public class CQMCommon_2_0_000
 		{
 			bool b_()
 			{
-				var c_ = request?.Medication;
-				var d_ = FHIRHelpers_4_3_000.ToValue(c_);
-				var e_ = d_ is CqlConcept;
+				DataType c_ = request?.Medication;
+				object d_ = FHIRHelpers_4_3_000.ToValue(c_);
+				bool e_ = d_ is CqlConcept;
 
 				return e_;
 			};
 			if (b_())
 			{
-				var f_ = request?.Medication;
-				var g_ = FHIRHelpers_4_3_000.ToValue(f_);
+				DataType f_ = request?.Medication;
+				object g_ = FHIRHelpers_4_3_000.ToValue(f_);
 
 				return (g_ as CqlConcept);
 			}
 			else
 			{
-				var h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
+				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
 				bool? i_(Medication M)
 				{
-					var m_ = M?.IdElement;
-					var n_ = m_?.Value;
-					var o_ = request?.Medication;
-					var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-					var q_ = (p_ as ResourceReference)?.ReferenceElement;
-					var r_ = q_?.Value;
-					var s_ = QICoreCommon_2_0_000.getId(r_);
-					var t_ = context.Operators.Equal(n_, s_);
+					Id n_ = M?.IdElement;
+					string o_ = n_?.Value;
+					DataType p_ = request?.Medication;
+					object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+					FhirString r_ = (q_ as ResourceReference)?.ReferenceElement;
+					string s_ = r_?.Value;
+					string t_ = QICoreCommon_2_0_000.getId(s_);
+					bool? u_ = context.Operators.Equal(o_, t_);
 
-					return t_;
+					return u_;
 				};
-				var j_ = context.Operators.Where<Medication>(h_, i_);
-				var k_ = context.Operators.SingletonFrom<Medication>(j_);
-				var l_ = FHIRHelpers_4_3_000.ToConcept(k_?.Code);
+				IEnumerable<Medication> j_ = context.Operators.Where<Medication>(h_, i_);
+				Medication k_ = context.Operators.SingletonFrom<Medication>(j_);
+				CodeableConcept l_ = k_?.Code;
+				CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
 
-				return l_;
+				return m_;
 			}
 		};
 
@@ -3308,40 +3323,41 @@ public class CQMCommon_2_0_000
 		{
 			bool b_()
 			{
-				var c_ = request?.Medication;
-				var d_ = FHIRHelpers_4_3_000.ToValue(c_);
-				var e_ = d_ is CqlConcept;
+				DataType c_ = request?.Medication;
+				object d_ = FHIRHelpers_4_3_000.ToValue(c_);
+				bool e_ = d_ is CqlConcept;
 
 				return e_;
 			};
 			if (b_())
 			{
-				var f_ = request?.Medication;
-				var g_ = FHIRHelpers_4_3_000.ToValue(f_);
+				DataType f_ = request?.Medication;
+				object g_ = FHIRHelpers_4_3_000.ToValue(f_);
 
 				return (g_ as CqlConcept);
 			}
 			else
 			{
-				var h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
+				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
 				bool? i_(Medication M)
 				{
-					var m_ = M?.IdElement;
-					var n_ = m_?.Value;
-					var o_ = request?.Medication;
-					var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-					var q_ = (p_ as ResourceReference)?.ReferenceElement;
-					var r_ = q_?.Value;
-					var s_ = QICoreCommon_2_0_000.getId(r_);
-					var t_ = context.Operators.Equal(n_, s_);
+					Id n_ = M?.IdElement;
+					string o_ = n_?.Value;
+					DataType p_ = request?.Medication;
+					object q_ = FHIRHelpers_4_3_000.ToValue(p_);
+					FhirString r_ = (q_ as ResourceReference)?.ReferenceElement;
+					string s_ = r_?.Value;
+					string t_ = QICoreCommon_2_0_000.getId(s_);
+					bool? u_ = context.Operators.Equal(o_, t_);
 
-					return t_;
+					return u_;
 				};
-				var j_ = context.Operators.Where<Medication>(h_, i_);
-				var k_ = context.Operators.SingletonFrom<Medication>(j_);
-				var l_ = FHIRHelpers_4_3_000.ToConcept(k_?.Code);
+				IEnumerable<Medication> j_ = context.Operators.Where<Medication>(h_, i_);
+				Medication k_ = context.Operators.SingletonFrom<Medication>(j_);
+				CodeableConcept l_ = k_?.Code;
+				CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(l_);
 
-				return l_;
+				return m_;
 			}
 		};
 

--- a/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
@@ -198,7 +198,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 			CqlInterval<CqlDateTime> y_ = this.Measurement_Period();
 			Period z_ = Encounter?.Period;
 			CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, "day");
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, null);
 			bool? ac_ = context.Operators.And(x_, ab_);
 
 			return ac_;
@@ -239,11 +239,11 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
 			CqlDateTime x_ = context.Operators.Start(w_);
 			CqlDateTime z_ = context.Operators.Start(w_);
-			int? aa_ = context.Operators.DateTimeComponentFrom(z_, "year");
+			int? aa_ = context.Operators.DateTimeComponentFrom(z_, null);
 			CqlDate ab_ = context.Operators.Date(aa_, 10, 31);
 			CqlDateTime ac_ = context.Operators.ConvertDateToDateTime(ab_);
 			CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
-			bool? ae_ = context.Operators.In<CqlDateTime>(v_, ad_, "day");
+			bool? ae_ = context.Operators.In<CqlDateTime>(v_, ad_, null);
 			bool? af_ = context.Operators.And(t_, ae_);
 
 			return af_;
@@ -396,7 +396,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(o_);
 				CqlDateTime ab_ = context.Operators.End(aa_);
 				CqlInterval<CqlDateTime> ac_ = this.Measurement_Period();
-				bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, "day");
+				bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, null);
 				bool? ae_ = context.Operators.And(y_, ad_);
 
 				return ae_;

--- a/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
@@ -741,7 +741,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.Start(h_);
 			CqlDate j_ = context.Operators.DateFrom(i_);
-			int? k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			int? k_ = context.Operators.CalculateAgeAt(g_, j_, null);
 			bool? l_ = context.Operators.GreaterOrEqual(k_, 18);
 
 			return l_;
@@ -990,7 +990,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 				CqlQuantity z_ = context.Operators.Quantity(90m, "days");
 				CqlDateTime aa_ = context.Operators.Add(y_, z_);
 				CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(u_, aa_, false, true);
-				bool? ac_ = context.Operators.In<CqlDateTime>(q_, ab_, "day");
+				bool? ac_ = context.Operators.In<CqlDateTime>(q_, ab_, null);
 				object ae_ = FHIRHelpers_4_3_000.ToValue(r_);
 				CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.toInterval(ae_);
 				CqlDateTime ag_ = context.Operators.End(af_);

--- a/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
@@ -226,7 +226,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 			Period v_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
 			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.toInterval((w_ as object));
-			bool? y_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, x_, "day");
+			bool? y_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, x_, null);
 
 			return y_;
 		};
@@ -248,7 +248,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(24, 64, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
@@ -400,7 +400,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 			CqlDateTime k_ = context.Operators.Subtract(i_, j_);
 			CqlDateTime m_ = context.Operators.End(h_);
 			CqlInterval<CqlDateTime> n_ = context.Operators.Interval(k_, m_, true, true);
-			bool? o_ = context.Operators.In<CqlDateTime>(g_, n_, "day");
+			bool? o_ = context.Operators.In<CqlDateTime>(g_, n_, null);
 			DataType p_ = CervicalCytology?.Value;
 			object q_ = FHIRHelpers_4_3_000.ToValue(p_);
 			bool? r_ = context.Operators.Not((bool?)(q_ is null));
@@ -482,7 +482,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 			};
 			CqlDateTime k_ = QICoreCommon_2_0_000.latest(j_());
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(i_, l_, null);
 			bool? n_ = context.Operators.GreaterOrEqual(m_, 30);
 			object o_()
 			{
@@ -543,7 +543,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
 			CqlDateTime v_ = context.Operators.End(q_);
 			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(t_, v_, true, true);
-			bool? x_ = context.Operators.In<CqlDateTime>(p_, w_, "day");
+			bool? x_ = context.Operators.In<CqlDateTime>(p_, w_, null);
 			bool? y_ = context.Operators.And(n_, x_);
 			DataType z_ = HPVTest?.Value;
 			object aa_ = FHIRHelpers_4_3_000.ToValue(z_);

--- a/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
@@ -395,14 +395,14 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.Start(h_);
 			CqlDate j_ = context.Operators.DateFrom(i_);
-			int? k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+			int? k_ = context.Operators.CalculateAgeAt(g_, j_, null);
 			bool? l_ = context.Operators.GreaterOrEqual(k_, 6);
 			Date n_ = d_?.BirthDateElement;
 			string o_ = n_?.Value;
 			CqlDate p_ = context.Operators.ConvertStringToDate(o_);
 			CqlDateTime r_ = context.Operators.Start(h_);
 			CqlDate s_ = context.Operators.DateFrom(r_);
-			int? t_ = context.Operators.CalculateAgeAt(p_, s_, "year");
+			int? t_ = context.Operators.CalculateAgeAt(p_, s_, null);
 			bool? u_ = context.Operators.LessOrEqual(t_, 16);
 			bool? v_ = context.Operators.And(l_, u_);
 

--- a/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
@@ -898,7 +898,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			Period aj_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
 			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval((ak_ as object));
-			bool? am_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ai_, al_, "day");
+			bool? am_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ai_, al_, null);
 
 			return am_;
 		};
@@ -920,7 +920,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.Equal(h_, 2);
 		IEnumerable<Encounter> j_ = this.Qualifying_Encounters();
 		bool? k_ = context.Operators.Exists<Encounter>(j_);
@@ -989,7 +989,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -1014,7 +1014,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -1039,7 +1039,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -1064,7 +1064,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -1089,7 +1089,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -1156,7 +1156,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
 			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, null);
 
 			return u_;
 		};
@@ -1184,7 +1184,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
 			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, null);
 
 			return ah_;
 		};
@@ -1232,12 +1232,12 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		{
 			CqlQuantity m_ = context.Operators.Quantity(1m, "day");
 			CqlDate n_ = context.Operators.Add(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination1, m_);
-			bool? o_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination2, n_, "day");
+			bool? o_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination2, n_, null);
 			CqlDate q_ = context.Operators.Add(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination2, m_);
-			bool? r_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination3, q_, "day");
+			bool? r_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination3, q_, null);
 			bool? s_ = context.Operators.And(o_, r_);
 			CqlDate u_ = context.Operators.Add(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination3, m_);
-			bool? v_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination4, u_, "day");
+			bool? v_ = context.Operators.SameOrAfter(tuple_emdhflcfhwveravvnflazyxji.DTaPVaccination4, u_, null);
 			bool? w_ = context.Operators.And(s_, v_);
 
 			return w_;
@@ -1268,7 +1268,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime j_ = context.Operators.Start(i_);
 			CqlDate k_ = context.Operators.DateFrom(j_);
 			CqlInterval<CqlDate> l_ = this.First_Two_Years();
-			bool? m_ = context.Operators.In<CqlDate>(k_, l_, "day");
+			bool? m_ = context.Operators.In<CqlDate>(k_, l_, null);
 
 			return m_;
 		};
@@ -1293,7 +1293,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
 			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, null);
 
 			return u_;
 		};
@@ -1321,7 +1321,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
 			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, null);
 
 			return ah_;
 		};
@@ -1368,9 +1368,9 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		{
 			CqlQuantity l_ = context.Operators.Quantity(1m, "day");
 			CqlDate m_ = context.Operators.Add(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination1, l_);
-			bool? n_ = context.Operators.SameOrAfter(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination2, m_, "day");
+			bool? n_ = context.Operators.SameOrAfter(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination2, m_, null);
 			CqlDate p_ = context.Operators.Add(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination2, l_);
-			bool? q_ = context.Operators.SameOrAfter(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination3, p_, "day");
+			bool? q_ = context.Operators.SameOrAfter(tuple_cnghazroxajthpiccbiajbrxv.PolioVaccination3, p_, null);
 			bool? r_ = context.Operators.And(n_, q_);
 
 			return r_;
@@ -1399,7 +1399,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -1496,7 +1496,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -1520,7 +1520,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlDate h_ = context.Operators.DateFrom(g_);
 			CqlInterval<CqlDate> i_ = this.First_Two_Years();
-			bool? j_ = context.Operators.In<CqlDate>(h_, i_, "day");
+			bool? j_ = context.Operators.In<CqlDate>(h_, i_, null);
 
 			return j_;
 		};
@@ -1544,7 +1544,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlDate h_ = context.Operators.DateFrom(g_);
 			CqlInterval<CqlDate> i_ = this.First_Two_Years();
-			bool? j_ = context.Operators.In<CqlDate>(h_, i_, "day");
+			bool? j_ = context.Operators.In<CqlDate>(h_, i_, null);
 
 			return j_;
 		};
@@ -1568,7 +1568,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlDate h_ = context.Operators.DateFrom(g_);
 			CqlInterval<CqlDate> i_ = this.First_Two_Years();
-			bool? j_ = context.Operators.In<CqlDate>(h_, i_, "day");
+			bool? j_ = context.Operators.In<CqlDate>(h_, i_, null);
 
 			return j_;
 		};
@@ -1593,7 +1593,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
 			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, null);
 
 			return u_;
 		};
@@ -1621,7 +1621,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
 			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, null);
 
 			return ah_;
 		};
@@ -1660,7 +1660,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
 			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, null);
 
 			return u_;
 		};
@@ -1688,7 +1688,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
 			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, null);
 
 			return ah_;
 		};
@@ -1810,7 +1810,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -1835,7 +1835,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
 			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, null);
 
 			return u_;
 		};
@@ -1863,7 +1863,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
 			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, null);
 
 			return ah_;
 		};
@@ -1910,9 +1910,9 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		{
 			CqlQuantity l_ = context.Operators.Quantity(1m, "day");
 			CqlDate m_ = context.Operators.Add(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination1, l_);
-			bool? n_ = context.Operators.SameOrAfter(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination2, m_, "day");
+			bool? n_ = context.Operators.SameOrAfter(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination2, m_, null);
 			CqlDate p_ = context.Operators.Add(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination2, l_);
-			bool? q_ = context.Operators.SameOrAfter(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination3, p_, "day");
+			bool? q_ = context.Operators.SameOrAfter(tuple_eztgahauwggsdgadcgqnnipgw.HepatitisBVaccination3, p_, null);
 			bool? r_ = context.Operators.And(n_, q_);
 
 			return r_;
@@ -1955,7 +1955,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.ToInterval(y_);
 			CqlInterval<CqlDate> aa_ = CQMCommon_2_0_000.ToDateInterval(z_);
-			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDate>(w_, aa_, "day");
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDate>(w_, aa_, null);
 
 			return ab_;
 		};
@@ -2000,12 +2000,12 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		{
 			CqlQuantity l_ = context.Operators.Quantity(1m, "day");
 			CqlDate m_ = context.Operators.Add(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination1, l_);
-			bool? n_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination2, m_, "day");
+			bool? n_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination2, m_, null);
 			CqlDate p_ = context.Operators.Add(tuple_hdfambzgbwdpfetgqnfbceeeg.NewBornVaccine3, l_);
-			bool? q_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination1, p_, "day");
+			bool? q_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination1, p_, null);
 			bool? r_ = context.Operators.And(n_, q_);
 			CqlDate t_ = context.Operators.Add(tuple_hdfambzgbwdpfetgqnfbceeeg.NewBornVaccine3, l_);
-			bool? u_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination2, t_, "day");
+			bool? u_ = context.Operators.SameOrAfter(tuple_hdfambzgbwdpfetgqnfbceeeg.HepatitisBVaccination2, t_, null);
 			bool? v_ = context.Operators.And(r_, u_);
 
 			return v_;
@@ -2037,7 +2037,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			CqlInterval<CqlDate> m_ = this.First_Two_Years();
-			bool? n_ = context.Operators.In<CqlDate>(l_, m_, "day");
+			bool? n_ = context.Operators.In<CqlDate>(l_, m_, null);
 
 			return n_;
 		};
@@ -2106,7 +2106,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			CqlInterval<CqlDate> m_ = this.First_Two_Years();
-			bool? n_ = context.Operators.In<CqlDate>(l_, m_, "day");
+			bool? n_ = context.Operators.In<CqlDate>(l_, m_, null);
 
 			return n_;
 		};
@@ -2131,7 +2131,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
 			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, null);
 
 			return u_;
 		};
@@ -2159,7 +2159,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
 			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, null);
 
 			return ah_;
 		};
@@ -2207,12 +2207,12 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		{
 			CqlQuantity m_ = context.Operators.Quantity(1m, "day");
 			CqlDate n_ = context.Operators.Add(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination1, m_);
-			bool? o_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination2, n_, "day");
+			bool? o_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination2, n_, null);
 			CqlDate q_ = context.Operators.Add(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination2, m_);
-			bool? r_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination3, q_, "day");
+			bool? r_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination3, q_, null);
 			bool? s_ = context.Operators.And(o_, r_);
 			CqlDate u_ = context.Operators.Add(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination3, m_);
-			bool? v_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination4, u_, "day");
+			bool? v_ = context.Operators.SameOrAfter(tuple_ddpdeojhpyesfhgcocbnoippp.PneumococcalVaccination4, u_, null);
 			bool? w_ = context.Operators.And(s_, v_);
 
 			return w_;
@@ -2241,7 +2241,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -2310,7 +2310,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			CqlInterval<CqlDate> m_ = this.First_Two_Years();
-			bool? n_ = context.Operators.In<CqlDate>(l_, m_, "day");
+			bool? n_ = context.Operators.In<CqlDate>(l_, m_, null);
 
 			return n_;
 		};
@@ -2336,7 +2336,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime s_ = context.Operators.LateBoundProperty<CqlDateTime>(r_, "value");
 			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.ToInterval((s_ as object));
 			CqlInterval<CqlDate> u_ = CQMCommon_2_0_000.ToDateInterval(t_);
-			bool? v_ = context.Operators.IntervalIncludesInterval<CqlDate>(q_, u_, "day");
+			bool? v_ = context.Operators.IntervalIncludesInterval<CqlDate>(q_, u_, null);
 
 			return v_;
 		};
@@ -2364,7 +2364,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
 			CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.ToInterval(af_);
 			CqlInterval<CqlDate> ah_ = CQMCommon_2_0_000.ToDateInterval(ag_);
-			bool? ai_ = context.Operators.IntervalIncludesInterval<CqlDate>(ad_, ah_, "day");
+			bool? ai_ = context.Operators.IntervalIncludesInterval<CqlDate>(ad_, ah_, null);
 
 			return ai_;
 		};
@@ -2403,7 +2403,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
 			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, null);
 
 			return u_;
 		};
@@ -2431,7 +2431,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
 			CqlInterval<CqlDate> ag_ = CQMCommon_2_0_000.ToDateInterval(af_);
-			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, "day");
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDate>(ac_, ag_, null);
 
 			return ah_;
 		};
@@ -2553,7 +2553,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};
@@ -2598,7 +2598,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.LateBoundProperty<CqlDateTime>(q_, "value");
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval((r_ as object));
 			CqlInterval<CqlDate> t_ = CQMCommon_2_0_000.ToDateInterval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, "day");
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDate>(p_, t_, null);
 
 			return u_;
 		};
@@ -2632,7 +2632,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			DataType an_ = InfluenzaAdministration?.Performed;
 			object ao_ = FHIRHelpers_4_3_000.ToValue(an_);
 			CqlInterval<CqlDateTime> ap_ = QICoreCommon_2_0_000.ToInterval(ao_);
-			bool? aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(am_, ap_, "day");
+			bool? aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(am_, ap_, null);
 
 			return aq_;
 		};
@@ -2678,7 +2678,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		{
 			CqlQuantity k_ = context.Operators.Quantity(1m, "day");
 			CqlDate l_ = context.Operators.Add(tuple_bzhflerdagbpqmnhevjcunfnq.FluVaccination1, k_);
-			bool? m_ = context.Operators.SameOrAfter(tuple_bzhflerdagbpqmnhevjcunfnq.FluVaccination2, l_, "day");
+			bool? m_ = context.Operators.SameOrAfter(tuple_bzhflerdagbpqmnhevjcunfnq.FluVaccination2, l_, null);
 
 			return m_;
 		};
@@ -2707,7 +2707,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime t_ = context.Operators.LateBoundProperty<CqlDateTime>(s_, "value");
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
 			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, "day");
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
 
 			return w_;
 		};
@@ -2736,7 +2736,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
 			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.ToInterval(ai_);
 			CqlInterval<CqlDate> ak_ = CQMCommon_2_0_000.ToDateInterval(aj_);
-			bool? al_ = context.Operators.IntervalIncludesInterval<CqlDate>(ag_, ak_, "day");
+			bool? al_ = context.Operators.IntervalIncludesInterval<CqlDate>(ag_, ak_, null);
 
 			return al_;
 		};
@@ -2790,7 +2790,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlDate i_ = context.Operators.DateFrom(h_);
 			CqlInterval<CqlDate> j_ = this.First_Two_Years();
-			bool? k_ = context.Operators.In<CqlDate>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDate>(i_, j_, null);
 
 			return k_;
 		};

--- a/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
@@ -232,7 +232,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			Period g_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, null);
 
 			return i_;
 		};
@@ -254,7 +254,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();

--- a/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
@@ -479,7 +479,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			Period ab_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
 			CqlInterval<CqlDateTime> ad_ = QICoreCommon_2_0_000.ToInterval((ac_ as object));
-			bool? ae_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aa_, ad_, "day");
+			bool? ae_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aa_, ad_, null);
 
 			return ae_;
 		};
@@ -619,7 +619,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			FhirDateTime k_ = OrderedContraceptives?.AuthoredOnElement;
 			CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
 			CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.ToInterval((l_ as object));
-			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, "day");
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, null);
 
 			return n_;
 		};
@@ -650,7 +650,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			FhirDateTime n_ = LabOrders?.AuthoredOnElement;
 			CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
 			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.ToInterval((o_ as object));
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
 
 			return q_;
 		};
@@ -675,7 +675,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			FhirDateTime j_ = PregnancyTest?.AuthoredOnElement;
 			CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
 			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.ToInterval((k_ as object));
-			bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, l_, "day");
+			bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(i_, l_, null);
 
 			return m_;
 		};
@@ -702,7 +702,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			FhirDateTime h_ = SexualActivityDiagnostics?.AuthoredOnElement;
 			CqlDateTime i_ = context.Operators.Convert<CqlDateTime>(h_);
 			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval((i_ as object));
-			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, null);
 
 			return k_;
 		};
@@ -727,7 +727,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			DataType h_ = ProceduresForSexualActivity?.Performed;
 			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
 			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval(i_);
-			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, null);
 
 			return k_;
 		};
@@ -750,7 +750,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(16, 24, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
@@ -820,7 +820,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 				CqlQuantity af_ = context.Operators.Quantity(6m, "days");
 				CqlDateTime ag_ = context.Operators.Add(ae_, af_);
 				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(aa_, ag_, true, true);
-				bool? ai_ = context.Operators.In<CqlDateTime>(w_, ah_, "day");
+				bool? ai_ = context.Operators.In<CqlDateTime>(w_, ah_, null);
 				CqlDateTime ak_ = context.Operators.Convert<CqlDateTime>(x_);
 				CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.ToInterval((ak_ as object));
 				CqlDateTime am_ = context.Operators.End(al_);
@@ -867,7 +867,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 				CqlQuantity br_ = context.Operators.Quantity(6m, "days");
 				CqlDateTime bs_ = context.Operators.Add(bq_, br_);
 				CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(bm_, bs_, true, true);
-				bool? bu_ = context.Operators.In<CqlDateTime>(bi_, bt_, "day");
+				bool? bu_ = context.Operators.In<CqlDateTime>(bi_, bt_, null);
 				CqlDateTime bw_ = context.Operators.Convert<CqlDateTime>(bj_);
 				CqlInterval<CqlDateTime> bx_ = QICoreCommon_2_0_000.ToInterval((bw_ as object));
 				CqlDateTime by_ = context.Operators.End(bx_);
@@ -994,7 +994,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			};
 			CqlDateTime h_ = QICoreCommon_2_0_000.Latest(g_());
 			CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
-			bool? j_ = context.Operators.In<CqlDateTime>(h_, i_, "day");
+			bool? j_ = context.Operators.In<CqlDateTime>(h_, i_, null);
 			DataType k_ = ChlamydiaTest?.Value;
 			object l_ = FHIRHelpers_4_3_000.ToValue(k_);
 			bool? m_ = context.Operators.Not((bool?)(l_ is null));
@@ -1021,7 +1021,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(16, 20, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
@@ -1041,7 +1041,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(21, 24, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 

--- a/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
@@ -239,7 +239,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(46, 75, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
@@ -275,7 +275,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.SameOrBefore(g_, i_, "day");
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, null);
 
 			return j_;
 		};
@@ -301,7 +301,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 			CqlDateTime i_ = context.Operators.End(h_);
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.End(j_);
-			bool? l_ = context.Operators.SameOrBefore(i_, k_, "day");
+			bool? l_ = context.Operators.SameOrBefore(i_, k_, null);
 
 			return l_;
 		};
@@ -401,7 +401,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 			};
 			CqlDateTime j_ = QICoreCommon_2_0_000.Latest(i_());
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
-			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, "day");
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, null);
 			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
@@ -484,7 +484,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, null);
 			bool? s_ = context.Operators.And(h_, r_);
 
 			return s_;
@@ -515,7 +515,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, "day");
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
 
 			return q_;
 		};
@@ -545,7 +545,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, "day");
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
 
 			return q_;
 		};
@@ -575,7 +575,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, "day");
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
 
 			return q_;
 		};
@@ -621,7 +621,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(46, 49, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
@@ -641,7 +641,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(50, 75, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 

--- a/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
@@ -2055,7 +2055,7 @@ public class CumulativeMedicationDuration_4_0_000
 				{
 					CqlDate f_ = context.Operators.Start(X);
 					CqlDate g_ = context.Operators.End(X);
-					int? h_ = context.Operators.DifferenceBetween(f_, g_, "day");
+					int? h_ = context.Operators.DifferenceBetween(f_, g_, null);
 					int? i_ = context.Operators.Add(h_, 1);
 
 					return i_;
@@ -2105,7 +2105,7 @@ public class CumulativeMedicationDuration_4_0_000
 				};
 				CqlDate v_ = context.Operators.Max<CqlDate>((u_ as IEnumerable<CqlDate>));
 				CqlDate x_ = context.Operators.End(X);
-				int? y_ = context.Operators.DurationBetween(m_, x_, "day");
+				int? y_ = context.Operators.DurationBetween(m_, x_, null);
 				decimal? z_ = context.Operators.ConvertIntegerToDecimal((y_ ?? 0));
 				CqlQuantity aa_ = this.Quantity(z_, "day");
 				CqlDate ab_ = context.Operators.Add(v_, aa_);

--- a/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
@@ -475,7 +475,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
 		IEnumerable<Encounter> j_ = this.Diabetic_Retinopathy_Encounter();
 		bool? k_ = context.Operators.Exists<Encounter>(j_);
@@ -576,7 +576,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				bool? r_ = context.Operators.After(n_, q_, null);
 				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
 				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
-				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
+				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, null);
 				bool? w_ = context.Operators.And(r_, v_);
 
 				return w_;
@@ -625,7 +625,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				bool? r_ = context.Operators.After(n_, q_, null);
 				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
 				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
-				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
+				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, null);
 				bool? w_ = context.Operators.And(r_, v_);
 
 				return w_;
@@ -674,7 +674,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				bool? r_ = context.Operators.After(n_, q_, null);
 				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
 				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
-				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
+				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, null);
 				bool? w_ = context.Operators.And(r_, v_);
 
 				return w_;

--- a/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
@@ -311,7 +311,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 				bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, null);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? q_ = context.Operators.Overlaps(n_, p_, "day");
+				bool? q_ = context.Operators.Overlaps(n_, p_, null);
 				bool? r_ = context.Operators.And(m_, q_);
 				bool? s_ = QICoreCommon_2_0_000.isActive(Dementia);
 				bool? t_ = context.Operators.And(r_, s_);
@@ -431,7 +431,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(s_);
 				CqlDateTime z_ = context.Operators.End(y_);
 				CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(w_, z_, true, true);
-				bool? ab_ = context.Operators.In<CqlDateTime>(r_, aa_, "day");
+				bool? ab_ = context.Operators.In<CqlDateTime>(r_, aa_, null);
 				CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(s_);
 				CqlDateTime ae_ = context.Operators.End(ad_);
 				bool? af_ = context.Operators.Not((bool?)(ae_ is null));

--- a/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
@@ -272,7 +272,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 			CqlInterval<CqlDateTime> x_ = this.Measurement_Period();
 			Period y_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, "day");
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, null);
 
 			return aa_;
 		};
@@ -294,7 +294,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
@@ -382,7 +382,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 			DataType g_ = RetinalExam?.Effective;
 			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.toInterval(h_);
-			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, "day");
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, null);
 
 			return j_;
 		};
@@ -411,7 +411,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 			DataType m_ = RetinalExam?.Effective;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
-			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
 
 			return p_;
 		};

--- a/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
@@ -181,7 +181,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
@@ -297,7 +297,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 			};
 			CqlDateTime j_ = QICoreCommon_2_0_000.Latest(i_());
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
-			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, "day");
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, null);
 
 			return l_;
 		};
@@ -412,7 +412,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 			};
 			CqlDateTime i_ = QICoreCommon_2_0_000.Latest(h_());
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
-			bool? k_ = context.Operators.In<CqlDateTime>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDateTime>(i_, j_, null);
 
 			return k_;
 		};

--- a/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -42,21 +42,23 @@ public class FHIRHelpers_4_3_000
 			}
 			else if ((period?.StartElement is null))
 			{
-				var b_ = period?.StartElement;
-				var c_ = context.Operators.Convert<CqlDateTime>(b_);
-				var d_ = period?.EndElement;
-				var e_ = context.Operators.Convert<CqlDateTime>(d_);
-				var f_ = context.Operators.Interval(c_, e_, false, true);
+				FhirDateTime b_ = period?.StartElement;
+				CqlDateTime c_ = context.Operators.Convert<CqlDateTime>(b_);
+				FhirDateTime d_ = period?.EndElement;
+				CqlDateTime e_ = context.Operators.Convert<CqlDateTime>(d_);
+				CqlInterval<CqlDateTime> f_ = context.Operators.Interval(c_, e_, false, true);
 
 				return f_;
 			}
 			else
 			{
-				var g_ = context.Operators.Convert<CqlDateTime>(period?.StartElement);
-				var h_ = context.Operators.Convert<CqlDateTime>(period?.EndElement);
-				var i_ = context.Operators.Interval(g_, h_, true, true);
+				FhirDateTime g_ = period?.StartElement;
+				CqlDateTime h_ = context.Operators.Convert<CqlDateTime>(g_);
+				FhirDateTime i_ = period?.EndElement;
+				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
+				CqlInterval<CqlDateTime> k_ = context.Operators.Interval(h_, j_, true, true);
 
-				return i_;
+				return k_;
 			}
 		};
 
@@ -80,72 +82,72 @@ public class FHIRHelpers_4_3_000
 				{
 					bool c_()
 					{
-						var g_ = quantity?.ComparatorElement;
-						var h_ = g_?.Value;
-						var i_ = context.Operators.Convert<string>(h_);
-						var j_ = context.Operators.Equal(i_, "<");
+						Code<Quantity.QuantityComparator> g_ = quantity?.ComparatorElement;
+						Quantity.QuantityComparator? h_ = g_?.Value;
+						string i_ = context.Operators.Convert<string>(h_);
+						bool? j_ = context.Operators.Equal(i_, "<");
 
 						return (j_ ?? false);
 					};
 					bool d_()
 					{
-						var k_ = quantity?.ComparatorElement;
-						var l_ = k_?.Value;
-						var m_ = context.Operators.Convert<string>(l_);
-						var n_ = context.Operators.Equal(m_, "<=");
+						Code<Quantity.QuantityComparator> k_ = quantity?.ComparatorElement;
+						Quantity.QuantityComparator? l_ = k_?.Value;
+						string m_ = context.Operators.Convert<string>(l_);
+						bool? n_ = context.Operators.Equal(m_, "<=");
 
 						return (n_ ?? false);
 					};
 					bool e_()
 					{
-						var o_ = quantity?.ComparatorElement;
-						var p_ = o_?.Value;
-						var q_ = context.Operators.Convert<string>(p_);
-						var r_ = context.Operators.Equal(q_, ">=");
+						Code<Quantity.QuantityComparator> o_ = quantity?.ComparatorElement;
+						Quantity.QuantityComparator? p_ = o_?.Value;
+						string q_ = context.Operators.Convert<string>(p_);
+						bool? r_ = context.Operators.Equal(q_, ">=");
 
 						return (r_ ?? false);
 					};
 					bool f_()
 					{
-						var s_ = quantity?.ComparatorElement;
-						var t_ = s_?.Value;
-						var u_ = context.Operators.Convert<string>(t_);
-						var v_ = context.Operators.Equal(u_, ">");
+						Code<Quantity.QuantityComparator> s_ = quantity?.ComparatorElement;
+						Quantity.QuantityComparator? t_ = s_?.Value;
+						string u_ = context.Operators.Convert<string>(t_);
+						bool? v_ = context.Operators.Equal(u_, ">");
 
 						return (v_ ?? false);
 					};
 					if (c_())
 					{
-						var w_ = this.ToQuantityIgnoringComparator(quantity);
-						var x_ = context.Operators.Interval(null, w_, true, false);
+						CqlQuantity w_ = this.ToQuantityIgnoringComparator(quantity);
+						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(null, w_, true, false);
 
 						return x_;
 					}
 					else if (d_())
 					{
-						var y_ = this.ToQuantityIgnoringComparator(quantity);
-						var z_ = context.Operators.Interval(null, y_, true, true);
+						CqlQuantity y_ = this.ToQuantityIgnoringComparator(quantity);
+						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(null, y_, true, true);
 
 						return z_;
 					}
 					else if (e_())
 					{
-						var aa_ = this.ToQuantityIgnoringComparator(quantity);
-						var ab_ = context.Operators.Interval(aa_, null, true, true);
+						CqlQuantity aa_ = this.ToQuantityIgnoringComparator(quantity);
+						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, null, true, true);
 
 						return ab_;
 					}
 					else if (f_())
 					{
-						var ac_ = this.ToQuantityIgnoringComparator(quantity);
-						var ad_ = context.Operators.Interval(ac_, null, false, true);
+						CqlQuantity ac_ = this.ToQuantityIgnoringComparator(quantity);
+						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, null, false, true);
 
 						return ad_;
 					}
 					else
 					{
-						var ae_ = this.ToQuantity(quantity);
-						var ag_ = context.Operators.Interval(ae_, ae_, true, true);
+						CqlQuantity ae_ = this.ToQuantity(quantity);
+						CqlInterval<CqlQuantity> ag_ = context.Operators.Interval(ae_, ae_, true, true);
 
 						return ag_;
 					}
@@ -170,11 +172,13 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				var b_ = this.ToQuantity(range?.Low);
-				var c_ = this.ToQuantity(range?.High);
-				var d_ = context.Operators.Interval(b_, c_, true, true);
+				Quantity b_ = range?.Low;
+				CqlQuantity c_ = this.ToQuantity(b_);
+				Quantity d_ = range?.High;
+				CqlQuantity e_ = this.ToQuantity(d_);
+				CqlInterval<CqlQuantity> f_ = context.Operators.Interval(c_, e_, true, true);
 
-				return d_;
+				return f_;
 			}
 		};
 
@@ -239,20 +243,20 @@ public class FHIRHelpers_4_3_000
 		{
 			bool b_()
 			{
-				var d_ = quantity?.ComparatorElement;
-				var e_ = context.Operators.Not((bool?)(d_ is null));
+				Code<Quantity.QuantityComparator> d_ = quantity?.ComparatorElement;
+				bool? e_ = context.Operators.Not((bool?)(d_ is null));
 
 				return (e_ ?? false);
 			};
 			bool c_()
 			{
-				var f_ = quantity?.SystemElement;
-				var h_ = f_?.Value;
-				var i_ = context.Operators.Equal(h_, "http://unitsofmeasure.org");
-				var j_ = context.Operators.Or((bool?)(f_ is null), i_);
-				var l_ = f_?.Value;
-				var m_ = context.Operators.Equal(l_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
-				var n_ = context.Operators.Or(j_, m_);
+				FhirUri f_ = quantity?.SystemElement;
+				string h_ = f_?.Value;
+				bool? i_ = context.Operators.Equal(h_, "http://unitsofmeasure.org");
+				bool? j_ = context.Operators.Or((bool?)(f_ is null), i_);
+				string l_ = f_?.Value;
+				bool? m_ = context.Operators.Equal(l_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
+				bool? n_ = context.Operators.Or(j_, m_);
 
 				return (n_ ?? false);
 			};
@@ -266,33 +270,39 @@ public class FHIRHelpers_4_3_000
 			}
 			else if (b_())
 			{
-				var o_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
+				object o_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
 
 				return (o_ as CqlQuantity);
 			}
 			else if (c_())
 			{
-				var p_ = quantity?.ValueElement;
-				var q_ = p_?.Value;
-				var r_ = quantity?.CodeElement;
-				var s_ = r_?.Value;
-				var t_ = quantity?.UnitElement;
-				var u_ = t_?.Value;
-				var v_ = this.ToCalendarUnit(((s_ ?? u_) ?? "1"));
+				FhirDecimal p_ = quantity?.ValueElement;
+				decimal? q_ = p_?.Value;
+				Code r_ = quantity?.CodeElement;
+				string s_ = r_?.Value;
+				FhirString t_ = quantity?.UnitElement;
+				string u_ = t_?.Value;
+				string v_ = this.ToCalendarUnit(((s_ ?? u_) ?? "1"));
 
 				return new CqlQuantity(q_, v_);
 			}
 			else
 			{
-				var w_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", (quantity?.UnitElement?.Value ?? ""));
-				var x_ = context.Operators.Concatenate((w_ ?? ""), " (");
-				var y_ = context.Operators.Concatenate((x_ ?? ""), (quantity?.SystemElement?.Value ?? ""));
-				var z_ = context.Operators.Concatenate((y_ ?? ""), "|");
-				var aa_ = context.Operators.Concatenate((z_ ?? ""), (quantity?.CodeElement?.Value ?? ""));
-				var ab_ = context.Operators.Concatenate((aa_ ?? ""), ")");
-				var ac_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ab_);
+				FhirString w_ = quantity?.UnitElement;
+				string x_ = w_?.Value;
+				string y_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", (x_ ?? ""));
+				string z_ = context.Operators.Concatenate((y_ ?? ""), " (");
+				FhirUri aa_ = quantity?.SystemElement;
+				string ab_ = aa_?.Value;
+				string ac_ = context.Operators.Concatenate((z_ ?? ""), (ab_ ?? ""));
+				string ad_ = context.Operators.Concatenate((ac_ ?? ""), "|");
+				Code ae_ = quantity?.CodeElement;
+				string af_ = ae_?.Value;
+				string ag_ = context.Operators.Concatenate((ad_ ?? ""), (af_ ?? ""));
+				string ah_ = context.Operators.Concatenate((ag_ ?? ""), ")");
+				object ai_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ah_);
 
-				return (ac_ as CqlQuantity);
+				return (ai_ as CqlQuantity);
 			}
 		};
 
@@ -309,13 +319,13 @@ public class FHIRHelpers_4_3_000
 		{
 			bool b_()
 			{
-				var c_ = quantity?.SystemElement;
-				var e_ = c_?.Value;
-				var f_ = context.Operators.Equal(e_, "http://unitsofmeasure.org");
-				var g_ = context.Operators.Or((bool?)(c_ is null), f_);
-				var i_ = c_?.Value;
-				var j_ = context.Operators.Equal(i_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
-				var k_ = context.Operators.Or(g_, j_);
+				FhirUri c_ = quantity?.SystemElement;
+				string e_ = c_?.Value;
+				bool? f_ = context.Operators.Equal(e_, "http://unitsofmeasure.org");
+				bool? g_ = context.Operators.Or((bool?)(c_ is null), f_);
+				string i_ = c_?.Value;
+				bool? j_ = context.Operators.Equal(i_, "http://hl7.org/fhirpath/CodeSystem/calendar-units");
+				bool? k_ = context.Operators.Or(g_, j_);
 
 				return (k_ ?? false);
 			};
@@ -329,27 +339,33 @@ public class FHIRHelpers_4_3_000
 			}
 			else if (b_())
 			{
-				var l_ = quantity?.ValueElement;
-				var m_ = l_?.Value;
-				var n_ = quantity?.CodeElement;
-				var o_ = n_?.Value;
-				var p_ = quantity?.UnitElement;
-				var q_ = p_?.Value;
-				var r_ = this.ToCalendarUnit(((o_ ?? q_) ?? "1"));
+				FhirDecimal l_ = quantity?.ValueElement;
+				decimal? m_ = l_?.Value;
+				Code n_ = quantity?.CodeElement;
+				string o_ = n_?.Value;
+				FhirString p_ = quantity?.UnitElement;
+				string q_ = p_?.Value;
+				string r_ = this.ToCalendarUnit(((o_ ?? q_) ?? "1"));
 
 				return new CqlQuantity(m_, r_);
 			}
 			else
 			{
-				var s_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", (quantity?.UnitElement?.Value ?? ""));
-				var t_ = context.Operators.Concatenate((s_ ?? ""), " (");
-				var u_ = context.Operators.Concatenate((t_ ?? ""), (quantity?.SystemElement?.Value ?? ""));
-				var v_ = context.Operators.Concatenate((u_ ?? ""), "|");
-				var w_ = context.Operators.Concatenate((v_ ?? ""), (quantity?.CodeElement?.Value ?? ""));
-				var x_ = context.Operators.Concatenate((w_ ?? ""), ")");
-				var y_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", x_);
+				FhirString s_ = quantity?.UnitElement;
+				string t_ = s_?.Value;
+				string u_ = context.Operators.Concatenate("Invalid FHIR Quantity code: ", (t_ ?? ""));
+				string v_ = context.Operators.Concatenate((u_ ?? ""), " (");
+				FhirUri w_ = quantity?.SystemElement;
+				string x_ = w_?.Value;
+				string y_ = context.Operators.Concatenate((v_ ?? ""), (x_ ?? ""));
+				string z_ = context.Operators.Concatenate((y_ ?? ""), "|");
+				Code aa_ = quantity?.CodeElement;
+				string ab_ = aa_?.Value;
+				string ac_ = context.Operators.Concatenate((z_ ?? ""), (ab_ ?? ""));
+				string ad_ = context.Operators.Concatenate((ac_ ?? ""), ")");
+				object ae_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ad_);
 
-				return (y_ as CqlQuantity);
+				return (ae_ as CqlQuantity);
 			}
 		};
 
@@ -368,10 +384,12 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				var b_ = this.ToQuantity(ratio?.Numerator);
-				var c_ = this.ToQuantity(ratio?.Denominator);
+				Quantity b_ = ratio?.Numerator;
+				CqlQuantity c_ = this.ToQuantity(b_);
+				Quantity d_ = ratio?.Denominator;
+				CqlQuantity e_ = this.ToQuantity(d_);
 
-				return new CqlRatio(b_, c_);
+				return new CqlRatio(c_, e_);
 			}
 		};
 
@@ -390,7 +408,16 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				return new CqlCode(coding?.CodeElement?.Value, coding?.SystemElement?.Value, coding?.VersionElement?.Value, coding?.DisplayElement?.Value);
+				Code b_ = coding?.CodeElement;
+				string c_ = b_?.Value;
+				FhirUri d_ = coding?.SystemElement;
+				string e_ = d_?.Value;
+				FhirString f_ = coding?.VersionElement;
+				string g_ = f_?.Value;
+				FhirString h_ = coding?.DisplayElement;
+				string i_ = h_?.Value;
+
+				return new CqlCode(c_, e_, g_, i_);
 			}
 		};
 
@@ -409,15 +436,18 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				CqlCode b_(Coding C)
+				List<Coding> b_ = concept?.Coding;
+				CqlCode c_(Coding C)
 				{
-					var d_ = this.ToCode(C);
+					CqlCode g_ = this.ToCode(C);
 
-					return d_;
+					return g_;
 				};
-				var c_ = context.Operators.Select<Coding, CqlCode>((IEnumerable<Coding>)concept?.Coding, b_);
+				IEnumerable<CqlCode> d_ = context.Operators.Select<Coding, CqlCode>((IEnumerable<Coding>)b_, c_);
+				FhirString e_ = concept?.TextElement;
+				string f_ = e_?.Value;
 
-				return new CqlConcept(c_, concept?.TextElement?.Value);
+				return new CqlConcept(d_, f_);
 			}
 		};
 
@@ -436,7 +466,7 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				var b_ = new CqlValueSet
+				CqlValueSet b_ = new CqlValueSet
 				{
 					id = uri,
 				};
@@ -460,11 +490,11 @@ public class FHIRHelpers_4_3_000
 			}
 			else
 			{
-				var b_ = new FhirString
+				FhirString b_ = new FhirString
 				{
 					Value = reference,
 				};
-				var c_ = new ResourceReference
+				ResourceReference c_ = new ResourceReference
 				{
 					ReferenceElement = b_,
 				};
@@ -489,179 +519,179 @@ public class FHIRHelpers_4_3_000
 		{
 			if (value is Base64Binary)
 			{
-				var b_ = (value as Base64Binary)?.Value;
-				var c_ = context.Operators.Convert<string>(b_);
+				byte[] b_ = (value as Base64Binary)?.Value;
+				string c_ = context.Operators.Convert<string>(b_);
 
 				return (c_ as object);
 			}
 			else if (value is FhirBoolean)
 			{
-				var d_ = (value as FhirBoolean)?.Value;
+				bool? d_ = (value as FhirBoolean)?.Value;
 
 				return d_;
 			}
 			else if (value is Canonical)
 			{
-				var e_ = (value as Canonical)?.Value;
+				string e_ = (value as Canonical)?.Value;
 
 				return (e_ as object);
 			}
 			else if (value is Code)
 			{
-				var f_ = (value as Code)?.Value;
+				string f_ = (value as Code)?.Value;
 
 				return (f_ as object);
 			}
 			else if (value is Date)
 			{
-				var g_ = (value as Date)?.Value;
-				var h_ = context.Operators.ConvertStringToDate(g_);
+				string g_ = (value as Date)?.Value;
+				CqlDate h_ = context.Operators.ConvertStringToDate(g_);
 
 				return (h_ as object);
 			}
 			else if (value is FhirDateTime)
 			{
-				var i_ = context.Operators.Convert<CqlDateTime>((value as FhirDateTime));
+				CqlDateTime i_ = context.Operators.Convert<CqlDateTime>((value as FhirDateTime));
 
 				return (i_ as object);
 			}
 			else if (value is FhirDecimal)
 			{
-				var j_ = (value as FhirDecimal)?.Value;
+				decimal? j_ = (value as FhirDecimal)?.Value;
 
 				return j_;
 			}
 			else if (value is Id)
 			{
-				var k_ = (value as Id)?.Value;
+				string k_ = (value as Id)?.Value;
 
 				return (k_ as object);
 			}
 			else if (value is Instant)
 			{
-				var l_ = (value as Instant)?.Value;
-				var m_ = context.Operators.Convert<CqlDateTime>(l_);
+				DateTimeOffset? l_ = (value as Instant)?.Value;
+				CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
 
 				return (m_ as object);
 			}
 			else if (value is Integer)
 			{
-				var n_ = (value as Integer)?.Value;
+				int? n_ = (value as Integer)?.Value;
 
 				return n_;
 			}
 			else if (value is Markdown)
 			{
-				var o_ = (value as Markdown)?.Value;
+				string o_ = (value as Markdown)?.Value;
 
 				return (o_ as object);
 			}
 			else if (value is Oid)
 			{
-				var p_ = (value as Oid)?.Value;
+				string p_ = (value as Oid)?.Value;
 
 				return (p_ as object);
 			}
 			else if (value is Integer)
 			{
-				var q_ = (value as Integer)?.Value;
+				int? q_ = (value as Integer)?.Value;
 
 				return q_;
 			}
 			else if (value is FhirString)
 			{
-				var r_ = (value as FhirString)?.Value;
+				string r_ = (value as FhirString)?.Value;
 
 				return (r_ as object);
 			}
 			else if (value is Time)
 			{
-				var s_ = (value as Time)?.Value;
-				var t_ = context.Operators.ConvertStringToTime(s_);
+				string s_ = (value as Time)?.Value;
+				CqlTime t_ = context.Operators.ConvertStringToTime(s_);
 
 				return (t_ as object);
 			}
 			else if (value is Integer)
 			{
-				var u_ = (value as Integer)?.Value;
+				int? u_ = (value as Integer)?.Value;
 
 				return u_;
 			}
 			else if (value is FhirUri)
 			{
-				var v_ = (value as FhirUri)?.Value;
+				string v_ = (value as FhirUri)?.Value;
 
 				return (v_ as object);
 			}
 			else if (value is FhirUrl)
 			{
-				var w_ = (value as FhirUrl)?.Value;
+				string w_ = (value as FhirUrl)?.Value;
 
 				return (w_ as object);
 			}
 			else if (value is Uuid)
 			{
-				var x_ = (value as Uuid)?.Value;
+				string x_ = (value as Uuid)?.Value;
 
 				return (x_ as object);
 			}
 			else if (value is Age)
 			{
-				var y_ = this.ToQuantity((value as Age));
+				CqlQuantity y_ = this.ToQuantity((Quantity)(value as Age));
 
 				return (y_ as object);
 			}
 			else if (value is CodeableConcept)
 			{
-				var z_ = this.ToConcept((value as CodeableConcept));
+				CqlConcept z_ = this.ToConcept((value as CodeableConcept));
 
 				return (z_ as object);
 			}
 			else if (value is Coding)
 			{
-				var aa_ = this.ToCode((value as Coding));
+				CqlCode aa_ = this.ToCode((value as Coding));
 
 				return (aa_ as object);
 			}
 			else if (value is Count)
 			{
-				var ab_ = this.ToQuantity((value as Count));
+				CqlQuantity ab_ = this.ToQuantity((Quantity)(value as Count));
 
 				return (ab_ as object);
 			}
 			else if (value is Distance)
 			{
-				var ac_ = this.ToQuantity((value as Distance));
+				CqlQuantity ac_ = this.ToQuantity((Quantity)(value as Distance));
 
 				return (ac_ as object);
 			}
 			else if (value is Duration)
 			{
-				var ad_ = this.ToQuantity((value as Duration));
+				CqlQuantity ad_ = this.ToQuantity((Quantity)(value as Duration));
 
 				return (ad_ as object);
 			}
 			else if (value is Quantity)
 			{
-				var ae_ = this.ToQuantity((value as Quantity));
+				CqlQuantity ae_ = this.ToQuantity((value as Quantity));
 
 				return (ae_ as object);
 			}
 			else if (value is Range)
 			{
-				var af_ = this.ToInterval((value as Range));
+				CqlInterval<CqlQuantity> af_ = this.ToInterval((value as Range));
 
 				return (af_ as object);
 			}
 			else if (value is Period)
 			{
-				var ag_ = this.ToInterval((value as Period));
+				CqlInterval<CqlDateTime> ag_ = this.ToInterval((value as Period));
 
 				return (ag_ as object);
 			}
 			else if (value is Ratio)
 			{
-				var ah_ = this.ToRatio((value as Ratio));
+				CqlRatio ah_ = this.ToRatio((value as Ratio));
 
 				return (ah_ as object);
 			}
@@ -781,1739 +811,1973 @@ public class FHIRHelpers_4_3_000
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Account.AccountStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Account.AccountStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionCardinalityBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionCardinalityBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionConditionKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionConditionKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionGroupingBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionGroupingBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionParticipantType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionParticipantType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionPrecheckBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionPrecheckBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionRelationshipType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionRelationshipType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionRequiredBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionRequiredBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActionSelectionBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActionSelectionBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ActivityDefinition.RequestResourceType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ActivityDefinition.RequestResourceType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Address.AddressType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Address.AddressType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Address.AddressUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Address.AddressUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AdministrativeGender> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AdministrativeGender? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AdverseEvent.AdverseEventActuality> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AdverseEvent.AdverseEventActuality? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.AggregationMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.AggregationMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AllergyIntolerance.AllergyIntoleranceCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AllergyIntolerance.AllergyIntoleranceCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AllergyIntolerance.AllergyIntoleranceCriticality> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AllergyIntolerance.AllergyIntoleranceCriticality? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AllergyIntolerance.AllergyIntoleranceSeverity> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AllergyIntolerance.AllergyIntoleranceSeverity? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AllergyIntolerance.AllergyIntoleranceType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AllergyIntolerance.AllergyIntoleranceType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Appointment.AppointmentStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Appointment.AppointmentStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestScript.AssertionDirectionType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestScript.AssertionDirectionType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestScript.AssertionOperatorType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestScript.AssertionOperatorType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestScript.AssertionResponseTypes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestScript.AssertionResponseTypes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AuditEvent.AuditEventAction> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AuditEvent.AuditEventAction? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AuditEvent.AuditEventAgentNetworkType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AuditEvent.AuditEventAgentNetworkType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<AuditEvent.AuditEventOutcome> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		AuditEvent.AuditEventOutcome? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<BindingStrength> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		BindingStrength? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<BiologicallyDerivedProduct.BiologicallyDerivedProductCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		BiologicallyDerivedProduct.BiologicallyDerivedProductCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<BiologicallyDerivedProduct.BiologicallyDerivedProductStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		BiologicallyDerivedProduct.BiologicallyDerivedProductStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<BiologicallyDerivedProduct.BiologicallyDerivedProductStorageScale> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		BiologicallyDerivedProduct.BiologicallyDerivedProductStorageScale? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Bundle.BundleType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Bundle.BundleType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatementKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatementKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CarePlan.CarePlanActivityKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CarePlan.CarePlanActivityKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CarePlan.CarePlanActivityStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CarePlan.CarePlanActivityStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CarePlan.CarePlanIntent> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CarePlan.CarePlanIntent? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<RequestStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		RequestStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CareTeam.CareTeamStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CareTeam.CareTeamStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CatalogEntry.CatalogEntryRelationType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CatalogEntry.CatalogEntryRelationType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<InvoicePriceComponentType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		InvoicePriceComponentType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ChargeItem.ChargeItemStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ChargeItem.ChargeItemStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FinancialResourceStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FinancialResourceStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ClinicalImpression.ClinicalImpressionStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ClinicalImpression.ClinicalImpressionStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TerminologyCapabilities.CodeSearchSupport> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TerminologyCapabilities.CodeSearchSupport? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CodeSystemContentMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CodeSystemContentMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CodeSystem.CodeSystemHierarchyMeaning> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CodeSystem.CodeSystemHierarchyMeaning? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<RequestPriority> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		RequestPriority? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<EventStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		EventStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CompartmentType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CompartmentType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Composition.CompositionAttestationMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Composition.CompositionAttestationMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CompositionStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CompositionStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ConceptMapEquivalence> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ConceptMapEquivalence? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ConceptMap.ConceptMapGroupUnmappedMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ConceptMap.ConceptMapGroupUnmappedMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.ConditionalDeleteStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.ConditionalDeleteStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.ConditionalReadStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.ConditionalReadStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Consent.ConsentDataMeaning> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Consent.ConsentDataMeaning? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Consent.ConsentProvisionType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Consent.ConsentProvisionType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Consent.ConsentState> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Consent.ConsentState? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ConstraintSeverity> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ConstraintSeverity? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ContactPoint.ContactPointSystem> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ContactPoint.ContactPointSystem? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ContactPoint.ContactPointUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ContactPoint.ContactPointUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Contract.ContractResourcePublicationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Contract.ContractResourcePublicationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Contract.ContractResourceStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Contract.ContractResourceStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Contributor.ContributorType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Contributor.ContributorType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Money.Currencies> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Money.Currencies? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DaysOfWeek> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DaysOfWeek? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DetectedIssue.DetectedIssueSeverity> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DetectedIssue.DetectedIssueSeverity? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ObservationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ObservationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricCalibrationState> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricCalibrationState? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricCalibrationType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricCalibrationType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricColor> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricColor? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceMetric.DeviceMetricOperationalStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceMetric.DeviceMetricOperationalStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceNameType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceNameType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DeviceUseStatement.DeviceUseStatementStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DeviceUseStatement.DeviceUseStatementStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DiagnosticReport.DiagnosticReportStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DiagnosticReport.DiagnosticReportStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.DiscriminatorType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.DiscriminatorType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Composition.V3ConfidentialityClassification> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Composition.V3ConfidentialityClassification? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.DocumentMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.DocumentMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DocumentReferenceStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DocumentReferenceStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DocumentRelationshipType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DocumentRelationshipType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CoverageEligibilityRequest.EligibilityRequestPurpose> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CoverageEligibilityRequest.EligibilityRequestPurpose? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CoverageEligibilityResponse.EligibilityResponsePurpose> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CoverageEligibilityResponse.EligibilityResponsePurpose? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Questionnaire.EnableWhenBehavior> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Questionnaire.EnableWhenBehavior? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Encounter.EncounterLocationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Encounter.EncounterLocationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Encounter.EncounterStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Encounter.EncounterStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Endpoint.EndpointStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Endpoint.EndpointStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<EpisodeOfCare.EpisodeOfCareStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		EpisodeOfCare.EpisodeOfCareStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.EventCapabilityMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.EventCapabilityMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Timing.EventTiming> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Timing.EventTiming? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<VariableTypeCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		VariableTypeCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ExampleScenario.ExampleScenarioActorType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ExampleScenario.ExampleScenarioActorType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ExplanationOfBenefit.ExplanationOfBenefitStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ExplanationOfBenefit.ExplanationOfBenefitStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<EffectEvidenceSynthesis.ExposureStateCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		EffectEvidenceSynthesis.ExposureStateCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureDefinition.ExtensionContextType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureDefinition.ExtensionContextType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FHIRAllTypes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FHIRAllTypes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FHIRDefinedType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FHIRDefinedType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Device.FHIRDeviceStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Device.FHIRDeviceStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ResourceType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ResourceType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Substance.FHIRSubstanceStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Substance.FHIRSubstanceStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FHIRVersion> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FHIRVersion? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FamilyMemberHistory.FamilyHistoryStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FamilyMemberHistory.FamilyHistoryStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<FilterOperator> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		FilterOperator? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Flag.FlagStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Flag.FlagStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Goal.GoalLifecycleStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Goal.GoalLifecycleStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<GraphDefinition.GraphCompartmentRule> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		GraphDefinition.GraphCompartmentRule? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<GraphDefinition.GraphCompartmentUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		GraphDefinition.GraphCompartmentUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<GroupMeasureCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		GroupMeasureCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Group.GroupType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Group.GroupType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<GuidanceResponse.GuidanceResponseStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		GuidanceResponse.GuidanceResponseStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImplementationGuide.GuidePageGeneration> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImplementationGuide.GuidePageGeneration? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImplementationGuide.GuideParameterCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImplementationGuide.GuideParameterCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Bundle.HTTPVerb> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Bundle.HTTPVerb? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Identifier.IdentifierUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Identifier.IdentifierUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Person.IdentityAssuranceLevel> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Person.IdentityAssuranceLevel? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImagingStudy.ImagingStudyStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImagingStudy.ImagingStudyStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImmunizationEvaluation.ImmunizationEvaluationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImmunizationEvaluation.ImmunizationEvaluationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Immunization.ImmunizationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Immunization.ImmunizationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Invoice.InvoiceStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Invoice.InvoiceStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<OperationOutcome.IssueSeverity> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		OperationOutcome.IssueSeverity? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<OperationOutcome.IssueType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		OperationOutcome.IssueType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Patient.LinkType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Patient.LinkType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Linkage.LinkageType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Linkage.LinkageType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ListMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ListMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<List.ListStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		List.ListStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Location.LocationMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Location.LocationMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Location.LocationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Location.LocationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MeasureReport.MeasureReportStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MeasureReport.MeasureReportStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MeasureReport.MeasureReportType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MeasureReport.MeasureReportType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationAdministration.MedicationAdministrationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationAdministration.MedicationAdministrationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationDispense.MedicationDispenseStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationDispense.MedicationDispenseStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationKnowledge.MedicationKnowledgeStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationKnowledge.MedicationKnowledgeStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationRequest.MedicationRequestIntent> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationRequest.MedicationRequestIntent? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationRequest.MedicationrequestStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationRequest.MedicationrequestStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MedicationStatement.MedicationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MedicationStatement.MedicationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Medication.MedicationStatusCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Medication.MedicationStatusCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MessageDefinition.MessageSignificanceCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MessageDefinition.MessageSignificanceCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MessageheaderResponseRequest> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MessageheaderResponseRequest? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("ToString")]
+	public string ToString(Code value)
+	{
+		string a_ = value?.Value;
 
 		return a_;
 	}
 
     [CqlDeclaration("ToString")]
-	public string ToString(Code value) => 
-		value?.Value;
-
-    [CqlDeclaration("ToString")]
 	public string ToString(Code<HumanName.NameUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		HumanName.NameUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<NamingSystem.NamingSystemIdentifierType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		NamingSystem.NamingSystemIdentifierType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<NamingSystem.NamingSystemType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		NamingSystem.NamingSystemType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Narrative.NarrativeStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Narrative.NarrativeStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<NoteType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		NoteType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<RequestIntent> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		RequestIntent? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ObservationDefinition.ObservationDataType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ObservationDefinition.ObservationDataType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ObservationDefinition.ObservationRangeCategory> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ObservationDefinition.ObservationRangeCategory? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<OperationDefinition.OperationKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		OperationDefinition.OperationKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<OperationParameterUse> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		OperationParameterUse? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.OrientationType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.OrientationType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Appointment.ParticipantRequired> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Appointment.ParticipantRequired? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ParticipationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ParticipationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.PropertyRepresentation> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.PropertyRepresentation? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CodeSystem.PropertyType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CodeSystem.PropertyType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Provenance.ProvenanceEntityRole> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Provenance.ProvenanceEntityRole? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<PublicationStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		PublicationStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.QualityType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.QualityType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Quantity.QuantityComparator> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Quantity.QuantityComparator? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Questionnaire.QuestionnaireItemOperator> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Questionnaire.QuestionnaireItemOperator? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Questionnaire.QuestionnaireItemType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Questionnaire.QuestionnaireItemType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<QuestionnaireResponse.QuestionnaireResponseStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		QuestionnaireResponse.QuestionnaireResponseStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.ReferenceHandlingPolicy> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.ReferenceHandlingPolicy? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.ReferenceVersionRules> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.ReferenceVersionRules? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<RelatedArtifact.RelatedArtifactType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		RelatedArtifact.RelatedArtifactType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ClaimProcessingCodes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ClaimProcessingCodes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.RepositoryType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.RepositoryType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ResearchElementDefinition.ResearchElementType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ResearchElementDefinition.ResearchElementType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ResearchStudy.ResearchStudyStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ResearchStudy.ResearchStudyStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ResearchSubject.ResearchSubjectStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ResearchSubject.ResearchSubjectStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.ResourceVersionPolicy> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.ResourceVersionPolicy? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MessageHeader.ResponseType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MessageHeader.ResponseType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.RestfulCapabilityMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.RestfulCapabilityMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ImplementationGuide.SPDXLicense> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ImplementationGuide.SPDXLicense? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SearchParameter.SearchComparator> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SearchParameter.SearchComparator? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Bundle.SearchEntryMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Bundle.SearchEntryMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SearchParameter.SearchModifierCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SearchParameter.SearchModifierCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SearchParamType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SearchParamType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.SequenceType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.SequenceType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ElementDefinition.SlicingRules> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ElementDefinition.SlicingRules? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Slot.SlotStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Slot.SlotStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<DataRequirement.SortDirection> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		DataRequirement.SortDirection? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SpecimenDefinition.SpecimenContainedPreference> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SpecimenDefinition.SpecimenContainedPreference? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Specimen.SpecimenStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Specimen.SpecimenStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<VerificationResult.StatusCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		VerificationResult.StatusCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<MolecularSequence.StrandType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		MolecularSequence.StrandType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureDefinition.StructureDefinitionKind> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureDefinition.StructureDefinitionKind? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapContextType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapContextType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapGroupTypeMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapGroupTypeMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapInputMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapInputMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapModelMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapModelMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapSourceListMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapSourceListMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapTargetListMode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapTargetListMode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureMap.StructureMapTransform> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureMap.StructureMapTransform? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Subscription.SubscriptionChannelType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Subscription.SubscriptionChannelType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Subscription.SubscriptionStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Subscription.SubscriptionStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SupplyDelivery.SupplyDeliveryStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SupplyDelivery.SupplyDeliveryStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SupplyRequest.SupplyRequestStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SupplyRequest.SupplyRequestStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.SystemRestfulInteraction> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.SystemRestfulInteraction? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Task.TaskIntent> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Task.TaskIntent? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Task.TaskStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Task.TaskStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestReport.TestReportActionResult> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestReport.TestReportActionResult? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestReport.TestReportParticipantType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestReport.TestReportParticipantType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestReport.TestReportResult> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestReport.TestReportResult? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestReport.TestReportStatus> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestReport.TestReportStatus? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TestScript.TestScriptRequestMethodCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TestScript.TestScriptRequestMethodCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<TriggerDefinition.TriggerType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		TriggerDefinition.TriggerType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<StructureDefinition.TypeDerivationRule> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		StructureDefinition.TypeDerivationRule? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<CapabilityStatement.TypeRestfulInteraction> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		CapabilityStatement.TypeRestfulInteraction? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Device.UDIEntryType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Device.UDIEntryType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<Timing.UnitsOfTime> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		Timing.UnitsOfTime? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<ClaimUseCode> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		ClaimUseCode? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<VisionPrescription.VisionBase> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		VisionPrescription.VisionBase? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<VisionPrescription.VisionEyes> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		VisionPrescription.VisionEyes? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Code<SearchParameter.XPathUsageType> value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		SearchParameter.XPathUsageType? a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToString")]
 	public string ToString(Base64Binary value)
 	{
-		var a_ = context.Operators.Convert<string>(value?.Value);
+		byte[] a_ = value?.Value;
+		string b_ = context.Operators.Convert<string>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("ToString")]
+	public string ToString(FhirString value)
+	{
+		string a_ = value?.Value;
 
 		return a_;
 	}
 
     [CqlDeclaration("ToString")]
-	public string ToString(FhirString value) => 
-		value?.Value;
+	public string ToString(FhirUri value)
+	{
+		string a_ = value?.Value;
+
+		return a_;
+	}
 
     [CqlDeclaration("ToString")]
-	public string ToString(FhirUri value) => 
-		value?.Value;
+	public string ToString(XHtml value)
+	{
+		string a_ = value?.Value;
 
-    [CqlDeclaration("ToString")]
-	public string ToString(XHtml value) => 
-		value?.Value;
+		return a_;
+	}
 
     [CqlDeclaration("ToBoolean")]
-	public bool? ToBoolean(FhirBoolean value) => 
-		value?.Value;
+	public bool? ToBoolean(FhirBoolean value)
+	{
+		bool? a_ = value?.Value;
+
+		return a_;
+	}
 
     [CqlDeclaration("ToDate")]
 	public CqlDate ToDate(Date value)
 	{
-		var a_ = context.Operators.ConvertStringToDate(value?.Value);
+		string a_ = value?.Value;
+		CqlDate b_ = context.Operators.ConvertStringToDate(a_);
 
-		return a_;
+		return b_;
 	}
 
     [CqlDeclaration("ToDateTime")]
 	public CqlDateTime ToDateTime(FhirDateTime value)
 	{
-		var a_ = context.Operators.Convert<CqlDateTime>(value);
+		CqlDateTime a_ = context.Operators.Convert<CqlDateTime>(value);
 
 		return a_;
 	}
@@ -2521,25 +2785,35 @@ public class FHIRHelpers_4_3_000
     [CqlDeclaration("ToDateTime")]
 	public CqlDateTime ToDateTime(Instant value)
 	{
-		var a_ = context.Operators.Convert<CqlDateTime>(value?.Value);
+		DateTimeOffset? a_ = value?.Value;
+		CqlDateTime b_ = context.Operators.Convert<CqlDateTime>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("ToDecimal")]
+	public decimal? ToDecimal(FhirDecimal value)
+	{
+		decimal? a_ = value?.Value;
 
 		return a_;
 	}
 
-    [CqlDeclaration("ToDecimal")]
-	public decimal? ToDecimal(FhirDecimal value) => 
-		value?.Value;
-
     [CqlDeclaration("ToInteger")]
-	public int? ToInteger(Integer value) => 
-		value?.Value;
+	public int? ToInteger(Integer value)
+	{
+		int? a_ = value?.Value;
+
+		return a_;
+	}
 
     [CqlDeclaration("ToTime")]
 	public CqlTime ToTime(Time value)
 	{
-		var a_ = context.Operators.ConvertStringToTime(value?.Value);
+		string a_ = value?.Value;
+		CqlTime b_ = context.Operators.ConvertStringToTime(a_);
 
-		return a_;
+		return b_;
 	}
 
 }

--- a/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
@@ -351,7 +351,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 			Period aw_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
 			CqlInterval<CqlDateTime> ay_ = QICoreCommon_2_0_000.ToInterval((ax_ as object));
-			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(av_, ay_, "day");
+			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(av_, ay_, null);
 
 			return az_;
 		};
@@ -373,7 +373,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 65);
 		IEnumerable<Encounter> j_ = this.Qualifying_Encounter();
 		bool? k_ = context.Operators.Exists<Encounter>(j_);
@@ -419,7 +419,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 			DataType h_ = FallsScreening?.Effective;
 			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
 			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval(i_);
-			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, null);
 
 			return k_;
 		};

--- a/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
@@ -425,7 +425,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		int? d_ = context.Operators.Subtract(c_, 1);
 		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime f_ = context.Operators.DateTime(d_, 3, 1, 0, 0, 0, 0, e_);
@@ -441,7 +441,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		decimal? d_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime e_ = context.Operators.DateTime(c_, 3, 1, 23, 59, 59, 0, d_);
 		CqlQuantity f_ = context.Operators.Quantity(1m, "day");
@@ -734,7 +734,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			Period ao_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
 			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.ToInterval((ap_ as object));
-			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(an_, aq_, "day");
+			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(an_, aq_, null);
 
 			return ar_;
 		};
@@ -828,7 +828,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			CqlQuantity j_ = context.Operators.Quantity(30m, "days");
 			CqlDate k_ = context.Operators.Add(h_, j_);
 			CqlInterval<CqlDate> l_ = context.Operators.Interval(h_, k_, false, true);
-			bool? m_ = context.Operators.In<CqlDate>(g_, l_, "day");
+			bool? m_ = context.Operators.In<CqlDate>(g_, l_, null);
 			bool? o_ = context.Operators.Not((bool?)(h_ is null));
 			bool? p_ = context.Operators.And(m_, o_);
 
@@ -852,14 +852,14 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Intake_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 6);
 		Date k_ = a_?.BirthDateElement;
 		string l_ = k_?.Value;
 		CqlDate m_ = context.Operators.ConvertStringToDate(l_);
 		CqlDateTime o_ = context.Operators.End(e_);
 		CqlDate p_ = context.Operators.DateFrom(o_);
-		int? q_ = context.Operators.CalculateAgeAt(m_, p_, "year");
+		int? q_ = context.Operators.CalculateAgeAt(m_, p_, null);
 		bool? r_ = context.Operators.LessOrEqual(q_, 12);
 		bool? s_ = context.Operators.And(i_, r_);
 		IEnumerable<Encounter> t_ = this.Qualifying_Encounter();
@@ -1015,7 +1015,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			CqlQuantity j_ = context.Operators.Quantity(30m, "days");
 			CqlDate k_ = context.Operators.Add(h_, j_);
 			CqlInterval<CqlDate> l_ = context.Operators.Interval(h_, k_, false, true);
-			bool? m_ = context.Operators.In<CqlDate>(g_, l_, "day");
+			bool? m_ = context.Operators.In<CqlDate>(g_, l_, null);
 			bool? o_ = context.Operators.Not((bool?)(h_ is null));
 			bool? p_ = context.Operators.And(m_, o_);
 
@@ -1429,7 +1429,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			CqlQuantity j_ = context.Operators.Quantity(300m, "days");
 			CqlDate k_ = context.Operators.Add(h_, j_);
 			CqlInterval<CqlDate> l_ = context.Operators.Interval(h_, k_, false, true);
-			bool? m_ = context.Operators.In<CqlDate>(g_, l_, "day");
+			bool? m_ = context.Operators.In<CqlDate>(g_, l_, null);
 			bool? o_ = context.Operators.Not((bool?)(h_ is null));
 			bool? p_ = context.Operators.And(m_, o_);
 
@@ -1453,14 +1453,14 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Intake_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 6);
 		Date k_ = a_?.BirthDateElement;
 		string l_ = k_?.Value;
 		CqlDate m_ = context.Operators.ConvertStringToDate(l_);
 		CqlDateTime o_ = context.Operators.End(e_);
 		CqlDate p_ = context.Operators.DateFrom(o_);
-		int? q_ = context.Operators.CalculateAgeAt(m_, p_, "year");
+		int? q_ = context.Operators.CalculateAgeAt(m_, p_, null);
 		bool? r_ = context.Operators.LessOrEqual(q_, 12);
 		bool? s_ = context.Operators.And(i_, r_);
 		IEnumerable<Encounter> t_ = this.Qualifying_Encounter();
@@ -1509,7 +1509,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			CqlQuantity n_ = context.Operators.Quantity(300m, "days");
 			CqlDate o_ = context.Operators.Add(j_, n_);
 			CqlInterval<CqlDate> p_ = context.Operators.Interval(l_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDate>(i_, p_, "day");
+			bool? q_ = context.Operators.In<CqlDate>(i_, p_, null);
 
 			return q_;
 		};
@@ -1561,7 +1561,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			CqlQuantity o_ = context.Operators.Quantity(300m, "days");
 			CqlDate p_ = context.Operators.Add(k_, o_);
 			CqlInterval<CqlDate> q_ = context.Operators.Interval(m_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDate>(j_, q_, "day");
+			bool? r_ = context.Operators.In<CqlDate>(j_, q_, null);
 
 			return r_;
 		};

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
@@ -610,7 +610,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		int? d_ = context.Operators.Subtract(c_, 1);
 		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime f_ = context.Operators.DateTime(d_, 11, 1, 0, 0, 0, 0, e_);
@@ -671,7 +671,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			Period ah_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_3_000.ToInterval(ah_);
 			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval((ai_ as object));
-			bool? ak_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ag_, aj_, "day");
+			bool? ak_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ag_, aj_, null);
 
 			return ak_;
 		};
@@ -689,7 +689,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		int? d_ = context.Operators.Subtract(c_, 2);
 		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime f_ = context.Operators.DateTime(d_, 11, 1, 0, 0, 0, 0, e_);
@@ -705,7 +705,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		int? d_ = context.Operators.Subtract(c_, 1);
 		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime f_ = context.Operators.DateTime(d_, 10, 31, 23, 59, 59, 0, e_);
@@ -731,7 +731,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			CqlDateTime j_ = this.November_1_Two_Years_Prior_to_the_Measurement_Period();
 			CqlDateTime k_ = this.October_31_Year_Prior_to_the_Measurement_Period();
 			CqlInterval<CqlDateTime> l_ = context.Operators.Interval(j_, k_, true, true);
-			bool? m_ = context.Operators.In<CqlDateTime>(i_, l_, "day");
+			bool? m_ = context.Operators.In<CqlDateTime>(i_, l_, null);
 
 			return m_;
 		};
@@ -757,7 +757,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
 		CqlDateTime j_ = context.Operators.Start(i_);
 		CqlDate k_ = context.Operators.DateFrom(j_);
-		int? l_ = context.Operators.CalculateAgeAt(h_, k_, "year");
+		int? l_ = context.Operators.CalculateAgeAt(h_, k_, null);
 		bool? m_ = context.Operators.GreaterOrEqual(l_, 19);
 		bool? n_ = context.Operators.And(d_, m_);
 
@@ -865,7 +865,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				DataType o_ = PartialTHAProcedure?.Performed;
 				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
 				CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
-				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, "day");
+				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, null);
 
 				return r_;
 			};
@@ -902,7 +902,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				DataType o_ = RevisionTHAProcedure?.Performed;
 				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
 				CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
-				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, "day");
+				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, null);
 
 				return r_;
 			};
@@ -1022,7 +1022,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlDateTime ae_ = context.Operators.Start(ad_);
 				CqlDateTime ag_ = context.Operators.Add(ae_, z_);
 				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(aa_, ag_, true, true);
-				bool? ai_ = context.Operators.In<CqlDateTime>(u_, ah_, "day");
+				bool? ai_ = context.Operators.In<CqlDateTime>(u_, ah_, null);
 				bool? aj_ = context.Operators.And(q_, ai_);
 
 				return aj_;
@@ -1065,7 +1065,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			CqlQuantity s_ = context.Operators.Quantity(300m, "days");
 			CqlDate t_ = context.Operators.Add(r_, s_);
 			CqlInterval<CqlDate> u_ = context.Operators.Interval(m_, t_, true, true);
-			bool? v_ = context.Operators.In<CqlDate>(h_, u_, "day");
+			bool? v_ = context.Operators.In<CqlDate>(h_, u_, null);
 
 			return v_;
 		};
@@ -1155,7 +1155,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
 			CqlDateTime ak_ = context.Operators.Start(aj_);
 			CqlDate al_ = context.Operators.DateFrom(ak_);
-			bool? am_ = context.Operators.SameAs(ag_, al_, "day");
+			bool? am_ = context.Operators.SameAs(ag_, al_, null);
 			DataType an_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSport?.Value;
 			object ao_ = FHIRHelpers_4_3_000.ToValue(an_);
 			bool? ap_ = context.Operators.Not((bool?)(ao_ is null));
@@ -1169,7 +1169,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			CqlInterval<CqlDateTime> ay_ = QICoreCommon_2_0_000.toInterval(ax_);
 			CqlDateTime az_ = context.Operators.Start(ay_);
 			CqlDate ba_ = context.Operators.DateFrom(az_);
-			bool? bb_ = context.Operators.SameAs(av_, ba_, "day");
+			bool? bb_ = context.Operators.SameAs(av_, ba_, null);
 			bool? bc_ = context.Operators.And(aq_, bb_);
 			DataType bd_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSActivityScore?.Value;
 			object be_ = FHIRHelpers_4_3_000.ToValue(bd_);
@@ -1184,7 +1184,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			CqlInterval<CqlDateTime> bo_ = QICoreCommon_2_0_000.toInterval(bn_);
 			CqlDateTime bp_ = context.Operators.Start(bo_);
 			CqlDate bq_ = context.Operators.DateFrom(bp_);
-			bool? br_ = context.Operators.SameAs(bl_, bq_, "day");
+			bool? br_ = context.Operators.SameAs(bl_, bq_, null);
 			bool? bs_ = context.Operators.And(bg_, br_);
 			DataType bt_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSSymptoms?.Value;
 			object bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
@@ -1199,7 +1199,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			CqlInterval<CqlDateTime> ce_ = QICoreCommon_2_0_000.toInterval(cd_);
 			CqlDateTime cf_ = context.Operators.Start(ce_);
 			CqlDate cg_ = context.Operators.DateFrom(cf_);
-			bool? ch_ = context.Operators.SameAs(cb_, cg_, "day");
+			bool? ch_ = context.Operators.SameAs(cb_, cg_, null);
 			bool? ci_ = context.Operators.And(bw_, ch_);
 			DataType cj_ = tuple_eipfmazvhfscjijaofhicpvmb.HOOSPain?.Value;
 			object ck_ = FHIRHelpers_4_3_000.ToValue(cj_);
@@ -1295,7 +1295,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessmentHOOS, ag_, true, true);
 				bool? ai_ = ah_?.highClosed;
 				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, null);
 				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessmentHOOS is null));
 				bool? am_ = context.Operators.And(ak_, al_);
 
@@ -1324,7 +1324,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
 				CqlDate bb_ = context.Operators.Add(az_, ba_);
 				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, null);
 
 				return bd_;
 			};
@@ -1412,7 +1412,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessment, ag_, true, true);
 				bool? ai_ = ah_?.highClosed;
 				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, null);
 				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessment is null));
 				bool? am_ = context.Operators.And(ak_, al_);
 
@@ -1441,7 +1441,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
 				CqlDate bb_ = context.Operators.Add(az_, ba_);
 				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, null);
 
 				return bd_;
 			};
@@ -1494,7 +1494,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.toInterval(u_);
 			CqlDateTime w_ = context.Operators.Start(v_);
 			CqlDate x_ = context.Operators.DateFrom(w_);
-			bool? y_ = context.Operators.SameAs(s_, x_, "day");
+			bool? y_ = context.Operators.SameAs(s_, x_, null);
 			DataType z_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10PhysicalScore?.Value;
 			object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
 			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
@@ -1571,7 +1571,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessmentPROMIS10, ag_, true, true);
 				bool? ai_ = ah_?.highClosed;
 				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, null);
 				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessmentPROMIS10 is null));
 				bool? am_ = context.Operators.And(ak_, al_);
 
@@ -1600,7 +1600,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
 				CqlDate bb_ = context.Operators.Add(az_, ba_);
 				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, null);
 
 				return bd_;
 			};
@@ -1653,7 +1653,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.toInterval(u_);
 			CqlDateTime w_ = context.Operators.Start(v_);
 			CqlDate x_ = context.Operators.DateFrom(w_);
-			bool? y_ = context.Operators.SameAs(s_, x_, "day");
+			bool? y_ = context.Operators.SameAs(s_, x_, null);
 			DataType z_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
 			object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
 			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
@@ -1730,7 +1730,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessmentOblique, ag_, true, true);
 				bool? ai_ = ah_?.highClosed;
 				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, null);
 				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessmentOblique is null));
 				bool? am_ = context.Operators.And(ak_, al_);
 
@@ -1759,7 +1759,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
 				CqlDate bb_ = context.Operators.Add(az_, ba_);
 				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, null);
 
 				return bd_;
 			};
@@ -1812,7 +1812,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 			CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.toInterval(u_);
 			CqlDateTime w_ = context.Operators.Start(v_);
 			CqlDate x_ = context.Operators.DateFrom(w_);
-			bool? y_ = context.Operators.SameAs(s_, x_, "day");
+			bool? y_ = context.Operators.SameAs(s_, x_, null);
 			DataType z_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
 			object aa_ = FHIRHelpers_4_3_000.ToValue(z_);
 			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
@@ -1889,7 +1889,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlInterval<CqlDate> ah_ = context.Operators.Interval(InitialHipAssessmentOrthogonal, ag_, true, true);
 				bool? ai_ = ah_?.highClosed;
 				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(v_, aa_, ae_, ai_);
-				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, "day");
+				bool? ak_ = context.Operators.In<CqlDateTime>(q_, aj_, null);
 				bool? al_ = context.Operators.Not((bool?)(InitialHipAssessmentOrthogonal is null));
 				bool? am_ = context.Operators.And(ak_, al_);
 
@@ -1918,7 +1918,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlQuantity ba_ = context.Operators.Quantity(425m, "days");
 				CqlDate bb_ = context.Operators.Add(az_, ba_);
 				CqlInterval<CqlDate> bc_ = context.Operators.Interval(ax_, bb_, true, true);
-				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, "day");
+				bool? bd_ = context.Operators.In<CqlDate>(at_, bc_, null);
 
 				return bd_;
 			};

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
@@ -567,7 +567,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			Period m_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, "day");
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
 
 			return p_;
 		};
@@ -607,7 +607,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(1m, "day");
 			CqlDateTime t_ = context.Operators.Add(r_, s_);
-			bool? u_ = context.Operators.SameOrAfter(n_, t_, "day");
+			bool? u_ = context.Operators.SameOrAfter(n_, t_, null);
 
 			return u_;
 		};
@@ -632,7 +632,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
 		CqlValueSet j_ = this.Heart_Failure();
 		IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, null);
@@ -728,7 +728,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
 			CqlDateTime y_ = context.Operators.Start(x_);
 			CqlDate z_ = context.Operators.DateFrom(y_);
-			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			bool? aa_ = context.Operators.SameAs(u_, z_, null);
 			DataType ab_ = tuple_ddtaodcfiesjbggrllzpybgqb.PROMIS10MentalScore?.Value;
 			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
@@ -798,7 +798,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_dzhwgxhmbfavmzfaszbeksohj.InitialPROMIS10Date);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -809,7 +809,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -824,7 +824,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
@@ -901,7 +901,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ar_ = QICoreCommon_2_0_000.ToInterval(aq_);
 			CqlDateTime as_ = context.Operators.Start(ar_);
 			CqlDate at_ = context.Operators.DateFrom(as_);
-			bool? au_ = context.Operators.SameAs(ao_, at_, "day");
+			bool? au_ = context.Operators.SameAs(ao_, at_, null);
 			DataType av_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29SocialRoles?.Value;
 			object aw_ = FHIRHelpers_4_3_000.ToValue(av_);
 			bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
@@ -915,7 +915,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> bg_ = QICoreCommon_2_0_000.ToInterval(bf_);
 			CqlDateTime bh_ = context.Operators.Start(bg_);
 			CqlDate bi_ = context.Operators.DateFrom(bh_);
-			bool? bj_ = context.Operators.SameAs(bd_, bi_, "day");
+			bool? bj_ = context.Operators.SameAs(bd_, bi_, null);
 			bool? bk_ = context.Operators.And(ay_, bj_);
 			DataType bl_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Physical?.Value;
 			object bm_ = FHIRHelpers_4_3_000.ToValue(bl_);
@@ -930,7 +930,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> bw_ = QICoreCommon_2_0_000.ToInterval(bv_);
 			CqlDateTime bx_ = context.Operators.Start(bw_);
 			CqlDate by_ = context.Operators.DateFrom(bx_);
-			bool? bz_ = context.Operators.SameAs(bt_, by_, "day");
+			bool? bz_ = context.Operators.SameAs(bt_, by_, null);
 			bool? ca_ = context.Operators.And(bo_, bz_);
 			DataType cb_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Pain?.Value;
 			object cc_ = FHIRHelpers_4_3_000.ToValue(cb_);
@@ -945,7 +945,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> cm_ = QICoreCommon_2_0_000.ToInterval(cl_);
 			CqlDateTime cn_ = context.Operators.Start(cm_);
 			CqlDate co_ = context.Operators.DateFrom(cn_);
-			bool? cp_ = context.Operators.SameAs(cj_, co_, "day");
+			bool? cp_ = context.Operators.SameAs(cj_, co_, null);
 			bool? cq_ = context.Operators.And(ce_, cp_);
 			DataType cr_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Fatigue?.Value;
 			object cs_ = FHIRHelpers_4_3_000.ToValue(cr_);
@@ -960,7 +960,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> dc_ = QICoreCommon_2_0_000.ToInterval(db_);
 			CqlDateTime dd_ = context.Operators.Start(dc_);
 			CqlDate de_ = context.Operators.DateFrom(dd_);
-			bool? df_ = context.Operators.SameAs(cz_, de_, "day");
+			bool? df_ = context.Operators.SameAs(cz_, de_, null);
 			bool? dg_ = context.Operators.And(cu_, df_);
 			DataType dh_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Depression?.Value;
 			object di_ = FHIRHelpers_4_3_000.ToValue(dh_);
@@ -975,7 +975,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ds_ = QICoreCommon_2_0_000.ToInterval(dr_);
 			CqlDateTime dt_ = context.Operators.Start(ds_);
 			CqlDate du_ = context.Operators.DateFrom(dt_);
-			bool? dv_ = context.Operators.SameAs(dp_, du_, "day");
+			bool? dv_ = context.Operators.SameAs(dp_, du_, null);
 			bool? dw_ = context.Operators.And(dk_, dv_);
 			DataType dx_ = tuple_cbgpsarvwrsewlglehinjanim.Promis29Anxiety?.Value;
 			object dy_ = FHIRHelpers_4_3_000.ToValue(dx_);
@@ -1076,7 +1076,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_kmpntxjuhkpbcwgftqigieao.InitialPROMIS29Date);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -1087,7 +1087,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -1102,7 +1102,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
@@ -1154,7 +1154,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
 			CqlDateTime y_ = context.Operators.Start(x_);
 			CqlDate z_ = context.Operators.DateFrom(y_);
-			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			bool? aa_ = context.Operators.SameAs(u_, z_, null);
 			DataType ab_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
 			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
@@ -1224,7 +1224,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_fppktdiagiekhptnsbacpswh.InitialVR12ObliqueDate);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -1235,7 +1235,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -1250,7 +1250,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
@@ -1302,7 +1302,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
 			CqlDateTime y_ = context.Operators.Start(x_);
 			CqlDate z_ = context.Operators.DateFrom(y_);
-			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			bool? aa_ = context.Operators.SameAs(u_, z_, null);
 			DataType ab_ = tuple_gadrfkrahuugjcvhwqwrujhrh.VR12MentalAssessment?.Value;
 			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
@@ -1372,7 +1372,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_fansvmjaedmvsdoyrozxdlsai.InitialVR12OrthogonalDate);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -1383,7 +1383,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -1398,7 +1398,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
@@ -1450,7 +1450,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
 			CqlDateTime y_ = context.Operators.Start(x_);
 			CqlDate z_ = context.Operators.DateFrom(y_);
-			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			bool? aa_ = context.Operators.SameAs(u_, z_, null);
 			DataType ab_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Value;
 			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
@@ -1520,7 +1520,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_elxicyhrdpyzpqyjphdifbiga.InitialVR36ObliqueDate);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -1531,7 +1531,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -1546,7 +1546,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
@@ -1598,7 +1598,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
 			CqlDateTime y_ = context.Operators.Start(x_);
 			CqlDate z_ = context.Operators.DateFrom(y_);
-			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			bool? aa_ = context.Operators.SameAs(u_, z_, null);
 			DataType ab_ = tuple_ducftclcqewdggqdfcwthfauk.VR36MentalAssessment?.Value;
 			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
@@ -1668,7 +1668,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_fucqujadjizabihdffformht.InitialVR36OrthogonalDate);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -1679,7 +1679,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -1694,7 +1694,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
@@ -1746,7 +1746,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
 			CqlDateTime y_ = context.Operators.Start(x_);
 			CqlDate z_ = context.Operators.DateFrom(y_);
-			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			bool? aa_ = context.Operators.SameAs(u_, z_, null);
 			DataType ab_ = tuple_fnofxckadaeusjerhbdqfoshe.MLHFQPhysical?.Value;
 			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
@@ -1816,7 +1816,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_ncdawctnmbfmtibmihsfbaig.InitialMLHFQDate);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -1827,7 +1827,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -1842,7 +1842,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
@@ -1894,7 +1894,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.ToInterval(w_);
 			CqlDateTime y_ = context.Operators.Start(x_);
 			CqlDate z_ = context.Operators.DateFrom(y_);
-			bool? aa_ = context.Operators.SameAs(u_, z_, "day");
+			bool? aa_ = context.Operators.SameAs(u_, z_, null);
 			DataType ab_ = tuple_dfkxorghhyafccusbqamfntdj.KCCQ12Item?.Value;
 			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 			bool? ad_ = context.Operators.Not((bool?)(ac_ is null));
@@ -1964,7 +1964,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_eoahgtwwdfqijhcjzqnvidvuo.InitialKCCQ12Date);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -1975,7 +1975,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -1990,7 +1990,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
@@ -2062,7 +2062,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> an_ = QICoreCommon_2_0_000.ToInterval(am_);
 			CqlDateTime ao_ = context.Operators.Start(an_);
 			CqlDate ap_ = context.Operators.DateFrom(ao_);
-			bool? aq_ = context.Operators.SameAs(ak_, ap_, "day");
+			bool? aq_ = context.Operators.SameAs(ak_, ap_, null);
 			DataType ar_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptomStability?.Value;
 			object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
 			bool? at_ = context.Operators.Not((bool?)(as_ is null));
@@ -2076,7 +2076,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> bc_ = QICoreCommon_2_0_000.ToInterval(bb_);
 			CqlDateTime bd_ = context.Operators.Start(bc_);
 			CqlDate be_ = context.Operators.DateFrom(bd_);
-			bool? bf_ = context.Operators.SameAs(az_, be_, "day");
+			bool? bf_ = context.Operators.SameAs(az_, be_, null);
 			bool? bg_ = context.Operators.And(au_, bf_);
 			DataType bh_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSelfEfficacy?.Value;
 			object bi_ = FHIRHelpers_4_3_000.ToValue(bh_);
@@ -2091,7 +2091,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> bs_ = QICoreCommon_2_0_000.ToInterval(br_);
 			CqlDateTime bt_ = context.Operators.Start(bs_);
 			CqlDate bu_ = context.Operators.DateFrom(bt_);
-			bool? bv_ = context.Operators.SameAs(bp_, bu_, "day");
+			bool? bv_ = context.Operators.SameAs(bp_, bu_, null);
 			bool? bw_ = context.Operators.And(bk_, bv_);
 			DataType bx_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSymptoms?.Value;
 			object by_ = FHIRHelpers_4_3_000.ToValue(bx_);
@@ -2106,7 +2106,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ci_ = QICoreCommon_2_0_000.ToInterval(ch_);
 			CqlDateTime cj_ = context.Operators.Start(ci_);
 			CqlDate ck_ = context.Operators.DateFrom(cj_);
-			bool? cl_ = context.Operators.SameAs(cf_, ck_, "day");
+			bool? cl_ = context.Operators.SameAs(cf_, ck_, null);
 			bool? cm_ = context.Operators.And(ca_, cl_);
 			DataType cn_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQPhysicalLimits?.Value;
 			object co_ = FHIRHelpers_4_3_000.ToValue(cn_);
@@ -2121,7 +2121,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> cy_ = QICoreCommon_2_0_000.ToInterval(cx_);
 			CqlDateTime cz_ = context.Operators.Start(cy_);
 			CqlDate da_ = context.Operators.DateFrom(cz_);
-			bool? db_ = context.Operators.SameAs(cv_, da_, "day");
+			bool? db_ = context.Operators.SameAs(cv_, da_, null);
 			bool? dc_ = context.Operators.And(cq_, db_);
 			DataType dd_ = tuple_etfcawdpmcqfbnayqdmdqqsdn.KCCQSocialLimits?.Value;
 			object de_ = FHIRHelpers_4_3_000.ToValue(dd_);
@@ -2216,7 +2216,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_hrluhbcfcsvnvrrnjajahdcea.InitialKCCQAssessmentDate);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -2227,7 +2227,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -2242,7 +2242,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;
@@ -2326,7 +2326,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDateTime r_ = context.Operators.End(q_);
 			CqlQuantity s_ = context.Operators.Quantity(180m, "days");
 			CqlDateTime t_ = context.Operators.Subtract(r_, s_);
-			bool? u_ = context.Operators.SameOrBefore(p_, t_, "day");
+			bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
 			CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_dgrojeekdvizsvyisepdjhjgj.InitialKCCQTotalScore);
 			CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval((x_ as object));
@@ -2337,7 +2337,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval((ad_ as object));
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, "day");
+			bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
 			CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.ToInterval((aj_ as object));
 			CqlDateTime al_ = context.Operators.End(ak_);
@@ -2352,7 +2352,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 			CqlDate aw_ = context.Operators.DateFrom(v_);
 			CqlDate ay_ = context.Operators.Add(aw_, s_);
 			CqlInterval<CqlDate> az_ = context.Operators.Interval(au_, ay_, true, true);
-			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, "day");
+			bool? ba_ = context.Operators.In<CqlDate>(aq_, az_, null);
 			bool? bb_ = context.Operators.And(ao_, ba_);
 
 			return bb_;

--- a/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
@@ -367,7 +367,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
 			CqlDateTime g_ = context.Operators.End(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
-			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
+			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, null);
 			Patient j_ = this.Patient();
 			Date k_ = j_?.BirthDateElement;
 			string l_ = k_?.Value;
@@ -375,14 +375,14 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(e_);
 			CqlDateTime p_ = context.Operators.Start(o_);
 			CqlDate q_ = context.Operators.DateFrom(p_);
-			int? r_ = context.Operators.CalculateAgeAt(m_, q_, "year");
+			int? r_ = context.Operators.CalculateAgeAt(m_, q_, null);
 			bool? s_ = context.Operators.GreaterOrEqual(r_, 65);
 			bool? t_ = context.Operators.And(i_, s_);
 			CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(e_);
 			CqlDateTime w_ = context.Operators.Start(v_);
 			CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(e_);
 			CqlDateTime z_ = context.Operators.End(y_);
-			int? aa_ = context.Operators.DurationBetween(w_, z_, "hour");
+			int? aa_ = context.Operators.DurationBetween(w_, z_, null);
 			bool? ab_ = context.Operators.GreaterOrEqual(aa_, 24);
 			bool? ac_ = context.Operators.And(t_, ab_);
 			Code<Encounter.EncounterStatus> ad_ = EncounterInpatient?.StatusElement;

--- a/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
@@ -292,7 +292,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
 		IEnumerable<Encounter> j_ = AHAOverall_2_6_000.Qualifying_Outpatient_Encounter_During_Measurement_Period();
 		int? k_ = context.Operators.Count<Encounter>(j_);

--- a/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
@@ -605,7 +605,7 @@ public class HIVRetentionFHIR_0_1_000
 			CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ak_, ao_, true, true);
 			Period aq_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_3_000.ToInterval(aq_);
-			bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, ar_, "day");
+			bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, ar_, null);
 
 			return as_;
 		};
@@ -711,7 +711,7 @@ public class HIVRetentionFHIR_0_1_000
 					}
 				};
 				CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				bool? av_ = context.Operators.SameOrBefore(as_(), au_, "day");
+				bool? av_ = context.Operators.SameOrBefore(as_(), au_, null);
 				bool? aw_ = context.Operators.And(ar_, av_);
 				bool? ax_ = QICoreCommon_2_0_000.isActive(HIVDiagnosis);
 				bool? ay_ = context.Operators.And(aw_, ax_);
@@ -744,7 +744,7 @@ public class HIVRetentionFHIR_0_1_000
 			DataType g_ = ViralLoadTest?.Effective;
 			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToInterval(h_);
-			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, "day");
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, null);
 
 			return j_;
 		};
@@ -780,14 +780,14 @@ public class HIVRetentionFHIR_0_1_000
 				CqlDateTime v_ = context.Operators.End(u_);
 				CqlQuantity w_ = context.Operators.Quantity(90m, "days");
 				CqlDateTime x_ = context.Operators.Add(v_, w_);
-				bool? y_ = context.Operators.SameOrAfter(s_, x_, "day");
+				bool? y_ = context.Operators.SameOrAfter(s_, x_, null);
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(t_);
 				CqlDateTime ab_ = context.Operators.Start(aa_);
 				object ad_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
 				CqlDateTime af_ = context.Operators.End(ae_);
 				CqlDateTime ah_ = context.Operators.Add(af_, w_);
-				bool? ai_ = context.Operators.SameOrAfter(ab_, ah_, "day");
+				bool? ai_ = context.Operators.SameOrAfter(ab_, ah_, null);
 				bool? aj_ = context.Operators.Or(y_, ai_);
 				bool? ak_ = context.Operators.And(o_, aj_);
 
@@ -828,7 +828,7 @@ public class HIVRetentionFHIR_0_1_000
 				CqlDateTime q_ = context.Operators.End(p_);
 				CqlQuantity r_ = context.Operators.Quantity(90m, "days");
 				CqlDateTime s_ = context.Operators.Add(q_, r_);
-				bool? t_ = context.Operators.SameOrAfter(n_, s_, "day");
+				bool? t_ = context.Operators.SameOrAfter(n_, s_, null);
 				bool? u_ = context.Operators.And(k_, t_);
 
 				return u_;

--- a/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
@@ -293,7 +293,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 			CqlDateTime i_ = context.Operators.Start(h_);
 			CqlQuantity j_ = context.Operators.Quantity(90m, "days");
 			CqlDateTime k_ = context.Operators.Add(i_, j_);
-			bool? l_ = context.Operators.Before(g_, k_, "day");
+			bool? l_ = context.Operators.Before(g_, k_, null);
 
 			return l_;
 		};
@@ -351,7 +351,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 			CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ak_, ao_, true, true);
 			Period aq_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_3_000.ToInterval(aq_);
-			bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, ar_, "day");
+			bool? as_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, ar_, null);
 
 			return as_;
 		};
@@ -493,7 +493,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 			};
 			CqlDateTime i_ = QICoreCommon_2_0_000.Latest(h_());
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
-			bool? k_ = context.Operators.In<CqlDateTime>(i_, j_, "day");
+			bool? k_ = context.Operators.In<CqlDateTime>(i_, j_, null);
 
 			return k_;
 		};

--- a/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
@@ -206,7 +206,7 @@ public class Hospice_6_9_000
 			CqlInterval<CqlDateTime> be_ = QICoreCommon_2_0_000.toInterval((bd_ as object));
 			CqlDateTime bf_ = context.Operators.End(be_);
 			CqlInterval<CqlDateTime> bg_ = this.Measurement_Period();
-			bool? bh_ = context.Operators.In<CqlDateTime>(bf_, bg_, "day");
+			bool? bh_ = context.Operators.In<CqlDateTime>(bf_, bg_, null);
 			bool? bi_ = context.Operators.And(bb_, bh_);
 
 			return bi_;
@@ -222,7 +222,7 @@ public class Hospice_6_9_000
 			CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_3_000.ToInterval(bj_);
 			CqlInterval<CqlDateTime> bl_ = QICoreCommon_2_0_000.toInterval((bk_ as object));
 			CqlInterval<CqlDateTime> bm_ = this.Measurement_Period();
-			bool? bn_ = context.Operators.Overlaps(bl_, bm_, "day");
+			bool? bn_ = context.Operators.Overlaps(bl_, bm_, null);
 
 			return bn_;
 		};
@@ -244,7 +244,7 @@ public class Hospice_6_9_000
 			object bu_ = FHIRHelpers_4_3_000.ToValue(bt_);
 			CqlInterval<CqlDateTime> bv_ = QICoreCommon_2_0_000.toInterval(bu_);
 			CqlInterval<CqlDateTime> bw_ = this.Measurement_Period();
-			bool? bx_ = context.Operators.Overlaps(bv_, bw_, "day");
+			bool? bx_ = context.Operators.Overlaps(bv_, bw_, null);
 			bool? by_ = context.Operators.And(bs_, bx_);
 
 			return by_;
@@ -261,7 +261,7 @@ public class Hospice_6_9_000
 			FhirDateTime ca_ = HospiceOrder?.AuthoredOnElement;
 			CqlDateTime cb_ = context.Operators.Convert<CqlDateTime>(ca_);
 			CqlInterval<CqlDateTime> cc_ = QICoreCommon_2_0_000.toInterval((cb_ as object));
-			bool? cd_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bz_, cc_, "day");
+			bool? cd_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bz_, cc_, null);
 
 			return cd_;
 		};
@@ -276,7 +276,7 @@ public class Hospice_6_9_000
 			object cf_ = FHIRHelpers_4_3_000.ToValue(ce_);
 			CqlInterval<CqlDateTime> cg_ = QICoreCommon_2_0_000.toInterval(cf_);
 			CqlInterval<CqlDateTime> ch_ = this.Measurement_Period();
-			bool? ci_ = context.Operators.Overlaps(cg_, ch_, "day");
+			bool? ci_ = context.Operators.Overlaps(cg_, ch_, null);
 
 			return ci_;
 		};
@@ -289,7 +289,7 @@ public class Hospice_6_9_000
 		{
 			CqlInterval<CqlDateTime> cj_ = QICoreCommon_2_0_000.prevalenceInterval(HospiceCareDiagnosis);
 			CqlInterval<CqlDateTime> ck_ = this.Measurement_Period();
-			bool? cl_ = context.Operators.Overlaps(cj_, ck_, "day");
+			bool? cl_ = context.Operators.Overlaps(cj_, ck_, null);
 
 			return cl_;
 		};

--- a/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
@@ -219,12 +219,12 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(h_, l_, null);
 			bool? n_ = context.Operators.GreaterOrEqual(m_, 18);
 			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(i_);
 			CqlDateTime q_ = context.Operators.End(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
-			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
 			bool? t_ = context.Operators.And(n_, s_);
 			Code<Encounter.EncounterStatus> u_ = InpatientEncounter?.StatusElement;
 			Encounter.EncounterStatus? v_ = u_?.Value;

--- a/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
@@ -255,12 +255,12 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(h_, l_, null);
 			bool? n_ = context.Operators.GreaterOrEqual(m_, 18);
 			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(i_);
 			CqlDateTime q_ = context.Operators.End(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
-			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
 			bool? t_ = context.Operators.And(n_, s_);
 			Code<Encounter.EncounterStatus> u_ = InpatientEncounter?.StatusElement;
 			Encounter.EncounterStatus? v_ = u_?.Value;

--- a/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
@@ -174,12 +174,12 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_3_000.ToInterval(i_);
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
-			int? m_ = context.Operators.CalculateAgeAt(h_, l_, "year");
+			int? m_ = context.Operators.CalculateAgeAt(h_, l_, null);
 			bool? n_ = context.Operators.GreaterOrEqual(m_, 18);
 			CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(i_);
 			CqlDateTime q_ = context.Operators.End(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
-			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
 			bool? t_ = context.Operators.And(n_, s_);
 			Code<Encounter.EncounterStatus> u_ = InpatientEncounter?.StatusElement;
 			Encounter.EncounterStatus? v_ = u_?.Value;

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
@@ -308,14 +308,14 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
 				CqlDateTime ab_ = context.Operators.Start(aa_);
 				CqlDate ac_ = context.Operators.DateFrom(ab_);
-				int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
+				int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, null);
 				CqlInterval<int?> ae_ = context.Operators.Interval(65, 94, true, true);
 				bool? af_ = context.Operators.In<int?>(ad_, ae_, null);
 				bool? ag_ = context.Operators.And(u_, af_);
 				CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_3_000.ToInterval(z_);
 				CqlDateTime aj_ = context.Operators.End(ai_);
 				CqlInterval<CqlDateTime> ak_ = this.Measurement_Period();
-				bool? al_ = context.Operators.In<CqlDateTime>(aj_, ak_, "day");
+				bool? al_ = context.Operators.In<CqlDateTime>(aj_, ak_, null);
 				bool? am_ = context.Operators.And(ag_, al_);
 
 				return am_;

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
@@ -324,13 +324,13 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
 				CqlDateTime ab_ = context.Operators.Start(aa_);
 				CqlDate ac_ = context.Operators.DateFrom(ab_);
-				int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
+				int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, null);
 				bool? ae_ = context.Operators.GreaterOrEqual(ad_, 65);
 				bool? af_ = context.Operators.And(u_, ae_);
 				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(z_);
 				CqlDateTime ai_ = context.Operators.End(ah_);
 				CqlInterval<CqlDateTime> aj_ = this.Measurement_Period();
-				bool? ak_ = context.Operators.In<CqlDateTime>(ai_, aj_, "day");
+				bool? ak_ = context.Operators.In<CqlDateTime>(ai_, aj_, null);
 				bool? al_ = context.Operators.And(af_, ak_);
 
 				return al_;

--- a/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
@@ -462,10 +462,10 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlDateTime s_ = context.Operators.Start(r_);
 				CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.prevalenceInterval(BladderCancer);
 				CqlDateTime u_ = context.Operators.Start(t_);
-				bool? v_ = context.Operators.SameOrBefore(s_, u_, "day");
+				bool? v_ = context.Operators.SameOrBefore(s_, u_, null);
 				object x_ = FHIRHelpers_4_3_000.ToValue(p_);
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
-				bool? aa_ = context.Operators.Overlaps(y_, t_, "day");
+				bool? aa_ = context.Operators.Overlaps(y_, t_, null);
 				bool? ab_ = context.Operators.And(v_, aa_);
 
 				return ab_;
@@ -511,7 +511,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		int? d_ = context.Operators.Subtract(c_, 1);
 		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime f_ = context.Operators.DateTime(d_, 7, 1, 0, 0, 0, 0, e_);
@@ -527,7 +527,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		decimal? d_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime e_ = context.Operators.DateTime(c_, 6, 30, 23, 59, 59, 0, d_);
 
@@ -553,7 +553,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 			DataType i_ = FirstBladderCancerStaging?.Performed;
 			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
-			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, "day");
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, null);
 
 			return l_;
 		};
@@ -582,7 +582,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 			DataType i_ = FirstBladderCancerStaging?.Performed;
 			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.toInterval(j_);
-			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, "day");
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, null);
 
 			return l_;
 		};

--- a/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
@@ -428,7 +428,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 85, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		bool? k_ = this.Has_Active_Diabetes_Overlaps_Measurement_Period();

--- a/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
@@ -245,7 +245,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 			CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_3_000.ToInterval(r_);
 			CqlDateTime ag_ = context.Operators.End(af_);
 			CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ad_, ag_, true, true);
-			bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, "day");
+			bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, null);
 			CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(r_);
 			CqlDateTime al_ = context.Operators.End(ak_);
 			bool? am_ = context.Operators.Not((bool?)(al_ is null));
@@ -261,7 +261,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 			CqlDateTime ay_ = context.Operators.End(ax_);
 			CqlDateTime ba_ = context.Operators.Add(ay_, ac_);
 			CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(av_, ba_, true, true);
-			bool? bc_ = context.Operators.In<CqlDateTime>(as_, bb_, "day");
+			bool? bc_ = context.Operators.In<CqlDateTime>(as_, bb_, null);
 			CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_3_000.ToInterval(r_);
 			CqlDateTime bf_ = context.Operators.End(be_);
 			bool? bg_ = context.Operators.Not((bool?)(bf_ is null));
@@ -271,7 +271,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 			CqlInterval<CqlDateTime> bl_ = QICoreCommon_2_0_000.toInterval(bk_);
 			object bn_ = FHIRHelpers_4_3_000.ToValue(v_);
 			CqlInterval<CqlDateTime> bo_ = QICoreCommon_2_0_000.toInterval(bn_);
-			bool? bp_ = context.Operators.SameAs<CqlDateTime>(bl_, bo_, "day");
+			bool? bp_ = context.Operators.SameAs<CqlDateTime>(bl_, bo_, null);
 			bool? bq_ = context.Operators.Not(bp_);
 			bool? br_ = context.Operators.And(bi_, bq_);
 			CqlInterval<CqlDateTime> bs_ = this.Measurement_Period();
@@ -468,7 +468,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 						CqlInterval<CqlDateTime> ao_ = FHIRHelpers_4_3_000.ToInterval(ai_);
 						CqlDateTime ap_ = context.Operators.Start(ao_);
 						CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(am_, ap_, true, true);
-						bool? ar_ = context.Operators.In<CqlDateTime>(ah_, aq_, "day");
+						bool? ar_ = context.Operators.In<CqlDateTime>(ah_, aq_, null);
 						CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_3_000.ToInterval(ai_);
 						CqlDateTime au_ = context.Operators.Start(at_);
 						bool? av_ = context.Operators.Not((bool?)(au_ is null));
@@ -483,7 +483,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 						DataType az_ = PainAssessed?.Effective;
 						object ba_ = FHIRHelpers_4_3_000.ToValue(az_);
 						CqlInterval<CqlDateTime> bb_ = QICoreCommon_2_0_000.toInterval(ba_);
-						bool? bc_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ay_, bb_, "day");
+						bool? bc_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ay_, bb_, null);
 
 						return bc_;
 					}

--- a/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
@@ -174,7 +174,7 @@ public class PCMaternal_5_16_000
 			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
 			CqlDateTime j_ = context.Operators.Start(i_);
 			CqlDate k_ = context.Operators.DateFrom(j_);
-			int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
+			int? l_ = context.Operators.CalculateAgeAt(g_, k_, null);
 			CqlInterval<int?> m_ = context.Operators.Interval(8, 65, true, false);
 			bool? n_ = context.Operators.In<int?>(l_, m_, null);
 
@@ -771,7 +771,7 @@ public class PCMaternal_5_16_000
 	{
 		CqlDateTime a_ = this.lastTimeOfDelivery(TheEncounter);
 		CqlDateTime b_ = this.lastEstimatedDeliveryDate(TheEncounter);
-		int? c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, null);
 		int? d_ = context.Operators.Subtract(280, c_);
 		int? e_ = context.Operators.TruncatedDivide(d_, 7);
 
@@ -939,7 +939,7 @@ public class PCMaternal_5_16_000
 				}
 			};
 			CqlDateTime ag_ = QICoreCommon_2_0_000.earliest(af_());
-			bool? ai_ = context.Operators.SameAs(ag_, l_, "day");
+			bool? ai_ = context.Operators.SameAs(ag_, l_, null);
 			object aj_()
 			{
 				bool cd_()

--- a/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
@@ -402,7 +402,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 			Period f_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_3_000.ToInterval(f_);
-			bool? h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, "day");
+			bool? h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, g_, null);
 			Code<Encounter.EncounterStatus> i_ = ValidEncounter?.StatusElement;
 			Encounter.EncounterStatus? j_ = i_?.Value;
 			Code<Encounter.EncounterStatus> k_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(j_);
@@ -437,7 +437,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlDateTime g_ = context.Operators.ConvertStringToDateTime(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.Start(h_);
-			int? j_ = context.Operators.CalculateAgeAt(g_, i_, "year");
+			int? j_ = context.Operators.CalculateAgeAt(g_, i_, null);
 			bool? k_ = context.Operators.GreaterOrEqual(j_, 18);
 
 			return k_;
@@ -501,7 +501,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				};
 				Period p_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
-				bool? r_ = context.Operators.SameOrBefore(o_(), q_, "day");
+				bool? r_ = context.Operators.SameOrBefore(o_(), q_, null);
 				bool? s_ = context.Operators.And(n_, r_);
 
 				return s_;
@@ -909,7 +909,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
 				Period q_ = ElevatedEncounter?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, "day");
+				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, null);
 
 				return s_;
 			};
@@ -930,7 +930,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime z_ = context.Operators.Convert<CqlDateTime>(y_);
 				Period aa_ = ElevatedEncounter?.Period;
 				CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_3_000.ToInterval(aa_);
-				bool? ac_ = context.Operators.In<CqlDateTime>(z_, ab_, "day");
+				bool? ac_ = context.Operators.In<CqlDateTime>(z_, ab_, null);
 
 				return ac_;
 			};
@@ -951,7 +951,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(ai_);
 				Period ak_ = ElevatedEncounter?.Period;
 				CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_3_000.ToInterval(ak_);
-				bool? am_ = context.Operators.In<CqlDateTime>(aj_, al_, "day");
+				bool? am_ = context.Operators.In<CqlDateTime>(aj_, al_, null);
 
 				return am_;
 			};
@@ -1282,7 +1282,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime bp_ = context.Operators.End(bo_);
 				Period bq_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_3_000.ToInterval(bq_);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bp_, br_, "day");
+				bool? bs_ = context.Operators.In<CqlDateTime>(bp_, br_, null);
 
 				return bs_;
 			};
@@ -1330,7 +1330,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime cn_ = context.Operators.End(cm_);
 				Period co_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_3_000.ToInterval(co_);
-				bool? cq_ = context.Operators.In<CqlDateTime>(cn_, cp_, "day");
+				bool? cq_ = context.Operators.In<CqlDateTime>(cn_, cp_, null);
 
 				return cq_;
 			};
@@ -1378,7 +1378,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime dl_ = context.Operators.End(dk_);
 				Period dm_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> dn_ = FHIRHelpers_4_3_000.ToInterval(dm_);
-				bool? do_ = context.Operators.In<CqlDateTime>(dl_, dn_, "day");
+				bool? do_ = context.Operators.In<CqlDateTime>(dl_, dn_, null);
 
 				return do_;
 			};
@@ -1426,7 +1426,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime ej_ = context.Operators.End(ei_);
 				Period ek_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> el_ = FHIRHelpers_4_3_000.ToInterval(ek_);
-				bool? em_ = context.Operators.In<CqlDateTime>(ej_, el_, "day");
+				bool? em_ = context.Operators.In<CqlDateTime>(ej_, el_, null);
 
 				return em_;
 			};
@@ -1494,10 +1494,10 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				FhirDateTime l_ = FourWeekRescreen?.AuthoredOnElement;
 				CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
 				CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
-				bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
+				bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, null);
 				FhirDateTime p_ = NonPharmInterventionsHTN?.AuthoredOnElement;
 				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
-				bool? s_ = context.Operators.In<CqlDateTime>(q_, n_, "day");
+				bool? s_ = context.Operators.In<CqlDateTime>(q_, n_, null);
 				bool? t_ = context.Operators.And(o_, s_);
 				Code<RequestIntent> u_ = FourWeekRescreen?.IntentElement;
 				RequestIntent? v_ = u_?.Value;
@@ -1537,7 +1537,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
 				Period k_ = FirstHTNEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, "day");
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
 
 				return m_;
 			};
@@ -1571,7 +1571,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime bv_ = context.Operators.End(bu_);
 				Period bw_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_3_000.ToInterval(bw_);
-				bool? by_ = context.Operators.In<CqlDateTime>(bv_, bx_, "day");
+				bool? by_ = context.Operators.In<CqlDateTime>(bv_, bx_, null);
 				Code<ObservationStatus> bz_ = BloodPressure?.StatusElement;
 				ObservationStatus? ca_ = bz_?.Value;
 				string cb_ = context.Operators.Convert<string>(ca_);
@@ -1632,7 +1632,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime cz_ = context.Operators.End(cy_);
 				Period da_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> db_ = FHIRHelpers_4_3_000.ToInterval(da_);
-				bool? dc_ = context.Operators.In<CqlDateTime>(cz_, db_, "day");
+				bool? dc_ = context.Operators.In<CqlDateTime>(cz_, db_, null);
 				Code<ObservationStatus> dd_ = BloodPressure?.StatusElement;
 				ObservationStatus? de_ = dd_?.Value;
 				string df_ = context.Operators.Convert<string>(de_);
@@ -1694,7 +1694,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime ed_ = context.Operators.End(ec_);
 				Period ee_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_3_000.ToInterval(ee_);
-				bool? eg_ = context.Operators.In<CqlDateTime>(ed_, ef_, "day");
+				bool? eg_ = context.Operators.In<CqlDateTime>(ed_, ef_, null);
 				Code<ObservationStatus> eh_ = BloodPressure?.StatusElement;
 				ObservationStatus? ei_ = eh_?.Value;
 				string ej_ = context.Operators.Convert<string>(ei_);
@@ -1753,7 +1753,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime fh_ = context.Operators.End(fg_);
 				Period fi_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> fj_ = FHIRHelpers_4_3_000.ToInterval(fi_);
-				bool? fk_ = context.Operators.In<CqlDateTime>(fh_, fj_, "day");
+				bool? fk_ = context.Operators.In<CqlDateTime>(fh_, fj_, null);
 				Code<ObservationStatus> fl_ = BloodPressure?.StatusElement;
 				ObservationStatus? fm_ = fl_?.Value;
 				string fn_ = context.Operators.Convert<string>(fm_);
@@ -1863,10 +1863,10 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				FhirDateTime k_ = Rescreen2to6?.AuthoredOnElement;
 				CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
 				CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, "day");
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
 				FhirDateTime o_ = LabECGIntervention?.AuthoredOnElement;
 				CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
-				bool? r_ = context.Operators.In<CqlDateTime>(p_, m_, "day");
+				bool? r_ = context.Operators.In<CqlDateTime>(p_, m_, null);
 				bool? s_ = context.Operators.And(n_, r_);
 
 				return s_;
@@ -1887,7 +1887,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				FhirDateTime y_ = NonPharmSecondIntervention?.AuthoredOnElement;
 				CqlDateTime z_ = context.Operators.Convert<CqlDateTime>(y_);
 				CqlInterval<CqlDateTime> aa_ = this.Measurement_Period();
-				bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
+				bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, null);
 
 				return ab_;
 			};
@@ -1919,7 +1919,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 				Period o_ = SecondHTNEncounterReading?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, null);
 
 				return q_;
 			};
@@ -1940,7 +1940,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
 				Period y_ = SecondHTNEncounterReading?.Period;
 				CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-				bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
+				bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, null);
 
 				return aa_;
 			};
@@ -2232,10 +2232,10 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				FhirDateTime n_ = WeeksRescreen?.AuthoredOnElement;
 				CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
 				CqlInterval<CqlDateTime> p_ = this.Measurement_Period();
-				bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, "day");
+				bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, null);
 				FhirDateTime r_ = ECGLabTest?.AuthoredOnElement;
 				CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(r_);
-				bool? u_ = context.Operators.In<CqlDateTime>(s_, p_, "day");
+				bool? u_ = context.Operators.In<CqlDateTime>(s_, p_, null);
 				bool? v_ = context.Operators.And(q_, u_);
 				Code<RequestIntent> w_ = WeeksRescreen?.IntentElement;
 				RequestIntent? x_ = w_?.Value;
@@ -2266,7 +2266,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				FhirDateTime al_ = HTNInterventions?.AuthoredOnElement;
 				CqlDateTime am_ = context.Operators.Convert<CqlDateTime>(al_);
 				CqlInterval<CqlDateTime> an_ = this.Measurement_Period();
-				bool? ao_ = context.Operators.In<CqlDateTime>(am_, an_, "day");
+				bool? ao_ = context.Operators.In<CqlDateTime>(am_, an_, null);
 
 				return ao_;
 			};
@@ -2289,7 +2289,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				FhirDateTime ay_ = Medications?.AuthoredOnElement;
 				CqlDateTime az_ = context.Operators.Convert<CqlDateTime>(ay_);
 				CqlInterval<CqlDateTime> ba_ = this.Measurement_Period();
-				bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, "day");
+				bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, null);
 				Code<MedicationRequest.MedicationrequestStatus> bc_ = Medications?.StatusElement;
 				MedicationRequest.MedicationrequestStatus? bd_ = bc_?.Value;
 				string be_ = context.Operators.Convert<string>(bd_);
@@ -2326,7 +2326,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 				Period o_ = SecondHTNEncounterReading140Over90?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, null);
 
 				return q_;
 			};
@@ -2347,7 +2347,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime x_ = context.Operators.Convert<CqlDateTime>(w_);
 				Period y_ = SecondHTNEncounterReading140Over90?.Period;
 				CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-				bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, "day");
+				bool? aa_ = context.Operators.In<CqlDateTime>(x_, z_, null);
 
 				return aa_;
 			};
@@ -2406,7 +2406,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
 				Period r_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
 				bool? u_(Extension @this)
 				{
 					string at_ = @this?.Url;
@@ -2783,7 +2783,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime ay_ = context.Operators.Convert<CqlDateTime>(ax_);
 				Period az_ = ElevatedBPEncounter?.Period;
 				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
-				bool? bb_ = context.Operators.In<CqlDateTime>(ay_, ba_, "day");
+				bool? bb_ = context.Operators.In<CqlDateTime>(ay_, ba_, null);
 				bool? bc_ = context.Operators.And(aw_, bb_);
 				Code<RequestStatus> bd_ = ElevatedBPDeclinedInterventions?.StatusElement;
 				RequestStatus? be_ = bd_?.Value;
@@ -2810,7 +2810,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime bt_ = context.Operators.Convert<CqlDateTime>(bs_);
 				Period bu_ = ElevatedBPEncounter?.Period;
 				CqlInterval<CqlDateTime> bv_ = FHIRHelpers_4_3_000.ToInterval(bu_);
-				bool? bw_ = context.Operators.In<CqlDateTime>(bt_, bv_, "day");
+				bool? bw_ = context.Operators.In<CqlDateTime>(bt_, bv_, null);
 
 				return bw_;
 			};
@@ -2865,7 +2865,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime cw_ = context.Operators.Convert<CqlDateTime>(cv_);
 				Period cx_ = FirstHTNEncounter?.Period;
 				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
-				bool? cz_ = context.Operators.In<CqlDateTime>(cw_, cy_, "day");
+				bool? cz_ = context.Operators.In<CqlDateTime>(cw_, cy_, null);
 				bool? da_ = context.Operators.And(cu_, cz_);
 				Code<RequestStatus> db_ = FirstHTNDeclinedInterventions?.StatusElement;
 				RequestStatus? dc_ = db_?.Value;
@@ -2892,7 +2892,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime dr_ = context.Operators.Convert<CqlDateTime>(dq_);
 				Period ds_ = FirstHTNEncounter?.Period;
 				CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(ds_);
-				bool? du_ = context.Operators.In<CqlDateTime>(dr_, dt_, "day");
+				bool? du_ = context.Operators.In<CqlDateTime>(dr_, dt_, null);
 
 				return du_;
 			};
@@ -2916,7 +2916,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime eb_ = context.Operators.Convert<CqlDateTime>(ea_);
 				Period ec_ = SecondHTNEncounter?.Period;
 				CqlInterval<CqlDateTime> ed_ = FHIRHelpers_4_3_000.ToInterval(ec_);
-				bool? ee_ = context.Operators.In<CqlDateTime>(eb_, ed_, "day");
+				bool? ee_ = context.Operators.In<CqlDateTime>(eb_, ed_, null);
 
 				return ee_;
 			};
@@ -2938,7 +2938,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime el_ = context.Operators.LateBoundProperty<CqlDateTime>(ek_, "value");
 				Period em_ = SecondHTN140Over90Encounter?.Period;
 				CqlInterval<CqlDateTime> en_ = FHIRHelpers_4_3_000.ToInterval(em_);
-				bool? eo_ = context.Operators.In<CqlDateTime>(el_, en_, "day");
+				bool? eo_ = context.Operators.In<CqlDateTime>(el_, en_, null);
 
 				return eo_;
 			};

--- a/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
@@ -382,7 +382,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
 		IEnumerable<Encounter> j_ = this.Primary_Open_Angle_Glaucoma_Encounter();
 		bool? k_ = context.Operators.Exists<Encounter>(j_);

--- a/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
@@ -136,7 +136,7 @@ public class PalliativeCare_1_9_000
 			object ac_ = FHIRHelpers_4_3_000.ToValue(ab_);
 			CqlInterval<CqlDateTime> ad_ = QICoreCommon_2_0_000.toInterval(ac_);
 			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
-			bool? af_ = context.Operators.Overlaps(ad_, ae_, "day");
+			bool? af_ = context.Operators.Overlaps(ad_, ae_, null);
 
 			return af_;
 		};
@@ -148,7 +148,7 @@ public class PalliativeCare_1_9_000
 		{
 			CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.prevalenceInterval(PalliativeDiagnosis);
 			CqlInterval<CqlDateTime> ah_ = this.Measurement_Period();
-			bool? ai_ = context.Operators.Overlaps(ag_, ah_, "day");
+			bool? ai_ = context.Operators.Overlaps(ag_, ah_, null);
 
 			return ai_;
 		};
@@ -164,7 +164,7 @@ public class PalliativeCare_1_9_000
 			CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
 			CqlInterval<CqlDateTime> al_ = QICoreCommon_2_0_000.toInterval((ak_ as object));
 			CqlInterval<CqlDateTime> am_ = this.Measurement_Period();
-			bool? an_ = context.Operators.Overlaps(al_, am_, "day");
+			bool? an_ = context.Operators.Overlaps(al_, am_, null);
 
 			return an_;
 		};
@@ -180,7 +180,7 @@ public class PalliativeCare_1_9_000
 			object ap_ = FHIRHelpers_4_3_000.ToValue(ao_);
 			CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.toInterval(ap_);
 			CqlInterval<CqlDateTime> ar_ = this.Measurement_Period();
-			bool? as_ = context.Operators.Overlaps(aq_, ar_, "day");
+			bool? as_ = context.Operators.Overlaps(aq_, ar_, null);
 
 			return as_;
 		};

--- a/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
@@ -528,7 +528,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 			Period bm_ = OfficeBasedEncounter?.Period;
 			CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_3_000.ToInterval(bm_);
 			CqlInterval<CqlDateTime> bo_ = QICoreCommon_2_0_000.toInterval((bn_ as object));
-			bool? bp_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bl_, bo_, "day");
+			bool? bp_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bl_, bo_, null);
 
 			return bp_;
 		};
@@ -618,7 +618,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 			Period ax_ = PreventiveEncounter?.Period;
 			CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_3_000.ToInterval(ax_);
 			CqlInterval<CqlDateTime> az_ = QICoreCommon_2_0_000.toInterval((ay_ as object));
-			bool? ba_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, az_, "day");
+			bool? ba_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, az_, null);
 
 			return ba_;
 		};
@@ -640,7 +640,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 12);
 		IEnumerable<Encounter> j_ = this.Qualifying_Visit_During_Measurement_Period();
 		int? k_ = context.Operators.Count<Encounter>(j_);
@@ -679,7 +679,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 			DataType n_ = TobaccoUseScreening?.Effective;
 			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
 
 			return q_;
 		};
@@ -754,7 +754,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 			DataType n_ = TobaccoUseScreening?.Effective;
 			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, "day");
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
 
 			return q_;
 		};
@@ -824,7 +824,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 			DataType s_ = TobaccoCessationCounseling?.Performed;
 			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
-			bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, "day");
+			bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, null);
 
 			return v_;
 		};
@@ -842,7 +842,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 			CqlDateTime ab_ = context.Operators.Subtract(z_, aa_);
 			CqlDateTime ad_ = context.Operators.End(y_);
 			CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(ab_, ad_, true, true);
-			bool? af_ = context.Operators.In<CqlDateTime>(x_, ae_, "day");
+			bool? af_ = context.Operators.In<CqlDateTime>(x_, ae_, null);
 
 			return af_;
 		};
@@ -873,7 +873,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, null);
 
 			return r_;
 		};
@@ -903,7 +903,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, null);
 
 			return r_;
 		};

--- a/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
+++ b/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
@@ -168,7 +168,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			Period g_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, null);
 
 			return i_;
 		};
@@ -190,7 +190,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
@@ -238,7 +238,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
 			CqlDateTime m_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
-			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
+			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, null);
 
 			return o_;
 		};
@@ -273,7 +273,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(1, 5, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
@@ -293,7 +293,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(6, 12, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
@@ -313,7 +313,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(13, 20, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 

--- a/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
@@ -316,7 +316,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		{
 			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.prevalenceInterval(ProstateCancer);
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
-			bool? g_ = context.Operators.Overlaps(e_, f_, "day");
+			bool? g_ = context.Operators.Overlaps(e_, f_, null);
 			bool? h_ = QICoreCommon_2_0_000.isProblemListItem(ProstateCancer);
 			bool? i_ = QICoreCommon_2_0_000.isHealthConcern(ProstateCancer);
 			bool? j_ = context.Operators.Or(h_, i_);
@@ -500,7 +500,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.toInterval(i_);
 			CqlDateTime k_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
-			bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
+			bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, null);
 			Code<EventStatus> n_ = ProstateCancerTreatment?.StatusElement;
 			EventStatus? o_ = n_?.Value;
 			string p_ = context.Operators.Convert<string>(o_);

--- a/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
@@ -592,7 +592,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] LOINC_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("21112-8", "http://loinc.org", null, null),
 		};
@@ -606,7 +606,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] SNOMEDCT_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("419099009", "http://snomed.info/sct", null, null),
 		};
@@ -620,7 +620,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] ActCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
 			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
@@ -644,7 +644,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] RoleCode_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
 			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
@@ -659,7 +659,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] Diagnosis_Role_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
 			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
@@ -680,7 +680,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] RequestIntent_Value()
 	{
-		var a_ = new CqlCode[0]
+		CqlCode[] a_ = new CqlCode[0]
 ;
 
 		return a_;
@@ -692,7 +692,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
 			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
@@ -709,7 +709,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
 			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
@@ -728,7 +728,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
 			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
@@ -747,7 +747,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
 			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
@@ -763,7 +763,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
 			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
@@ -779,7 +779,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
 			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
@@ -801,7 +801,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] USCoreObservationCategoryExtensionCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", null, null),
 		};
@@ -815,7 +815,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] ConditionCategory_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
 			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
@@ -830,7 +830,7 @@ public class QICoreCommon_2_0_000
 
 	private CqlCode[] USCoreConditionCategoryExtensionCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", null, null),
 		};
@@ -844,8 +844,8 @@ public class QICoreCommon_2_0_000
 
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
@@ -858,443 +858,463 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Returns true if the given condition has a clinical status of active, recurrence, or relapse")]
 	public bool? isActive(Condition condition)
 	{
-		var a_ = FHIRHelpers_4_3_000.ToConcept(condition?.ClinicalStatus);
-		var b_ = this.active();
-		var c_ = context.Operators.ConvertCodeToConcept(b_);
-		var d_ = context.Operators.Equivalent(a_, c_);
-		var f_ = this.recurrence();
-		var g_ = context.Operators.ConvertCodeToConcept(f_);
-		var h_ = context.Operators.Equivalent(a_, g_);
-		var i_ = context.Operators.Or(d_, h_);
-		var k_ = this.relapse();
-		var l_ = context.Operators.ConvertCodeToConcept(k_);
-		var m_ = context.Operators.Equivalent(a_, l_);
-		var n_ = context.Operators.Or(i_, m_);
+		CodeableConcept a_ = condition?.ClinicalStatus;
+		CqlConcept b_ = FHIRHelpers_4_3_000.ToConcept(a_);
+		CqlCode c_ = this.active();
+		CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+		bool? e_ = context.Operators.Equivalent(b_, d_);
+		CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(a_);
+		CqlCode h_ = this.recurrence();
+		CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+		bool? j_ = context.Operators.Equivalent(g_, i_);
+		bool? k_ = context.Operators.Or(e_, j_);
+		CqlConcept m_ = FHIRHelpers_4_3_000.ToConcept(a_);
+		CqlCode n_ = this.relapse();
+		CqlConcept o_ = context.Operators.ConvertCodeToConcept(n_);
+		bool? p_ = context.Operators.Equivalent(m_, o_);
+		bool? q_ = context.Operators.Or(k_, p_);
 
-		return n_;
+		return q_;
 	}
 
     [CqlDeclaration("hasCategory")]
     [CqlTag("description", "Returns true if the given condition has the given category")]
 	public bool? hasCategory(Condition condition, CqlCode category)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = condition?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)condition?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = context.Operators.ConvertCodeToConcept(category);
-			var h_ = context.Operators.Equivalent(C, g_);
+			CqlConcept h_ = context.Operators.ConvertCodeToConcept(category);
+			bool? i_ = context.Operators.Equivalent(C, h_);
 
-			return h_;
+			return i_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("hasCategory")]
     [CqlTag("description", "Returns true if the given observation has the given category")]
 	public bool? hasCategory(Observation observation, CqlCode category)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = context.Operators.ConvertCodeToConcept(category);
-			var h_ = context.Operators.Equivalent(C, g_);
+			CqlConcept h_ = context.Operators.ConvertCodeToConcept(category);
+			bool? i_ = context.Operators.Equivalent(C, h_);
 
-			return h_;
+			return i_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isProblemListItem")]
     [CqlTag("description", "Returns true if the given condition is a problem list item.")]
 	public bool? isProblemListItem(Condition condition)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = condition?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)condition?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.problem_list_item();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.problem_list_item();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isEncounterDiagnosis")]
     [CqlTag("description", "Returns true if the given condition is an encounter diagnosis")]
 	public bool? isEncounterDiagnosis(Condition condition)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = condition?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)condition?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.encounter_diagnosis();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.encounter_diagnosis();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isHealthConcern")]
     [CqlTag("description", "Returns true if the given condition is a health concern")]
 	public bool? isHealthConcern(Condition condition)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = condition?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)condition?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.health_concern();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.health_concern();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isSocialHistory")]
     [CqlTag("description", "Returns true if the given observation is a social history observation")]
 	public bool? isSocialHistory(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.social_history();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.social_history();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isVitalSign")]
     [CqlTag("description", "Returns true if the given observation is a vital sign")]
 	public bool? isVitalSign(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.vital_signs();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.vital_signs();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isImaging")]
     [CqlTag("description", "Returns true if the given observation is an imaging observation")]
 	public bool? isImaging(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.imaging();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.imaging();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isLaboratory")]
     [CqlTag("description", "Returns true if the given observation is a laboratory observation")]
 	public bool? isLaboratory(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.laboratory();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.laboratory();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isProcedure")]
     [CqlTag("description", "REturns true if the given observation is a procedure observation")]
 	public bool? isProcedure(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.procedure();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.procedure();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isSurvey")]
     [CqlTag("description", "Returns true if the given observation is a survey observation")]
 	public bool? isSurvey(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.survey();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.survey();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isExam")]
     [CqlTag("description", "Returns true if the given observation is an exam observation")]
 	public bool? isExam(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.exam();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.exam();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isTherapy")]
     [CqlTag("description", "Returns true if the given observation is a therapy observation")]
 	public bool? isTherapy(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.therapy();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.therapy();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isActivity")]
     [CqlTag("description", "Returns true if the given observation is an activity observation")]
 	public bool? isActivity(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.activity();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.activity();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isClinicalTest")]
     [CqlTag("description", "Returns true if the given observation is a clinical test result")]
 	public bool? isClinicalTest(Observation observation)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = observation?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)observation?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.clinical_test();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.clinical_test();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isCommunity")]
     [CqlTag("description", "Returns true if the given MedicationRequest has a category of Community")]
 	public bool? isCommunity(MedicationRequest medicationRequest)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = medicationRequest?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)medicationRequest?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.Community();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.Community();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("isDischarge")]
     [CqlTag("description", "Returns true if the given MedicationRequest has a category of Discharge")]
 	public bool? isDischarge(MedicationRequest medicationRequest)
 	{
-		CqlConcept a_(CodeableConcept @this)
+		List<CodeableConcept> a_ = medicationRequest?.Category;
+		CqlConcept b_(CodeableConcept @this)
 		{
-			var f_ = FHIRHelpers_4_3_000.ToConcept(@this);
+			CqlConcept g_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
-			return f_;
+			return g_;
 		};
-		var b_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)medicationRequest?.Category, a_);
-		bool? c_(CqlConcept C)
+		IEnumerable<CqlConcept> c_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)a_, b_);
+		bool? d_(CqlConcept C)
 		{
-			var g_ = this.Discharge();
-			var h_ = context.Operators.ConvertCodeToConcept(g_);
-			var i_ = context.Operators.Equivalent(C, h_);
+			CqlCode h_ = this.Discharge();
+			CqlConcept i_ = context.Operators.ConvertCodeToConcept(h_);
+			bool? j_ = context.Operators.Equivalent(C, i_);
 
-			return i_;
+			return j_;
 		};
-		var d_ = context.Operators.Where<CqlConcept>(b_, c_);
-		var e_ = context.Operators.Exists<CqlConcept>(d_);
+		IEnumerable<CqlConcept> e_ = context.Operators.Where<CqlConcept>(c_, d_);
+		bool? f_ = context.Operators.Exists<CqlConcept>(e_);
 
-		return e_;
+		return f_;
 	}
 
     [CqlDeclaration("doNotPerform")]
@@ -1303,24 +1323,24 @@ public class QICoreCommon_2_0_000
 	{
 		bool? a_(Extension E)
 		{
-			var f_ = E?.Url;
-			var g_ = context.Operators.LateBoundProperty<string>(f_, "value");
-			var h_ = context.Operators.Equal(g_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerform");
+			string f_ = E?.Url;
+			string g_ = context.Operators.LateBoundProperty<string>(f_, "value");
+			bool? h_ = context.Operators.Equal(g_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-doNotPerform");
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Extension>(((deviceRequest is DomainResource)
+		IEnumerable<Extension> b_ = context.Operators.Where<Extension>(((deviceRequest is DomainResource)
 				? ((IEnumerable<Extension>)(deviceRequest as DomainResource).ModifierExtension)
 				: null), a_);
 		bool? c_(Extension E)
 		{
-			var i_ = E?.Value;
-			var j_ = FHIRHelpers_4_3_000.ToValue(i_);
+			DataType i_ = E?.Value;
+			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 
 			return (j_ as bool?);
 		};
-		var d_ = context.Operators.Select<Extension, bool?>(b_, c_);
-		var e_ = context.Operators.SingletonFrom<bool?>(d_);
+		IEnumerable<bool?> d_ = context.Operators.Select<Extension, bool?>(b_, c_);
+		bool? e_ = context.Operators.SingletonFrom<bool?>(d_);
 
 		return e_;
 	}
@@ -1335,7 +1355,7 @@ public class QICoreCommon_2_0_000
 		{
 			if (choice is CqlDateTime)
 			{
-				var b_ = context.Operators.Interval((choice as CqlDateTime), (choice as CqlDateTime), true, true);
+				CqlInterval<CqlDateTime> b_ = context.Operators.Interval((choice as CqlDateTime), (choice as CqlDateTime), true, true);
 
 				return b_;
 			}
@@ -1345,117 +1365,117 @@ public class QICoreCommon_2_0_000
 			}
 			else if (choice is CqlQuantity)
 			{
-				var c_ = this.Patient();
-				var d_ = c_?.BirthDateElement;
-				var e_ = d_?.Value;
-				var f_ = context.Operators.ConvertStringToDate(e_);
-				var g_ = context.Operators.Add(f_, (choice as CqlQuantity));
-				var i_ = c_?.BirthDateElement;
-				var j_ = i_?.Value;
-				var k_ = context.Operators.ConvertStringToDate(j_);
-				var l_ = context.Operators.Add(k_, (choice as CqlQuantity));
-				var m_ = context.Operators.Quantity(1m, "year");
-				var n_ = context.Operators.Add(l_, m_);
-				var o_ = context.Operators.Interval(g_, n_, true, false);
-				var p_ = o_?.low;
-				var q_ = context.Operators.ConvertDateToDateTime(p_);
-				var s_ = c_?.BirthDateElement;
-				var t_ = s_?.Value;
-				var u_ = context.Operators.ConvertStringToDate(t_);
-				var v_ = context.Operators.Add(u_, (choice as CqlQuantity));
-				var x_ = c_?.BirthDateElement;
-				var y_ = x_?.Value;
-				var z_ = context.Operators.ConvertStringToDate(y_);
-				var aa_ = context.Operators.Add(z_, (choice as CqlQuantity));
-				var ac_ = context.Operators.Add(aa_, m_);
-				var ad_ = context.Operators.Interval(v_, ac_, true, false);
-				var ae_ = ad_?.high;
-				var af_ = context.Operators.ConvertDateToDateTime(ae_);
-				var ah_ = c_?.BirthDateElement;
-				var ai_ = ah_?.Value;
-				var aj_ = context.Operators.ConvertStringToDate(ai_);
-				var ak_ = context.Operators.Add(aj_, (choice as CqlQuantity));
-				var am_ = c_?.BirthDateElement;
-				var an_ = am_?.Value;
-				var ao_ = context.Operators.ConvertStringToDate(an_);
-				var ap_ = context.Operators.Add(ao_, (choice as CqlQuantity));
-				var ar_ = context.Operators.Add(ap_, m_);
-				var as_ = context.Operators.Interval(ak_, ar_, true, false);
-				var at_ = as_?.lowClosed;
-				var av_ = c_?.BirthDateElement;
-				var aw_ = av_?.Value;
-				var ax_ = context.Operators.ConvertStringToDate(aw_);
-				var ay_ = context.Operators.Add(ax_, (choice as CqlQuantity));
-				var ba_ = c_?.BirthDateElement;
-				var bb_ = ba_?.Value;
-				var bc_ = context.Operators.ConvertStringToDate(bb_);
-				var bd_ = context.Operators.Add(bc_, (choice as CqlQuantity));
-				var bf_ = context.Operators.Add(bd_, m_);
-				var bg_ = context.Operators.Interval(ay_, bf_, true, false);
-				var bh_ = bg_?.highClosed;
-				var bi_ = context.Operators.Interval(q_, af_, at_, bh_);
+				Patient c_ = this.Patient();
+				Date d_ = c_?.BirthDateElement;
+				string e_ = d_?.Value;
+				CqlDate f_ = context.Operators.ConvertStringToDate(e_);
+				CqlDate g_ = context.Operators.Add(f_, (choice as CqlQuantity));
+				Date i_ = c_?.BirthDateElement;
+				string j_ = i_?.Value;
+				CqlDate k_ = context.Operators.ConvertStringToDate(j_);
+				CqlDate l_ = context.Operators.Add(k_, (choice as CqlQuantity));
+				CqlQuantity m_ = context.Operators.Quantity(1m, "year");
+				CqlDate n_ = context.Operators.Add(l_, m_);
+				CqlInterval<CqlDate> o_ = context.Operators.Interval(g_, n_, true, false);
+				CqlDate p_ = o_?.low;
+				CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+				Date s_ = c_?.BirthDateElement;
+				string t_ = s_?.Value;
+				CqlDate u_ = context.Operators.ConvertStringToDate(t_);
+				CqlDate v_ = context.Operators.Add(u_, (choice as CqlQuantity));
+				Date x_ = c_?.BirthDateElement;
+				string y_ = x_?.Value;
+				CqlDate z_ = context.Operators.ConvertStringToDate(y_);
+				CqlDate aa_ = context.Operators.Add(z_, (choice as CqlQuantity));
+				CqlDate ac_ = context.Operators.Add(aa_, m_);
+				CqlInterval<CqlDate> ad_ = context.Operators.Interval(v_, ac_, true, false);
+				CqlDate ae_ = ad_?.high;
+				CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
+				Date ah_ = c_?.BirthDateElement;
+				string ai_ = ah_?.Value;
+				CqlDate aj_ = context.Operators.ConvertStringToDate(ai_);
+				CqlDate ak_ = context.Operators.Add(aj_, (choice as CqlQuantity));
+				Date am_ = c_?.BirthDateElement;
+				string an_ = am_?.Value;
+				CqlDate ao_ = context.Operators.ConvertStringToDate(an_);
+				CqlDate ap_ = context.Operators.Add(ao_, (choice as CqlQuantity));
+				CqlDate ar_ = context.Operators.Add(ap_, m_);
+				CqlInterval<CqlDate> as_ = context.Operators.Interval(ak_, ar_, true, false);
+				bool? at_ = as_?.lowClosed;
+				Date av_ = c_?.BirthDateElement;
+				string aw_ = av_?.Value;
+				CqlDate ax_ = context.Operators.ConvertStringToDate(aw_);
+				CqlDate ay_ = context.Operators.Add(ax_, (choice as CqlQuantity));
+				Date ba_ = c_?.BirthDateElement;
+				string bb_ = ba_?.Value;
+				CqlDate bc_ = context.Operators.ConvertStringToDate(bb_);
+				CqlDate bd_ = context.Operators.Add(bc_, (choice as CqlQuantity));
+				CqlDate bf_ = context.Operators.Add(bd_, m_);
+				CqlInterval<CqlDate> bg_ = context.Operators.Interval(ay_, bf_, true, false);
+				bool? bh_ = bg_?.highClosed;
+				CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(q_, af_, at_, bh_);
 
 				return bi_;
 			}
 			else if (choice is CqlInterval<CqlQuantity>)
 			{
-				var bj_ = this.Patient();
-				var bk_ = bj_?.BirthDateElement;
-				var bl_ = bk_?.Value;
-				var bm_ = context.Operators.ConvertStringToDate(bl_);
-				var bn_ = context.Operators.LateBoundProperty<object>(choice, "low");
-				var bo_ = context.Operators.Add(bm_, (bn_ as CqlQuantity));
-				var bq_ = bj_?.BirthDateElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.ConvertStringToDate(br_);
-				var bt_ = context.Operators.LateBoundProperty<object>(choice, "high");
-				var bu_ = context.Operators.Add(bs_, (bt_ as CqlQuantity));
-				var bv_ = context.Operators.Quantity(1m, "year");
-				var bw_ = context.Operators.Add(bu_, bv_);
-				var bx_ = context.Operators.Interval(bo_, bw_, true, false);
-				var by_ = bx_?.low;
-				var bz_ = context.Operators.ConvertDateToDateTime(by_);
-				var cb_ = bj_?.BirthDateElement;
-				var cc_ = cb_?.Value;
-				var cd_ = context.Operators.ConvertStringToDate(cc_);
-				var cf_ = context.Operators.Add(cd_, (bn_ as CqlQuantity));
-				var ch_ = bj_?.BirthDateElement;
-				var ci_ = ch_?.Value;
-				var cj_ = context.Operators.ConvertStringToDate(ci_);
-				var cl_ = context.Operators.Add(cj_, (bt_ as CqlQuantity));
-				var cn_ = context.Operators.Add(cl_, bv_);
-				var co_ = context.Operators.Interval(cf_, cn_, true, false);
-				var cp_ = co_?.high;
-				var cq_ = context.Operators.ConvertDateToDateTime(cp_);
-				var cs_ = bj_?.BirthDateElement;
-				var ct_ = cs_?.Value;
-				var cu_ = context.Operators.ConvertStringToDate(ct_);
-				var cw_ = context.Operators.Add(cu_, (bn_ as CqlQuantity));
-				var cy_ = bj_?.BirthDateElement;
-				var cz_ = cy_?.Value;
-				var da_ = context.Operators.ConvertStringToDate(cz_);
-				var dc_ = context.Operators.Add(da_, (bt_ as CqlQuantity));
-				var de_ = context.Operators.Add(dc_, bv_);
-				var df_ = context.Operators.Interval(cw_, de_, true, false);
-				var dg_ = df_?.lowClosed;
-				var di_ = bj_?.BirthDateElement;
-				var dj_ = di_?.Value;
-				var dk_ = context.Operators.ConvertStringToDate(dj_);
-				var dm_ = context.Operators.Add(dk_, (bn_ as CqlQuantity));
-				var do_ = bj_?.BirthDateElement;
-				var dp_ = do_?.Value;
-				var dq_ = context.Operators.ConvertStringToDate(dp_);
-				var ds_ = context.Operators.Add(dq_, (bt_ as CqlQuantity));
-				var du_ = context.Operators.Add(ds_, bv_);
-				var dv_ = context.Operators.Interval(dm_, du_, true, false);
-				var dw_ = dv_?.highClosed;
-				var dx_ = context.Operators.Interval(bz_, cq_, dg_, dw_);
+				Patient bj_ = this.Patient();
+				Date bk_ = bj_?.BirthDateElement;
+				string bl_ = bk_?.Value;
+				CqlDate bm_ = context.Operators.ConvertStringToDate(bl_);
+				object bn_ = context.Operators.LateBoundProperty<object>(choice, "low");
+				CqlDate bo_ = context.Operators.Add(bm_, (bn_ as CqlQuantity));
+				Date bq_ = bj_?.BirthDateElement;
+				string br_ = bq_?.Value;
+				CqlDate bs_ = context.Operators.ConvertStringToDate(br_);
+				object bt_ = context.Operators.LateBoundProperty<object>(choice, "high");
+				CqlDate bu_ = context.Operators.Add(bs_, (bt_ as CqlQuantity));
+				CqlQuantity bv_ = context.Operators.Quantity(1m, "year");
+				CqlDate bw_ = context.Operators.Add(bu_, bv_);
+				CqlInterval<CqlDate> bx_ = context.Operators.Interval(bo_, bw_, true, false);
+				CqlDate by_ = bx_?.low;
+				CqlDateTime bz_ = context.Operators.ConvertDateToDateTime(by_);
+				Date cb_ = bj_?.BirthDateElement;
+				string cc_ = cb_?.Value;
+				CqlDate cd_ = context.Operators.ConvertStringToDate(cc_);
+				CqlDate cf_ = context.Operators.Add(cd_, (bn_ as CqlQuantity));
+				Date ch_ = bj_?.BirthDateElement;
+				string ci_ = ch_?.Value;
+				CqlDate cj_ = context.Operators.ConvertStringToDate(ci_);
+				CqlDate cl_ = context.Operators.Add(cj_, (bt_ as CqlQuantity));
+				CqlDate cn_ = context.Operators.Add(cl_, bv_);
+				CqlInterval<CqlDate> co_ = context.Operators.Interval(cf_, cn_, true, false);
+				CqlDate cp_ = co_?.high;
+				CqlDateTime cq_ = context.Operators.ConvertDateToDateTime(cp_);
+				Date cs_ = bj_?.BirthDateElement;
+				string ct_ = cs_?.Value;
+				CqlDate cu_ = context.Operators.ConvertStringToDate(ct_);
+				CqlDate cw_ = context.Operators.Add(cu_, (bn_ as CqlQuantity));
+				Date cy_ = bj_?.BirthDateElement;
+				string cz_ = cy_?.Value;
+				CqlDate da_ = context.Operators.ConvertStringToDate(cz_);
+				CqlDate dc_ = context.Operators.Add(da_, (bt_ as CqlQuantity));
+				CqlDate de_ = context.Operators.Add(dc_, bv_);
+				CqlInterval<CqlDate> df_ = context.Operators.Interval(cw_, de_, true, false);
+				bool? dg_ = df_?.lowClosed;
+				Date di_ = bj_?.BirthDateElement;
+				string dj_ = di_?.Value;
+				CqlDate dk_ = context.Operators.ConvertStringToDate(dj_);
+				CqlDate dm_ = context.Operators.Add(dk_, (bn_ as CqlQuantity));
+				Date do_ = bj_?.BirthDateElement;
+				string dp_ = do_?.Value;
+				CqlDate dq_ = context.Operators.ConvertStringToDate(dp_);
+				CqlDate ds_ = context.Operators.Add(dq_, (bt_ as CqlQuantity));
+				CqlDate du_ = context.Operators.Add(ds_, bv_);
+				CqlInterval<CqlDate> dv_ = context.Operators.Interval(dm_, du_, true, false);
+				bool? dw_ = dv_?.highClosed;
+				CqlInterval<CqlDateTime> dx_ = context.Operators.Interval(bz_, cq_, dg_, dw_);
 
 				return dx_;
 			}
 			else if (choice is Timing)
 			{
-				var dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
+				object dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
 
 				return (dy_ as CqlInterval<CqlDateTime>);
 			}
@@ -1477,7 +1497,7 @@ public class QICoreCommon_2_0_000
 		{
 			if (choice is CqlDateTime)
 			{
-				var b_ = context.Operators.Interval((choice as CqlDateTime), (choice as CqlDateTime), true, true);
+				CqlInterval<CqlDateTime> b_ = context.Operators.Interval((choice as CqlDateTime), (choice as CqlDateTime), true, true);
 
 				return b_;
 			}
@@ -1487,117 +1507,117 @@ public class QICoreCommon_2_0_000
 			}
 			else if (choice is CqlQuantity)
 			{
-				var c_ = this.Patient();
-				var d_ = c_?.BirthDateElement;
-				var e_ = d_?.Value;
-				var f_ = context.Operators.ConvertStringToDate(e_);
-				var g_ = context.Operators.Add(f_, (choice as CqlQuantity));
-				var i_ = c_?.BirthDateElement;
-				var j_ = i_?.Value;
-				var k_ = context.Operators.ConvertStringToDate(j_);
-				var l_ = context.Operators.Add(k_, (choice as CqlQuantity));
-				var m_ = context.Operators.Quantity(1m, "year");
-				var n_ = context.Operators.Add(l_, m_);
-				var o_ = context.Operators.Interval(g_, n_, true, false);
-				var p_ = o_?.low;
-				var q_ = context.Operators.ConvertDateToDateTime(p_);
-				var s_ = c_?.BirthDateElement;
-				var t_ = s_?.Value;
-				var u_ = context.Operators.ConvertStringToDate(t_);
-				var v_ = context.Operators.Add(u_, (choice as CqlQuantity));
-				var x_ = c_?.BirthDateElement;
-				var y_ = x_?.Value;
-				var z_ = context.Operators.ConvertStringToDate(y_);
-				var aa_ = context.Operators.Add(z_, (choice as CqlQuantity));
-				var ac_ = context.Operators.Add(aa_, m_);
-				var ad_ = context.Operators.Interval(v_, ac_, true, false);
-				var ae_ = ad_?.high;
-				var af_ = context.Operators.ConvertDateToDateTime(ae_);
-				var ah_ = c_?.BirthDateElement;
-				var ai_ = ah_?.Value;
-				var aj_ = context.Operators.ConvertStringToDate(ai_);
-				var ak_ = context.Operators.Add(aj_, (choice as CqlQuantity));
-				var am_ = c_?.BirthDateElement;
-				var an_ = am_?.Value;
-				var ao_ = context.Operators.ConvertStringToDate(an_);
-				var ap_ = context.Operators.Add(ao_, (choice as CqlQuantity));
-				var ar_ = context.Operators.Add(ap_, m_);
-				var as_ = context.Operators.Interval(ak_, ar_, true, false);
-				var at_ = as_?.lowClosed;
-				var av_ = c_?.BirthDateElement;
-				var aw_ = av_?.Value;
-				var ax_ = context.Operators.ConvertStringToDate(aw_);
-				var ay_ = context.Operators.Add(ax_, (choice as CqlQuantity));
-				var ba_ = c_?.BirthDateElement;
-				var bb_ = ba_?.Value;
-				var bc_ = context.Operators.ConvertStringToDate(bb_);
-				var bd_ = context.Operators.Add(bc_, (choice as CqlQuantity));
-				var bf_ = context.Operators.Add(bd_, m_);
-				var bg_ = context.Operators.Interval(ay_, bf_, true, false);
-				var bh_ = bg_?.highClosed;
-				var bi_ = context.Operators.Interval(q_, af_, at_, bh_);
+				Patient c_ = this.Patient();
+				Date d_ = c_?.BirthDateElement;
+				string e_ = d_?.Value;
+				CqlDate f_ = context.Operators.ConvertStringToDate(e_);
+				CqlDate g_ = context.Operators.Add(f_, (choice as CqlQuantity));
+				Date i_ = c_?.BirthDateElement;
+				string j_ = i_?.Value;
+				CqlDate k_ = context.Operators.ConvertStringToDate(j_);
+				CqlDate l_ = context.Operators.Add(k_, (choice as CqlQuantity));
+				CqlQuantity m_ = context.Operators.Quantity(1m, "year");
+				CqlDate n_ = context.Operators.Add(l_, m_);
+				CqlInterval<CqlDate> o_ = context.Operators.Interval(g_, n_, true, false);
+				CqlDate p_ = o_?.low;
+				CqlDateTime q_ = context.Operators.ConvertDateToDateTime(p_);
+				Date s_ = c_?.BirthDateElement;
+				string t_ = s_?.Value;
+				CqlDate u_ = context.Operators.ConvertStringToDate(t_);
+				CqlDate v_ = context.Operators.Add(u_, (choice as CqlQuantity));
+				Date x_ = c_?.BirthDateElement;
+				string y_ = x_?.Value;
+				CqlDate z_ = context.Operators.ConvertStringToDate(y_);
+				CqlDate aa_ = context.Operators.Add(z_, (choice as CqlQuantity));
+				CqlDate ac_ = context.Operators.Add(aa_, m_);
+				CqlInterval<CqlDate> ad_ = context.Operators.Interval(v_, ac_, true, false);
+				CqlDate ae_ = ad_?.high;
+				CqlDateTime af_ = context.Operators.ConvertDateToDateTime(ae_);
+				Date ah_ = c_?.BirthDateElement;
+				string ai_ = ah_?.Value;
+				CqlDate aj_ = context.Operators.ConvertStringToDate(ai_);
+				CqlDate ak_ = context.Operators.Add(aj_, (choice as CqlQuantity));
+				Date am_ = c_?.BirthDateElement;
+				string an_ = am_?.Value;
+				CqlDate ao_ = context.Operators.ConvertStringToDate(an_);
+				CqlDate ap_ = context.Operators.Add(ao_, (choice as CqlQuantity));
+				CqlDate ar_ = context.Operators.Add(ap_, m_);
+				CqlInterval<CqlDate> as_ = context.Operators.Interval(ak_, ar_, true, false);
+				bool? at_ = as_?.lowClosed;
+				Date av_ = c_?.BirthDateElement;
+				string aw_ = av_?.Value;
+				CqlDate ax_ = context.Operators.ConvertStringToDate(aw_);
+				CqlDate ay_ = context.Operators.Add(ax_, (choice as CqlQuantity));
+				Date ba_ = c_?.BirthDateElement;
+				string bb_ = ba_?.Value;
+				CqlDate bc_ = context.Operators.ConvertStringToDate(bb_);
+				CqlDate bd_ = context.Operators.Add(bc_, (choice as CqlQuantity));
+				CqlDate bf_ = context.Operators.Add(bd_, m_);
+				CqlInterval<CqlDate> bg_ = context.Operators.Interval(ay_, bf_, true, false);
+				bool? bh_ = bg_?.highClosed;
+				CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(q_, af_, at_, bh_);
 
 				return bi_;
 			}
 			else if (choice is CqlInterval<CqlQuantity>)
 			{
-				var bj_ = this.Patient();
-				var bk_ = bj_?.BirthDateElement;
-				var bl_ = bk_?.Value;
-				var bm_ = context.Operators.ConvertStringToDate(bl_);
-				var bn_ = context.Operators.LateBoundProperty<object>(choice, "low");
-				var bo_ = context.Operators.Add(bm_, (bn_ as CqlQuantity));
-				var bq_ = bj_?.BirthDateElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.ConvertStringToDate(br_);
-				var bt_ = context.Operators.LateBoundProperty<object>(choice, "high");
-				var bu_ = context.Operators.Add(bs_, (bt_ as CqlQuantity));
-				var bv_ = context.Operators.Quantity(1m, "year");
-				var bw_ = context.Operators.Add(bu_, bv_);
-				var bx_ = context.Operators.Interval(bo_, bw_, true, false);
-				var by_ = bx_?.low;
-				var bz_ = context.Operators.ConvertDateToDateTime(by_);
-				var cb_ = bj_?.BirthDateElement;
-				var cc_ = cb_?.Value;
-				var cd_ = context.Operators.ConvertStringToDate(cc_);
-				var cf_ = context.Operators.Add(cd_, (bn_ as CqlQuantity));
-				var ch_ = bj_?.BirthDateElement;
-				var ci_ = ch_?.Value;
-				var cj_ = context.Operators.ConvertStringToDate(ci_);
-				var cl_ = context.Operators.Add(cj_, (bt_ as CqlQuantity));
-				var cn_ = context.Operators.Add(cl_, bv_);
-				var co_ = context.Operators.Interval(cf_, cn_, true, false);
-				var cp_ = co_?.high;
-				var cq_ = context.Operators.ConvertDateToDateTime(cp_);
-				var cs_ = bj_?.BirthDateElement;
-				var ct_ = cs_?.Value;
-				var cu_ = context.Operators.ConvertStringToDate(ct_);
-				var cw_ = context.Operators.Add(cu_, (bn_ as CqlQuantity));
-				var cy_ = bj_?.BirthDateElement;
-				var cz_ = cy_?.Value;
-				var da_ = context.Operators.ConvertStringToDate(cz_);
-				var dc_ = context.Operators.Add(da_, (bt_ as CqlQuantity));
-				var de_ = context.Operators.Add(dc_, bv_);
-				var df_ = context.Operators.Interval(cw_, de_, true, false);
-				var dg_ = df_?.lowClosed;
-				var di_ = bj_?.BirthDateElement;
-				var dj_ = di_?.Value;
-				var dk_ = context.Operators.ConvertStringToDate(dj_);
-				var dm_ = context.Operators.Add(dk_, (bn_ as CqlQuantity));
-				var do_ = bj_?.BirthDateElement;
-				var dp_ = do_?.Value;
-				var dq_ = context.Operators.ConvertStringToDate(dp_);
-				var ds_ = context.Operators.Add(dq_, (bt_ as CqlQuantity));
-				var du_ = context.Operators.Add(ds_, bv_);
-				var dv_ = context.Operators.Interval(dm_, du_, true, false);
-				var dw_ = dv_?.highClosed;
-				var dx_ = context.Operators.Interval(bz_, cq_, dg_, dw_);
+				Patient bj_ = this.Patient();
+				Date bk_ = bj_?.BirthDateElement;
+				string bl_ = bk_?.Value;
+				CqlDate bm_ = context.Operators.ConvertStringToDate(bl_);
+				object bn_ = context.Operators.LateBoundProperty<object>(choice, "low");
+				CqlDate bo_ = context.Operators.Add(bm_, (bn_ as CqlQuantity));
+				Date bq_ = bj_?.BirthDateElement;
+				string br_ = bq_?.Value;
+				CqlDate bs_ = context.Operators.ConvertStringToDate(br_);
+				object bt_ = context.Operators.LateBoundProperty<object>(choice, "high");
+				CqlDate bu_ = context.Operators.Add(bs_, (bt_ as CqlQuantity));
+				CqlQuantity bv_ = context.Operators.Quantity(1m, "year");
+				CqlDate bw_ = context.Operators.Add(bu_, bv_);
+				CqlInterval<CqlDate> bx_ = context.Operators.Interval(bo_, bw_, true, false);
+				CqlDate by_ = bx_?.low;
+				CqlDateTime bz_ = context.Operators.ConvertDateToDateTime(by_);
+				Date cb_ = bj_?.BirthDateElement;
+				string cc_ = cb_?.Value;
+				CqlDate cd_ = context.Operators.ConvertStringToDate(cc_);
+				CqlDate cf_ = context.Operators.Add(cd_, (bn_ as CqlQuantity));
+				Date ch_ = bj_?.BirthDateElement;
+				string ci_ = ch_?.Value;
+				CqlDate cj_ = context.Operators.ConvertStringToDate(ci_);
+				CqlDate cl_ = context.Operators.Add(cj_, (bt_ as CqlQuantity));
+				CqlDate cn_ = context.Operators.Add(cl_, bv_);
+				CqlInterval<CqlDate> co_ = context.Operators.Interval(cf_, cn_, true, false);
+				CqlDate cp_ = co_?.high;
+				CqlDateTime cq_ = context.Operators.ConvertDateToDateTime(cp_);
+				Date cs_ = bj_?.BirthDateElement;
+				string ct_ = cs_?.Value;
+				CqlDate cu_ = context.Operators.ConvertStringToDate(ct_);
+				CqlDate cw_ = context.Operators.Add(cu_, (bn_ as CqlQuantity));
+				Date cy_ = bj_?.BirthDateElement;
+				string cz_ = cy_?.Value;
+				CqlDate da_ = context.Operators.ConvertStringToDate(cz_);
+				CqlDate dc_ = context.Operators.Add(da_, (bt_ as CqlQuantity));
+				CqlDate de_ = context.Operators.Add(dc_, bv_);
+				CqlInterval<CqlDate> df_ = context.Operators.Interval(cw_, de_, true, false);
+				bool? dg_ = df_?.lowClosed;
+				Date di_ = bj_?.BirthDateElement;
+				string dj_ = di_?.Value;
+				CqlDate dk_ = context.Operators.ConvertStringToDate(dj_);
+				CqlDate dm_ = context.Operators.Add(dk_, (bn_ as CqlQuantity));
+				Date do_ = bj_?.BirthDateElement;
+				string dp_ = do_?.Value;
+				CqlDate dq_ = context.Operators.ConvertStringToDate(dp_);
+				CqlDate ds_ = context.Operators.Add(dq_, (bt_ as CqlQuantity));
+				CqlDate du_ = context.Operators.Add(ds_, bv_);
+				CqlInterval<CqlDate> dv_ = context.Operators.Interval(dm_, du_, true, false);
+				bool? dw_ = dv_?.highClosed;
+				CqlInterval<CqlDateTime> dx_ = context.Operators.Interval(bz_, cq_, dg_, dw_);
 
 				return dx_;
 			}
 			else if (choice is Timing)
 			{
-				var dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
+				object dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
 
 				return (dy_ as CqlInterval<CqlDateTime>);
 			}
@@ -1620,187 +1640,187 @@ public class QICoreCommon_2_0_000
 		{
 			bool b_()
 			{
-				var f_ = condition?.Abatement;
-				var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-				var h_ = g_ is CqlDateTime;
+				DataType f_ = condition?.Abatement;
+				object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+				bool h_ = g_ is CqlDateTime;
 
 				return h_;
 			};
 			bool c_()
 			{
-				var i_ = condition?.Abatement;
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = j_ is CqlQuantity;
+				DataType i_ = condition?.Abatement;
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				bool k_ = j_ is CqlQuantity;
 
 				return k_;
 			};
 			bool d_()
 			{
-				var l_ = condition?.Abatement;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = m_ is CqlInterval<CqlQuantity>;
+				DataType l_ = condition?.Abatement;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				bool n_ = m_ is CqlInterval<CqlQuantity>;
 
 				return n_;
 			};
 			bool e_()
 			{
-				var o_ = condition?.Abatement;
-				var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-				var q_ = p_ is CqlInterval<CqlDateTime>;
+				DataType o_ = condition?.Abatement;
+				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+				bool q_ = p_ is CqlInterval<CqlDateTime>;
 
 				return q_;
 			};
 			if (b_())
 			{
-				var r_ = condition?.Abatement;
-				var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var u_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var v_ = context.Operators.Interval((s_ as CqlDateTime), (u_ as CqlDateTime), true, true);
+				DataType r_ = condition?.Abatement;
+				object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+				object u_ = FHIRHelpers_4_3_000.ToValue(r_);
+				CqlInterval<CqlDateTime> v_ = context.Operators.Interval((s_ as CqlDateTime), (u_ as CqlDateTime), true, true);
 
 				return v_;
 			}
 			else if (c_())
 			{
-				var w_ = this.Patient();
-				var x_ = w_?.BirthDateElement;
-				var y_ = x_?.Value;
-				var z_ = context.Operators.ConvertStringToDate(y_);
-				var aa_ = condition?.Abatement;
-				var ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var ac_ = context.Operators.Add(z_, (ab_ as CqlQuantity));
-				var ae_ = w_?.BirthDateElement;
-				var af_ = ae_?.Value;
-				var ag_ = context.Operators.ConvertStringToDate(af_);
-				var ai_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var aj_ = context.Operators.Add(ag_, (ai_ as CqlQuantity));
-				var ak_ = context.Operators.Quantity(1m, "year");
-				var al_ = context.Operators.Add(aj_, ak_);
-				var am_ = context.Operators.Interval(ac_, al_, true, false);
-				var an_ = am_?.low;
-				var ao_ = context.Operators.ConvertDateToDateTime(an_);
-				var aq_ = w_?.BirthDateElement;
-				var ar_ = aq_?.Value;
-				var as_ = context.Operators.ConvertStringToDate(ar_);
-				var au_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var av_ = context.Operators.Add(as_, (au_ as CqlQuantity));
-				var ax_ = w_?.BirthDateElement;
-				var ay_ = ax_?.Value;
-				var az_ = context.Operators.ConvertStringToDate(ay_);
-				var bb_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bc_ = context.Operators.Add(az_, (bb_ as CqlQuantity));
-				var be_ = context.Operators.Add(bc_, ak_);
-				var bf_ = context.Operators.Interval(av_, be_, true, false);
-				var bg_ = bf_?.high;
-				var bh_ = context.Operators.ConvertDateToDateTime(bg_);
-				var bj_ = w_?.BirthDateElement;
-				var bk_ = bj_?.Value;
-				var bl_ = context.Operators.ConvertStringToDate(bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bo_ = context.Operators.Add(bl_, (bn_ as CqlQuantity));
-				var bq_ = w_?.BirthDateElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.ConvertStringToDate(br_);
-				var bu_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bv_ = context.Operators.Add(bs_, (bu_ as CqlQuantity));
-				var bx_ = context.Operators.Add(bv_, ak_);
-				var by_ = context.Operators.Interval(bo_, bx_, true, false);
-				var bz_ = by_?.lowClosed;
-				var cb_ = w_?.BirthDateElement;
-				var cc_ = cb_?.Value;
-				var cd_ = context.Operators.ConvertStringToDate(cc_);
-				var cf_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var cg_ = context.Operators.Add(cd_, (cf_ as CqlQuantity));
-				var ci_ = w_?.BirthDateElement;
-				var cj_ = ci_?.Value;
-				var ck_ = context.Operators.ConvertStringToDate(cj_);
-				var cm_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var cn_ = context.Operators.Add(ck_, (cm_ as CqlQuantity));
-				var cp_ = context.Operators.Add(cn_, ak_);
-				var cq_ = context.Operators.Interval(cg_, cp_, true, false);
-				var cr_ = cq_?.highClosed;
-				var cs_ = context.Operators.Interval(ao_, bh_, bz_, cr_);
+				Patient w_ = this.Patient();
+				Date x_ = w_?.BirthDateElement;
+				string y_ = x_?.Value;
+				CqlDate z_ = context.Operators.ConvertStringToDate(y_);
+				DataType aa_ = condition?.Abatement;
+				object ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate ac_ = context.Operators.Add(z_, (ab_ as CqlQuantity));
+				Date ae_ = w_?.BirthDateElement;
+				string af_ = ae_?.Value;
+				CqlDate ag_ = context.Operators.ConvertStringToDate(af_);
+				object ai_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate aj_ = context.Operators.Add(ag_, (ai_ as CqlQuantity));
+				CqlQuantity ak_ = context.Operators.Quantity(1m, "year");
+				CqlDate al_ = context.Operators.Add(aj_, ak_);
+				CqlInterval<CqlDate> am_ = context.Operators.Interval(ac_, al_, true, false);
+				CqlDate an_ = am_?.low;
+				CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
+				Date aq_ = w_?.BirthDateElement;
+				string ar_ = aq_?.Value;
+				CqlDate as_ = context.Operators.ConvertStringToDate(ar_);
+				object au_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate av_ = context.Operators.Add(as_, (au_ as CqlQuantity));
+				Date ax_ = w_?.BirthDateElement;
+				string ay_ = ax_?.Value;
+				CqlDate az_ = context.Operators.ConvertStringToDate(ay_);
+				object bb_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bc_ = context.Operators.Add(az_, (bb_ as CqlQuantity));
+				CqlDate be_ = context.Operators.Add(bc_, ak_);
+				CqlInterval<CqlDate> bf_ = context.Operators.Interval(av_, be_, true, false);
+				CqlDate bg_ = bf_?.high;
+				CqlDateTime bh_ = context.Operators.ConvertDateToDateTime(bg_);
+				Date bj_ = w_?.BirthDateElement;
+				string bk_ = bj_?.Value;
+				CqlDate bl_ = context.Operators.ConvertStringToDate(bk_);
+				object bn_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bo_ = context.Operators.Add(bl_, (bn_ as CqlQuantity));
+				Date bq_ = w_?.BirthDateElement;
+				string br_ = bq_?.Value;
+				CqlDate bs_ = context.Operators.ConvertStringToDate(br_);
+				object bu_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bv_ = context.Operators.Add(bs_, (bu_ as CqlQuantity));
+				CqlDate bx_ = context.Operators.Add(bv_, ak_);
+				CqlInterval<CqlDate> by_ = context.Operators.Interval(bo_, bx_, true, false);
+				bool? bz_ = by_?.lowClosed;
+				Date cb_ = w_?.BirthDateElement;
+				string cc_ = cb_?.Value;
+				CqlDate cd_ = context.Operators.ConvertStringToDate(cc_);
+				object cf_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate cg_ = context.Operators.Add(cd_, (cf_ as CqlQuantity));
+				Date ci_ = w_?.BirthDateElement;
+				string cj_ = ci_?.Value;
+				CqlDate ck_ = context.Operators.ConvertStringToDate(cj_);
+				object cm_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate cn_ = context.Operators.Add(ck_, (cm_ as CqlQuantity));
+				CqlDate cp_ = context.Operators.Add(cn_, ak_);
+				CqlInterval<CqlDate> cq_ = context.Operators.Interval(cg_, cp_, true, false);
+				bool? cr_ = cq_?.highClosed;
+				CqlInterval<CqlDateTime> cs_ = context.Operators.Interval(ao_, bh_, bz_, cr_);
 
 				return cs_;
 			}
 			else if (d_())
 			{
-				var ct_ = this.Patient();
-				var cu_ = ct_?.BirthDateElement;
-				var cv_ = cu_?.Value;
-				var cw_ = context.Operators.ConvertStringToDate(cv_);
-				var cx_ = condition?.Abatement;
-				var cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var cz_ = context.Operators.LateBoundProperty<object>(cy_, "low");
-				var da_ = context.Operators.Add(cw_, (cz_ as CqlQuantity));
-				var dc_ = ct_?.BirthDateElement;
-				var dd_ = dc_?.Value;
-				var de_ = context.Operators.ConvertStringToDate(dd_);
-				var dg_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var dh_ = context.Operators.LateBoundProperty<object>(dg_, "high");
-				var di_ = context.Operators.Add(de_, (dh_ as CqlQuantity));
-				var dj_ = context.Operators.Quantity(1m, "year");
-				var dk_ = context.Operators.Add(di_, dj_);
-				var dl_ = context.Operators.Interval(da_, dk_, true, false);
-				var dm_ = dl_?.low;
-				var dn_ = context.Operators.ConvertDateToDateTime(dm_);
-				var dp_ = ct_?.BirthDateElement;
-				var dq_ = dp_?.Value;
-				var dr_ = context.Operators.ConvertStringToDate(dq_);
-				var dt_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var du_ = context.Operators.LateBoundProperty<object>(dt_, "low");
-				var dv_ = context.Operators.Add(dr_, (du_ as CqlQuantity));
-				var dx_ = ct_?.BirthDateElement;
-				var dy_ = dx_?.Value;
-				var dz_ = context.Operators.ConvertStringToDate(dy_);
-				var eb_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ec_ = context.Operators.LateBoundProperty<object>(eb_, "high");
-				var ed_ = context.Operators.Add(dz_, (ec_ as CqlQuantity));
-				var ef_ = context.Operators.Add(ed_, dj_);
-				var eg_ = context.Operators.Interval(dv_, ef_, true, false);
-				var eh_ = eg_?.high;
-				var ei_ = context.Operators.ConvertDateToDateTime(eh_);
-				var ek_ = ct_?.BirthDateElement;
-				var el_ = ek_?.Value;
-				var em_ = context.Operators.ConvertStringToDate(el_);
-				var eo_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ep_ = context.Operators.LateBoundProperty<object>(eo_, "low");
-				var eq_ = context.Operators.Add(em_, (ep_ as CqlQuantity));
-				var es_ = ct_?.BirthDateElement;
-				var et_ = es_?.Value;
-				var eu_ = context.Operators.ConvertStringToDate(et_);
-				var ew_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ex_ = context.Operators.LateBoundProperty<object>(ew_, "high");
-				var ey_ = context.Operators.Add(eu_, (ex_ as CqlQuantity));
-				var fa_ = context.Operators.Add(ey_, dj_);
-				var fb_ = context.Operators.Interval(eq_, fa_, true, false);
-				var fc_ = fb_?.lowClosed;
-				var fe_ = ct_?.BirthDateElement;
-				var ff_ = fe_?.Value;
-				var fg_ = context.Operators.ConvertStringToDate(ff_);
-				var fi_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var fj_ = context.Operators.LateBoundProperty<object>(fi_, "low");
-				var fk_ = context.Operators.Add(fg_, (fj_ as CqlQuantity));
-				var fm_ = ct_?.BirthDateElement;
-				var fn_ = fm_?.Value;
-				var fo_ = context.Operators.ConvertStringToDate(fn_);
-				var fq_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var fr_ = context.Operators.LateBoundProperty<object>(fq_, "high");
-				var fs_ = context.Operators.Add(fo_, (fr_ as CqlQuantity));
-				var fu_ = context.Operators.Add(fs_, dj_);
-				var fv_ = context.Operators.Interval(fk_, fu_, true, false);
-				var fw_ = fv_?.highClosed;
-				var fx_ = context.Operators.Interval(dn_, ei_, fc_, fw_);
+				Patient ct_ = this.Patient();
+				Date cu_ = ct_?.BirthDateElement;
+				string cv_ = cu_?.Value;
+				CqlDate cw_ = context.Operators.ConvertStringToDate(cv_);
+				DataType cx_ = condition?.Abatement;
+				object cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object cz_ = context.Operators.LateBoundProperty<object>(cy_, "low");
+				CqlDate da_ = context.Operators.Add(cw_, (cz_ as CqlQuantity));
+				Date dc_ = ct_?.BirthDateElement;
+				string dd_ = dc_?.Value;
+				CqlDate de_ = context.Operators.ConvertStringToDate(dd_);
+				object dg_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object dh_ = context.Operators.LateBoundProperty<object>(dg_, "high");
+				CqlDate di_ = context.Operators.Add(de_, (dh_ as CqlQuantity));
+				CqlQuantity dj_ = context.Operators.Quantity(1m, "year");
+				CqlDate dk_ = context.Operators.Add(di_, dj_);
+				CqlInterval<CqlDate> dl_ = context.Operators.Interval(da_, dk_, true, false);
+				CqlDate dm_ = dl_?.low;
+				CqlDateTime dn_ = context.Operators.ConvertDateToDateTime(dm_);
+				Date dp_ = ct_?.BirthDateElement;
+				string dq_ = dp_?.Value;
+				CqlDate dr_ = context.Operators.ConvertStringToDate(dq_);
+				object dt_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object du_ = context.Operators.LateBoundProperty<object>(dt_, "low");
+				CqlDate dv_ = context.Operators.Add(dr_, (du_ as CqlQuantity));
+				Date dx_ = ct_?.BirthDateElement;
+				string dy_ = dx_?.Value;
+				CqlDate dz_ = context.Operators.ConvertStringToDate(dy_);
+				object eb_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ec_ = context.Operators.LateBoundProperty<object>(eb_, "high");
+				CqlDate ed_ = context.Operators.Add(dz_, (ec_ as CqlQuantity));
+				CqlDate ef_ = context.Operators.Add(ed_, dj_);
+				CqlInterval<CqlDate> eg_ = context.Operators.Interval(dv_, ef_, true, false);
+				CqlDate eh_ = eg_?.high;
+				CqlDateTime ei_ = context.Operators.ConvertDateToDateTime(eh_);
+				Date ek_ = ct_?.BirthDateElement;
+				string el_ = ek_?.Value;
+				CqlDate em_ = context.Operators.ConvertStringToDate(el_);
+				object eo_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ep_ = context.Operators.LateBoundProperty<object>(eo_, "low");
+				CqlDate eq_ = context.Operators.Add(em_, (ep_ as CqlQuantity));
+				Date es_ = ct_?.BirthDateElement;
+				string et_ = es_?.Value;
+				CqlDate eu_ = context.Operators.ConvertStringToDate(et_);
+				object ew_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ex_ = context.Operators.LateBoundProperty<object>(ew_, "high");
+				CqlDate ey_ = context.Operators.Add(eu_, (ex_ as CqlQuantity));
+				CqlDate fa_ = context.Operators.Add(ey_, dj_);
+				CqlInterval<CqlDate> fb_ = context.Operators.Interval(eq_, fa_, true, false);
+				bool? fc_ = fb_?.lowClosed;
+				Date fe_ = ct_?.BirthDateElement;
+				string ff_ = fe_?.Value;
+				CqlDate fg_ = context.Operators.ConvertStringToDate(ff_);
+				object fi_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object fj_ = context.Operators.LateBoundProperty<object>(fi_, "low");
+				CqlDate fk_ = context.Operators.Add(fg_, (fj_ as CqlQuantity));
+				Date fm_ = ct_?.BirthDateElement;
+				string fn_ = fm_?.Value;
+				CqlDate fo_ = context.Operators.ConvertStringToDate(fn_);
+				object fq_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object fr_ = context.Operators.LateBoundProperty<object>(fq_, "high");
+				CqlDate fs_ = context.Operators.Add(fo_, (fr_ as CqlQuantity));
+				CqlDate fu_ = context.Operators.Add(fs_, dj_);
+				CqlInterval<CqlDate> fv_ = context.Operators.Interval(fk_, fu_, true, false);
+				bool? fw_ = fv_?.highClosed;
+				CqlInterval<CqlDateTime> fx_ = context.Operators.Interval(dn_, ei_, fc_, fw_);
 
 				return fx_;
 			}
 			else if (e_())
 			{
-				var fy_ = condition?.Abatement;
-				var fz_ = FHIRHelpers_4_3_000.ToValue(fy_);
-				var ga_ = context.Operators.LateBoundProperty<object>(fz_, "low");
-				var gc_ = FHIRHelpers_4_3_000.ToValue(fy_);
-				var gd_ = context.Operators.LateBoundProperty<object>(gc_, "high");
-				var ge_ = context.Operators.Interval((ga_ as CqlDateTime), (gd_ as CqlDateTime), true, false);
+				DataType fy_ = condition?.Abatement;
+				object fz_ = FHIRHelpers_4_3_000.ToValue(fy_);
+				object ga_ = context.Operators.LateBoundProperty<object>(fz_, "low");
+				object gc_ = FHIRHelpers_4_3_000.ToValue(fy_);
+				object gd_ = context.Operators.LateBoundProperty<object>(gc_, "high");
+				CqlInterval<CqlDateTime> ge_ = context.Operators.Interval((ga_ as CqlDateTime), (gd_ as CqlDateTime), true, false);
 
 				return ge_;
 			}
@@ -1822,187 +1842,187 @@ public class QICoreCommon_2_0_000
 		{
 			bool b_()
 			{
-				var f_ = condition?.Abatement;
-				var g_ = FHIRHelpers_4_3_000.ToValue(f_);
-				var h_ = g_ is CqlDateTime;
+				DataType f_ = condition?.Abatement;
+				object g_ = FHIRHelpers_4_3_000.ToValue(f_);
+				bool h_ = g_ is CqlDateTime;
 
 				return h_;
 			};
 			bool c_()
 			{
-				var i_ = condition?.Abatement;
-				var j_ = FHIRHelpers_4_3_000.ToValue(i_);
-				var k_ = j_ is CqlQuantity;
+				DataType i_ = condition?.Abatement;
+				object j_ = FHIRHelpers_4_3_000.ToValue(i_);
+				bool k_ = j_ is CqlQuantity;
 
 				return k_;
 			};
 			bool d_()
 			{
-				var l_ = condition?.Abatement;
-				var m_ = FHIRHelpers_4_3_000.ToValue(l_);
-				var n_ = m_ is CqlInterval<CqlQuantity>;
+				DataType l_ = condition?.Abatement;
+				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
+				bool n_ = m_ is CqlInterval<CqlQuantity>;
 
 				return n_;
 			};
 			bool e_()
 			{
-				var o_ = condition?.Abatement;
-				var p_ = FHIRHelpers_4_3_000.ToValue(o_);
-				var q_ = p_ is CqlInterval<CqlDateTime>;
+				DataType o_ = condition?.Abatement;
+				object p_ = FHIRHelpers_4_3_000.ToValue(o_);
+				bool q_ = p_ is CqlInterval<CqlDateTime>;
 
 				return q_;
 			};
 			if (b_())
 			{
-				var r_ = condition?.Abatement;
-				var s_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var u_ = FHIRHelpers_4_3_000.ToValue(r_);
-				var v_ = context.Operators.Interval((s_ as CqlDateTime), (u_ as CqlDateTime), true, true);
+				DataType r_ = condition?.Abatement;
+				object s_ = FHIRHelpers_4_3_000.ToValue(r_);
+				object u_ = FHIRHelpers_4_3_000.ToValue(r_);
+				CqlInterval<CqlDateTime> v_ = context.Operators.Interval((s_ as CqlDateTime), (u_ as CqlDateTime), true, true);
 
 				return v_;
 			}
 			else if (c_())
 			{
-				var w_ = this.Patient();
-				var x_ = w_?.BirthDateElement;
-				var y_ = x_?.Value;
-				var z_ = context.Operators.ConvertStringToDate(y_);
-				var aa_ = condition?.Abatement;
-				var ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var ac_ = context.Operators.Add(z_, (ab_ as CqlQuantity));
-				var ae_ = w_?.BirthDateElement;
-				var af_ = ae_?.Value;
-				var ag_ = context.Operators.ConvertStringToDate(af_);
-				var ai_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var aj_ = context.Operators.Add(ag_, (ai_ as CqlQuantity));
-				var ak_ = context.Operators.Quantity(1m, "year");
-				var al_ = context.Operators.Add(aj_, ak_);
-				var am_ = context.Operators.Interval(ac_, al_, true, false);
-				var an_ = am_?.low;
-				var ao_ = context.Operators.ConvertDateToDateTime(an_);
-				var aq_ = w_?.BirthDateElement;
-				var ar_ = aq_?.Value;
-				var as_ = context.Operators.ConvertStringToDate(ar_);
-				var au_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var av_ = context.Operators.Add(as_, (au_ as CqlQuantity));
-				var ax_ = w_?.BirthDateElement;
-				var ay_ = ax_?.Value;
-				var az_ = context.Operators.ConvertStringToDate(ay_);
-				var bb_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bc_ = context.Operators.Add(az_, (bb_ as CqlQuantity));
-				var be_ = context.Operators.Add(bc_, ak_);
-				var bf_ = context.Operators.Interval(av_, be_, true, false);
-				var bg_ = bf_?.high;
-				var bh_ = context.Operators.ConvertDateToDateTime(bg_);
-				var bj_ = w_?.BirthDateElement;
-				var bk_ = bj_?.Value;
-				var bl_ = context.Operators.ConvertStringToDate(bk_);
-				var bn_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bo_ = context.Operators.Add(bl_, (bn_ as CqlQuantity));
-				var bq_ = w_?.BirthDateElement;
-				var br_ = bq_?.Value;
-				var bs_ = context.Operators.ConvertStringToDate(br_);
-				var bu_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var bv_ = context.Operators.Add(bs_, (bu_ as CqlQuantity));
-				var bx_ = context.Operators.Add(bv_, ak_);
-				var by_ = context.Operators.Interval(bo_, bx_, true, false);
-				var bz_ = by_?.lowClosed;
-				var cb_ = w_?.BirthDateElement;
-				var cc_ = cb_?.Value;
-				var cd_ = context.Operators.ConvertStringToDate(cc_);
-				var cf_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var cg_ = context.Operators.Add(cd_, (cf_ as CqlQuantity));
-				var ci_ = w_?.BirthDateElement;
-				var cj_ = ci_?.Value;
-				var ck_ = context.Operators.ConvertStringToDate(cj_);
-				var cm_ = FHIRHelpers_4_3_000.ToValue(aa_);
-				var cn_ = context.Operators.Add(ck_, (cm_ as CqlQuantity));
-				var cp_ = context.Operators.Add(cn_, ak_);
-				var cq_ = context.Operators.Interval(cg_, cp_, true, false);
-				var cr_ = cq_?.highClosed;
-				var cs_ = context.Operators.Interval(ao_, bh_, bz_, cr_);
+				Patient w_ = this.Patient();
+				Date x_ = w_?.BirthDateElement;
+				string y_ = x_?.Value;
+				CqlDate z_ = context.Operators.ConvertStringToDate(y_);
+				DataType aa_ = condition?.Abatement;
+				object ab_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate ac_ = context.Operators.Add(z_, (ab_ as CqlQuantity));
+				Date ae_ = w_?.BirthDateElement;
+				string af_ = ae_?.Value;
+				CqlDate ag_ = context.Operators.ConvertStringToDate(af_);
+				object ai_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate aj_ = context.Operators.Add(ag_, (ai_ as CqlQuantity));
+				CqlQuantity ak_ = context.Operators.Quantity(1m, "year");
+				CqlDate al_ = context.Operators.Add(aj_, ak_);
+				CqlInterval<CqlDate> am_ = context.Operators.Interval(ac_, al_, true, false);
+				CqlDate an_ = am_?.low;
+				CqlDateTime ao_ = context.Operators.ConvertDateToDateTime(an_);
+				Date aq_ = w_?.BirthDateElement;
+				string ar_ = aq_?.Value;
+				CqlDate as_ = context.Operators.ConvertStringToDate(ar_);
+				object au_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate av_ = context.Operators.Add(as_, (au_ as CqlQuantity));
+				Date ax_ = w_?.BirthDateElement;
+				string ay_ = ax_?.Value;
+				CqlDate az_ = context.Operators.ConvertStringToDate(ay_);
+				object bb_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bc_ = context.Operators.Add(az_, (bb_ as CqlQuantity));
+				CqlDate be_ = context.Operators.Add(bc_, ak_);
+				CqlInterval<CqlDate> bf_ = context.Operators.Interval(av_, be_, true, false);
+				CqlDate bg_ = bf_?.high;
+				CqlDateTime bh_ = context.Operators.ConvertDateToDateTime(bg_);
+				Date bj_ = w_?.BirthDateElement;
+				string bk_ = bj_?.Value;
+				CqlDate bl_ = context.Operators.ConvertStringToDate(bk_);
+				object bn_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bo_ = context.Operators.Add(bl_, (bn_ as CqlQuantity));
+				Date bq_ = w_?.BirthDateElement;
+				string br_ = bq_?.Value;
+				CqlDate bs_ = context.Operators.ConvertStringToDate(br_);
+				object bu_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate bv_ = context.Operators.Add(bs_, (bu_ as CqlQuantity));
+				CqlDate bx_ = context.Operators.Add(bv_, ak_);
+				CqlInterval<CqlDate> by_ = context.Operators.Interval(bo_, bx_, true, false);
+				bool? bz_ = by_?.lowClosed;
+				Date cb_ = w_?.BirthDateElement;
+				string cc_ = cb_?.Value;
+				CqlDate cd_ = context.Operators.ConvertStringToDate(cc_);
+				object cf_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate cg_ = context.Operators.Add(cd_, (cf_ as CqlQuantity));
+				Date ci_ = w_?.BirthDateElement;
+				string cj_ = ci_?.Value;
+				CqlDate ck_ = context.Operators.ConvertStringToDate(cj_);
+				object cm_ = FHIRHelpers_4_3_000.ToValue(aa_);
+				CqlDate cn_ = context.Operators.Add(ck_, (cm_ as CqlQuantity));
+				CqlDate cp_ = context.Operators.Add(cn_, ak_);
+				CqlInterval<CqlDate> cq_ = context.Operators.Interval(cg_, cp_, true, false);
+				bool? cr_ = cq_?.highClosed;
+				CqlInterval<CqlDateTime> cs_ = context.Operators.Interval(ao_, bh_, bz_, cr_);
 
 				return cs_;
 			}
 			else if (d_())
 			{
-				var ct_ = this.Patient();
-				var cu_ = ct_?.BirthDateElement;
-				var cv_ = cu_?.Value;
-				var cw_ = context.Operators.ConvertStringToDate(cv_);
-				var cx_ = condition?.Abatement;
-				var cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var cz_ = context.Operators.LateBoundProperty<object>(cy_, "low");
-				var da_ = context.Operators.Add(cw_, (cz_ as CqlQuantity));
-				var dc_ = ct_?.BirthDateElement;
-				var dd_ = dc_?.Value;
-				var de_ = context.Operators.ConvertStringToDate(dd_);
-				var dg_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var dh_ = context.Operators.LateBoundProperty<object>(dg_, "high");
-				var di_ = context.Operators.Add(de_, (dh_ as CqlQuantity));
-				var dj_ = context.Operators.Quantity(1m, "year");
-				var dk_ = context.Operators.Add(di_, dj_);
-				var dl_ = context.Operators.Interval(da_, dk_, true, false);
-				var dm_ = dl_?.low;
-				var dn_ = context.Operators.ConvertDateToDateTime(dm_);
-				var dp_ = ct_?.BirthDateElement;
-				var dq_ = dp_?.Value;
-				var dr_ = context.Operators.ConvertStringToDate(dq_);
-				var dt_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var du_ = context.Operators.LateBoundProperty<object>(dt_, "low");
-				var dv_ = context.Operators.Add(dr_, (du_ as CqlQuantity));
-				var dx_ = ct_?.BirthDateElement;
-				var dy_ = dx_?.Value;
-				var dz_ = context.Operators.ConvertStringToDate(dy_);
-				var eb_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ec_ = context.Operators.LateBoundProperty<object>(eb_, "high");
-				var ed_ = context.Operators.Add(dz_, (ec_ as CqlQuantity));
-				var ef_ = context.Operators.Add(ed_, dj_);
-				var eg_ = context.Operators.Interval(dv_, ef_, true, false);
-				var eh_ = eg_?.high;
-				var ei_ = context.Operators.ConvertDateToDateTime(eh_);
-				var ek_ = ct_?.BirthDateElement;
-				var el_ = ek_?.Value;
-				var em_ = context.Operators.ConvertStringToDate(el_);
-				var eo_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ep_ = context.Operators.LateBoundProperty<object>(eo_, "low");
-				var eq_ = context.Operators.Add(em_, (ep_ as CqlQuantity));
-				var es_ = ct_?.BirthDateElement;
-				var et_ = es_?.Value;
-				var eu_ = context.Operators.ConvertStringToDate(et_);
-				var ew_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var ex_ = context.Operators.LateBoundProperty<object>(ew_, "high");
-				var ey_ = context.Operators.Add(eu_, (ex_ as CqlQuantity));
-				var fa_ = context.Operators.Add(ey_, dj_);
-				var fb_ = context.Operators.Interval(eq_, fa_, true, false);
-				var fc_ = fb_?.lowClosed;
-				var fe_ = ct_?.BirthDateElement;
-				var ff_ = fe_?.Value;
-				var fg_ = context.Operators.ConvertStringToDate(ff_);
-				var fi_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var fj_ = context.Operators.LateBoundProperty<object>(fi_, "low");
-				var fk_ = context.Operators.Add(fg_, (fj_ as CqlQuantity));
-				var fm_ = ct_?.BirthDateElement;
-				var fn_ = fm_?.Value;
-				var fo_ = context.Operators.ConvertStringToDate(fn_);
-				var fq_ = FHIRHelpers_4_3_000.ToValue(cx_);
-				var fr_ = context.Operators.LateBoundProperty<object>(fq_, "high");
-				var fs_ = context.Operators.Add(fo_, (fr_ as CqlQuantity));
-				var fu_ = context.Operators.Add(fs_, dj_);
-				var fv_ = context.Operators.Interval(fk_, fu_, true, false);
-				var fw_ = fv_?.highClosed;
-				var fx_ = context.Operators.Interval(dn_, ei_, fc_, fw_);
+				Patient ct_ = this.Patient();
+				Date cu_ = ct_?.BirthDateElement;
+				string cv_ = cu_?.Value;
+				CqlDate cw_ = context.Operators.ConvertStringToDate(cv_);
+				DataType cx_ = condition?.Abatement;
+				object cy_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object cz_ = context.Operators.LateBoundProperty<object>(cy_, "low");
+				CqlDate da_ = context.Operators.Add(cw_, (cz_ as CqlQuantity));
+				Date dc_ = ct_?.BirthDateElement;
+				string dd_ = dc_?.Value;
+				CqlDate de_ = context.Operators.ConvertStringToDate(dd_);
+				object dg_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object dh_ = context.Operators.LateBoundProperty<object>(dg_, "high");
+				CqlDate di_ = context.Operators.Add(de_, (dh_ as CqlQuantity));
+				CqlQuantity dj_ = context.Operators.Quantity(1m, "year");
+				CqlDate dk_ = context.Operators.Add(di_, dj_);
+				CqlInterval<CqlDate> dl_ = context.Operators.Interval(da_, dk_, true, false);
+				CqlDate dm_ = dl_?.low;
+				CqlDateTime dn_ = context.Operators.ConvertDateToDateTime(dm_);
+				Date dp_ = ct_?.BirthDateElement;
+				string dq_ = dp_?.Value;
+				CqlDate dr_ = context.Operators.ConvertStringToDate(dq_);
+				object dt_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object du_ = context.Operators.LateBoundProperty<object>(dt_, "low");
+				CqlDate dv_ = context.Operators.Add(dr_, (du_ as CqlQuantity));
+				Date dx_ = ct_?.BirthDateElement;
+				string dy_ = dx_?.Value;
+				CqlDate dz_ = context.Operators.ConvertStringToDate(dy_);
+				object eb_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ec_ = context.Operators.LateBoundProperty<object>(eb_, "high");
+				CqlDate ed_ = context.Operators.Add(dz_, (ec_ as CqlQuantity));
+				CqlDate ef_ = context.Operators.Add(ed_, dj_);
+				CqlInterval<CqlDate> eg_ = context.Operators.Interval(dv_, ef_, true, false);
+				CqlDate eh_ = eg_?.high;
+				CqlDateTime ei_ = context.Operators.ConvertDateToDateTime(eh_);
+				Date ek_ = ct_?.BirthDateElement;
+				string el_ = ek_?.Value;
+				CqlDate em_ = context.Operators.ConvertStringToDate(el_);
+				object eo_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ep_ = context.Operators.LateBoundProperty<object>(eo_, "low");
+				CqlDate eq_ = context.Operators.Add(em_, (ep_ as CqlQuantity));
+				Date es_ = ct_?.BirthDateElement;
+				string et_ = es_?.Value;
+				CqlDate eu_ = context.Operators.ConvertStringToDate(et_);
+				object ew_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object ex_ = context.Operators.LateBoundProperty<object>(ew_, "high");
+				CqlDate ey_ = context.Operators.Add(eu_, (ex_ as CqlQuantity));
+				CqlDate fa_ = context.Operators.Add(ey_, dj_);
+				CqlInterval<CqlDate> fb_ = context.Operators.Interval(eq_, fa_, true, false);
+				bool? fc_ = fb_?.lowClosed;
+				Date fe_ = ct_?.BirthDateElement;
+				string ff_ = fe_?.Value;
+				CqlDate fg_ = context.Operators.ConvertStringToDate(ff_);
+				object fi_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object fj_ = context.Operators.LateBoundProperty<object>(fi_, "low");
+				CqlDate fk_ = context.Operators.Add(fg_, (fj_ as CqlQuantity));
+				Date fm_ = ct_?.BirthDateElement;
+				string fn_ = fm_?.Value;
+				CqlDate fo_ = context.Operators.ConvertStringToDate(fn_);
+				object fq_ = FHIRHelpers_4_3_000.ToValue(cx_);
+				object fr_ = context.Operators.LateBoundProperty<object>(fq_, "high");
+				CqlDate fs_ = context.Operators.Add(fo_, (fr_ as CqlQuantity));
+				CqlDate fu_ = context.Operators.Add(fs_, dj_);
+				CqlInterval<CqlDate> fv_ = context.Operators.Interval(fk_, fu_, true, false);
+				bool? fw_ = fv_?.highClosed;
+				CqlInterval<CqlDateTime> fx_ = context.Operators.Interval(dn_, ei_, fc_, fw_);
 
 				return fx_;
 			}
 			else if (e_())
 			{
-				var fy_ = condition?.Abatement;
-				var fz_ = FHIRHelpers_4_3_000.ToValue(fy_);
-				var ga_ = context.Operators.LateBoundProperty<object>(fz_, "low");
-				var gc_ = FHIRHelpers_4_3_000.ToValue(fy_);
-				var gd_ = context.Operators.LateBoundProperty<object>(gc_, "high");
-				var ge_ = context.Operators.Interval((ga_ as CqlDateTime), (gd_ as CqlDateTime), true, false);
+				DataType fy_ = condition?.Abatement;
+				object fz_ = FHIRHelpers_4_3_000.ToValue(fy_);
+				object ga_ = context.Operators.LateBoundProperty<object>(fz_, "low");
+				object gc_ = FHIRHelpers_4_3_000.ToValue(fy_);
+				object gd_ = context.Operators.LateBoundProperty<object>(gc_, "high");
+				CqlInterval<CqlDateTime> ge_ = context.Operators.Interval((ga_ as CqlDateTime), (gd_ as CqlDateTime), true, false);
 
 				return ge_;
 			}
@@ -2025,41 +2045,41 @@ public class QICoreCommon_2_0_000
 		{
 			bool b_()
 			{
-				var c_ = condition?.ClinicalStatus;
-				var d_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var e_ = this.active();
-				var f_ = context.Operators.ConvertCodeToConcept(e_);
-				var g_ = context.Operators.Equivalent(d_, f_);
-				var i_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var j_ = this.recurrence();
-				var k_ = context.Operators.ConvertCodeToConcept(j_);
-				var l_ = context.Operators.Equivalent(i_, k_);
-				var m_ = context.Operators.Or(g_, l_);
-				var o_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var p_ = this.relapse();
-				var q_ = context.Operators.ConvertCodeToConcept(p_);
-				var r_ = context.Operators.Equivalent(o_, q_);
-				var s_ = context.Operators.Or(m_, r_);
+				CodeableConcept c_ = condition?.ClinicalStatus;
+				CqlConcept d_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode e_ = this.active();
+				CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+				bool? g_ = context.Operators.Equivalent(d_, f_);
+				CqlConcept i_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode j_ = this.recurrence();
+				CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+				bool? l_ = context.Operators.Equivalent(i_, k_);
+				bool? m_ = context.Operators.Or(g_, l_);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode p_ = this.relapse();
+				CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+				bool? r_ = context.Operators.Equivalent(o_, q_);
+				bool? s_ = context.Operators.Or(m_, r_);
 
 				return (s_ ?? false);
 			};
 			if (b_())
 			{
-				var t_ = condition?.Onset;
-				var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-				var v_ = this.ToInterval(u_);
-				var w_ = context.Operators.Start(v_);
-				var x_ = this.ToAbatementInterval(condition);
-				var y_ = context.Operators.End(x_);
-				var z_ = context.Operators.Interval(w_, y_, true, true);
+				DataType t_ = condition?.Onset;
+				object u_ = FHIRHelpers_4_3_000.ToValue(t_);
+				CqlInterval<CqlDateTime> v_ = this.ToInterval(u_);
+				CqlDateTime w_ = context.Operators.Start(v_);
+				CqlInterval<CqlDateTime> x_ = this.ToAbatementInterval(condition);
+				CqlDateTime y_ = context.Operators.End(x_);
+				CqlInterval<CqlDateTime> z_ = context.Operators.Interval(w_, y_, true, true);
 
 				return z_;
 			}
 			else
 			{
-				var aa_ = this.ToAbatementInterval(condition);
-				var ab_ = context.Operators.End(aa_);
-				var ac_ = new CqlDateTime[]
+				CqlInterval<CqlDateTime> aa_ = this.ToAbatementInterval(condition);
+				CqlDateTime ab_ = context.Operators.End(aa_);
+				CqlDateTime[] ac_ = new CqlDateTime[]
 				{
 					ab_,
 				};
@@ -2069,21 +2089,21 @@ public class QICoreCommon_2_0_000
 					{
 						if ((abatementDate is null))
 						{
-							var ah_ = condition?.Onset;
-							var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-							var aj_ = this.ToInterval(ai_);
-							var ak_ = context.Operators.Start(aj_);
-							var al_ = context.Operators.Interval(ak_, abatementDate, true, false);
+							DataType ah_ = condition?.Onset;
+							object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+							CqlInterval<CqlDateTime> aj_ = this.ToInterval(ai_);
+							CqlDateTime ak_ = context.Operators.Start(aj_);
+							CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ak_, abatementDate, true, false);
 
 							return al_;
 						}
 						else
 						{
-							var am_ = condition?.Onset;
-							var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-							var ao_ = this.ToInterval(an_);
-							var ap_ = context.Operators.Start(ao_);
-							var aq_ = context.Operators.Interval(ap_, abatementDate, true, true);
+							DataType am_ = condition?.Onset;
+							object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+							CqlInterval<CqlDateTime> ao_ = this.ToInterval(an_);
+							CqlDateTime ap_ = context.Operators.Start(ao_);
+							CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ap_, abatementDate, true, true);
 
 							return aq_;
 						}
@@ -2091,8 +2111,8 @@ public class QICoreCommon_2_0_000
 
 					return ag_();
 				};
-				var ae_ = context.Operators.Select<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)ac_, ad_);
-				var af_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ae_);
+				IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.Select<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)ac_, ad_);
+				CqlInterval<CqlDateTime> af_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ae_);
 
 				return af_;
 			}
@@ -2110,41 +2130,41 @@ public class QICoreCommon_2_0_000
 		{
 			bool b_()
 			{
-				var c_ = condition?.ClinicalStatus;
-				var d_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var e_ = this.active();
-				var f_ = context.Operators.ConvertCodeToConcept(e_);
-				var g_ = context.Operators.Equivalent(d_, f_);
-				var i_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var j_ = this.recurrence();
-				var k_ = context.Operators.ConvertCodeToConcept(j_);
-				var l_ = context.Operators.Equivalent(i_, k_);
-				var m_ = context.Operators.Or(g_, l_);
-				var o_ = FHIRHelpers_4_3_000.ToConcept(c_);
-				var p_ = this.relapse();
-				var q_ = context.Operators.ConvertCodeToConcept(p_);
-				var r_ = context.Operators.Equivalent(o_, q_);
-				var s_ = context.Operators.Or(m_, r_);
+				CodeableConcept c_ = condition?.ClinicalStatus;
+				CqlConcept d_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode e_ = this.active();
+				CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+				bool? g_ = context.Operators.Equivalent(d_, f_);
+				CqlConcept i_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode j_ = this.recurrence();
+				CqlConcept k_ = context.Operators.ConvertCodeToConcept(j_);
+				bool? l_ = context.Operators.Equivalent(i_, k_);
+				bool? m_ = context.Operators.Or(g_, l_);
+				CqlConcept o_ = FHIRHelpers_4_3_000.ToConcept(c_);
+				CqlCode p_ = this.relapse();
+				CqlConcept q_ = context.Operators.ConvertCodeToConcept(p_);
+				bool? r_ = context.Operators.Equivalent(o_, q_);
+				bool? s_ = context.Operators.Or(m_, r_);
 
 				return (s_ ?? false);
 			};
 			if (b_())
 			{
-				var t_ = condition?.Onset;
-				var u_ = FHIRHelpers_4_3_000.ToValue(t_);
-				var v_ = this.toInterval(u_);
-				var w_ = context.Operators.Start(v_);
-				var x_ = this.abatementInterval(condition);
-				var y_ = context.Operators.End(x_);
-				var z_ = context.Operators.Interval(w_, y_, true, true);
+				DataType t_ = condition?.Onset;
+				object u_ = FHIRHelpers_4_3_000.ToValue(t_);
+				CqlInterval<CqlDateTime> v_ = this.toInterval(u_);
+				CqlDateTime w_ = context.Operators.Start(v_);
+				CqlInterval<CqlDateTime> x_ = this.abatementInterval(condition);
+				CqlDateTime y_ = context.Operators.End(x_);
+				CqlInterval<CqlDateTime> z_ = context.Operators.Interval(w_, y_, true, true);
 
 				return z_;
 			}
 			else
 			{
-				var aa_ = this.ToAbatementInterval(condition);
-				var ab_ = context.Operators.End(aa_);
-				var ac_ = new CqlDateTime[]
+				CqlInterval<CqlDateTime> aa_ = this.ToAbatementInterval(condition);
+				CqlDateTime ab_ = context.Operators.End(aa_);
+				CqlDateTime[] ac_ = new CqlDateTime[]
 				{
 					ab_,
 				};
@@ -2154,21 +2174,21 @@ public class QICoreCommon_2_0_000
 					{
 						if ((abatementDate is null))
 						{
-							var ah_ = condition?.Onset;
-							var ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
-							var aj_ = this.ToInterval(ai_);
-							var ak_ = context.Operators.Start(aj_);
-							var al_ = context.Operators.Interval(ak_, abatementDate, true, false);
+							DataType ah_ = condition?.Onset;
+							object ai_ = FHIRHelpers_4_3_000.ToValue(ah_);
+							CqlInterval<CqlDateTime> aj_ = this.ToInterval(ai_);
+							CqlDateTime ak_ = context.Operators.Start(aj_);
+							CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ak_, abatementDate, true, false);
 
 							return al_;
 						}
 						else
 						{
-							var am_ = condition?.Onset;
-							var an_ = FHIRHelpers_4_3_000.ToValue(am_);
-							var ao_ = this.ToInterval(an_);
-							var ap_ = context.Operators.Start(ao_);
-							var aq_ = context.Operators.Interval(ap_, abatementDate, true, true);
+							DataType am_ = condition?.Onset;
+							object an_ = FHIRHelpers_4_3_000.ToValue(am_);
+							CqlInterval<CqlDateTime> ao_ = this.ToInterval(an_);
+							CqlDateTime ap_ = context.Operators.Start(ao_);
+							CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ap_, abatementDate, true, true);
 
 							return aq_;
 						}
@@ -2176,8 +2196,8 @@ public class QICoreCommon_2_0_000
 
 					return ag_();
 				};
-				var ae_ = context.Operators.Select<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)ac_, ad_);
-				var af_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ae_);
+				IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.Select<CqlDateTime, CqlInterval<CqlDateTime>>((IEnumerable<CqlDateTime>)ac_, ad_);
+				CqlInterval<CqlDateTime> af_ = context.Operators.SingletonFrom<CqlInterval<CqlDateTime>>(ae_);
 
 				return af_;
 			}
@@ -2192,8 +2212,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getId()` instead")]
 	public string GetId(string uri)
 	{
-		var a_ = context.Operators.Split(uri, "/");
-		var b_ = context.Operators.Last<string>(a_);
+		IEnumerable<string> a_ = context.Operators.Split(uri, "/");
+		string b_ = context.Operators.Last<string>(a_);
 
 		return b_;
 	}
@@ -2203,8 +2223,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("comment", "This function can be used to determine the logical id of a given resource. It can be used in a single-server environment to trace references. However, this function does not attempt to resolve or distinguish the base of the given url, and so cannot be used safely in multi-server environments.")]
 	public string getId(string uri)
 	{
-		var a_ = context.Operators.Split(uri, "/");
-		var b_ = context.Operators.Last<string>(a_);
+		IEnumerable<string> a_ = context.Operators.Split(uri, "/");
+		string b_ = context.Operators.Last<string>(a_);
 
 		return b_;
 	}
@@ -2214,11 +2234,11 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Uee the fluent function `hasStart()` instead")]
 	public bool? HasStart(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.Start(period);
-		var c_ = context.Operators.MinValue<CqlDateTime>();
-		var d_ = context.Operators.Equal(a_, c_);
-		var e_ = context.Operators.Or((bool?)(a_ is null), d_);
-		var f_ = context.Operators.Not(e_);
+		CqlDateTime a_ = context.Operators.Start(period);
+		CqlDateTime c_ = context.Operators.MinValue<CqlDateTime>();
+		bool? d_ = context.Operators.Equal(a_, c_);
+		bool? e_ = context.Operators.Or((bool?)(a_ is null), d_);
+		bool? f_ = context.Operators.Not(e_);
 
 		return f_;
 	}
@@ -2227,11 +2247,11 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Given an interval, return true if the interval has a starting boundary specified (i.e. the start of the interval is not null and not the minimum DateTime value)")]
 	public bool? hasStart(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.Start(period);
-		var c_ = context.Operators.MinValue<CqlDateTime>();
-		var d_ = context.Operators.Equal(a_, c_);
-		var e_ = context.Operators.Or((bool?)(a_ is null), d_);
-		var f_ = context.Operators.Not(e_);
+		CqlDateTime a_ = context.Operators.Start(period);
+		CqlDateTime c_ = context.Operators.MinValue<CqlDateTime>();
+		bool? d_ = context.Operators.Equal(a_, c_);
+		bool? e_ = context.Operators.Or((bool?)(a_ is null), d_);
+		bool? f_ = context.Operators.Not(e_);
 
 		return f_;
 	}
@@ -2241,11 +2261,11 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `hasEnd()` instead")]
 	public bool? HasEnd(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.End(period);
-		var c_ = context.Operators.MaxValue<CqlDateTime>();
-		var d_ = context.Operators.Equal(a_, c_);
-		var e_ = context.Operators.Or((bool?)(a_ is null), d_);
-		var f_ = context.Operators.Not(e_);
+		CqlDateTime a_ = context.Operators.End(period);
+		CqlDateTime c_ = context.Operators.MaxValue<CqlDateTime>();
+		bool? d_ = context.Operators.Equal(a_, c_);
+		bool? e_ = context.Operators.Or((bool?)(a_ is null), d_);
+		bool? f_ = context.Operators.Not(e_);
 
 		return f_;
 	}
@@ -2254,11 +2274,11 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Given an interval, returns true if the interval has an ending boundary specified (i.e. the end of the interval is not null and not the maximum DateTime value)")]
 	public bool? hasEnd(CqlInterval<CqlDateTime> period)
 	{
-		var a_ = context.Operators.End(period);
-		var c_ = context.Operators.MaxValue<CqlDateTime>();
-		var d_ = context.Operators.Equal(a_, c_);
-		var e_ = context.Operators.Or((bool?)(a_ is null), d_);
-		var f_ = context.Operators.Not(e_);
+		CqlDateTime a_ = context.Operators.End(period);
+		CqlDateTime c_ = context.Operators.MaxValue<CqlDateTime>();
+		bool? d_ = context.Operators.Equal(a_, c_);
+		bool? e_ = context.Operators.Or((bool?)(a_ is null), d_);
+		bool? f_ = context.Operators.Not(e_);
 
 		return f_;
 	}
@@ -2268,8 +2288,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `latest()` instead")]
 	public CqlDateTime Latest(object choice)
 	{
-		var a_ = this.toInterval(choice);
-		var b_ = new CqlInterval<CqlDateTime>[]
+		CqlInterval<CqlDateTime> a_ = this.toInterval(choice);
+		CqlInterval<CqlDateTime>[] b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
 		};
@@ -2279,13 +2299,13 @@ public class QICoreCommon_2_0_000
 			{
 				if ((this.HasEnd(period) ?? false))
 				{
-					var g_ = context.Operators.End(period);
+					CqlDateTime g_ = context.Operators.End(period);
 
 					return g_;
 				}
 				else
 				{
-					var h_ = context.Operators.Start(period);
+					CqlDateTime h_ = context.Operators.Start(period);
 
 					return h_;
 				}
@@ -2293,8 +2313,8 @@ public class QICoreCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
+		IEnumerable<CqlDateTime> d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
+		CqlDateTime e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
 
 		return e_;
 	}
@@ -2303,8 +2323,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Given an interval, returns the ending point if the interval has an ending boundary specified, otherwise, returns the starting point")]
 	public CqlDateTime latest(object choice)
 	{
-		var a_ = this.toInterval(choice);
-		var b_ = new CqlInterval<CqlDateTime>[]
+		CqlInterval<CqlDateTime> a_ = this.toInterval(choice);
+		CqlInterval<CqlDateTime>[] b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
 		};
@@ -2314,13 +2334,13 @@ public class QICoreCommon_2_0_000
 			{
 				if ((this.hasEnd(period) ?? false))
 				{
-					var g_ = context.Operators.End(period);
+					CqlDateTime g_ = context.Operators.End(period);
 
 					return g_;
 				}
 				else
 				{
-					var h_ = context.Operators.Start(period);
+					CqlDateTime h_ = context.Operators.Start(period);
 
 					return h_;
 				}
@@ -2328,8 +2348,8 @@ public class QICoreCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
+		IEnumerable<CqlDateTime> d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
+		CqlDateTime e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
 
 		return e_;
 	}
@@ -2339,8 +2359,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `earliest()` instead")]
 	public CqlDateTime Earliest(object choice)
 	{
-		var a_ = this.toInterval(choice);
-		var b_ = new CqlInterval<CqlDateTime>[]
+		CqlInterval<CqlDateTime> a_ = this.toInterval(choice);
+		CqlInterval<CqlDateTime>[] b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
 		};
@@ -2350,13 +2370,13 @@ public class QICoreCommon_2_0_000
 			{
 				if ((this.HasStart(period) ?? false))
 				{
-					var g_ = context.Operators.Start(period);
+					CqlDateTime g_ = context.Operators.Start(period);
 
 					return g_;
 				}
 				else
 				{
-					var h_ = context.Operators.End(period);
+					CqlDateTime h_ = context.Operators.End(period);
 
 					return h_;
 				}
@@ -2364,8 +2384,8 @@ public class QICoreCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
+		IEnumerable<CqlDateTime> d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
+		CqlDateTime e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
 
 		return e_;
 	}
@@ -2374,8 +2394,8 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Given an interval, return the starting point if the interval has a starting boundary specified, otherwise, return the ending point")]
 	public CqlDateTime earliest(object choice)
 	{
-		var a_ = this.toInterval(choice);
-		var b_ = new CqlInterval<CqlDateTime>[]
+		CqlInterval<CqlDateTime> a_ = this.toInterval(choice);
+		CqlInterval<CqlDateTime>[] b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
 		};
@@ -2385,13 +2405,13 @@ public class QICoreCommon_2_0_000
 			{
 				if ((this.hasStart(period) ?? false))
 				{
-					var g_ = context.Operators.Start(period);
+					CqlDateTime g_ = context.Operators.Start(period);
 
 					return g_;
 				}
 				else
 				{
-					var h_ = context.Operators.End(period);
+					CqlDateTime h_ = context.Operators.End(period);
 
 					return h_;
 				}
@@ -2399,8 +2419,8 @@ public class QICoreCommon_2_0_000
 
 			return f_();
 		};
-		var d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
-		var e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
+		IEnumerable<CqlDateTime> d_ = context.Operators.Select<CqlInterval<CqlDateTime>, CqlDateTime>((IEnumerable<CqlInterval<CqlDateTime>>)b_, c_);
+		CqlDateTime e_ = context.Operators.SingletonFrom<CqlDateTime>(d_);
 
 		return e_;
 	}
@@ -2410,22 +2430,22 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `toDayNumbers()` instead")]
 	public IEnumerable<int?> Interval_To_Day_Numbers(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = context.Operators.Start(Period);
-		var b_ = context.Operators.End(Period);
-		var c_ = context.Operators.DurationBetween(a_, b_, "day");
-		var d_ = context.Operators.Interval(1, c_, true, true);
-		var e_ = new CqlInterval<int?>[]
+		CqlDateTime a_ = context.Operators.Start(Period);
+		CqlDateTime b_ = context.Operators.End(Period);
+		int? c_ = context.Operators.DurationBetween(a_, b_, null);
+		CqlInterval<int?> d_ = context.Operators.Interval(1, c_, true, true);
+		CqlInterval<int?>[] e_ = new CqlInterval<int?>[]
 		{
 			d_,
 		};
-		var f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
 		int? g_(CqlInterval<int?> DayNumber)
 		{
-			var i_ = context.Operators.End(DayNumber);
+			int? i_ = context.Operators.End(DayNumber);
 
 			return i_;
 		};
-		var h_ = context.Operators.Select<CqlInterval<int?>, int?>(f_, g_);
+		IEnumerable<int?> h_ = context.Operators.Select<CqlInterval<int?>, int?>(f_, g_);
 
 		return h_;
 	}
@@ -2434,22 +2454,22 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Creates a list of integers from 1 to how many days are in the interval. Note, this wont create an index for the final day if it is less than 24 hours. This also includes the first 24 hour period.")]
 	public IEnumerable<int?> toDayNumbers(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = context.Operators.Start(Period);
-		var b_ = context.Operators.End(Period);
-		var c_ = context.Operators.DurationBetween(a_, b_, "day");
-		var d_ = context.Operators.Interval(1, c_, true, true);
-		var e_ = new CqlInterval<int?>[]
+		CqlDateTime a_ = context.Operators.Start(Period);
+		CqlDateTime b_ = context.Operators.End(Period);
+		int? c_ = context.Operators.DurationBetween(a_, b_, null);
+		CqlInterval<int?> d_ = context.Operators.Interval(1, c_, true, true);
+		CqlInterval<int?>[] e_ = new CqlInterval<int?>[]
 		{
 			d_,
 		};
-		var f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
 		int? g_(CqlInterval<int?> DayNumber)
 		{
-			var i_ = context.Operators.End(DayNumber);
+			int? i_ = context.Operators.End(DayNumber);
 
 			return i_;
 		};
-		var h_ = context.Operators.Select<CqlInterval<int?>, int?>(f_, g_);
+		IEnumerable<int?> h_ = context.Operators.Select<CqlInterval<int?>, int?>(f_, g_);
 
 		return h_;
 	}
@@ -2459,55 +2479,55 @@ public class QICoreCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `daysInPeriod()` instead")]
 	public IEnumerable<Tuple_ddJhZGNHefSCOAJJFEIEcXie> Days_In_Period(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = this.Interval_To_Day_Numbers(Period);
+		IEnumerable<int?> a_ = this.Interval_To_Day_Numbers(Period);
 		Tuple_ddJhZGNHefSCOAJJFEIEcXie b_(int? DayIndex)
 		{
-			var d_ = context.Operators.Start(Period);
-			var e_ = context.Operators.Quantity(24m, "hours");
-			var f_ = context.Operators.Subtract(DayIndex, 1);
-			var g_ = context.Operators.ConvertIntegerToQuantity(f_);
-			var h_ = context.Operators.Multiply(e_, g_);
-			var i_ = context.Operators.Add(d_, h_);
+			CqlDateTime d_ = context.Operators.Start(Period);
+			CqlQuantity e_ = context.Operators.Quantity(24m, "hours");
+			int? f_ = context.Operators.Subtract(DayIndex, 1);
+			CqlQuantity g_ = context.Operators.ConvertIntegerToQuantity(f_);
+			CqlQuantity h_ = context.Operators.Multiply(e_, g_);
+			CqlDateTime i_ = context.Operators.Add(d_, h_);
 			CqlDateTime j_()
 			{
 				bool m_()
 				{
-					var n_ = context.Operators.Start(Period);
-					var o_ = context.Operators.Quantity(24m, "hours");
-					var p_ = context.Operators.Subtract(DayIndex, 1);
-					var q_ = context.Operators.ConvertIntegerToQuantity(p_);
-					var r_ = context.Operators.Multiply(o_, q_);
-					var s_ = context.Operators.Add(n_, r_);
-					var t_ = context.Operators.End(Period);
-					var u_ = context.Operators.DurationBetween(s_, t_, "hour");
-					var v_ = context.Operators.Less(u_, 24);
+					CqlDateTime n_ = context.Operators.Start(Period);
+					CqlQuantity o_ = context.Operators.Quantity(24m, "hours");
+					int? p_ = context.Operators.Subtract(DayIndex, 1);
+					CqlQuantity q_ = context.Operators.ConvertIntegerToQuantity(p_);
+					CqlQuantity r_ = context.Operators.Multiply(o_, q_);
+					CqlDateTime s_ = context.Operators.Add(n_, r_);
+					CqlDateTime t_ = context.Operators.End(Period);
+					int? u_ = context.Operators.DurationBetween(s_, t_, null);
+					bool? v_ = context.Operators.Less(u_, 24);
 
 					return (v_ ?? false);
 				};
 				if (m_())
 				{
-					var w_ = context.Operators.Start(Period);
-					var x_ = context.Operators.Quantity(24m, "hours");
-					var y_ = context.Operators.Subtract(DayIndex, 1);
-					var z_ = context.Operators.ConvertIntegerToQuantity(y_);
-					var aa_ = context.Operators.Multiply(x_, z_);
-					var ab_ = context.Operators.Add(w_, aa_);
+					CqlDateTime w_ = context.Operators.Start(Period);
+					CqlQuantity x_ = context.Operators.Quantity(24m, "hours");
+					int? y_ = context.Operators.Subtract(DayIndex, 1);
+					CqlQuantity z_ = context.Operators.ConvertIntegerToQuantity(y_);
+					CqlQuantity aa_ = context.Operators.Multiply(x_, z_);
+					CqlDateTime ab_ = context.Operators.Add(w_, aa_);
 
 					return ab_;
 				}
 				else
 				{
-					var ac_ = context.Operators.Start(Period);
-					var ad_ = context.Operators.Quantity(24m, "hours");
-					var ae_ = context.Operators.ConvertIntegerToQuantity(DayIndex);
-					var af_ = context.Operators.Multiply(ad_, ae_);
-					var ag_ = context.Operators.Add(ac_, af_);
+					CqlDateTime ac_ = context.Operators.Start(Period);
+					CqlQuantity ad_ = context.Operators.Quantity(24m, "hours");
+					CqlQuantity ae_ = context.Operators.ConvertIntegerToQuantity(DayIndex);
+					CqlQuantity af_ = context.Operators.Multiply(ad_, ae_);
+					CqlDateTime ag_ = context.Operators.Add(ac_, af_);
 
 					return ag_;
 				}
 			};
-			var k_ = context.Operators.Interval(i_, j_(), true, false);
-			var l_ = new Tuple_ddJhZGNHefSCOAJJFEIEcXie
+			CqlInterval<CqlDateTime> k_ = context.Operators.Interval(i_, j_(), true, false);
+			Tuple_ddJhZGNHefSCOAJJFEIEcXie l_ = new Tuple_ddJhZGNHefSCOAJJFEIEcXie
 			{
 				dayIndex = DayIndex,
 				dayPeriod = k_,
@@ -2515,7 +2535,7 @@ public class QICoreCommon_2_0_000
 
 			return l_;
 		};
-		var c_ = context.Operators.Select<int?, Tuple_ddJhZGNHefSCOAJJFEIEcXie>(a_, b_);
+		IEnumerable<Tuple_ddJhZGNHefSCOAJJFEIEcXie> c_ = context.Operators.Select<int?, Tuple_ddJhZGNHefSCOAJJFEIEcXie>(a_, b_);
 
 		return c_;
 	}
@@ -2524,55 +2544,55 @@ public class QICoreCommon_2_0_000
     [CqlTag("description", "Creates a list of 24 hour long intervals in an interval paired with the index (1 indexed) to which 24 hour interval it is. Note that the result will include intervals that are closed at the beginning and open at the end")]
 	public IEnumerable<Tuple_ddJhZGNHefSCOAJJFEIEcXie> daysInPeriod(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = this.Interval_To_Day_Numbers(Period);
+		IEnumerable<int?> a_ = this.Interval_To_Day_Numbers(Period);
 		Tuple_ddJhZGNHefSCOAJJFEIEcXie b_(int? DayIndex)
 		{
-			var d_ = context.Operators.Start(Period);
-			var e_ = context.Operators.Quantity(24m, "hours");
-			var f_ = context.Operators.Subtract(DayIndex, 1);
-			var g_ = context.Operators.ConvertIntegerToQuantity(f_);
-			var h_ = context.Operators.Multiply(e_, g_);
-			var i_ = context.Operators.Add(d_, h_);
+			CqlDateTime d_ = context.Operators.Start(Period);
+			CqlQuantity e_ = context.Operators.Quantity(24m, "hours");
+			int? f_ = context.Operators.Subtract(DayIndex, 1);
+			CqlQuantity g_ = context.Operators.ConvertIntegerToQuantity(f_);
+			CqlQuantity h_ = context.Operators.Multiply(e_, g_);
+			CqlDateTime i_ = context.Operators.Add(d_, h_);
 			CqlDateTime j_()
 			{
 				bool m_()
 				{
-					var n_ = context.Operators.Start(Period);
-					var o_ = context.Operators.Quantity(24m, "hours");
-					var p_ = context.Operators.Subtract(DayIndex, 1);
-					var q_ = context.Operators.ConvertIntegerToQuantity(p_);
-					var r_ = context.Operators.Multiply(o_, q_);
-					var s_ = context.Operators.Add(n_, r_);
-					var t_ = context.Operators.End(Period);
-					var u_ = context.Operators.DurationBetween(s_, t_, "hour");
-					var v_ = context.Operators.Less(u_, 24);
+					CqlDateTime n_ = context.Operators.Start(Period);
+					CqlQuantity o_ = context.Operators.Quantity(24m, "hours");
+					int? p_ = context.Operators.Subtract(DayIndex, 1);
+					CqlQuantity q_ = context.Operators.ConvertIntegerToQuantity(p_);
+					CqlQuantity r_ = context.Operators.Multiply(o_, q_);
+					CqlDateTime s_ = context.Operators.Add(n_, r_);
+					CqlDateTime t_ = context.Operators.End(Period);
+					int? u_ = context.Operators.DurationBetween(s_, t_, null);
+					bool? v_ = context.Operators.Less(u_, 24);
 
 					return (v_ ?? false);
 				};
 				if (m_())
 				{
-					var w_ = context.Operators.Start(Period);
-					var x_ = context.Operators.Quantity(24m, "hours");
-					var y_ = context.Operators.Subtract(DayIndex, 1);
-					var z_ = context.Operators.ConvertIntegerToQuantity(y_);
-					var aa_ = context.Operators.Multiply(x_, z_);
-					var ab_ = context.Operators.Add(w_, aa_);
+					CqlDateTime w_ = context.Operators.Start(Period);
+					CqlQuantity x_ = context.Operators.Quantity(24m, "hours");
+					int? y_ = context.Operators.Subtract(DayIndex, 1);
+					CqlQuantity z_ = context.Operators.ConvertIntegerToQuantity(y_);
+					CqlQuantity aa_ = context.Operators.Multiply(x_, z_);
+					CqlDateTime ab_ = context.Operators.Add(w_, aa_);
 
 					return ab_;
 				}
 				else
 				{
-					var ac_ = context.Operators.Start(Period);
-					var ad_ = context.Operators.Quantity(24m, "hours");
-					var ae_ = context.Operators.ConvertIntegerToQuantity(DayIndex);
-					var af_ = context.Operators.Multiply(ad_, ae_);
-					var ag_ = context.Operators.Add(ac_, af_);
+					CqlDateTime ac_ = context.Operators.Start(Period);
+					CqlQuantity ad_ = context.Operators.Quantity(24m, "hours");
+					CqlQuantity ae_ = context.Operators.ConvertIntegerToQuantity(DayIndex);
+					CqlQuantity af_ = context.Operators.Multiply(ad_, ae_);
+					CqlDateTime ag_ = context.Operators.Add(ac_, af_);
 
 					return ag_;
 				}
 			};
-			var k_ = context.Operators.Interval(i_, j_(), true, false);
-			var l_ = new Tuple_ddJhZGNHefSCOAJJFEIEcXie
+			CqlInterval<CqlDateTime> k_ = context.Operators.Interval(i_, j_(), true, false);
+			Tuple_ddJhZGNHefSCOAJJFEIEcXie l_ = new Tuple_ddJhZGNHefSCOAJJFEIEcXie
 			{
 				dayIndex = DayIndex,
 				dayPeriod = k_,
@@ -2580,7 +2600,7 @@ public class QICoreCommon_2_0_000
 
 			return l_;
 		};
-		var c_ = context.Operators.Select<int?, Tuple_ddJhZGNHefSCOAJJFEIEcXie>(a_, b_);
+		IEnumerable<Tuple_ddJhZGNHefSCOAJJFEIEcXie> c_ = context.Operators.Select<int?, Tuple_ddJhZGNHefSCOAJJFEIEcXie>(a_, b_);
 
 		return c_;
 	}

--- a/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
@@ -882,7 +882,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_0_000.toInterval(an_);
 				CqlDateTime ap_ = context.Operators.Start(ao_);
 				CqlInterval<CqlDateTime> aq_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				bool? ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, "day");
+				bool? ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, null);
 				bool? as_ = context.Operators.And(al_, ar_);
 
 				return as_;
@@ -942,7 +942,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
 				CqlInterval<CqlDateTime> r_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, "day");
+				bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
 				bool? t_ = context.Operators.And(m_, s_);
 
 				return t_;
@@ -1030,7 +1030,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.toInterval(af_);
 				CqlDateTime ah_ = context.Operators.Start(ag_);
 				CqlInterval<CqlDateTime> ai_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(TwentyWeeksPlusEncounter);
-				bool? aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, "day");
+				bool? aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, null);
 				bool? ak_ = context.Operators.And(ad_, aj_);
 
 				return ak_;

--- a/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
@@ -89,7 +89,7 @@ public class Status_1_6_000
 
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
 			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
@@ -106,7 +106,7 @@ public class Status_1_6_000
 
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
-		var a_ = new CqlCode[]
+		CqlCode[] a_ = new CqlCode[]
 		{
 			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
 		};
@@ -120,8 +120,8 @@ public class Status_1_6_000
 
 	private Patient Patient_Value()
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
-		var b_ = context.Operators.SingletonFrom<Patient>(a_);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
 	}
@@ -135,40 +135,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.survey();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.survey();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -178,40 +178,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.survey();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.survey();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -221,15 +221,15 @@ public class Status_1_6_000
 	{
 		bool? a_(Condition C)
 		{
-			var c_ = C?.ClinicalStatus;
-			var d_ = FHIRHelpers_4_3_000.ToConcept(c_);
-			var e_ = this.active();
-			var f_ = context.Operators.ConvertCodeToConcept(e_);
-			var g_ = context.Operators.Equivalent(d_, f_);
+			CodeableConcept c_ = C?.ClinicalStatus;
+			CqlConcept d_ = FHIRHelpers_4_3_000.ToConcept(c_);
+			CqlCode e_ = this.active();
+			CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+			bool? g_ = context.Operators.Equivalent(d_, f_);
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Condition>(Condition, a_);
+		IEnumerable<Condition> b_ = context.Operators.Where<Condition>(Condition, a_);
 
 		return b_;
 	}
@@ -239,15 +239,15 @@ public class Status_1_6_000
 	{
 		bool? a_(Condition C)
 		{
-			var c_ = C?.ClinicalStatus;
-			var d_ = FHIRHelpers_4_3_000.ToConcept(c_);
-			var e_ = this.active();
-			var f_ = context.Operators.ConvertCodeToConcept(e_);
-			var g_ = context.Operators.Equivalent(d_, f_);
+			CodeableConcept c_ = C?.ClinicalStatus;
+			CqlConcept d_ = FHIRHelpers_4_3_000.ToConcept(c_);
+			CqlCode e_ = this.active();
+			CqlConcept f_ = context.Operators.ConvertCodeToConcept(e_);
+			bool? g_ = context.Operators.Equivalent(d_, f_);
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Condition>(Condition, a_);
+		IEnumerable<Condition> b_ = context.Operators.Where<Condition>(Condition, a_);
 
 		return b_;
 	}
@@ -257,25 +257,25 @@ public class Status_1_6_000
 	{
 		bool? a_(DeviceRequest D)
 		{
-			var c_ = D?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = D?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = D?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = D?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<DeviceRequest>(DeviceRequest, a_);
+		IEnumerable<DeviceRequest> b_ = context.Operators.Where<DeviceRequest>(DeviceRequest, a_);
 
 		return b_;
 	}
@@ -285,25 +285,25 @@ public class Status_1_6_000
 	{
 		bool? a_(DeviceRequest D)
 		{
-			var c_ = D?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = D?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = D?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = D?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<DeviceRequest>(DeviceRequest, a_);
+		IEnumerable<DeviceRequest> b_ = context.Operators.Where<DeviceRequest>(DeviceRequest, a_);
 
 		return b_;
 	}
@@ -313,25 +313,25 @@ public class Status_1_6_000
 	{
 		bool? a_(ServiceRequest S)
 		{
-			var c_ = S?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = S?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = S?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = S?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
+		IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
 
 		return b_;
 	}
@@ -341,25 +341,25 @@ public class Status_1_6_000
 	{
 		bool? a_(ServiceRequest S)
 		{
-			var c_ = S?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = S?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = S?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = S?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
+		IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
 
 		return b_;
 	}
@@ -369,25 +369,25 @@ public class Status_1_6_000
 	{
 		bool? a_(ServiceRequest S)
 		{
-			var c_ = S?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = S?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = S?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = S?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
+		IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
 
 		return b_;
 	}
@@ -397,25 +397,25 @@ public class Status_1_6_000
 	{
 		bool? a_(ServiceRequest S)
 		{
-			var c_ = S?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<RequestStatus> c_ = S?.StatusElement;
+			RequestStatus? d_ = c_?.Value;
+			Code<RequestStatus> e_ = context.Operators.Convert<Code<RequestStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = S?.IntentElement;
-			var j_ = i_?.Value;
-			var k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
-			var l_ = context.Operators.Equal(k_, "order");
-			var m_ = context.Operators.And(h_, l_);
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			Code<RequestIntent> i_ = S?.IntentElement;
+			RequestIntent? j_ = i_?.Value;
+			Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
+			bool? l_ = context.Operators.Equal(k_, "order");
+			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
 		};
-		var b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
+		IEnumerable<ServiceRequest> b_ = context.Operators.Where<ServiceRequest>(ServiceRequest, a_);
 
 		return b_;
 	}
@@ -425,21 +425,21 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -449,21 +449,21 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -473,11 +473,11 @@ public class Status_1_6_000
 	{
 		bool? a_(Encounter E)
 		{
-			var c_ = E?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<Encounter.EncounterStatus> c_ = E?.StatusElement;
+			Encounter.EncounterStatus? d_ = c_?.Value;
+			Code<Encounter.EncounterStatus> e_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"finished",
 				"arrived",
@@ -485,11 +485,11 @@ public class Status_1_6_000
 				"in-progress",
 				"onleave",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Encounter>(Enc, a_);
+		IEnumerable<Encounter> b_ = context.Operators.Where<Encounter>(Enc, a_);
 
 		return b_;
 	}
@@ -499,11 +499,11 @@ public class Status_1_6_000
 	{
 		bool? a_(Encounter E)
 		{
-			var c_ = E?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<Encounter.EncounterStatus> c_ = E?.StatusElement;
+			Encounter.EncounterStatus? d_ = c_?.Value;
+			Code<Encounter.EncounterStatus> e_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"finished",
 				"arrived",
@@ -511,11 +511,11 @@ public class Status_1_6_000
 				"in-progress",
 				"onleave",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Encounter>(Enc, a_);
+		IEnumerable<Encounter> b_ = context.Operators.Where<Encounter>(Enc, a_);
 
 		return b_;
 	}
@@ -525,14 +525,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Immunization I)
 		{
-			var c_ = I?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<Immunization.ImmunizationStatusCodes> c_ = I?.StatusElement;
+			Immunization.ImmunizationStatusCodes? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Immunization>(Immunization, a_);
+		IEnumerable<Immunization> b_ = context.Operators.Where<Immunization>(Immunization, a_);
 
 		return b_;
 	}
@@ -542,14 +542,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Immunization I)
 		{
-			var c_ = I?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<Immunization.ImmunizationStatusCodes> c_ = I?.StatusElement;
+			Immunization.ImmunizationStatusCodes? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Immunization>(Immunization, a_);
+		IEnumerable<Immunization> b_ = context.Operators.Where<Immunization>(Immunization, a_);
 
 		return b_;
 	}
@@ -559,14 +559,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Procedure P)
 		{
-			var c_ = P?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<EventStatus> c_ = P?.StatusElement;
+			EventStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Procedure>(Proc, a_);
+		IEnumerable<Procedure> b_ = context.Operators.Where<Procedure>(Proc, a_);
 
 		return b_;
 	}
@@ -576,14 +576,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Procedure P)
 		{
-			var c_ = P?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<EventStatus> c_ = P?.StatusElement;
+			EventStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Procedure>(Proc, a_);
+		IEnumerable<Procedure> b_ = context.Operators.Where<Procedure>(Proc, a_);
 
 		return b_;
 	}
@@ -593,14 +593,14 @@ public class Status_1_6_000
 	{
 		bool? a_(Procedure P)
 		{
-			var c_ = P?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equivalent(e_, "completed");
+			Code<EventStatus> c_ = P?.StatusElement;
+			EventStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equivalent(e_, "completed");
 
 			return f_;
 		};
-		var b_ = context.Operators.Where<Procedure>(Proc, a_);
+		IEnumerable<Procedure> b_ = context.Operators.Where<Procedure>(Proc, a_);
 
 		return b_;
 	}
@@ -610,40 +610,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.laboratory();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.laboratory();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -653,40 +653,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.laboratory();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.laboratory();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -696,19 +696,19 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationRequest M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equal(e_, "active");
-			var g_ = M?.IntentElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<string>(h_);
-			var j_ = context.Operators.Equal(i_, "order");
-			var k_ = context.Operators.And(f_, j_);
+			Code<MedicationRequest.MedicationrequestStatus> c_ = M?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equal(e_, "active");
+			Code<MedicationRequest.MedicationRequestIntent> g_ = M?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? h_ = g_?.Value;
+			string i_ = context.Operators.Convert<string>(h_);
+			bool? j_ = context.Operators.Equal(i_, "order");
+			bool? k_ = context.Operators.And(f_, j_);
 
 			return k_;
 		};
-		var b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
+		IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
 
 		return b_;
 	}
@@ -718,19 +718,19 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationRequest M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = context.Operators.Equal(e_, "active");
-			var g_ = M?.IntentElement;
-			var h_ = g_?.Value;
-			var i_ = context.Operators.Convert<string>(h_);
-			var j_ = context.Operators.Equal(i_, "order");
-			var k_ = context.Operators.And(f_, j_);
+			Code<MedicationRequest.MedicationrequestStatus> c_ = M?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			bool? f_ = context.Operators.Equal(e_, "active");
+			Code<MedicationRequest.MedicationRequestIntent> g_ = M?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? h_ = g_?.Value;
+			string i_ = context.Operators.Convert<string>(h_);
+			bool? j_ = context.Operators.Equal(i_, "order");
+			bool? k_ = context.Operators.And(f_, j_);
 
 			return k_;
 		};
-		var b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
+		IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
 
 		return b_;
 	}
@@ -740,21 +740,21 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationDispense M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<MedicationDispense.MedicationDispenseStatusCodes>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<MedicationDispense.MedicationDispenseStatusCodes> c_ = M?.StatusElement;
+			MedicationDispense.MedicationDispenseStatusCodes? d_ = c_?.Value;
+			Code<MedicationDispense.MedicationDispenseStatusCodes> e_ = context.Operators.Convert<Code<MedicationDispense.MedicationDispenseStatusCodes>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"completed",
 				"in-progress",
 				"on-hold",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<MedicationDispense>(Med, a_);
+		IEnumerable<MedicationDispense> b_ = context.Operators.Where<MedicationDispense>(Med, a_);
 
 		return b_;
 	}
@@ -764,21 +764,21 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationDispense M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<MedicationDispense.MedicationDispenseStatusCodes>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<MedicationDispense.MedicationDispenseStatusCodes> c_ = M?.StatusElement;
+			MedicationDispense.MedicationDispenseStatusCodes? d_ = c_?.Value;
+			Code<MedicationDispense.MedicationDispenseStatusCodes> e_ = context.Operators.Convert<Code<MedicationDispense.MedicationDispenseStatusCodes>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"completed",
 				"in-progress",
 				"on-hold",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<MedicationDispense>(Med, a_);
+		IEnumerable<MedicationDispense> b_ = context.Operators.Where<MedicationDispense>(Med, a_);
 
 		return b_;
 	}
@@ -788,24 +788,24 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationRequest M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<MedicationRequest.MedicationrequestStatus> c_ = M?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
-			var h_ = M?.IntentElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<string>(i_);
-			var k_ = context.Operators.Equal(j_, "order");
-			var l_ = context.Operators.And(g_, k_);
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
+			string j_ = context.Operators.Convert<string>(i_);
+			bool? k_ = context.Operators.Equal(j_, "order");
+			bool? l_ = context.Operators.And(g_, k_);
 
 			return l_;
 		};
-		var b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
+		IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
 
 		return b_;
 	}
@@ -815,24 +815,24 @@ public class Status_1_6_000
 	{
 		bool? a_(MedicationRequest M)
 		{
-			var c_ = M?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<MedicationRequest.MedicationrequestStatus> c_ = M?.StatusElement;
+			MedicationRequest.MedicationrequestStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"active",
 				"completed",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
-			var h_ = M?.IntentElement;
-			var i_ = h_?.Value;
-			var j_ = context.Operators.Convert<string>(i_);
-			var k_ = context.Operators.Equal(j_, "order");
-			var l_ = context.Operators.And(g_, k_);
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
+			MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
+			string j_ = context.Operators.Convert<string>(i_);
+			bool? k_ = context.Operators.Equal(j_, "order");
+			bool? l_ = context.Operators.And(g_, k_);
 
 			return l_;
 		};
-		var b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
+		IEnumerable<MedicationRequest> b_ = context.Operators.Where<MedicationRequest>(MedicationRequest, a_);
 
 		return b_;
 	}
@@ -842,40 +842,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.exam();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.exam();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -885,40 +885,40 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = O?.Category;
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			List<CodeableConcept> i_ = O?.Category;
 			CqlConcept j_(CodeableConcept @this)
 			{
-				var p_ = FHIRHelpers_4_3_000.ToConcept(@this);
+				CqlConcept p_ = FHIRHelpers_4_3_000.ToConcept(@this);
 
 				return p_;
 			};
-			var k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
+			IEnumerable<CqlConcept> k_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)i_, j_);
 			bool? l_(CqlConcept ObservationCategory)
 			{
-				var q_ = this.exam();
-				var r_ = context.Operators.ConvertCodeToConcept(q_);
-				var s_ = context.Operators.Equivalent(ObservationCategory, r_);
+				CqlCode q_ = this.exam();
+				CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+				bool? s_ = context.Operators.Equivalent(ObservationCategory, r_);
 
 				return s_;
 			};
-			var m_ = context.Operators.Where<CqlConcept>(k_, l_);
-			var n_ = context.Operators.Exists<CqlConcept>(m_);
-			var o_ = context.Operators.And(h_, n_);
+			IEnumerable<CqlConcept> m_ = context.Operators.Where<CqlConcept>(k_, l_);
+			bool? n_ = context.Operators.Exists<CqlConcept>(m_);
+			bool? o_ = context.Operators.And(h_, n_);
 
 			return o_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -928,20 +928,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -951,20 +951,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -974,20 +974,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -997,20 +997,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1020,20 +1020,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1043,20 +1043,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1066,20 +1066,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1089,20 +1089,20 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<string>(d_);
-			var f_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			string e_ = context.Operators.Convert<string>(d_);
+			string[] f_ = new string[]
 			{
 				"final",
 				"amended",
 				"corrected",
 			};
-			var g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
+			bool? g_ = context.Operators.In<string>(e_, (f_ as IEnumerable<string>));
 
 			return g_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1112,22 +1112,22 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"preliminary",
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}
@@ -1137,22 +1137,22 @@ public class Status_1_6_000
 	{
 		bool? a_(Observation O)
 		{
-			var c_ = O?.StatusElement;
-			var d_ = c_?.Value;
-			var e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
-			var f_ = context.Operators.Convert<string>(e_);
-			var g_ = new string[]
+			Code<ObservationStatus> c_ = O?.StatusElement;
+			ObservationStatus? d_ = c_?.Value;
+			Code<ObservationStatus> e_ = context.Operators.Convert<Code<ObservationStatus>>(d_);
+			string f_ = context.Operators.Convert<string>(e_);
+			string[] g_ = new string[]
 			{
 				"preliminary",
 				"final",
 				"amended",
 				"corrected",
 			};
-			var h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
+			bool? h_ = context.Operators.In<string>(f_, (g_ as IEnumerable<string>));
 
 			return h_;
 		};
-		var b_ = context.Operators.Where<Observation>(Obs, a_);
+		IEnumerable<Observation> b_ = context.Operators.Where<Observation>(Obs, a_);
 
 		return b_;
 	}

--- a/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
@@ -183,7 +183,7 @@ public class TJCOverall_8_11_000
 			CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
 			CqlDateTime g_ = context.Operators.End(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
-			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, "day");
+			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, null);
 
 			return i_;
 		};
@@ -236,7 +236,7 @@ public class TJCOverall_8_11_000
 			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
 			CqlDateTime j_ = context.Operators.Start(i_);
 			CqlDate k_ = context.Operators.DateFrom(j_);
-			int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
+			int? l_ = context.Operators.CalculateAgeAt(g_, k_, null);
 			bool? m_ = context.Operators.GreaterOrEqual(l_, 18);
 
 			return m_;

--- a/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
@@ -302,7 +302,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			Period g_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, "day");
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, null);
 			Coding j_ = ValidEncounter?.Class;
 			CqlCode k_ = FHIRHelpers_4_3_000.ToCode(j_);
 			CqlCode l_ = this.@virtual();
@@ -383,7 +383,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, "day");
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, null);
 			bool? s_ = this.isConfirmedActiveDiagnosis(NewBPHDiagnosis);
 			bool? t_ = context.Operators.And(r_, s_);
 
@@ -734,7 +734,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 					}
 				};
 				CqlDateTime bn_ = QICoreCommon_2_0_000.earliest(bm_());
-				bool? bo_ = context.Operators.SameAs(bl_, bn_, "day");
+				bool? bo_ = context.Operators.SameAs(bl_, bn_, null);
 				List<CodeableConcept> bp_ = QOLAssessment?.Category;
 				CqlConcept bq_(CodeableConcept @this)
 				{
@@ -886,7 +886,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				CqlQuantity r_ = context.Operators.Quantity(1m, "month");
 				CqlDateTime s_ = context.Operators.Add(q_, r_);
 				CqlInterval<CqlDateTime> t_ = context.Operators.Interval(o_, s_, true, true);
-				bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, "day");
+				bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, null);
 				CqlDateTime w_ = context.Operators.Start(n_);
 				bool? x_ = context.Operators.Not((bool?)(w_ is null));
 				bool? y_ = context.Operators.And(u_, x_);
@@ -932,7 +932,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
 				CqlDateTime n_ = context.Operators.Start(m_);
 				CqlDateTime o_ = USSAssessment?.effectiveDatetime;
-				int? p_ = context.Operators.DurationBetween(n_, o_, "month");
+				int? p_ = context.Operators.DurationBetween(n_, o_, null);
 				CqlInterval<int?> q_ = context.Operators.Interval(6, 12, true, true);
 				bool? r_ = context.Operators.In<int?>(p_, q_, null);
 
@@ -1015,7 +1015,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				CqlQuantity s_ = context.Operators.Quantity(1m, "year");
 				CqlDateTime t_ = context.Operators.Add(r_, s_);
 				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
-				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
 				CqlDateTime x_ = context.Operators.Start(o_);
 				bool? y_ = context.Operators.Not((bool?)(x_ is null));
 				bool? z_ = context.Operators.And(v_, y_);
@@ -1167,7 +1167,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 				CqlDateTime z_ = QICoreCommon_2_0_000.earliest(y_);
 				CqlInterval<CqlDateTime> aa_ = this.Measurement_Period();
-				bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, "day");
+				bool? ab_ = context.Operators.In<CqlDateTime>(z_, aa_, null);
 				bool? ac_ = context.Operators.And(w_, ab_);
 				object ae_ = FHIRHelpers_4_3_000.ToValue(x_);
 				CqlDateTime af_ = QICoreCommon_2_0_000.earliest(ae_);

--- a/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
@@ -823,7 +823,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 65);
 		IEnumerable<Encounter> j_ = this.Qualifying_Encounters();
 		bool? k_ = context.Operators.Exists<Encounter>(j_);

--- a/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
@@ -152,7 +152,7 @@ public class VTE_8_6_000
 			CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_3_000.ToInterval(j_);
 			CqlDateTime l_ = context.Operators.Start(k_);
 			CqlDate m_ = context.Operators.DateFrom(l_);
-			int? n_ = context.Operators.CalculateAgeAt(i_, m_, "year");
+			int? n_ = context.Operators.CalculateAgeAt(i_, m_, null);
 			bool? o_ = context.Operators.GreaterOrEqual(n_, 18);
 
 			return o_;

--- a/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
@@ -528,7 +528,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(3, 17, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounter();
@@ -599,7 +599,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 			DataType f_ = BMIPercentile?.Effective;
 			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
 			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, null);
 			DataType j_ = BMIPercentile?.Value;
 			Quantity k_ = context.Operators.Convert<Quantity>(j_);
 			CqlQuantity l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
@@ -627,7 +627,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 			DataType f_ = Height?.Effective;
 			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
 			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, null);
 			DataType j_ = Height?.Value;
 			Quantity k_ = context.Operators.Convert<Quantity>(j_);
 			CqlQuantity l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
@@ -655,7 +655,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 			DataType f_ = Weight?.Effective;
 			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
 			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, "day");
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, null);
 			DataType j_ = Weight?.Value;
 			Quantity k_ = context.Operators.Convert<Quantity>(j_);
 			CqlQuantity l_ = FHIRHelpers_4_3_000.ToQuantity(k_);
@@ -702,7 +702,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 			DataType h_ = NutritionCounseling?.Performed;
 			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
 			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval(i_);
-			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, null);
 
 			return k_;
 		};
@@ -727,7 +727,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 			DataType h_ = ActivityCounseling?.Performed;
 			object i_ = FHIRHelpers_4_3_000.ToValue(h_);
 			CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.ToInterval(i_);
-			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, "day");
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, j_, null);
 
 			return k_;
 		};
@@ -750,7 +750,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(3, 11, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
@@ -770,7 +770,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(12, 17, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 

--- a/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
@@ -384,7 +384,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			CqlDateTime p_ = context.Operators.End(o_);
 			CqlQuantity q_ = context.Operators.Quantity(1m, "day");
 			CqlDateTime r_ = context.Operators.Add(p_, q_);
-			bool? s_ = context.Operators.SameOrAfter(m_, r_, "day");
+			bool? s_ = context.Operators.SameOrAfter(m_, r_, null);
 
 			return s_;
 		};
@@ -469,7 +469,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		{
 			CqlDateTime h_ = context.Operators.Start(LTCPeriods);
 			CqlDateTime i_ = context.Operators.End(LTCPeriods);
-			int? j_ = context.Operators.DurationBetween(h_, i_, "day");
+			int? j_ = context.Operators.DurationBetween(h_, i_, null);
 
 			return j_;
 		};
@@ -664,7 +664,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(65, 79, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		bool? k_ = this.Has_Criteria_Indicating_Frailty();
@@ -683,7 +683,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		CqlDate y_ = context.Operators.ConvertStringToDate(x_);
 		CqlDateTime aa_ = context.Operators.Start(e_);
 		CqlDate ab_ = context.Operators.DateFrom(aa_);
-		int? ac_ = context.Operators.CalculateAgeAt(y_, ab_, "year");
+		int? ac_ = context.Operators.CalculateAgeAt(y_, ab_, null);
 		bool? ad_ = context.Operators.GreaterOrEqual(ac_, 80);
 		bool? af_ = context.Operators.And(ad_, k_);
 		bool? ag_ = context.Operators.Or(u_, af_);
@@ -704,7 +704,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 65);
 		bool? j_ = this.Has_Criteria_Indicating_Frailty();
 		bool? k_ = context.Operators.And(i_, j_);

--- a/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
@@ -259,7 +259,7 @@ public class BCSEHEDISMY2022_1_0_0
 	{
 		CqlInterval<CqlDateTime> a_ = this.Measurement_Period();
 		CqlDateTime b_ = context.Operators.Start(a_);
-		int? c_ = context.Operators.DateTimeComponentFrom(b_, "year");
+		int? c_ = context.Operators.DateTimeComponentFrom(b_, null);
 		int? d_ = context.Operators.Subtract(c_, 2);
 		decimal? e_ = context.Operators.ConvertIntegerToDecimal(0);
 		CqlDateTime f_ = context.Operators.DateTime(d_, 10, 1, 0, 0, 0, 0, e_);
@@ -358,7 +358,7 @@ public class BCSEHEDISMY2022_1_0_0
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(52, 74, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;

--- a/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
@@ -324,7 +324,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 
 		return h_;
 	}
@@ -342,7 +342,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 74, true, false);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
@@ -594,7 +594,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		CqlInterval<CqlDateTime> z_ = this.Measurement_Period();
 		CqlDateTime aa_ = context.Operators.Start(z_);
 		CqlDate ab_ = context.Operators.DateFrom(aa_);
-		int? ac_ = context.Operators.CalculateAgeAt(y_, ab_, "year");
+		int? ac_ = context.Operators.CalculateAgeAt(y_, ab_, null);
 		bool? ad_ = context.Operators.GreaterOrEqual(ac_, 65);
 		bool? ae_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		bool? af_ = context.Operators.And(ad_, ae_);

--- a/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
@@ -321,7 +321,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(23, 64, true, false);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
@@ -500,7 +500,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlInterval<CqlDateTime> s_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(r_);
 			CqlDateTime t_ = context.Operators.Start(s_);
 			CqlDate u_ = context.Operators.DateFrom(t_);
-			int? v_ = context.Operators.CalculateAgeAt(q_, u_, "year");
+			int? v_ = context.Operators.CalculateAgeAt(q_, u_, null);
 			bool? w_ = context.Operators.GreaterOrEqual(v_, 30);
 			bool? x_ = context.Operators.And(m_, w_);
 			CqlDateTime z_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(r_);
@@ -650,7 +650,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlInterval<CqlDateTime> m_ = this.toInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlDate o_ = context.Operators.DateFrom(n_);
-			int? p_ = context.Operators.CalculateAgeAt(k_, o_, "year");
+			int? p_ = context.Operators.CalculateAgeAt(k_, o_, null);
 			bool? q_ = context.Operators.GreaterOrEqual(p_, 30);
 			bool? r_ = context.Operators.And(g_, q_);
 			CqlDateTime t_ = this.latest(l_);

--- a/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
@@ -563,7 +563,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 
 		return h_;
 	}
@@ -581,7 +581,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 75, true, false);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
@@ -703,7 +703,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
 		CqlDateTime r_ = context.Operators.Start(q_);
 		CqlDate s_ = context.Operators.DateFrom(r_);
-		int? t_ = context.Operators.CalculateAgeAt(p_, s_, "year");
+		int? t_ = context.Operators.CalculateAgeAt(p_, s_, null);
 		bool? u_ = context.Operators.GreaterOrEqual(t_, 65);
 		bool? v_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		bool? w_ = context.Operators.And(u_, v_);
@@ -971,7 +971,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			DataType q_ = FecalOccult?.Effective;
 			CqlDateTime r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(q_);
 			CqlInterval<CqlDateTime> s_ = this.Measurement_Period();
-			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, "day");
+			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, null);
 			bool? u_ = context.Operators.And(p_, t_);
 
 			return u_;
@@ -1042,7 +1042,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			DataType l_ = FecalOccult?.Effective;
 			CqlDateTime m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(l_);
 			CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
-			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
+			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, null);
 			bool? p_ = context.Operators.And(k_, o_);
 
 			return p_;
@@ -1078,7 +1078,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			DataType m_ = FecalOccult?.Effective;
 			CqlDateTime n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
-			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
 			bool? q_ = context.Operators.And(l_, p_);
 
 			return q_;
@@ -1361,7 +1361,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime v_ = context.Operators.Subtract(t_, u_);
 			CqlDateTime x_ = context.Operators.End(s_);
 			CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, true);
-			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, "day");
+			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, null);
 			CqlDateTime ab_ = context.Operators.End(s_);
 			bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
 			bool? ad_ = context.Operators.And(z_, ac_);
@@ -1440,7 +1440,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, "day");
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, null);
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);
@@ -1484,7 +1484,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime r_ = context.Operators.Subtract(p_, q_);
 			CqlDateTime t_ = context.Operators.End(o_);
 			CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
-			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
+			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
 			CqlDateTime x_ = context.Operators.End(o_);
 			bool? y_ = context.Operators.Not((bool?)(x_ is null));
 			bool? z_ = context.Operators.And(v_, y_);

--- a/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
@@ -1079,7 +1079,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 		{
 			CqlDateTime e_ = context.Operators.Start(X);
 			CqlDateTime f_ = context.Operators.End(X);
-			int? g_ = context.Operators.DifferenceBetween(e_, f_, "day");
+			int? g_ = context.Operators.DifferenceBetween(e_, f_, null);
 
 			return g_;
 		};
@@ -1120,7 +1120,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 				};
 				CqlDateTime v_ = context.Operators.Max<CqlDateTime>((u_ as IEnumerable<CqlDateTime>));
 				CqlDateTime x_ = context.Operators.End(X);
-				int? y_ = context.Operators.DurationBetween(m_, x_, "day");
+				int? y_ = context.Operators.DurationBetween(m_, x_, null);
 				decimal? z_ = context.Operators.ConvertIntegerToDecimal((y_ ?? 0));
 				CqlDateTime aa_ = context.Operators.Add(v_, new CqlQuantity(z_, "day"));
 				CqlInterval<CqlDateTime> ab_ = context.Operators.Interval(o_, aa_, true, true);

--- a/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
+++ b/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
@@ -665,7 +665,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		CqlDateTime d_ = context.Operators.ConvertStringToDateTime(c_);
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
-		int? g_ = context.Operators.CalculateAgeAt(d_, f_, "year");
+		int? g_ = context.Operators.CalculateAgeAt(d_, f_, null);
 		bool? h_ = context.Operators.GreaterOrEqual(g_, 18);
 		IEnumerable<Encounter> i_ = this.Diabetic_Retinopathy_Encounter();
 		bool? j_ = context.Operators.Exists<Encounter>(i_);

--- a/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
+++ b/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
@@ -327,7 +327,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, false);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
@@ -499,7 +499,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 		CqlDateTime i_ = context.Operators.Start(h_);
 		CqlDate j_ = context.Operators.DateFrom(i_);
-		int? k_ = context.Operators.CalculateAgeAt(g_, j_, "year");
+		int? k_ = context.Operators.CalculateAgeAt(g_, j_, null);
 		bool? l_ = context.Operators.GreaterOrEqual(k_, 65);
 		bool? m_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		bool? n_ = context.Operators.And(l_, m_);

--- a/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
@@ -324,7 +324,7 @@ public class Exam125FHIR_0_0_009
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 
 		return h_;
 	}
@@ -342,7 +342,7 @@ public class Exam125FHIR_0_0_009
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 74, true, false);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
@@ -594,7 +594,7 @@ public class Exam125FHIR_0_0_009
 		CqlInterval<CqlDateTime> z_ = this.Measurement_Period();
 		CqlDateTime aa_ = context.Operators.Start(z_);
 		CqlDate ab_ = context.Operators.DateFrom(aa_);
-		int? ac_ = context.Operators.CalculateAgeAt(y_, ab_, "year");
+		int? ac_ = context.Operators.CalculateAgeAt(y_, ab_, null);
 		bool? ad_ = context.Operators.GreaterOrEqual(ac_, 65);
 		bool? ae_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		bool? af_ = context.Operators.And(ad_, ae_);

--- a/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
@@ -563,7 +563,7 @@ public class Exam130FHIR_0_0_003
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 
 		return h_;
 	}
@@ -581,7 +581,7 @@ public class Exam130FHIR_0_0_003
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 75, true, false);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
@@ -703,7 +703,7 @@ public class Exam130FHIR_0_0_003
 		CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
 		CqlDateTime r_ = context.Operators.Start(q_);
 		CqlDate s_ = context.Operators.DateFrom(r_);
-		int? t_ = context.Operators.CalculateAgeAt(p_, s_, "year");
+		int? t_ = context.Operators.CalculateAgeAt(p_, s_, null);
 		bool? u_ = context.Operators.GreaterOrEqual(t_, 65);
 		bool? v_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		bool? w_ = context.Operators.And(u_, v_);
@@ -971,7 +971,7 @@ public class Exam130FHIR_0_0_003
 			DataType q_ = FecalOccult?.Effective;
 			CqlDateTime r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(q_);
 			CqlInterval<CqlDateTime> s_ = this.Measurement_Period();
-			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, "day");
+			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, null);
 			bool? u_ = context.Operators.And(p_, t_);
 
 			return u_;
@@ -1042,7 +1042,7 @@ public class Exam130FHIR_0_0_003
 			DataType l_ = FecalOccult?.Effective;
 			CqlDateTime m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(l_);
 			CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
-			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, "day");
+			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, null);
 			bool? p_ = context.Operators.And(k_, o_);
 
 			return p_;
@@ -1078,7 +1078,7 @@ public class Exam130FHIR_0_0_003
 			DataType m_ = FecalOccult?.Effective;
 			CqlDateTime n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
-			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, "day");
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
 			bool? q_ = context.Operators.And(l_, p_);
 
 			return q_;
@@ -1361,7 +1361,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime v_ = context.Operators.Subtract(t_, u_);
 			CqlDateTime x_ = context.Operators.End(s_);
 			CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, true);
-			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, "day");
+			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, null);
 			CqlDateTime ab_ = context.Operators.End(s_);
 			bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
 			bool? ad_ = context.Operators.And(z_, ac_);
@@ -1440,7 +1440,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, "day");
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, null);
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);
@@ -1484,7 +1484,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime r_ = context.Operators.Subtract(p_, q_);
 			CqlDateTime t_ = context.Operators.End(o_);
 			CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
-			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
+			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
 			CqlDateTime x_ = context.Operators.End(o_);
 			bool? y_ = context.Operators.Not((bool?)(x_ is null));
 			bool? z_ = context.Operators.And(v_, y_);

--- a/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
@@ -644,7 +644,7 @@ public class FHIR347_0_1_021
 		CqlDateTime d_ = context.Operators.ConvertStringToDateTime(c_);
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
-		int? g_ = context.Operators.CalculateAgeAt(d_, f_, "year");
+		int? g_ = context.Operators.CalculateAgeAt(d_, f_, null);
 		bool? h_ = context.Operators.GreaterOrEqual(g_, 20);
 
 		return h_;
@@ -792,7 +792,7 @@ public class FHIR347_0_1_021
 		CqlDateTime d_ = context.Operators.ConvertStringToDateTime(c_);
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
-		int? g_ = context.Operators.CalculateAgeAt(d_, f_, "year");
+		int? g_ = context.Operators.CalculateAgeAt(d_, f_, null);
 		CqlInterval<int?> h_ = context.Operators.Interval(40, 75, true, true);
 		bool? i_ = context.Operators.In<int?>(g_, h_, null);
 		bool? j_ = this.Has_Diabetes_Diagnosis();

--- a/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
@@ -241,7 +241,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 			CqlDateTime g_ = context.Operators.ConvertStringToDateTime(f_);
 			CqlInterval<CqlDateTime> h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(InpatientEncounter);
 			CqlDateTime i_ = context.Operators.Start(h_);
-			int? j_ = context.Operators.CalculateAgeAt(g_, i_, "year");
+			int? j_ = context.Operators.CalculateAgeAt(g_, i_, null);
 			bool? k_ = context.Operators.GreaterOrEqual(j_, 18);
 
 			return k_;
@@ -469,7 +469,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	{
 		CqlDateTime a_ = context.Operators.Start(Period);
 		CqlDateTime b_ = context.Operators.End(Period);
-		int? c_ = context.Operators.DurationBetween(a_, b_, "day");
+		int? c_ = context.Operators.DurationBetween(a_, b_, null);
 		CqlInterval<int?> d_ = context.Operators.Interval(1, c_, true, true);
 		CqlInterval<int?>[] e_ = new CqlInterval<int?>[]
 		{
@@ -510,7 +510,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 					CqlQuantity r_ = context.Operators.Multiply(o_, q_);
 					CqlDateTime s_ = context.Operators.Add(n_, r_);
 					CqlDateTime t_ = context.Operators.End(Period);
-					int? u_ = context.Operators.DurationBetween(s_, t_, "hour");
+					int? u_ = context.Operators.DurationBetween(s_, t_, null);
 					bool? v_ = context.Operators.Less(u_, 24);
 
 					return (v_ ?? false);

--- a/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
@@ -260,7 +260,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 			CqlDateTime g_ = context.Operators.ConvertStringToDateTime(f_);
 			CqlInterval<CqlDateTime> h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(InpatientEncounter);
 			CqlDateTime i_ = context.Operators.Start(h_);
-			int? j_ = context.Operators.CalculateAgeAt(g_, i_, "year");
+			int? j_ = context.Operators.CalculateAgeAt(g_, i_, null);
 			bool? k_ = context.Operators.GreaterOrEqual(j_, 18);
 
 			return k_;

--- a/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
@@ -338,7 +338,7 @@ public class HybridHWMFHIR_0_102_005
 	{
 		CqlDateTime a_ = context.Operators.Start(Value);
 		CqlDateTime b_ = context.Operators.End(Value);
-		int? c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, null);
 
 		return c_;
 	}
@@ -374,7 +374,7 @@ public class HybridHWMFHIR_0_102_005
 			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_0_001.ToInterval(t_);
 			CqlDateTime v_ = context.Operators.End(u_);
 			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
-			bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, "day");
+			bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, null);
 			bool? y_ = context.Operators.And(s_, x_);
 			Patient z_ = this.Patient();
 			Date aa_ = z_?.BirthDateElement;
@@ -383,7 +383,7 @@ public class HybridHWMFHIR_0_102_005
 			CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_0_001.ToInterval(t_);
 			CqlDateTime af_ = context.Operators.Start(ae_);
 			CqlDate ag_ = context.Operators.DateFrom(af_);
-			int? ah_ = context.Operators.CalculateAgeAt(ac_, ag_, "year");
+			int? ah_ = context.Operators.CalculateAgeAt(ac_, ag_, null);
 			CqlInterval<int?> ai_ = context.Operators.Interval(65, 94, true, true);
 			bool? aj_ = context.Operators.In<int?>(ah_, ai_, null);
 			bool? ak_ = context.Operators.And(y_, aj_);
@@ -710,7 +710,7 @@ public class HybridHWMFHIR_0_102_005
 	{
 		CqlDate a_ = context.Operators.ConvertDateTimeToDate(BirthDateTime);
 		CqlDate b_ = context.Operators.ConvertDateTimeToDate(AsOf);
-		int? c_ = context.Operators.DurationBetween(a_, b_, "year");
+		int? c_ = context.Operators.DurationBetween(a_, b_, null);
 
 		return c_;
 	}
@@ -718,11 +718,9 @@ public class HybridHWMFHIR_0_102_005
     [CqlDeclaration("ToDate")]
 	public CqlDateTime ToDate(CqlDateTime Value)
 	{
-		int? a_ = context.Operators.DateTimeComponentFrom(Value, "year");
-		int? b_ = context.Operators.DateTimeComponentFrom(Value, "month");
-		int? c_ = context.Operators.DateTimeComponentFrom(Value, "day");
+		int? a_ = context.Operators.DateTimeComponentFrom(Value, null);
 		decimal? d_ = context.Operators.TimezoneOffsetFrom(Value);
-		CqlDateTime e_ = context.Operators.DateTime(a_, b_, c_, 0, 0, 0, 0, d_);
+		CqlDateTime e_ = context.Operators.DateTime(a_, a_, a_, 0, 0, 0, 0, d_);
 
 		return e_;
 	}
@@ -732,7 +730,7 @@ public class HybridHWMFHIR_0_102_005
 	{
 		CqlDateTime a_ = context.Operators.Start(Stay);
 		CqlDateTime b_ = context.Operators.End(Stay);
-		int? c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, null);
 
 		return c_;
 	}

--- a/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
@@ -575,7 +575,7 @@ public class HybridHWRFHIR_1_3_005
 	{
 		CqlDateTime a_ = context.Operators.Start(Value);
 		CqlDateTime b_ = context.Operators.End(Value);
-		int? c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, null);
 
 		return c_;
 	}
@@ -611,7 +611,7 @@ public class HybridHWRFHIR_1_3_005
 			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_0_001.ToInterval(t_);
 			CqlDateTime v_ = context.Operators.End(u_);
 			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
-			bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, "day");
+			bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, null);
 			bool? y_ = context.Operators.And(s_, x_);
 			Patient z_ = this.Patient();
 			Date aa_ = z_?.BirthDateElement;
@@ -620,7 +620,7 @@ public class HybridHWRFHIR_1_3_005
 			CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_0_001.ToInterval(t_);
 			CqlDateTime af_ = context.Operators.Start(ae_);
 			CqlDate ag_ = context.Operators.DateFrom(af_);
-			int? ah_ = context.Operators.CalculateAgeAt(ac_, ag_, "year");
+			int? ah_ = context.Operators.CalculateAgeAt(ac_, ag_, null);
 			bool? ai_ = context.Operators.GreaterOrEqual(ah_, 65);
 			bool? aj_ = context.Operators.And(y_, ai_);
 
@@ -1081,7 +1081,7 @@ public class HybridHWRFHIR_1_3_005
 	{
 		CqlDate a_ = context.Operators.ConvertDateTimeToDate(BirthDateTime);
 		CqlDate b_ = context.Operators.ConvertDateTimeToDate(AsOf);
-		int? c_ = context.Operators.DurationBetween(a_, b_, "year");
+		int? c_ = context.Operators.DurationBetween(a_, b_, null);
 
 		return c_;
 	}
@@ -1089,11 +1089,9 @@ public class HybridHWRFHIR_1_3_005
     [CqlDeclaration("ToDate")]
 	public CqlDateTime ToDate(CqlDateTime Value)
 	{
-		int? a_ = context.Operators.DateTimeComponentFrom(Value, "year");
-		int? b_ = context.Operators.DateTimeComponentFrom(Value, "month");
-		int? c_ = context.Operators.DateTimeComponentFrom(Value, "day");
+		int? a_ = context.Operators.DateTimeComponentFrom(Value, null);
 		decimal? d_ = context.Operators.TimezoneOffsetFrom(Value);
-		CqlDateTime e_ = context.Operators.DateTime(a_, b_, c_, 0, 0, 0, 0, d_);
+		CqlDateTime e_ = context.Operators.DateTime(a_, a_, a_, 0, 0, 0, 0, d_);
 
 		return e_;
 	}
@@ -1103,7 +1101,7 @@ public class HybridHWRFHIR_1_3_005
 	{
 		CqlDateTime a_ = context.Operators.Start(Stay);
 		CqlDateTime b_ = context.Operators.End(Stay);
-		int? c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, null);
 
 		return c_;
 	}

--- a/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
@@ -498,7 +498,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	{
 		CqlDateTime a_ = context.Operators.Start(Value);
 		CqlDateTime b_ = context.Operators.End(Value);
-		int? c_ = context.Operators.DifferenceBetween(a_, b_, "day");
+		int? c_ = context.Operators.DifferenceBetween(a_, b_, null);
 
 		return c_;
 	}

--- a/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
@@ -588,7 +588,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 		bool? k_ = this.Has_Criteria_Indicating_Frailty();
@@ -606,7 +606,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		CqlDate x_ = context.Operators.ConvertStringToDate(w_);
 		CqlDateTime z_ = context.Operators.End(e_);
 		CqlDate aa_ = context.Operators.DateFrom(z_);
-		int? ab_ = context.Operators.CalculateAgeAt(x_, aa_, "year");
+		int? ab_ = context.Operators.CalculateAgeAt(x_, aa_, null);
 		bool? ac_ = context.Operators.GreaterOrEqual(ab_, 81);
 		bool? ae_ = context.Operators.And(ac_, k_);
 		bool? af_ = context.Operators.Or(t_, ae_);
@@ -627,7 +627,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.End(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 66);
 		bool? j_ = this.Has_Criteria_Indicating_Frailty();
 		bool? k_ = context.Operators.And(i_, j_);

--- a/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
@@ -636,7 +636,7 @@ public class NCQACQLBase_1_0_0
 				{
 					CqlDate l_ = context.Operators.Start(I);
 					CqlDate m_ = context.Operators.End(I);
-					int? n_ = context.Operators.DurationBetween(l_, m_, "day");
+					int? n_ = context.Operators.DurationBetween(l_, m_, null);
 					int? o_ = context.Operators.Add(n_, 1);
 					int?[] p_ = new int?[]
 					{
@@ -672,7 +672,7 @@ public class NCQACQLBase_1_0_0
 				{
 					CqlDate aa_ = context.Operators.Start(I);
 					CqlDate ab_ = context.Operators.End(I);
-					int? ac_ = context.Operators.DurationBetween(aa_, ab_, "day");
+					int? ac_ = context.Operators.DurationBetween(aa_, ab_, null);
 					int? ad_ = context.Operators.Add(ac_, 1);
 					int?[] ae_ = new int?[]
 					{
@@ -721,7 +721,7 @@ public class NCQACQLBase_1_0_0
 				{
 					CqlDate bd_ = context.Operators.Start(I);
 					CqlDate be_ = context.Operators.End(I);
-					int? bf_ = context.Operators.DurationBetween(bd_, be_, "day");
+					int? bf_ = context.Operators.DurationBetween(bd_, be_, null);
 					int? bg_ = context.Operators.Add(bf_, 1);
 					int?[] bh_ = new int?[]
 					{
@@ -752,7 +752,7 @@ public class NCQACQLBase_1_0_0
 				{
 					CqlDate bl_ = context.Operators.Start(I);
 					CqlDate bm_ = context.Operators.End(I);
-					int? bn_ = context.Operators.DurationBetween(bl_, bm_, "day");
+					int? bn_ = context.Operators.DurationBetween(bl_, bm_, null);
 					int? bo_ = context.Operators.Add(bn_, 1);
 					int?[] bp_ = new int?[]
 					{
@@ -779,7 +779,7 @@ public class NCQACQLBase_1_0_0
 				Tuple_CaKfRdNEDgKGCjhSPMGWIWQVV aw_ = context.Operators.First<Tuple_CaKfRdNEDgKGCjhSPMGWIWQVV>(av_);
 				CqlInterval<CqlDate> ax_ = aw_?.interval;
 				CqlDate ay_ = context.Operators.End(ax_);
-				int? az_ = context.Operators.DurationBetween(ar_, ay_, "day");
+				int? az_ = context.Operators.DurationBetween(ar_, ay_, null);
 				int? ba_ = context.Operators.Add(az_, 1);
 				int?[] bb_ = new int?[]
 				{
@@ -857,13 +857,13 @@ public class NCQACQLBase_1_0_0
 	public CqlInterval<CqlDateTime> DateTime_Interval_Set_Nulls_to_Zero(CqlInterval<CqlDateTime> interval)
 	{
 		CqlDateTime a_ = context.Operators.Start(interval);
-		int? b_ = context.Operators.DateTimeComponentFrom(a_, "year");
+		int? b_ = context.Operators.DateTimeComponentFrom(a_, null);
 		int? c_()
 		{
 			bool v_()
 			{
 				CqlDateTime w_ = context.Operators.Start(interval);
-				int? x_ = context.Operators.DateTimeComponentFrom(w_, "month");
+				int? x_ = context.Operators.DateTimeComponentFrom(w_, null);
 
 				return (x_ is null);
 			};
@@ -874,7 +874,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime y_ = context.Operators.Start(interval);
-				int? z_ = context.Operators.DateTimeComponentFrom(y_, "month");
+				int? z_ = context.Operators.DateTimeComponentFrom(y_, null);
 
 				return z_;
 			}
@@ -884,7 +884,7 @@ public class NCQACQLBase_1_0_0
 			bool aa_()
 			{
 				CqlDateTime ab_ = context.Operators.Start(interval);
-				int? ac_ = context.Operators.DateTimeComponentFrom(ab_, "day");
+				int? ac_ = context.Operators.DateTimeComponentFrom(ab_, null);
 
 				return (ac_ is null);
 			};
@@ -895,7 +895,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime ad_ = context.Operators.Start(interval);
-				int? ae_ = context.Operators.DateTimeComponentFrom(ad_, "day");
+				int? ae_ = context.Operators.DateTimeComponentFrom(ad_, null);
 
 				return ae_;
 			}
@@ -905,7 +905,7 @@ public class NCQACQLBase_1_0_0
 			bool af_()
 			{
 				CqlDateTime ag_ = context.Operators.Start(interval);
-				int? ah_ = context.Operators.DateTimeComponentFrom(ag_, "hour");
+				int? ah_ = context.Operators.DateTimeComponentFrom(ag_, null);
 
 				return (ah_ is null);
 			};
@@ -916,7 +916,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime ai_ = context.Operators.Start(interval);
-				int? aj_ = context.Operators.DateTimeComponentFrom(ai_, "hour");
+				int? aj_ = context.Operators.DateTimeComponentFrom(ai_, null);
 
 				return aj_;
 			}
@@ -926,7 +926,7 @@ public class NCQACQLBase_1_0_0
 			bool ak_()
 			{
 				CqlDateTime al_ = context.Operators.Start(interval);
-				int? am_ = context.Operators.DateTimeComponentFrom(al_, "minute");
+				int? am_ = context.Operators.DateTimeComponentFrom(al_, null);
 
 				return (am_ is null);
 			};
@@ -937,7 +937,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime an_ = context.Operators.Start(interval);
-				int? ao_ = context.Operators.DateTimeComponentFrom(an_, "minute");
+				int? ao_ = context.Operators.DateTimeComponentFrom(an_, null);
 
 				return ao_;
 			}
@@ -947,7 +947,7 @@ public class NCQACQLBase_1_0_0
 			bool ap_()
 			{
 				CqlDateTime aq_ = context.Operators.Start(interval);
-				int? ar_ = context.Operators.DateTimeComponentFrom(aq_, "second");
+				int? ar_ = context.Operators.DateTimeComponentFrom(aq_, null);
 
 				return (ar_ is null);
 			};
@@ -958,7 +958,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime as_ = context.Operators.Start(interval);
-				int? at_ = context.Operators.DateTimeComponentFrom(as_, "second");
+				int? at_ = context.Operators.DateTimeComponentFrom(as_, null);
 
 				return at_;
 			}
@@ -968,7 +968,7 @@ public class NCQACQLBase_1_0_0
 			bool au_()
 			{
 				CqlDateTime av_ = context.Operators.Start(interval);
-				int? aw_ = context.Operators.DateTimeComponentFrom(av_, "millisecond");
+				int? aw_ = context.Operators.DateTimeComponentFrom(av_, null);
 
 				return (aw_ is null);
 			};
@@ -979,19 +979,19 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime ax_ = context.Operators.Start(interval);
-				int? ay_ = context.Operators.DateTimeComponentFrom(ax_, "millisecond");
+				int? ay_ = context.Operators.DateTimeComponentFrom(ax_, null);
 
 				return ay_;
 			}
 		};
 		CqlDateTime i_ = context.Operators.End(interval);
-		int? j_ = context.Operators.DateTimeComponentFrom(i_, "year");
+		int? j_ = context.Operators.DateTimeComponentFrom(i_, null);
 		int? k_()
 		{
 			bool az_()
 			{
 				CqlDateTime ba_ = context.Operators.End(interval);
-				int? bb_ = context.Operators.DateTimeComponentFrom(ba_, "month");
+				int? bb_ = context.Operators.DateTimeComponentFrom(ba_, null);
 
 				return (bb_ is null);
 			};
@@ -1002,7 +1002,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime bc_ = context.Operators.End(interval);
-				int? bd_ = context.Operators.DateTimeComponentFrom(bc_, "month");
+				int? bd_ = context.Operators.DateTimeComponentFrom(bc_, null);
 
 				return bd_;
 			}
@@ -1012,7 +1012,7 @@ public class NCQACQLBase_1_0_0
 			bool be_()
 			{
 				CqlDateTime bf_ = context.Operators.End(interval);
-				int? bg_ = context.Operators.DateTimeComponentFrom(bf_, "day");
+				int? bg_ = context.Operators.DateTimeComponentFrom(bf_, null);
 
 				return (bg_ is null);
 			};
@@ -1023,7 +1023,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime bh_ = context.Operators.End(interval);
-				int? bi_ = context.Operators.DateTimeComponentFrom(bh_, "day");
+				int? bi_ = context.Operators.DateTimeComponentFrom(bh_, null);
 
 				return bi_;
 			}
@@ -1033,7 +1033,7 @@ public class NCQACQLBase_1_0_0
 			bool bj_()
 			{
 				CqlDateTime bk_ = context.Operators.End(interval);
-				int? bl_ = context.Operators.DateTimeComponentFrom(bk_, "hour");
+				int? bl_ = context.Operators.DateTimeComponentFrom(bk_, null);
 
 				return (bl_ is null);
 			};
@@ -1044,7 +1044,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime bm_ = context.Operators.End(interval);
-				int? bn_ = context.Operators.DateTimeComponentFrom(bm_, "hour");
+				int? bn_ = context.Operators.DateTimeComponentFrom(bm_, null);
 
 				return bn_;
 			}
@@ -1054,7 +1054,7 @@ public class NCQACQLBase_1_0_0
 			bool bo_()
 			{
 				CqlDateTime bp_ = context.Operators.End(interval);
-				int? bq_ = context.Operators.DateTimeComponentFrom(bp_, "minute");
+				int? bq_ = context.Operators.DateTimeComponentFrom(bp_, null);
 
 				return (bq_ is null);
 			};
@@ -1065,7 +1065,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime br_ = context.Operators.End(interval);
-				int? bs_ = context.Operators.DateTimeComponentFrom(br_, "minute");
+				int? bs_ = context.Operators.DateTimeComponentFrom(br_, null);
 
 				return bs_;
 			}
@@ -1075,7 +1075,7 @@ public class NCQACQLBase_1_0_0
 			bool bt_()
 			{
 				CqlDateTime bu_ = context.Operators.End(interval);
-				int? bv_ = context.Operators.DateTimeComponentFrom(bu_, "second");
+				int? bv_ = context.Operators.DateTimeComponentFrom(bu_, null);
 
 				return (bv_ is null);
 			};
@@ -1086,7 +1086,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime bw_ = context.Operators.End(interval);
-				int? bx_ = context.Operators.DateTimeComponentFrom(bw_, "second");
+				int? bx_ = context.Operators.DateTimeComponentFrom(bw_, null);
 
 				return bx_;
 			}
@@ -1096,7 +1096,7 @@ public class NCQACQLBase_1_0_0
 			bool by_()
 			{
 				CqlDateTime bz_ = context.Operators.End(interval);
-				int? ca_ = context.Operators.DateTimeComponentFrom(bz_, "millisecond");
+				int? ca_ = context.Operators.DateTimeComponentFrom(bz_, null);
 
 				return (ca_ is null);
 			};
@@ -1107,7 +1107,7 @@ public class NCQACQLBase_1_0_0
 			else
 			{
 				CqlDateTime cb_ = context.Operators.End(interval);
-				int? cc_ = context.Operators.DateTimeComponentFrom(cb_, "millisecond");
+				int? cc_ = context.Operators.DateTimeComponentFrom(cb_, null);
 
 				return cc_;
 			}
@@ -1185,7 +1185,7 @@ public class NCQACQLBase_1_0_0
 					CqlInterval<CqlDateTime> l_ = this.DateTime_Interval_Set_Nulls_to_Zero(I);
 					CqlDateTime m_ = context.Operators.Start(l_);
 					CqlDateTime o_ = context.Operators.End(l_);
-					int? p_ = context.Operators.DurationBetween(m_, o_, "day");
+					int? p_ = context.Operators.DurationBetween(m_, o_, null);
 					int? q_ = context.Operators.Add(p_, 1);
 					int?[] r_ = new int?[]
 					{
@@ -1222,7 +1222,7 @@ public class NCQACQLBase_1_0_0
 					CqlInterval<CqlDateTime> ac_ = this.DateTime_Interval_Set_Nulls_to_Zero(I);
 					CqlDateTime ad_ = context.Operators.Start(ac_);
 					CqlDateTime af_ = context.Operators.End(ac_);
-					int? ag_ = context.Operators.DurationBetween(ad_, af_, "day");
+					int? ag_ = context.Operators.DurationBetween(ad_, af_, null);
 					int? ah_ = context.Operators.Add(ag_, 1);
 					int?[] ai_ = new int?[]
 					{
@@ -1272,7 +1272,7 @@ public class NCQACQLBase_1_0_0
 					CqlInterval<CqlDateTime> bj_ = this.DateTime_Interval_Set_Nulls_to_Zero(I);
 					CqlDateTime bk_ = context.Operators.Start(bj_);
 					CqlDateTime bm_ = context.Operators.End(bj_);
-					int? bn_ = context.Operators.DurationBetween(bk_, bm_, "day");
+					int? bn_ = context.Operators.DurationBetween(bk_, bm_, null);
 					int? bo_ = context.Operators.Add(bn_, 1);
 					int?[] bp_ = new int?[]
 					{
@@ -1305,7 +1305,7 @@ public class NCQACQLBase_1_0_0
 					CqlInterval<CqlDateTime> bt_ = this.DateTime_Interval_Set_Nulls_to_Zero(I);
 					CqlDateTime bu_ = context.Operators.Start(bt_);
 					CqlDateTime bw_ = context.Operators.End(bt_);
-					int? bx_ = context.Operators.DurationBetween(bu_, bw_, "day");
+					int? bx_ = context.Operators.DurationBetween(bu_, bw_, null);
 					int? by_ = context.Operators.Add(bx_, 1);
 					int?[] bz_ = new int?[]
 					{
@@ -1333,7 +1333,7 @@ public class NCQACQLBase_1_0_0
 				CqlInterval<CqlDateTime> bc_ = bb_?.interval;
 				CqlInterval<CqlDateTime> bd_ = this.DateTime_Interval_Set_Nulls_to_Zero(bc_);
 				CqlDateTime be_ = context.Operators.End(bd_);
-				int? bf_ = context.Operators.DurationBetween(aw_, be_, "day");
+				int? bf_ = context.Operators.DurationBetween(aw_, be_, null);
 				int? bg_ = context.Operators.Add(bf_, 1);
 				int?[] bh_ = new int?[]
 				{
@@ -1410,29 +1410,29 @@ public class NCQACQLBase_1_0_0
     [CqlDeclaration("Convert To UTC DateTime")]
 	public CqlDateTime Convert_To_UTC_DateTime(CqlDate d)
 	{
-		int? a_ = context.Operators.DateTimeComponentFrom(d, "year");
+		int? a_ = context.Operators.DateTimeComponentFrom(d, null);
 		int? b_()
 		{
-			if ((context.Operators.DateTimeComponentFrom(d, "month") is null))
+			if ((context.Operators.DateTimeComponentFrom(d, null) is null))
 			{
 				return 0;
 			}
 			else
 			{
-				int? i_ = context.Operators.DateTimeComponentFrom(d, "month");
+				int? i_ = context.Operators.DateTimeComponentFrom(d, null);
 
 				return i_;
 			}
 		};
 		int? c_()
 		{
-			if ((context.Operators.DateTimeComponentFrom(d, "day") is null))
+			if ((context.Operators.DateTimeComponentFrom(d, null) is null))
 			{
 				return 0;
 			}
 			else
 			{
-				int? j_ = context.Operators.DateTimeComponentFrom(d, "day");
+				int? j_ = context.Operators.DateTimeComponentFrom(d, null);
 
 				return j_;
 			}

--- a/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
+++ b/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
@@ -308,14 +308,14 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "month");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 6);
 		Date k_ = a_?.BirthDateElement;
 		string l_ = k_?.Value;
 		CqlDate m_ = context.Operators.ConvertStringToDate(l_);
 		CqlDateTime o_ = context.Operators.Start(e_);
 		CqlDate p_ = context.Operators.DateFrom(o_);
-		int? q_ = context.Operators.CalculateAgeAt(m_, p_, "year");
+		int? q_ = context.Operators.CalculateAgeAt(m_, p_, null);
 		bool? r_ = context.Operators.Less(q_, 20);
 		bool? s_ = context.Operators.And(i_, r_);
 		IEnumerable<Encounter> t_ = this.Qualifying_Encounters();
@@ -360,14 +360,14 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "month");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 6);
 		Date k_ = a_?.BirthDateElement;
 		string l_ = k_?.Value;
 		CqlDate m_ = context.Operators.ConvertStringToDate(l_);
 		CqlDateTime o_ = context.Operators.Start(e_);
 		CqlDate p_ = context.Operators.DateFrom(o_);
-		int? q_ = context.Operators.CalculateAgeAt(m_, p_, "year");
+		int? q_ = context.Operators.CalculateAgeAt(m_, p_, null);
 		bool? r_ = context.Operators.LessOrEqual(q_, 4);
 		bool? s_ = context.Operators.And(i_, r_);
 
@@ -387,7 +387,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(5, 11, true, true);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 
@@ -407,7 +407,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 		CqlDateTime f_ = context.Operators.Start(e_);
 		CqlDate g_ = context.Operators.DateFrom(f_);
-		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+		int? h_ = context.Operators.CalculateAgeAt(d_, g_, null);
 		CqlInterval<int?> i_ = context.Operators.Interval(12, 20, true, false);
 		bool? j_ = context.Operators.In<int?>(h_, i_, null);
 

--- a/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
@@ -203,7 +203,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_0_001.ToInterval(h_);
 			CqlDateTime j_ = context.Operators.Start(i_);
 			CqlDate k_ = context.Operators.DateFrom(j_);
-			int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
+			int? l_ = context.Operators.CalculateAgeAt(g_, k_, null);
 			bool? m_ = context.Operators.GreaterOrEqual(l_, 18);
 			Code<Encounter.EncounterStatus> n_ = EncounterInpatient?.StatusElement;
 			string o_ = FHIRHelpers_4_0_001.ToString(n_);

--- a/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
@@ -252,7 +252,7 @@ public class TJCOverallFHIR_1_8_000
 			CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_0_001.ToInterval(e_);
 			CqlDateTime k_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
-			bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, "day");
+			bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, null);
 			bool? n_ = context.Operators.And(h_, m_);
 
 			return n_;
@@ -308,7 +308,7 @@ public class TJCOverallFHIR_1_8_000
 				Period m_ = AllStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_0_001.ToInterval(m_);
 				CqlDateTime o_ = context.Operators.Start(n_);
-				int? p_ = context.Operators.CalculateAgeAt(l_, o_, "year");
+				int? p_ = context.Operators.CalculateAgeAt(l_, o_, null);
 				bool? q_ = context.Operators.GreaterOrEqual(p_, 18);
 
 				return q_;


### PR DESCRIPTION
ℹ️Fix for #432 (also regenerating files that were missed in #423 )

* Fixed reading JsonTokens when the JSON exceeded a depth of 64
* Set the MaxDepth to 4096. ( int.MaxValue is not a good choice )
* Regenerate C# - notice that not all vars changed to explicit types from an earlier PR. Also it seems values provided to precision parameters go missing. Must get fixed in another ticket