### PR TITLE
477 Add extension in library resource that refers to the contained resource

### DIFF
--- a/Cql/MultiPackagerCLI/Program.cs
+++ b/Cql/MultiPackagerCLI/Program.cs
@@ -5,7 +5,7 @@ using Hl7.Cql.CodeGeneration.NET;
 using Microsoft.CodeAnalysis;
 
 var solutionDir = new DirectoryInfo(Environment.CurrentDirectory)
-	.FindParentDirectoryContaining("CqlAndDemo.sln")!;
+	.FindParentDirectoryContaining("*.sln")!;
 
 CSharpCodeWriterTypeFormat csTypeFormat = CSharpCodeWriterTypeFormat.Explicit;
 (string subDir, string measureSubDir)[] iteration = [


### PR DESCRIPTION
Fix for #477 

`extension` added to library resource to refer to the `contained` inline resource above it, as is required.

![image](https://github.com/user-attachments/assets/abd748b5-1961-4844-9ae0-f176dc3ba675)
